### PR TITLE
fix: prevent DJ enqueue from resetting active playback state

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java
@@ -61,12 +61,14 @@ public class DjCommandService {
         DjData dj = DjData.create(partyroom.getPartyroomId(), playlistId, crewId, nextOrder);
         DjData saved = aggregatePort.saveDj(dj);
 
-        playbackState.activate(null, null);
-        aggregatePort.savePlaybackState(playbackState);
+        if (isPostActivationProcessingRequired) {
+            playbackState.activate(null, null);
+            aggregatePort.savePlaybackState(playbackState);
+        }
 
         eventPublisher.publishEvent(new DjQueueChangedEvent(partyroom.getPartyroomId(), DjChangeType.ENQUEUE, crewId));
 
-        if(isPostActivationProcessingRequired) {
+        if (isPostActivationProcessingRequired) {
             playbackControlPort.startPlayback(partyroom);
         }
         return saved.getId();

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomQueryService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomQueryService.java
@@ -166,7 +166,7 @@ public class PartyroomQueryService {
         QueueStatus queueStatus = djQueue.isClosed() ? QueueStatus.CLOSE : QueueStatus.OPEN;
         boolean isRegistered = isAlreadyRegistered(partyroom.getPartyroomId());
         PlaybackData playback = null;
-        if (isPlaybackActivated) {
+        if (isPlaybackActivated && playbackState.getCurrentPlaybackId() != null) {
             playback = playbackQueryService.getPlaybackById(playbackState.getCurrentPlaybackId());
         }
         List<DjWithProfileDto> djWithProfiles = getDjs(partyroom.getPartyroomId());


### PR DESCRIPTION
## Summary
- DJ enqueue 시 `activate(null, null)` 호출이 기존 활성 playback 상태를 덮어쓰는 문제 수정
- `getDjQueueInfo`에서 `currentPlaybackId` null 방어 처리 추가

## Root Cause
`enqueueDj()`가 무조건 `activate(null, null)`을 호출하여, 두 번째 DJ 등록 시 `currentPlaybackId`가 null로 초기화됨 → `GET /dj-queue` 500 에러 (NPE)

## Test plan
- [x] `:app:compileJava` 빌드 성공
- [x] `DjCommandService*` 테스트 통과
- [x] `PartyroomQueryServiceTest` 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)