### PR TITLE
chore: sync develop to release (deploy readiness + prod api-docs)

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -255,3 +255,5 @@ app:
 springdoc:
   swagger-ui:
     enabled: false
+  api-docs:
+    enabled: false

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -35,13 +35,15 @@ echo "[deploy:$ENV] pulling app image..."
 echo "[deploy:$ENV] restarting app (mysql/redis/pytube intact)..."
 "${COMPOSE[@]}" up -d --no-deps app
 
-echo "[deploy:$ENV] waiting for health on http://localhost:${PORT}..."
+echo "[deploy:$ENV] waiting for app on http://localhost:${PORT}..."
+# /v3/api-docs는 인증 없이 200 응답하는 엔드포인트라 readiness 검증으로 적합.
+# (actuator 미사용 환경 대응)
 for i in $(seq 1 30); do
-  if curl -sf "http://localhost:${PORT}/actuator/health" >/dev/null 2>&1; then
+  if curl -sf "http://localhost:${PORT}/v3/api-docs" >/dev/null 2>&1; then
     echo "[deploy:$ENV] OK"
     exit 0
   fi
   sleep 2
 done
-echo "[deploy:$ENV] WARN: health check timed out (container may still be starting)" >&2
+echo "[deploy:$ENV] WARN: readiness check timed out (container may still be starting)" >&2
 exit 0


### PR DESCRIPTION
## Summary
PR #164 (deploy.sh readiness check 변경 + prod api-docs 차단)을 release로 동기화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)