### PR TITLE
fix: inject all env vars from .env.{dev,stg} via env_file

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,21 +50,14 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    env_file:
+      - .env.dev
     environment:
-      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-local}
+      # compose-only override (컨테이너 내부 hostname)
       DB_URL: jdbc:mysql://mysql:3306/pfplay?characterEncoding=UTF-8&useUnicode=true&serverTimezone=Asia/Seoul
-      DB_USERNAME: ${DB_USERNAME:-pfplay}
-      DB_PASSWORD: ${DB_PASSWORD}
       REDIS_HOST: redis
       REDIS_PORT: 6379
       PYTUBE_URI: http://pytube:9000
-      PYTUBE_API_KEY: ${PYTUBE_API_KEY:-pfplay_streaming}
-      PYTUBE_API_SECRET: ${PYTUBE_API_SECRET}
-      JWT_SECRET: ${JWT_SECRET}
-      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
-      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
-      TWITTER_CLIENT_ID: ${TWITTER_CLIENT_ID}
-      TWITTER_CLIENT_SECRET: ${TWITTER_CLIENT_SECRET}
     ports:
       - "9090:8080"
     restart: unless-stopped

--- a/docker-compose.stg.yml
+++ b/docker-compose.stg.yml
@@ -50,21 +50,14 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    env_file:
+      - .env.stg
     environment:
-      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-local}
+      # compose-only override (컨테이너 내부 hostname)
       DB_URL: jdbc:mysql://mysql:3306/pfplay?characterEncoding=UTF-8&useUnicode=true&serverTimezone=Asia/Seoul
-      DB_USERNAME: ${DB_USERNAME:-pfplay}
-      DB_PASSWORD: ${DB_PASSWORD}
       REDIS_HOST: redis
       REDIS_PORT: 6379
       PYTUBE_URI: http://pytube:9000
-      PYTUBE_API_KEY: ${PYTUBE_API_KEY:-pfplay_streaming}
-      PYTUBE_API_SECRET: ${PYTUBE_API_SECRET}
-      JWT_SECRET: ${JWT_SECRET}
-      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
-      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
-      TWITTER_CLIENT_ID: ${TWITTER_CLIENT_ID}
-      TWITTER_CLIENT_SECRET: ${TWITTER_CLIENT_SECRET}
     ports:
       - "8080:8080"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
docker-compose의 \`app.environment:\`가 명시한 변수만 컨테이너에 주입되어, .env에 추가된 신규 변수가 누락되는 버그 수정.

## Bug
- \`.env.dev\`/\`.env.stg\`에 \`COOKIE_DOMAIN=pfplay.xyz\` 적었는데 컨테이너 내부에선 빈 문자열
- 이유: compose가 \`environment:\` 블록에 명시된 변수만 주입. .env에 있어도 자동 주입 안 함
- 영향 변수: COOKIE_DOMAIN/SECURE/SAME_SITE, CORS_*, GOOGLE/TWITTER_REDIRECT_URI

## Fix
- \`env_file: [.env.dev]\` 추가 → .env 파일 전체 자동 주입
- \`environment:\`는 컨테이너 내부 hostname override만 남김 (DB_URL, REDIS_HOST/PORT, PYTUBE_URI)
- precedence: environment > env_file (compose-internal override 안전)

## Test
로컬에서 dev 컨테이너 재기동 후 검증:
\`\`\`
COOKIE_DOMAIN: [pfplay.xyz]
CORS_ALLOWED_ORIGINS: [https://localhost:3000,https://dev-admin.pfplay.xyz,https://dev-api.pfplay.xyz]
GOOGLE_REDIRECT_URI: [https://localhost:3000/auth/callback/google]
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)