### PR TITLE
fix: DJ enqueue playback state reset bug

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java
@@ -61,12 +61,14 @@ public class DjCommandService {
         DjData dj = DjData.create(partyroom.getPartyroomId(), playlistId, crewId, nextOrder);
         DjData saved = aggregatePort.saveDj(dj);
 
-        playbackState.activate(null, null);
-        aggregatePort.savePlaybackState(playbackState);
+        if (isPostActivationProcessingRequired) {
+            playbackState.activate(null, null);
+            aggregatePort.savePlaybackState(playbackState);
+        }
 
         eventPublisher.publishEvent(new DjQueueChangedEvent(partyroom.getPartyroomId(), DjChangeType.ENQUEUE, crewId));
 
-        if(isPostActivationProcessingRequired) {
+        if (isPostActivationProcessingRequired) {
             playbackControlPort.startPlayback(partyroom);
         }
         return saved.getId();

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomQueryService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomQueryService.java
@@ -166,7 +166,7 @@ public class PartyroomQueryService {
         QueueStatus queueStatus = djQueue.isClosed() ? QueueStatus.CLOSE : QueueStatus.OPEN;
         boolean isRegistered = isAlreadyRegistered(partyroom.getPartyroomId());
         PlaybackData playback = null;
-        if (isPlaybackActivated) {
+        if (isPlaybackActivated && playbackState.getCurrentPlaybackId() != null) {
             playback = playbackQueryService.getPlaybackById(playbackState.getCurrentPlaybackId());
         }
         List<DjWithProfileDto> djWithProfiles = getDjs(partyroom.getPartyroomId());


### PR DESCRIPTION
## Summary
- DJ enqueue 시 활성 playback 상태를 덮어쓰는 버그 수정 (#152)
- `activate(null, null)` 호출을 최초 활성화 시에만 실행하도록 변경
- `getDjQueueInfo`에서 `currentPlaybackId` null 방어 처리

## Test plan
- [x] 빌드 및 관련 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)