### PR TITLE
feat(crew): add country code at partyroom entry (Flyway V2)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/admin/application/service/AdminDemoService.java
+++ b/app/src/main/java/com/pfplaybackend/api/admin/application/service/AdminDemoService.java
@@ -253,7 +253,7 @@ public class AdminDemoService {
         PartyroomData loadedPartyroom = adminPartyroomPort.findPartyroomById(partyroom.getPartyroomId().getId())
                 .orElseThrow();
 
-        CrewData crew = CrewData.create(loadedPartyroom.getPartyroomId(), userId, GradeType.LISTENER, LocalDateTime.now(clock));
+        CrewData crew = CrewData.create(loadedPartyroom.getPartyroomId(), userId, GradeType.LISTENER, null, LocalDateTime.now(clock));
         adminPartyroomPort.saveCrew(crew);
     }
 

--- a/app/src/main/java/com/pfplaybackend/api/admin/application/service/AdminPartyroomService.java
+++ b/app/src/main/java/com/pfplaybackend/api/admin/application/service/AdminPartyroomService.java
@@ -158,7 +158,7 @@ public class AdminPartyroomService {
         PartyroomData loadedPartyroom = adminPartyroomPort.findPartyroomById(partyroom.getPartyroomId().getId())
                 .orElseThrow();
 
-        CrewData crew = CrewData.create(loadedPartyroom.getPartyroomId(), userId, GradeType.LISTENER, LocalDateTime.now(clock));
+        CrewData crew = CrewData.create(loadedPartyroom.getPartyroomId(), userId, GradeType.LISTENER, null, LocalDateTime.now(clock));
         adminPartyroomPort.saveCrew(crew);
     }
 

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/PartyroomAccessCommandController.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/PartyroomAccessCommandController.java
@@ -2,18 +2,21 @@ package com.pfplaybackend.api.party.adapter.in.web;
 
 import com.pfplaybackend.api.common.ApiCommonResponse;
 import com.pfplaybackend.api.common.config.swagger.ApiErrorCodes;
+import com.pfplaybackend.api.party.adapter.in.web.payload.request.access.EnterPartyroomRequest;
 import com.pfplaybackend.api.party.adapter.in.web.payload.response.access.EnterPartyroomResponse;
 import com.pfplaybackend.api.party.application.service.PartyroomAccessCommandService;
 import com.pfplaybackend.api.party.domain.entity.data.CrewData;
 import com.pfplaybackend.api.party.domain.exception.CrewException;
 import com.pfplaybackend.api.party.domain.exception.PartyroomException;
 import com.pfplaybackend.api.party.domain.exception.PenaltyException;
