### PR TITLE
chore: relax cookie same-site to Lax for staging/prod

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -205,7 +205,7 @@ app:
     cookie:
       domain: ${COOKIE_DOMAIN}
       secure: true
-      same-site: Strict
+      same-site: Lax
 
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS}
@@ -247,7 +247,7 @@ app:
     cookie:
       domain: ${COOKIE_DOMAIN}
       secure: true
-      same-site: Strict
+      same-site: Lax
 
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS}


### PR DESCRIPTION
## Summary
staging/prod 프로파일의 쿠키 `same-site` 정책을 `Strict` → `Lax`로 완화.

## Why
Strict는 다른 도메인에서 우리 서비스로의 모든 cross-site 요청에 쿠키를 첨부하지 않음. Cloudflare 분리 도메인(예: `api.pfplay.xyz` ← `pfplay.xyz`)이나 OAuth 콜백 같은 정상 시나리오에서도 쿠키 누락이 일어날 수 있어 Lax가 더 적절.

## Profile별 same-site 정책
| profile | same-site |
|---|---|
| local (common) | None (개발 편의) |
| dev | `${COOKIE_SAME_SITE:Lax}` (env override 가능) |
| staging | **Lax** ← 변경 |
| prod | **Lax** ← 변경 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)