### PR TITLE
feature: dev/stg docker compose stacks with auto-deploy CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,14 @@
+# Spring profile (local | dev | staging | prod)
+SPRING_PROFILES_ACTIVE=local
+
 # Database
 DB_URL=jdbc:mysql://localhost:3306/pfplay?characterEncoding=UTF-8&useUnicode=true&serverTimezone=Asia/Seoul
 DB_USERNAME=pfplay
 DB_PASSWORD=
+
+# Redis
+REDIS_HOST=localhost
+REDIS_PORT=6379
 
 # Pytube Service API
 PYTUBE_URI=http://localhost:9000
@@ -21,12 +28,18 @@ TWITTER_REDIRECT_URI=http://localhost:3000/auth/callback/twitter
 # JWT
 JWT_SECRET=
 
-# CORS (comma-separated list; required for dev/staging/prod profiles)
-# Examples:
+# Cookie (required for dev/staging/prod)
+COOKIE_DOMAIN=
+COOKIE_SECURE=true
+COOKIE_SAME_SITE=Lax
+
+# CORS
+# allowed-origins is required for dev/staging/prod profiles (comma-separated)
 #   dev:     https://dev.pfplay.xyz,https://dev-admin.pfplay.xyz,https://dev-api.pfplay.xyz
 #   staging: https://stg.pfplay.xyz,https://stg-admin.pfplay.xyz,https://stg-api.pfplay.xyz
 #   prod:    https://pfplay.xyz,https://admin.pfplay.xyz,https://api.pfplay.xyz
 CORS_ALLOWED_ORIGINS=
-
-# Production
-PRODUCTION_DOMAIN=
+CORS_ALLOWED_METHODS=GET,POST,PUT,PATCH,DELETE,OPTIONS
+CORS_ALLOWED_HEADERS=*
+CORS_ALLOW_CREDENTIALS=true
+CORS_MAX_AGE=3600

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ['**']
   pull_request:
-    branches: [main]
+    branches: [main, develop, release]
 
 permissions:
   contents: read

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -9,7 +9,7 @@ on:
 env:
   IMAGE: ghcr.io/pfplay/pfplay-api
   TAG: dev
-  TARGET_DIR: /home/eisen/PFPlay/pfplay-backend-java
+  TARGET_DIR: /home/eisen/PFPlay/pfplay-platform
 
 jobs:
   build:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,74 @@
+name: Deploy to dev (this machine)
+
+# develop 브랜치로의 PR이 merge되면 트리거.
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+
+env:
+  IMAGE: ghcr.io/pfplay/pfplay-api
+  TAG: dev
+  TARGET_DIR: /home/eisen/PFPlay/pfplay-backend-java
+
+jobs:
+  build:
+    if: github.event.pull_request.merged == true
+    name: Build & push image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: gradle
+
+      - name: Build jar
+        run: chmod +x ./gradlew && ./gradlew :app:bootJar -x test
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./app/Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ env.TAG }}
+            ${{ env.IMAGE }}:${{ env.TAG }}-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build
+    name: Pull & restart on this machine
+    runs-on: [self-hosted, pfplay-host]
+    steps:
+      - name: Sync working tree to develop
+        working-directory: ${{ env.TARGET_DIR }}
+        run: |
+          git fetch origin develop
+          git reset --hard origin/develop
+
+      - name: Run deploy script
+        working-directory: ${{ env.TARGET_DIR }}
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.PACKAGE_ACCESS_TOKEN }}
+        run: ./scripts/deploy.sh dev

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -1,0 +1,74 @@
+name: Deploy to stg (this machine)
+
+# release 브랜치로의 PR이 merge되면 트리거.
+on:
+  pull_request:
+    types: [closed]
+    branches: [release]
+
+env:
+  IMAGE: ghcr.io/pfplay/pfplay-api
+  TAG: stg
+  TARGET_DIR: /home/eisen/PFPlay/pfplay-backend-java
+
+jobs:
+  build:
+    if: github.event.pull_request.merged == true
+    name: Build & push image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: release
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: gradle
+
+      - name: Build jar
+        run: chmod +x ./gradlew && ./gradlew :app:bootJar -x test
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./app/Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ env.TAG }}
+            ${{ env.IMAGE }}:${{ env.TAG }}-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build
+    name: Pull & restart on this machine
+    runs-on: [self-hosted, pfplay-host]
+    steps:
+      - name: Sync working tree to release
+        working-directory: ${{ env.TARGET_DIR }}
+        run: |
+          git fetch origin release
+          git reset --hard origin/release
+
+      - name: Run deploy script
+        working-directory: ${{ env.TARGET_DIR }}
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.PACKAGE_ACCESS_TOKEN }}
+        run: ./scripts/deploy.sh stg

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -9,7 +9,7 @@ on:
 env:
   IMAGE: ghcr.io/pfplay/pfplay-api
   TAG: stg
