### PR TITLE
chore(exception): return 400 on @Valid @RequestBody failures

### DIFF
--- a/common/src/main/java/com/pfplaybackend/api/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/pfplaybackend/api/common/exception/GlobalExceptionHandler.java
@@ -7,9 +7,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.stream.Collectors;
 
 /**
  * 공통 handle Exception
@@ -67,6 +71,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(e.getStatus())
                 .body(ApiErrorResponse.of(e.getStatus(), e.getErrorCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiErrorResponse> handleValidationFailure(MethodArgumentNotValidException e) {
+        String detail = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .collect(Collectors.joining("; "));
+        log.error("Validation failed: {}", detail);
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiErrorResponse.of(HttpStatus.BAD_REQUEST, null, detail));
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)

--- a/common/src/test/java/com/pfplaybackend/api/common/exception/GlobalExceptionHandlerTest.java
+++ b/common/src/test/java/com/pfplaybackend/api/common/exception/GlobalExceptionHandlerTest.java
@@ -6,9 +6,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -115,5 +121,57 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().status()).isEqualTo(403);
+    }
+
+    @Test
+    @DisplayName("handleValidationFailure — @Valid 실패 시 400 상태코드를 반환한다")
+    void handleValidationFailureReturns400() throws NoSuchMethodException {
+        // given — build a MethodArgumentNotValidException with one field error
+        MethodParameter methodParameter = methodParameterForTarget();
+        BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(new Object(), "target");
+        bindingResult.addError(new FieldError("target", "countryCode",
+                "countryCode는 대문자 2글자여야 합니다 (ISO 3166-1 alpha-2)."));
+        MethodArgumentNotValidException ex = new MethodArgumentNotValidException(methodParameter, bindingResult);
+
+        // when
+        ResponseEntity<ApiErrorResponse> response = handler.handleValidationFailure(ex);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo(400);
+        assertThat(response.getBody().message()).contains("countryCode");
+        assertThat(response.getBody().message()).contains("대문자 2글자");
+    }
+
+    @Test
+    @DisplayName("handleValidationFailure — 다중 필드 에러는 메시지에 세미콜론으로 결합된다")
+    void handleValidationFailureConcatenatesMultipleErrors() throws NoSuchMethodException {
+        // given
+        MethodParameter methodParameter = methodParameterForTarget();
+        BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(new Object(), "target");
+        bindingResult.addError(new FieldError("target", "fieldA", "A must not be null"));
+        bindingResult.addError(new FieldError("target", "fieldB", "B must be positive"));
+        MethodArgumentNotValidException ex = new MethodArgumentNotValidException(methodParameter, bindingResult);
+
+        // when
+        ResponseEntity<ApiErrorResponse> response = handler.handleValidationFailure(ex);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().message())
+                .contains("fieldA: A must not be null")
+                .contains("fieldB: B must be positive")
+                .contains(";");
+    }
+
+    private static MethodParameter methodParameterForTarget() throws NoSuchMethodException {
+        Method method = GlobalExceptionHandlerTest.class.getDeclaredMethod("dummyTarget", String.class);
+        return new MethodParameter(method, 0);
+    }
+
+    @SuppressWarnings("unused")
+    private void dummyTarget(String arg) {
+        // placeholder for MethodParameter construction in tests
     }
 }


### PR DESCRIPTION
## Summary
`MethodArgumentNotValidException` (Bean Validation 실패)이 `GlobalExceptionHandler`에서 잡히지 않아 기존 `Exception.class` fallback으로 빠져 **500 Internal Server Error**를 반환하고 있었음.

## Why
- `MethodArgumentTypeMismatchException` 핸들러는 이미 있음 (line 72)
- 그 옆의 `@Valid` 실패 핸들러만 누락 — 정책 변화가 아니라 **명백한 코드 갭**
- 현재 `@Valid @RequestBody`를 쓰는 컨트롤러 10개(admin/demo, admin/user, auth, crew-block, crew-grade, crew-penalty, dj, party-access, partyroom, playback-reaction) 전부 묵시적 500 반환 중

## What
- `GlobalExceptionHandler`에 `@ExceptionHandler(MethodArgumentNotValidException.class)` 추가 → 400 + 필드별 에러 메시지
- 응답 메시지 포맷: `"field: message; field: message"` (여러 필드 오류 시 세미콜론 결합)
- `GlobalExceptionHandlerTest`에 단일/다중 필드 케이스 테스트 2개 추가

## Risk
거의 0. 이전엔 500을 받던 요청이 이제 400을 받음 — 이미 500은 서비스 로직상 올바른 응답이 아니었으므로 클라이언트가 의존할 일 없음.

## Test plan
- [x] `:common:test` pass (handler 유닛 테스트)
- [ ] merge 후 develop 기반 feature 브랜치의 `@Valid` 실패 케이스 통합 테스트에서 400 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)