### PR TITLE
chore(ci): Simplify image tagging and add registry cleanup

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -51,7 +51,6 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE }}:${{ env.TAG }}
-            ${{ env.IMAGE }}:${{ env.TAG }}-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -51,7 +51,6 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE }}:${{ env.TAG }}
-            ${{ env.IMAGE }}:${{ env.TAG }}-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/registry-cleanup.yml
+++ b/.github/workflows/registry-cleanup.yml
@@ -1,0 +1,33 @@
+name: Registry cleanup (pfplay-api)
+
+# Deletes untagged container image versions in ghcr.io/pfplay/pfplay-api.
+# With SHA tags dropped from deploy workflows, untagged versions are the
+# accumulation source: each floating-tag reassignment leaves the previous
+# image untagged. A small buffer is kept for emergency rollback.
+
+on:
+  workflow_dispatch:
+    inputs:
+      keep-count:
+        description: 'Number of most-recent untagged versions to keep'
+        default: '3'
+        required: true
+  schedule:
+    # Every Sunday at 18:00 UTC (03:00 KST Monday)
+    - cron: '0 18 * * 0'
+
+jobs:
+  cleanup:
+    name: Delete untagged versions
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete old untagged pfplay-api versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: pfplay-api
+          package-type: container
+          owner: pfplay
+          min-versions-to-keep: ${{ github.event.inputs.keep-count || '3' }}
+          delete-only-untagged-versions: true


### PR DESCRIPTION
## Summary
- Drop per-commit SHA tags (`:dev-<sha>`, `:stg-<sha>`) from dev/stg deploy workflows — main storage driver in the private ghcr.io registry, with low real rollback value (git revert + redeploy is the common path)
- Add `registry-cleanup.yml` workflow that prunes untagged versions left behind by floating-tag reassignments; keeps 3 most-recent untagged as soft rollback buffer
- Cleanup runs weekly (Sun 18:00 UTC / 03:00 KST Mon) + manual dispatch

## Notes
- Cleanup workflow only triggers once this reaches the default branch (`main`) — normal develop → release → main promotion applies
- Prod CI workflow (`build-and-deploy.yml`) untouched here; a separate branch will handle its rename + tag unification (`:prod`) + compose-based deploy refactor

## Test plan
- [ ] After merge to main: `workflow_dispatch` registry-cleanup with `keep-count=3` to verify deletion behavior against current registry state
- [ ] Next dev/stg deploy: confirm only floating tag is pushed (no SHA tag)
- [ ] One week later: verify scheduled cleanup ran and registry size stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)