-  TARGET_DIR: /home/eisen/PFPlay/pfplay-backend-java
+  TARGET_DIR: /home/eisen/PFPlay/pfplay-platform
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ The project follows **Hexagonal Architecture (Ports & Adapters)** with DDD princ
 
 1. **Clone the repository**
 ```bash
-git clone https://github.com/pfplay/pfplay-backend.git
-cd pfplay-backend-java
+git clone https://github.com/pfplay/pfplay-platform.git
+cd pfplay-platform
 ```
 
 2. **Start infrastructure services (MySQL, Redis)**
@@ -375,7 +375,7 @@ stompClient.subscribe('/sub/events/' + partyroomId + '/playback-start',
 ## Project Structure
 
 ```
-pfplay-backend-java/
+pfplay-platform/
 ├── common/                             # Shared Kernel + infrastructure config
 │   └── src/main/java/com/pfplaybackend/api/common/
 │       ├── config/                     # Configuration (Security, Redis, JPA, Cache, Swagger)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,74 @@
+# 개발계 (development) — 호스트 노출 포트: app 9090
+# 실행: docker compose -f docker-compose.dev.yml -p pfplay-dev --env-file .env.dev up -d --build
+services:
+  mysql:
+    image: mysql:8.0.30
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
+      MYSQL_DATABASE: pfplay
+      MYSQL_USER: ${DB_USERNAME:-pfplay}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --default-time-zone=+09:00
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD:-root}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  pytube:
+    build:
+      context: ../pfplay-streaming
+    environment:
+      API_KEY: ${PYTUBE_API_KEY:-pfplay_streaming}
+      API_SECRET: ${PYTUBE_API_SECRET}
+    restart: unless-stopped
+
+  app:
+    image: ghcr.io/pfplay/pfplay-api:dev
+    build:
+      context: .
+      dockerfile: app/Dockerfile
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-local}
+      DB_URL: jdbc:mysql://mysql:3306/pfplay?characterEncoding=UTF-8&useUnicode=true&serverTimezone=Asia/Seoul
+      DB_USERNAME: ${DB_USERNAME:-pfplay}
+      DB_PASSWORD: ${DB_PASSWORD}
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      PYTUBE_URI: http://pytube:9000
+      PYTUBE_API_KEY: ${PYTUBE_API_KEY:-pfplay_streaming}
+      PYTUBE_API_SECRET: ${PYTUBE_API_SECRET}
+      JWT_SECRET: ${JWT_SECRET}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      TWITTER_CLIENT_ID: ${TWITTER_CLIENT_ID}
+      TWITTER_CLIENT_SECRET: ${TWITTER_CLIENT_SECRET}
+    ports:
+      - "9090:8080"
+    restart: unless-stopped
+
+volumes:
+  mysql-data:
+  redis-data:

--- a/docker-compose.stg.yml
+++ b/docker-compose.stg.yml
@@ -1,0 +1,74 @@
+# 검증계 (staging) — 호스트 노출 포트: app 8080
+# 실행: docker compose -f docker-compose.stg.yml -p pfplay-stg --env-file .env.stg up -d --build
+services:
+  mysql:
+    image: mysql:8.0.30
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
+      MYSQL_DATABASE: pfplay
+      MYSQL_USER: ${DB_USERNAME:-pfplay}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --default-time-zone=+09:00
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD:-root}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  pytube:
+    build:
+      context: ../pfplay-streaming
+    environment:
+      API_KEY: ${PYTUBE_API_KEY:-pfplay_streaming}
+      API_SECRET: ${PYTUBE_API_SECRET}
+    restart: unless-stopped
+
+  app:
+    image: ghcr.io/pfplay/pfplay-api:stg
+    build:
+      context: .
+      dockerfile: app/Dockerfile
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-local}
+      DB_URL: jdbc:mysql://mysql:3306/pfplay?characterEncoding=UTF-8&useUnicode=true&serverTimezone=Asia/Seoul
+      DB_USERNAME: ${DB_USERNAME:-pfplay}
+      DB_PASSWORD: ${DB_PASSWORD}
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      PYTUBE_URI: http://pytube:9000
+      PYTUBE_API_KEY: ${PYTUBE_API_KEY:-pfplay_streaming}
+      PYTUBE_API_SECRET: ${PYTUBE_API_SECRET}
+      JWT_SECRET: ${JWT_SECRET}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      TWITTER_CLIENT_ID: ${TWITTER_CLIENT_ID}
+      TWITTER_CLIENT_SECRET: ${TWITTER_CLIENT_SECRET}
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+
+volumes:
+  mysql-data:
+  redis-data:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# GHCR에서 image pull 후 app 컨테이너만 재기동 (mysql/redis/pytube 유지).
+# Usage: ./scripts/deploy.sh {dev|stg}
+#
+# CI에서 호출 시 환경변수 GHCR_USER, GHCR_TOKEN을 넘기면 자동 로그인.
+# 로컬 수동 호출 시 docker login ghcr.io 가 이미 돼있다면 그대로 동작.
+#
+# 로컬에서 코드 변경분으로 다시 빌드하고 싶다면 이 스크립트 대신:
+#   docker compose -f docker-compose.{env}.yml -p pfplay-{env} --env-file .env.{env} up -d --build app
+set -euo pipefail
+
+ENV="${1:-}"
+case "$ENV" in
+  dev) PORT=9090 ;;
+  stg) PORT=8080 ;;
+  *) echo "Usage: $0 {dev|stg}" >&2; exit 1 ;;
+esac
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [[ -n "${GHCR_TOKEN:-}" && -n "${GHCR_USER:-}" ]]; then
+  echo "[deploy:$ENV] docker login ghcr.io..."
+  echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+fi
+
+COMPOSE=(docker compose
+  -f "docker-compose.${ENV}.yml"
+  -p "pfplay-${ENV}"
+  --env-file ".env.${ENV}")
+
+echo "[deploy:$ENV] pulling app image..."
+"${COMPOSE[@]}" pull app
+
+echo "[deploy:$ENV] restarting app (mysql/redis/pytube intact)..."
+"${COMPOSE[@]}" up -d --no-deps app
+
+echo "[deploy:$ENV] waiting for health on http://localhost:${PORT}..."
+for i in $(seq 1 30); do
+  if curl -sf "http://localhost:${PORT}/actuator/health" >/dev/null 2>&1; then
+    echo "[deploy:$ENV] OK"
+    exit 0
+  fi
+  sleep 2
+done
+echo "[deploy:$ENV] WARN: health check timed out (container may still be starting)" >&2
+exit 0


### PR DESCRIPTION
## Summary
- 개발계(9090)/검증계(8080) docker compose 스택 신규 (`docker-compose.{dev,stg}.yml`)
- GHCR 이미지 우선 + 로컬 build fallback (`image:` + `build:` 둘 다 정의)
- mysql/redis/pytube는 호스트 노출 없이 compose 네트워크 내부 통신
- `scripts/deploy.sh`: GHCR pull 후 app 컨테이너만 재기동 (no-deps), CI/수동 양쪽 진입점
- Workflow:
  - `deploy-dev.yml`: develop PR merge → `:dev` 푸시 → self-hosted runner(`pfplay-host`) pull/재기동
  - `deploy-stg.yml`: release 동일 흐름, 태그 `:stg`
- `ci-test.yml`: PR target에 develop, release 추가
- 리포지터리 rename(`pfplay-backend-java` → `pfplay-platform`) 반영 (workflow TARGET_DIR, README)

## Test plan
- [ ] Self-hosted runner 등록 (라벨 `pfplay-host`)
- [ ] `.env.dev` / `.env.stg` 시크릿 작성
- [ ] 최초 1회 부트스트랩 (Phase 4 가이드 참조)
- [ ] develop에 sentinel PR 머지 → Actions 탭에서 `Deploy to dev (this machine)` 통과 확인
- [ ] release도 동일 검증

> ⚠️ 이번 PR 머지 시점엔 workflow가 develop에 없어 자동 배포가 트리거되지 않음. 다음 PR부터 정상 작동.

🤖 Generated with [Claude Code](https://claude.com/claude-code)