+import com.pfplaybackend.api.party.domain.value.CountryCode;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,14 +30,16 @@ public class PartyroomAccessCommandController {
 
     private final PartyroomAccessCommandService partyroomAccessCommandService;
 
-    @Operation(summary = "파티룸 입장", description = "파티룸에 입장합니다. 입장 시 크루(Crew)로 등록되며, 크루 정보가 반환됩니다.")
+    @Operation(summary = "파티룸 입장", description = "파티룸에 입장합니다. 입장 시 크루(Crew)로 등록되며, 크루 정보가 반환됩니다. 요청 본문의 countryCode(ISO 3166-1 alpha-2)는 선택값으로, 주어진 경우 해당 입장 시점의 국가 코드로 저장되고 생략/null이면 비워집니다.")
     @ApiResponse(responseCode = "201", description = "파티룸 입장 성공")
     @SecurityRequirement(name = "cookieAuth")
     @ApiErrorCodes({PartyroomException.class, PenaltyException.class})
     @PostMapping("/{partyroomId}/crews")
     public ResponseEntity<ApiCommonResponse<EnterPartyroomResponse>> enterPartyroom(
-            @Parameter(description = "파티룸 ID") @PathVariable Long partyroomId) {
-        CrewData crew = partyroomAccessCommandService.tryEnter(new PartyroomId(partyroomId));
+            @Parameter(description = "파티룸 ID") @PathVariable Long partyroomId,
+            @Valid @RequestBody EnterPartyroomRequest request) {
+        CountryCode countryCode = request.countryCode() == null ? null : CountryCode.of(request.countryCode());
+        CrewData crew = partyroomAccessCommandService.tryEnter(new PartyroomId(partyroomId), countryCode);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiCommonResponse.success(EnterPartyroomResponse.from(crew)));
     }
 

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/payload/request/access/EnterPartyroomRequest.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/payload/request/access/EnterPartyroomRequest.java
@@ -1,0 +1,13 @@
+package com.pfplaybackend.api.party.adapter.in.web.payload.request.access;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+
+public record EnterPartyroomRequest(
+        @Schema(description = "입장 시점에 프론트엔드가 추출한 ISO 3166-1 alpha-2 국가 코드. 추출 불가 또는 미제공이면 null.",
+                example = "KR",
+                nullable = true)
+        @Pattern(regexp = "^[A-Z]{2}$", message = "countryCode는 대문자 2글자여야 합니다 (ISO 3166-1 alpha-2).")
+        String countryCode
+) {
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/application/dto/crew/CrewSummaryDto.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/dto/crew/CrewSummaryDto.java
@@ -3,18 +3,22 @@ package com.pfplaybackend.api.party.application.dto.crew;
 import com.pfplaybackend.api.party.application.dto.shared.AvatarProfile;
 import com.pfplaybackend.api.party.domain.entity.data.CrewData;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
+import com.pfplaybackend.api.party.domain.value.CountryCode;
 import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
 
 public record CrewSummaryDto(
         long crewId,
         GradeType gradeType,
         String nickname,
-        AvatarProfile avatar
+        AvatarProfile avatar,
+        String countryCode
 ) {
     public static CrewSummaryDto from(CrewData crew, ProfileSettingDto p) {
+        CountryCode cc = crew.getCountryCode();
         return new CrewSummaryDto(crew.getId(), crew.getGradeType(), p.nickname(),
                 AvatarProfile.from(p.avatarCompositionType(), p.avatarBodyUri(), p.avatarFaceUri(),
                         p.avatarIconUri(), p.combinePositionX(), p.combinePositionY(),
-                        p.offsetX(), p.offsetY(), p.scale()));
+                        p.offsetX(), p.offsetY(), p.scale()),
+                cc == null ? null : cc.getValue());
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
@@ -97,7 +97,7 @@ public class PartyroomAccessCommandService {
         } else {
             log.info("[addOrActivateCrew] Adding new crew - userId={}, partyroomId={}, gradeType=LISTENER",
                     userId, partyroom.getPartyroomId().getId());
-            CrewData crew = CrewData.create(partyroom.getPartyroomId(), userId, GradeType.LISTENER, LocalDateTime.now(clock));
+            CrewData crew = CrewData.create(partyroom.getPartyroomId(), userId, GradeType.LISTENER, null, LocalDateTime.now(clock));
             return aggregatePort.saveCrew(crew);
         }
     }
