### PR TITLE
refactor: externalize CORS config and add staging profile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,5 +21,12 @@ TWITTER_REDIRECT_URI=http://localhost:3000/auth/callback/twitter
 # JWT
 JWT_SECRET=
 
+# CORS (comma-separated list; required for dev/staging/prod profiles)
+# Examples:
+#   dev:     https://dev.pfplay.xyz,https://dev-admin.pfplay.xyz,https://dev-api.pfplay.xyz
+#   staging: https://stg.pfplay.xyz,https://stg-admin.pfplay.xyz,https://stg-api.pfplay.xyz
+#   prod:    https://pfplay.xyz,https://admin.pfplay.xyz,https://api.pfplay.xyz
+CORS_ALLOWED_ORIGINS=
+
 # Production
 PRODUCTION_DOMAIN=

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -6,6 +6,8 @@ spring:
         - common
       dev:
         - common
+      staging:
+        - common
       prod:
         - common
 
@@ -120,6 +122,13 @@ app:
       read: 5000
       write: 5000
 
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,https://localhost:3000,http://localhost:8080}
+    allowed-methods: ${CORS_ALLOWED_METHODS:GET,POST,PUT,PATCH,DELETE,OPTIONS}
+    allowed-headers: ${CORS_ALLOWED_HEADERS:*}
+    allow-credentials: ${CORS_ALLOW_CREDENTIALS:true}
+    max-age: ${CORS_MAX_AGE:3600}
+
 ---
 
 # 🟡 개발 환경
@@ -155,6 +164,51 @@ app:
       domain: ${COOKIE_DOMAIN}
       secure: ${COOKIE_SECURE:true}
       same-site: ${COOKIE_SAME_SITE:Lax}
+
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS}
+
+---
+
+# 🟠 검증 환경
+spring:
+  config:
+    activate:
+      on-profile: staging
+
+  jpa:
+    show-sql: false
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: false
+
+  sql:
+    init:
+      mode: never
+
+server:
+  error:
+    include-message: never
+    include-binding-errors: never
+    include-stacktrace: never
+    include-exception: false
+
+logging:
+  level:
+    org.springframework.security: INFO
+    org.springframework.web.reactive.function.client: INFO
+
+app:
+  jwt:
+    cookie:
+      domain: ${COOKIE_DOMAIN}
+      secure: true
+      same-site: Strict
+
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS}
 
 ---
 
@@ -194,6 +248,9 @@ app:
       domain: ${COOKIE_DOMAIN}
       secure: true
       same-site: Strict
+
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS}
 
 springdoc:
   swagger-ui:

--- a/common/src/main/java/com/pfplaybackend/api/common/config/security/SecurityConfig.java
+++ b/common/src/main/java/com/pfplaybackend/api/common/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.pfplaybackend.api.common.config.security;
 
+import com.pfplaybackend.api.common.config.security.cors.properties.CorsProperties;
 import com.pfplaybackend.api.common.config.security.jwt.CookieBearerTokenResolver;
 import com.pfplaybackend.api.common.config.security.jwt.CustomJwtAuthenticationConverter;
 import lombok.RequiredArgsConstructor;
@@ -14,15 +15,13 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.Arrays;
-import java.util.List;
-
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
 
     private final CookieBearerTokenResolver customBearerTokenResolver;
     private final CustomJwtAuthenticationConverter jwtAuthenticationConverter;
+    private final CorsProperties corsProperties;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -58,17 +57,11 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of(
-                "https://localhost:3000",
-                "http://localhost:3000",
-                "http://localhost:8080",
-                "http://admin.pfplay.xyz",
-                "https://pfplay.xyz",
-                "https://api.pfplay.xyz"));
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(List.of("*"));
-        configuration.setAllowCredentials(true);
-        configuration.setMaxAge(3600L);
+        configuration.setAllowedOrigins(corsProperties.getAllowedOrigins());
+        configuration.setAllowedMethods(corsProperties.getAllowedMethods());
+        configuration.setAllowedHeaders(corsProperties.getAllowedHeaders());
+        configuration.setAllowCredentials(corsProperties.isAllowCredentials());
+        configuration.setMaxAge(corsProperties.getMaxAge());
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/common/src/main/java/com/pfplaybackend/api/common/config/security/cors/properties/CorsProperties.java
+++ b/common/src/main/java/com/pfplaybackend/api/common/config/security/cors/properties/CorsProperties.java
@@ -1,0 +1,19 @@
+package com.pfplaybackend.api.common.config.security.cors.properties;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "app.cors")
+public class CorsProperties {
+
+    private List<String> allowedOrigins;
+    private List<String> allowedMethods;
+    private List<String> allowedHeaders;
+    private boolean allowCredentials = true;
+    private Long maxAge = 3600L;
+}


### PR DESCRIPTION
## Summary
- `SecurityConfig`의 하드코딩된 CORS 허용 Origin/Method를 `app.cors.*` 프로퍼티로 외부화 (`CorsProperties` 추가)
- 프로파일 구조에 `staging` 추가 (기존 `local`/`dev`/`prod`와 동일 패턴)
- `common` 프로파일은 로컬 기본값 유지, `dev`/`staging`/`prod`는 `CORS_ALLOWED_ORIGINS` env 필수 → 운영에 localhost 새어 나가는 문제 차단
- `.env.example`에 `CORS_ALLOWED_ORIGINS` 추가 + 환경별 예시 주석

## Environment variables
| 환경 | `CORS_ALLOWED_ORIGINS` 예시 |
|------|----------------------------|
| dev | `https://dev.pfplay.xyz,https://dev-admin.pfplay.xyz,https://dev-api.pfplay.xyz` |
| staging | `https://stg.pfplay.xyz,https://stg-admin.pfplay.xyz,https://stg-api.pfplay.xyz` |
| prod | `https://pfplay.xyz,https://admin.pfplay.xyz,https://api.pfplay.xyz` |

## Test plan
- [x] 로컬 빌드 성공 (`./gradlew :app:compileJava`, JDK 21)
- [x] 전체 테스트 통과 (`./gradlew test`)
- [ ] dev 배포 후 프론트 CORS preflight 정상 동작 확인
- [ ] staging 배포 환경변수(`CORS_ALLOWED_ORIGINS`) 세팅 확인
- [ ] 운영 배포 전 env 시크릿 등록 필수