### PR TITLE
fix: gate seed data initialization to local/dev profiles

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/bootstrap/ApplicationReadyEventListener.java
+++ b/app/src/main/java/com/pfplaybackend/api/bootstrap/ApplicationReadyEventListener.java
@@ -26,15 +26,18 @@ public class ApplicationReadyEventListener {
 
     @EventListener(ApplicationReadyEvent.class)
     public void onApplicationEvent() {
-        if (!environment.acceptsProfiles(Profiles.of("prod"))) {
-            avatarResourceInitializeService.addAvatarBodies();
-            avatarResourceInitializeService.addAvatarFaces();
-            avatarResourceInitializeService.addAvatarIcons();
+        // 시드 데이터는 schema가 fresh인 환경(ddl-auto=create: local, dev)에서만 의미가 있음.
+        // staging/prod(ddl-auto=validate)는 기존 데이터와 충돌하므로 스킵.
+        if (!environment.acceptsProfiles(Profiles.of("local", "dev"))) {
+            return;
         }
+
+        avatarResourceInitializeService.addAvatarBodies();
+        avatarResourceInitializeService.addAvatarFaces();
+        avatarResourceInitializeService.addAvatarIcons();
+
         // FIXME 서비스 간 '구동 순서에 대한 의존 문제'를 해소
-        // Add AdminUser
         UserId adminId = adminUserInitializeService.addAdminUser();
-        // Add Main Partyroom
         partyroomCommandService.initializeMainStage(adminId);
 
         if (environment.acceptsProfiles(Profiles.of("local"))) {


### PR DESCRIPTION
## Summary
\`ApplicationReadyEventListener\`가 매 부팅마다 admin user / main partyroom을 insert해 \`ddl-auto=validate\` 환경(staging/prod)의 두 번째 부팅부터 unique constraint violation으로 크래시되는 버그 수정.

## Bug
- listener는 매 부팅에서 \`adminUserInitializeService.addAdminUser()\` + \`partyroomCommandService.initializeMainStage()\`를 무조건 실행
- local/dev (ddl create): schema가 매 부팅 새로 생성되니 충돌 없음
- staging/prod (ddl validate): 기존 데이터 그대로 → 두 번째 부팅 시 \`Duplicate entry '1000000000000000-DJ_PNT'\` 등으로 부팅 실패

## Why this gate over per-initializer idempotency
- 시드 데이터는 schema가 fresh할 때만 의미가 있음 → ddl-auto=create인 환경(local, dev)에서만 실행하면 문제 자체가 발생하지 않음
- 각 initializer에 existence check를 추가하는 대안 대비 변경 범위가 한 곳, 트랜잭션 경계도 안 건드림

## Behavior matrix
| profile | seed 실행 | 비고 |
|---|:-:|---|
| local | ✓ | + temporary users (기존 분기 유지) |
| dev | ✓ | |
| staging | **✗** | early return |
| prod | **✗** | early return |

## Test
- [x] \`./gradlew :app:build\` 성공
- [x] 머지 후 staging 컨테이너 재기동 시 \`APP_INITIALIZATION_ENABLED=false\` 우회 없이도 정상 부팅 가능해질 것

🤖 Generated with [Claude Code](https://claude.com/claude-code)