@@ -108,7 +108,7 @@ public class PartyroomAccessCommandService {
 
     @Transactional
     public void enterByHost(UserId hostId, PartyroomData partyroom) {
-        CrewData crew = CrewData.create(partyroom.getPartyroomId(), hostId, GradeType.HOST, LocalDateTime.now(clock));
+        CrewData crew = CrewData.create(partyroom.getPartyroomId(), hostId, GradeType.HOST, null, LocalDateTime.now(clock));
         aggregatePort.saveCrew(crew);
     }
 

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
@@ -18,6 +18,7 @@ import com.pfplaybackend.api.party.domain.exception.CrewException;
 import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
 import com.pfplaybackend.api.party.domain.service.PartyroomAggregateService;
 import com.pfplaybackend.api.party.domain.specification.PartyroomEntrySpecification;
+import com.pfplaybackend.api.party.domain.value.CountryCode;
 import com.pfplaybackend.api.party.domain.value.CrewId;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import lombok.RequiredArgsConstructor;
@@ -43,7 +44,7 @@ public class PartyroomAccessCommandService {
     private final Clock clock;
 
     @Transactional
-    public CrewData tryEnter(PartyroomId partyroomId) {
+    public CrewData tryEnter(PartyroomId partyroomId, CountryCode countryCode) {
         AuthContext authContext = ThreadLocalContext.getAuthContext();
         UserId userId = authContext.getUserId();
         log.info("[tryEnter] START - userId={}, targetPartyroomId={}",
@@ -75,29 +76,32 @@ public class PartyroomAccessCommandService {
                 log.info("[tryEnter] Same room re-entry - userId={}, partyroomId={}", userId, partyroomId.getId());
                 CrewData crew = aggregatePort.findCrew(partyroomId, userId)
                         .orElseThrow();
+                crew.updateCountryCode(countryCode);
+                aggregatePort.saveCrew(crew);
                 publishAccessChangedEvent(partyroom.getPartyroomId(), crew, userId);
                 return crew;
             }
         }
 
-        CrewData crew = addOrActivateCrew(partyroom, userId);
+        CrewData crew = addOrActivateCrew(partyroom, userId, countryCode);
         log.info("[tryEnter] SUCCESS - userId={}, partyroomId={}, crewId={}", userId, partyroomId.getId(), crew.getId());
         publishAccessChangedEvent(partyroom.getPartyroomId(), crew, userId);
         return crew;
     }
 
-    private CrewData addOrActivateCrew(PartyroomData partyroom, UserId userId) {
+    private CrewData addOrActivateCrew(PartyroomData partyroom, UserId userId, CountryCode countryCode) {
         Optional<CrewData> existingCrew = aggregatePort.findCrew(partyroom.getPartyroomId(), userId);
         if (existingCrew.isPresent() && !existingCrew.get().isActive()) {
             CrewData crew = existingCrew.get();
             log.info("[addOrActivateCrew] Reactivating inactive crew - userId={}, partyroomId={}",
                     userId, partyroom.getPartyroomId().getId());
             crew.activatePresence(LocalDateTime.now(clock));
+            crew.updateCountryCode(countryCode);
             return aggregatePort.saveCrew(crew);
         } else {
             log.info("[addOrActivateCrew] Adding new crew - userId={}, partyroomId={}, gradeType=LISTENER",
                     userId, partyroom.getPartyroomId().getId());
-            CrewData crew = CrewData.create(partyroom.getPartyroomId(), userId, GradeType.LISTENER, null, LocalDateTime.now(clock));
+            CrewData crew = CrewData.create(partyroom.getPartyroomId(), userId, GradeType.LISTENER, countryCode, LocalDateTime.now(clock));
             return aggregatePort.saveCrew(crew);
         }
     }

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/CrewData.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/CrewData.java
@@ -3,6 +3,8 @@ package com.pfplaybackend.api.party.domain.entity.data;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.entity.BaseEntity;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
+import com.pfplaybackend.api.party.domain.value.CountryCode;
+import com.pfplaybackend.api.party.domain.value.CountryCodeConverter;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -56,6 +58,10 @@ public class CrewData extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime enteredAt;
     private LocalDateTime exitedAt;
+    // 입장 시점에 프론트엔드가 전달한 국가 코드 (ISO 3166-1 alpha-2). 전달되지 않으면 null.
+    @Column(name = "country_code", length = 2)
+    @Convert(converter = CountryCodeConverter.class)
+    private CountryCode countryCode;
 
     // 데이터 엔티티 생성자
     protected CrewData() {}
@@ -63,6 +69,7 @@ public class CrewData extends BaseEntity {
     @Builder
     public CrewData(Long id, PartyroomId partyroomId, UserId userId, GradeType gradeType,
                     boolean isActive, boolean isBanned, LocalDateTime enteredAt, LocalDateTime exitedAt,
+                    CountryCode countryCode,
                     LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.partyroomId = partyroomId;
@@ -72,13 +79,15 @@ public class CrewData extends BaseEntity {
         this.isBanned = isBanned;
         this.enteredAt = enteredAt;
         this.exitedAt = exitedAt;
+        this.countryCode = countryCode;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
 
     // ── Business Methods ──
 
-    public static CrewData create(PartyroomId partyroomId, UserId userId, GradeType gradeType, LocalDateTime now) {
+    public static CrewData create(PartyroomId partyroomId, UserId userId, GradeType gradeType,
+                                  CountryCode countryCode, LocalDateTime now) {
         return CrewData.builder()
                 .partyroomId(partyroomId)
                 .userId(userId)
@@ -86,11 +95,13 @@ public class CrewData extends BaseEntity {
                 .isActive(true)
                 .isBanned(false)
                 .enteredAt(now)
+                .countryCode(countryCode)
                 .build();
     }
 
-    public static CrewData create(PartyroomId partyroomId, UserId userId, GradeType gradeType) {
-        return create(partyroomId, userId, gradeType, LocalDateTime.now());
+    public static CrewData create(PartyroomId partyroomId, UserId userId, GradeType gradeType,
+                                  CountryCode countryCode) {
+        return create(partyroomId, userId, gradeType, countryCode, LocalDateTime.now());
     }
 
     public void deactivatePresence(LocalDateTime now) {
@@ -113,6 +124,10 @@ public class CrewData extends BaseEntity {
 
     public void updateGrade(GradeType gradeType) {
         this.gradeType = gradeType;
+    }
+
+    public void updateCountryCode(CountryCode countryCode) {
+        this.countryCode = countryCode;
     }
 
     public boolean isBelowGrade(GradeType threshold) {

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/value/CountryCode.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/value/CountryCode.java
@@ -1,0 +1,48 @@
+package com.pfplaybackend.api.party.domain.value;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public class CountryCode implements Serializable {
+
+    private static final Pattern PATTERN = Pattern.compile("^[A-Z]{2}$");
+
+    private final String value;
+
+    private CountryCode(String value) {
+        this.value = value;
+    }
+
+    public static CountryCode of(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("CountryCode requires a non-null value; use a null reference for an absent country code");
+        }
+        if (!PATTERN.matcher(value).matches()) {
+            throw new IllegalArgumentException("CountryCode must be ISO 3166-1 alpha-2 (two uppercase ASCII letters): " + value);
+        }
+        return new CountryCode(value);
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CountryCode that = (CountryCode) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/value/CountryCodeConverter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/value/CountryCodeConverter.java
@@ -1,0 +1,18 @@
+package com.pfplaybackend.api.party.domain.value;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class CountryCodeConverter implements AttributeConverter<CountryCode, String> {
+
+    @Override
+    public String convertToDatabaseColumn(CountryCode countryCode) {
+        return countryCode == null ? null : countryCode.getValue();
+    }
+
+    @Override
+    public CountryCode convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : CountryCode.of(dbData);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/partyview/application/dto/CrewSetupDto.java
+++ b/app/src/main/java/com/pfplaybackend/api/partyview/application/dto/CrewSetupDto.java
@@ -3,6 +3,7 @@ package com.pfplaybackend.api.partyview.application.dto;
 import com.pfplaybackend.api.common.domain.enums.AvatarCompositionType;
 import com.pfplaybackend.api.party.domain.entity.data.CrewData;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
+import com.pfplaybackend.api.party.domain.value.CountryCode;
 import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -18,11 +19,15 @@ public record CrewSetupDto(
         @Schema(example = "0") int combinePositionY,
         @Schema(example = "0.0") double offsetX,
         @Schema(example = "0.0") double offsetY,
-        @Schema(example = "1.0") double scale
+        @Schema(example = "1.0") double scale,
+        @Schema(example = "KR", nullable = true, description = "ISO 3166-1 alpha-2 country code captured at entry time")
+        String countryCode
 ) {
     public static CrewSetupDto from(CrewData crew, ProfileSettingDto p) {
+        CountryCode cc = crew.getCountryCode();
         return new CrewSetupDto(crew.getId(), crew.getGradeType(),
                 p.nickname(), p.avatarCompositionType(), p.avatarBodyUri(), p.avatarFaceUri(), p.avatarIconUri(),
-                p.combinePositionX(), p.combinePositionY(), p.offsetX(), p.offsetY(), p.scale());
+                p.combinePositionX(), p.combinePositionY(), p.offsetX(), p.offsetY(), p.scale(),
+                cc == null ? null : cc.getValue());
     }
 }

--- a/app/src/main/resources/db/migration/V2__add_country_code_to_crew.sql
+++ b/app/src/main/resources/db/migration/V2__add_country_code_to_crew.sql
@@ -1,0 +1,2 @@
+ALTER TABLE crew
+    ADD COLUMN country_code VARCHAR(2) NULL COMMENT 'ISO 3166-1 alpha-2 country code captured at entry time';

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/PartyroomAccessCommandControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/PartyroomAccessCommandControllerTest.java
@@ -4,6 +4,7 @@ import com.pfplaybackend.api.party.domain.entity.data.CrewData;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -17,19 +18,50 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class PartyroomAccessCommandControllerTest extends AbstractPartyCommandWebMvcTest {
 
     @Test
-    @DisplayName("enterPartyroom — 201 Created")
-    void enterPartyroomReturns201() throws Exception {
+    @DisplayName("enterPartyroom — countryCode 포함 요청 시 201 Created")
+    void enterPartyroomWithCountryCodeReturns201() throws Exception {
         // given
         CrewData crew = mock(CrewData.class);
         when(crew.getId()).thenReturn(1L);
         when(crew.getGradeType()).thenReturn(GradeType.CLUBBER);
-        when(partyroomAccessCommandService.tryEnter(any())).thenReturn(crew);
+        when(partyroomAccessCommandService.tryEnter(any(), any())).thenReturn(crew);
 
         // when & then
         mockMvc.perform(post("/api/v1/partyrooms/1/crews")
                         .with(jwt().authorities(() -> "ROLE_MEMBER"))
-                        .with(csrf()))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"countryCode\":\"KR\"}"))
                 .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("enterPartyroom — countryCode null 요청도 201 Created")
+    void enterPartyroomWithNullCountryCodeReturns201() throws Exception {
+        // given
+        CrewData crew = mock(CrewData.class);
+        when(crew.getId()).thenReturn(1L);
+        when(crew.getGradeType()).thenReturn(GradeType.CLUBBER);
+        when(partyroomAccessCommandService.tryEnter(any(), any())).thenReturn(crew);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/partyrooms/1/crews")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"countryCode\":null}"))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("enterPartyroom — 잘못된 countryCode 형식은 400")
+    void enterPartyroomWithInvalidCountryCodeReturns400() throws Exception {
+        mockMvc.perform(post("/api/v1/partyrooms/1/crews")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"countryCode\":\"kr\"}"))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -45,7 +77,9 @@ class PartyroomAccessCommandControllerTest extends AbstractPartyCommandWebMvcTes
     @DisplayName("enterPartyroom — 인증 없으면 401")
     void enterPartyroomUnauthenticatedReturns401() throws Exception {
         mockMvc.perform(post("/api/v1/partyrooms/1/crews")
-                        .with(csrf()))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"countryCode\":\"KR\"}"))
                 .andExpect(status().isUnauthorized());
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceTest.java
@@ -93,7 +93,7 @@ class PartyroomAccessCommandServiceTest {
         when(partyroomQueryService.getMyActivePartyroom(userId)).thenReturn(Optional.of(activeRoomInfo));
 
         // when
-        partyroomAccessCommandService.tryEnter(partyroomId);
+        partyroomAccessCommandService.tryEnter(partyroomId, null);
 
         // then — 재진입 시에도 이벤트가 발행되어야 함
         verify(eventPublisher, times(1)).publishEvent(any(CrewAccessedEvent.class));
@@ -155,7 +155,7 @@ class PartyroomAccessCommandServiceTest {
         when(aggregatePort.saveCrew(any(CrewData.class))).thenReturn(newRoomCrew);
 
         // when — 예외 없이 정상 실행되어야 함
-        partyroomAccessCommandService.tryEnter(newRoomId);
+        partyroomAccessCommandService.tryEnter(newRoomId, null);
 
         // then — exit 이벤트 + enter 이벤트 = 최소 2번 publish 호출
         verify(eventPublisher, atLeast(2)).publishEvent(any(Object.class));

--- a/app/src/test/java/com/pfplaybackend/api/party/domain/entity/data/CrewDataTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/domain/entity/data/CrewDataTest.java
@@ -2,6 +2,7 @@ package com.pfplaybackend.api.party.domain.entity.data;
 
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
+import com.pfplaybackend.api.party.domain.value.CountryCode;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,7 +18,7 @@ class CrewDataTest {
         UserId userId = new UserId(10L);
 
         // when
-        CrewData crew = CrewData.create(new PartyroomId(1L), userId, GradeType.CLUBBER);
+        CrewData crew = CrewData.create(new PartyroomId(1L), userId, GradeType.CLUBBER, null);
 
         // then
         assertThat(crew.isActive()).isTrue();
@@ -30,17 +31,37 @@ class CrewDataTest {
     @DisplayName("create — 팩토리 메서드로 생성 시 partyroomId가 설정된다")
     void createPartyroomIdAssigned() {
         // when
-        CrewData crew = CrewData.create(new PartyroomId(99L), new UserId(10L), GradeType.CLUBBER);
+        CrewData crew = CrewData.create(new PartyroomId(99L), new UserId(10L), GradeType.CLUBBER, null);
 
         // then
         assertThat(crew.getPartyroomId()).isEqualTo(new PartyroomId(99L));
     }
 
     @Test
+    @DisplayName("create — countryCode가 주어지면 저장된다")
+    void createWithCountryCode() {
+        // when
+        CrewData crew = CrewData.create(new PartyroomId(1L), new UserId(10L), GradeType.CLUBBER, CountryCode.of("KR"));
+
+        // then
+        assertThat(crew.getCountryCode()).isEqualTo(CountryCode.of("KR"));
+    }
+
+    @Test
+    @DisplayName("create — countryCode가 null이면 null로 저장된다")
+    void createWithoutCountryCode() {
+        // when
+        CrewData crew = CrewData.create(new PartyroomId(1L), new UserId(10L), GradeType.CLUBBER, null);
+
+        // then
+        assertThat(crew.getCountryCode()).isNull();
+    }
+
+    @Test
     @DisplayName("deactivatePresence — 퇴장 시 isActive가 false이고 exitedAt이 설정된다")
     void deactivatePresence() {
         // given
-        CrewData crew = CrewData.create(new PartyroomId(1L),new UserId(10L), GradeType.CLUBBER);
+        CrewData crew = CrewData.create(new PartyroomId(1L),new UserId(10L), GradeType.CLUBBER, null);
 
         // when
         crew.deactivatePresence();
@@ -54,7 +75,7 @@ class CrewDataTest {
     @DisplayName("activatePresence — 재입장 시 isActive가 true이고 enteredAt이 갱신된다")
     void activatePresence() {
         // given
-        CrewData crew = CrewData.create(new PartyroomId(1L),new UserId(10L), GradeType.CLUBBER);
+        CrewData crew = CrewData.create(new PartyroomId(1L),new UserId(10L), GradeType.CLUBBER, null);
         crew.deactivatePresence();
 
         // when
@@ -69,7 +90,7 @@ class CrewDataTest {
     @DisplayName("updateGrade — 등급 변경 시 gradeType이 업데이트된다")
     void updateGrade() {
         // given
-        CrewData crew = CrewData.create(new PartyroomId(1L),new UserId(10L), GradeType.CLUBBER);
+        CrewData crew = CrewData.create(new PartyroomId(1L),new UserId(10L), GradeType.CLUBBER, null);
 
         // when
         crew.updateGrade(GradeType.MODERATOR);
@@ -79,10 +100,36 @@ class CrewDataTest {
     }
 
     @Test
+    @DisplayName("updateCountryCode — 재입장 시 최신 countryCode로 갱신된다")
+    void updateCountryCode() {
+        // given
+        CrewData crew = CrewData.create(new PartyroomId(1L), new UserId(10L), GradeType.CLUBBER, CountryCode.of("KR"));
+
+        // when
+        crew.updateCountryCode(CountryCode.of("JP"));
+
+        // then
+        assertThat(crew.getCountryCode()).isEqualTo(CountryCode.of("JP"));
+    }
+
+    @Test
+    @DisplayName("updateCountryCode — null로 갱신하면 countryCode가 비워진다")
+    void updateCountryCodeToNull() {
+        // given
+        CrewData crew = CrewData.create(new PartyroomId(1L), new UserId(10L), GradeType.CLUBBER, CountryCode.of("KR"));
+
+        // when
+        crew.updateCountryCode(null);
+
+        // then
+        assertThat(crew.getCountryCode()).isNull();
+    }
+
+    @Test
     @DisplayName("enforceBan — 밴 부과 시 isBanned이 true가 된다")
     void enforceBan() {
         // given
-        CrewData crew = CrewData.create(new PartyroomId(1L),new UserId(10L), GradeType.CLUBBER);
+        CrewData crew = CrewData.create(new PartyroomId(1L),new UserId(10L), GradeType.CLUBBER, null);
 
         // when
         crew.enforceBan();
@@ -95,7 +142,7 @@ class CrewDataTest {
     @DisplayName("releaseBan — 밴 해제 시 isBanned이 false가 된다")
     void releaseBan() {
         // given
-        CrewData crew = CrewData.create(new PartyroomId(1L),new UserId(10L), GradeType.CLUBBER);
+        CrewData crew = CrewData.create(new PartyroomId(1L),new UserId(10L), GradeType.CLUBBER, null);
         crew.enforceBan();
 
         // when

--- a/app/src/test/java/com/pfplaybackend/api/party/domain/value/CountryCodeTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/domain/value/CountryCodeTest.java
@@ -1,0 +1,60 @@
+package com.pfplaybackend.api.party.domain.value;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CountryCodeTest {
+
+    @Test
+    @DisplayName("of — 대문자 2글자는 그대로 생성된다")
+    void acceptsTwoUppercaseLetters() {
+        assertThat(CountryCode.of("KR").getValue()).isEqualTo("KR");
+        assertThat(CountryCode.of("US").getValue()).isEqualTo("US");
+        assertThat(CountryCode.of("JP").getValue()).isEqualTo("JP");
+    }
+
+    @Test
+    @DisplayName("of — null은 허용되지 않는다 (명시적 금지)")
+    void rejectsNull() {
+        assertThatThrownBy(() -> CountryCode.of(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("of — 소문자는 거절된다")
+    void rejectsLowercase() {
+        assertThatThrownBy(() -> CountryCode.of("kr"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("of — 2글자가 아니면 거절된다")
+    void rejectsWrongLength() {
+        assertThatThrownBy(() -> CountryCode.of("K"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> CountryCode.of("KOR"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> CountryCode.of(""))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("of — 숫자/특수문자는 거절된다")
+    void rejectsNonLetters() {
+        assertThatThrownBy(() -> CountryCode.of("K1"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> CountryCode.of("K!"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("equals/hashCode — 같은 값은 equal")
+    void equalityByValue() {
+        assertThat(CountryCode.of("KR")).isEqualTo(CountryCode.of("KR"));
+        assertThat(CountryCode.of("KR")).isNotEqualTo(CountryCode.of("JP"));
+        assertThat(CountryCode.of("KR").hashCode()).isEqualTo(CountryCode.of("KR").hashCode());
+    }
+}


### PR DESCRIPTION
## Summary
파티룸 입장 시 프론트엔드가 전달하는 ISO 3166-1 alpha-2 국가 코드를 `crew` 레코드에 저장하고, 채팅 UI 국기 표시를 위해 setup 응답과 `CREW_ENTERED` WebSocket 이벤트에 노출.

**Flyway 도입 후 첫 실제 스키마 변경 PR** — V2 migration이 정상 작동하는지 확인하는 시험대.

## Requirement
- `POST /api/v1/partyrooms/{partyroomId}/crews` Request body에 `countryCode?: string` 추가
- `GET /api/v1/partyrooms/{partyroomId}/setup` 응답 `crews[].countryCode: string | null` 추가
- `CREW_ENTERED` WebSocket 이벤트의 `crew.countryCode: string | null` 추가
- `CHAT_MESSAGE_SENT` 이벤트는 변경 없음 (프론트엔드가 crew store에서 조회)
- 값 저장 정책: 매 입장마다 최신값으로 덮어쓰기 (VPN/여행/디바이스 변경 반영)
- 서버측 validation: ISO alpha-2 형식(대문자 2글자) 체크, null 허용

## Changes (3 commits)

### 1. `feat(crew): Add country_code column and CountryCode VO (Flyway V2)` (5e1ba979)
- `V2__add_country_code_to_crew.sql`: `ALTER TABLE crew ADD COLUMN country_code VARCHAR(2) NULL`
- `CountryCode` VO (immutable, validation 내장) + `CountryCodeConverter` (JPA AttributeConverter) — 기존 `LinkDomain` 패턴 그대로
- `CrewData.countryCode` 필드, `create()` 팩토리 시그니처 확장, `updateCountryCode()` 추가
- 기존 `CrewData.create()` 10개 호출부 모두 `null` 전달로 업데이트 (빌드 breakage 방지)
- 유닛 테스트: `CountryCodeTest` (validation matrix), `CrewDataTest`에 countryCode create/update 케이스 추가

### 2. `feat(party-access): Accept countryCode on partyroom enter` (c7928773)
- `EnterPartyroomRequest` 신규 request DTO (`@Pattern(^[A-Z]{2}$)`)
- `PartyroomAccessCommandController`: `@Valid @RequestBody` 받아서 `CountryCode.of()`로 변환
- `PartyroomAccessCommandService.tryEnter()`: `CountryCode` 파라미터 추가 + 3가지 입장 경로(신규 생성 / 비활성 crew 재활성 / 같은 방 재진입) 모두에서 `updateCountryCode` 호출 → 매 입장마다 최신값 반영
- `enterByHost` (admin seed path)는 `null` 전달 — 프론트 미관여
- 컨트롤러 테스트: valid / null / invalid format / unauthenticated 4개 시나리오 커버

### 3. `feat(chat): Expose countryCode in crew setup and crew-entered events` (efe52db1)
- `CrewSetupDto`: `countryCode` 필드 추가 → `GET /setup` 응답에 자동 포함
- `CrewSummaryDto`: `countryCode` 필드 추가 → `CrewEnteredMessage`가 이를 래핑해 `CREW_ENTERED` 이벤트에 자동 포함
- `CrewEnteredMessage`, `DomainEventRedisRelay`, 채팅 파이프라인 **건드리지 않음**

## Design decisions
- **Crew-level (not user-level)**: navigator.language는 세션/디바이스마다 다를 수 있음. VPN/여행 시나리오를 고려해 Identity가 아닌 입장 기록에 저장
- **VO + AttributeConverter**: 프로젝트 기존 패턴(`LinkDomain`/`LinkDomainConverter`)과 일치
- **Raw String vs VO**: CrewData의 기존 단순값 필드(gradeType, isActive)와 달리 country code는 형식 제약이 있어 VO 채택
- **매번 업데이트 정책**: 요구사항 확인 결과, "이번 입장 시점의 국가"가 source of truth

## Dependencies
**이 PR은 #168(chore/exception-handle-valid-400) 머지 후 리베이스됨**. `@Valid @RequestBody` 실패 시 400을 반환하는 `MethodArgumentNotValidException` 핸들러는 #168에서 추가됨 — 본 PR의 컨트롤러 테스트(`invalid countryCode 400`)가 이에 의존.

## Test plan
- [x] `:common:test :playlist:test :user:test :app:test` 전체 통과
- [ ] develop 머지 후 로컬 MySQL 재생성 → Flyway V2 적용 → Hibernate validate 통과 확인
- [ ] dev 환경 배포 후 실제 프론트에서 POST 요청 시 country_code 저장/노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)