### PR TITLE
fix: align id column definition to bigint unsigned

### DIFF
--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/entity/data/PlaylistData.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/entity/data/PlaylistData.java
@@ -26,7 +26,7 @@ public class PlaylistData extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(columnDefinition = "integer unsigned")
+    @Column(columnDefinition = "bigint unsigned")
     private Long id;
 
     @Embedded

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/entity/data/TrackData.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/entity/data/TrackData.java
@@ -25,7 +25,7 @@ import org.hibernate.annotations.DynamicUpdate;
 public class TrackData extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(columnDefinition = "integer unsigned")
+    @Column(columnDefinition = "bigint unsigned")
     private Long id;
 
     @Embedded

--- a/user/src/main/java/com/pfplaybackend/api/user/domain/entity/data/ActivityData.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/domain/entity/data/ActivityData.java
@@ -26,7 +26,7 @@ public class ActivityData extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(columnDefinition = "integer unsigned")
+    @Column(columnDefinition = "bigint unsigned")
     private Long id;
 
     @Embedded

--- a/user/src/main/java/com/pfplaybackend/api/user/domain/entity/data/ProfileData.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/domain/entity/data/ProfileData.java
@@ -23,7 +23,7 @@ public class ProfileData extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(columnDefinition = "integer unsigned")
+    @Column(columnDefinition = "bigint unsigned")
     private Long id;
 
     @Embedded


### PR DESCRIPTION
## Summary
ID 컬럼 정의 불일치로 \`ddl-auto=validate\` 프로파일(staging/prod)에서 앱 부팅이 실패하는 버그 수정.

## Bug
\`Long\` 필드에 \`@Column(columnDefinition = \"integer unsigned\")\`가 박혀있음.
- \`ddl-auto: create\` (local/dev): INTEGER UNSIGNED로 컬럼 생성
- \`ddl-auto: validate\` (staging/prod): Java Long → BIGINT 기대 → 검증 실패
\`\`\`
Schema-validation: wrong column type encountered in column [id] in table [playlist];
found [int unsigned (Types#INTEGER)], but expecting [integer unsigned (Types#BIGINT)]
\`\`\`

## Fix
4개 엔티티의 ID 컬럼 정의를 \`bigint unsigned\`로 통일:
- \`PlaylistData.id\`
- \`TrackData.id\`
- \`ActivityData.id\`
- \`ProfileData.id\`

다른 \`columnDefinition\` 사용처는 일관됨 (수정 없음):
- \`*.orderNumber\` (Integer ↔ integer unsigned) ✓
- \`ActivityData.score\` (Score → Integer 컨버터 ↔ integer unsigned) ✓
- \`BaseEntity\` datetime 컬럼 ✓

## ⚠️ 주의 — 기존 데이터 있는 환경 마이그레이션 필요
prod처럼 INT 컬럼이 이미 있는 DB는 ALTER TABLE 필요:
\`\`\`sql
ALTER TABLE playlist MODIFY COLUMN id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT;
ALTER TABLE track    MODIFY COLUMN id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT;
ALTER TABLE user_activity MODIFY COLUMN id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT;
ALTER TABLE user_profile  MODIFY COLUMN id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT;
\`\`\`
참조하는 외래키도 함께 BIGINT로 변경 필요할 수 있음.

## Test
- [x] \`./gradlew :app:build\` 성공 (테스트 포함, 17s)
- [ ] 머지 후 staging 프로파일로 컨테이너 재기동, 부팅 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)