### PR TITLE
chore: switch deploy readiness check + hide api-docs in prod

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -255,3 +255,5 @@ app:
 springdoc:
   swagger-ui:
     enabled: false
+  api-docs:
+    enabled: false

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -35,13 +35,15 @@ echo "[deploy:$ENV] pulling app image..."
 echo "[deploy:$ENV] restarting app (mysql/redis/pytube intact)..."
 "${COMPOSE[@]}" up -d --no-deps app
 
-echo "[deploy:$ENV] waiting for health on http://localhost:${PORT}..."
+echo "[deploy:$ENV] waiting for app on http://localhost:${PORT}..."
+# /v3/api-docs는 인증 없이 200 응답하는 엔드포인트라 readiness 검증으로 적합.
+# (actuator 미사용 환경 대응)
 for i in $(seq 1 30); do
-  if curl -sf "http://localhost:${PORT}/actuator/health" >/dev/null 2>&1; then
+  if curl -sf "http://localhost:${PORT}/v3/api-docs" >/dev/null 2>&1; then
     echo "[deploy:$ENV] OK"
     exit 0
   fi
   sleep 2
 done
-echo "[deploy:$ENV] WARN: health check timed out (container may still be starting)" >&2
+echo "[deploy:$ENV] WARN: readiness check timed out (container may still be starting)" >&2
 exit 0


### PR DESCRIPTION
## Summary
1. \`scripts/deploy.sh\`의 readiness check를 \`/actuator/health\` → \`/v3/api-docs\`로 변경
2. prod 프로파일에서 \`springdoc.api-docs.enabled=false\` 추가 (보안)

## (1) Why deploy.sh readiness check 변경
- 앱이 \`spring-boot-starter-actuator\`를 포함하지 않아 \`/actuator/health\`는 항상 404
- workflow의 \`Deploy to {dev,stg}\`가 매번 \"readiness check timed out\" warning으로 종료
- \`/v3/api-docs\`는 인증 없이 200 응답해 readiness 검증으로 적합

## (2) Why hide api-docs in prod
- 기존엔 swagger UI(\`/spec/api\`)만 비활성, \`/v3/api-docs\` JSON spec은 노출 상태
- 운영 환경에서 API 스펙이 외부에 노출될 필요 없음 → 모두 차단
- dev/staging에선 계속 노출 (개발/검증 + deploy.sh readiness 활용)

## Test
- [x] \`./gradlew :app:build\` 성공
- [x] \`bash -n scripts/deploy.sh\` 통과
- [ ] 머지 후 dev/stg 자동 배포 워크플로우 deploy job이 \"OK\"로 종료되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)