### PR TITLE
chore(compose): Enable Redis keyspace expiration notifications

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,6 +23,7 @@ services:
 
   redis:
     image: redis:7-alpine
+    command: ["redis-server", "--notify-keyspace-events", "Ex"]
     volumes:
       - redis-data:/data
     healthcheck:

--- a/docker-compose.stg.yml
+++ b/docker-compose.stg.yml
@@ -23,6 +23,7 @@ services:
 
   redis:
     image: redis:7-alpine
+    command: ["redis-server", "--notify-keyspace-events", "Ex"]
     volumes:
       - redis-data:/data
     healthcheck:


### PR DESCRIPTION
## Summary
- Add `--notify-keyspace-events Ex` to redis service command in `docker-compose.dev.yml` and `docker-compose.stg.yml`
- Ensures `__keyevent@*__:expired` listeners keep working across container restarts (previously relied on manual `CONFIG SET` which was lost on restart)

## Test plan
- [x] dev: `down -v` + `up -d` → Flyway V1-V3 applied, Hibernate validate passed, Tomcat started, `CONFIG GET notify-keyspace-events` returns `xE`
- [x] stg: same verified after local jar+image rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)