### PR TITLE
fix(ci): Place prod deploy assets in SSH user home

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -11,7 +11,6 @@ env:
   GCE_ZONE: asia-northeast3-a
   IMAGE: ghcr.io/pfplay/pfplay-api
   TAG: prod
-  TARGET_DIR: /home/dev_pfplay_xyz
 
 jobs:
   build:
@@ -90,6 +89,10 @@ jobs:
             --project=${{ env.PROJECT_ID }}
 
       # 파일 배치 → deploy.sh 호출 (mysql/redis/pytube는 유지, app만 재기동).
+      # SSH 유저의 홈 디렉토리(~)에 배치 — gcloud compute ssh가 WIF 서비스 계정
+      # 기반 posix 유저로 접속하므로 해당 유저가 쓸 수 있는 곳이어야 함.
+      # docker compose는 -p pfplay-prod 프로젝트명으로 기존 mysql/redis/pytube
+      # 컨테이너를 식별하므로 compose 파일 위치와 무관하게 app만 재기동 가능.
       - name: Deploy via IAP tunnel
         env:
           GHCR_USER: ${{ github.actor }}
@@ -101,13 +104,13 @@ jobs:
             --project=${{ env.PROJECT_ID }} \
             --command="
               set -e
-              mv /tmp/.env.prod ${{ env.TARGET_DIR }}/.env.prod
-              chmod 600 ${{ env.TARGET_DIR }}/.env.prod
-              mv /tmp/docker-compose.prod.yml ${{ env.TARGET_DIR }}/
-              mkdir -p ${{ env.TARGET_DIR }}/scripts
-              mv /tmp/deploy.sh ${{ env.TARGET_DIR }}/scripts/deploy.sh
-              chmod +x ${{ env.TARGET_DIR }}/scripts/deploy.sh
-              cd ${{ env.TARGET_DIR }}
+              cd ~
+              mv /tmp/.env.prod .env.prod
+              chmod 600 .env.prod
+              mv /tmp/docker-compose.prod.yml .
+              mkdir -p scripts
+              mv /tmp/deploy.sh scripts/deploy.sh
+              chmod +x scripts/deploy.sh
               GHCR_USER='$GHCR_USER' GHCR_TOKEN='$GHCR_TOKEN' ./scripts/deploy.sh prod
               docker image prune -f
             "


### PR DESCRIPTION
## Summary
- Previous deploy-prod.yml hardcoded \`TARGET_DIR=/home/dev_pfplay_xyz\`, which is the human operator's home — not the SSH user that \`gcloud compute ssh\` logs in as (WIF service account → posix mapping)
- That user has no write permission there, so the first prod deploy failed at \`mv /tmp/.env.prod\` with "Permission denied"

## Fix
- Drop \`TARGET_DIR\` env var
- SSH command now does \`cd ~\` and places all files in the SSH user's own home

## Why this still works
- docker compose uses \`-p pfplay-prod\` to identify containers; mysql/redis/pytube were brought up manually under that project name and remain discoverable regardless of compose file location
- Pytube image (\`pfplay-prod-pytube:latest\`) is globally present on the Docker daemon, not tied to filesystem path
- Only side effect: the human-placed copies of compose/env at /home/dev_pfplay_xyz/ stay around but are unused by CI from now on — can be cleaned up manually later

## Test plan
- [ ] After merge → develop → release → main, next \`Deploy to prod (GCP VM via IAP)\` run should succeed end-to-end
- [ ] Verify \`.env.prod\` / \`docker-compose.prod.yml\` / \`scripts/deploy.sh\` land in SSH user's home and that \`docker compose up -d --no-deps app\` brings up the :prod image

🤖 Generated with [Claude Code](https://claude.com/claude-code)