### PR TITLE
chore: sync develop to release (registry cleanup + simplified tagging)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -51,7 +51,6 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE }}:${{ env.TAG }}
-            ${{ env.IMAGE }}:${{ env.TAG }}-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -51,7 +51,6 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE }}:${{ env.TAG }}
-            ${{ env.IMAGE }}:${{ env.TAG }}-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/registry-cleanup.yml
+++ b/.github/workflows/registry-cleanup.yml
@@ -1,0 +1,33 @@
+name: Registry cleanup (pfplay-api)
+
+# Deletes untagged container image versions in ghcr.io/pfplay/pfplay-api.
+# With SHA tags dropped from deploy workflows, untagged versions are the
+# accumulation source: each floating-tag reassignment leaves the previous
+# image untagged. A small buffer is kept for emergency rollback.
+
+on:
+  workflow_dispatch:
+    inputs:
+      keep-count:
+        description: 'Number of most-recent untagged versions to keep'
+        default: '3'
+        required: true
+  schedule:
+    # Every Sunday at 18:00 UTC (03:00 KST Monday)
+    - cron: '0 18 * * 0'
+
+jobs:
+  cleanup:
+    name: Delete untagged versions
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete old untagged pfplay-api versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: pfplay-api
+          package-type: container
+          owner: pfplay
+          min-versions-to-keep: ${{ github.event.inputs.keep-count || '3' }}
+          delete-only-untagged-versions: true


### PR DESCRIPTION
## Summary
- Drop per-commit SHA tags from dev/stg deploy workflows
- Add `registry-cleanup.yml` to prune untagged versions on a weekly schedule and via manual dispatch

## Notes
- Workflow activation still requires reaching `main` (scheduled/workflow_dispatch only fire from the default branch)
- Next: promote release → main to actually activate cleanup
- Prod CI refactor (rename + `:prod` tag + compose-based deploy) will come in a separate follow-up branch

## Test plan
- [x] dev/stg deploy workflows verified via diff review
- [ ] After merge to main: manual `workflow_dispatch` of registry-cleanup with `keep-count=3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)