### PR TITLE
fix(deploy): Remove legacy non-compose container before compose up

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -25,6 +25,13 @@ if [[ -n "${GHCR_TOKEN:-}" && -n "${GHCR_USER:-}" ]]; then
   echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 fi
 
+# Remove any legacy non-compose container that would contend for the host port.
+# Prod had a 'pfplay-api' container from the pre-compose `docker run` workflow.
+# Safe no-op if the name is not present.
+for legacy in pfplay-api; do
+  docker rm -f "$legacy" 2>/dev/null || true
+done
+
 COMPOSE=(docker compose
   -f "docker-compose.${ENV}.yml"
   -p "pfplay-${ENV}"


### PR DESCRIPTION
## Problem
First prod deploy via the new compose workflow failed with:
\`\`\`
Bind for 0.0.0.0:8080 failed: port is already allocated
\`\`\`
because the old \`pfplay-api\` container (created by the pre-compose \`docker run\` workflow) is still running and holding port 8080.

## Fix
Add an idempotent pre-step to \`scripts/deploy.sh\` that force-removes any legacy non-compose container name before compose takes over:
\`\`\`bash
for legacy in pfplay-api; do
  docker rm -f "\$legacy" 2>/dev/null || true
done
\`\`\`
Safe no-op when the container doesn't exist, so this doesn't affect dev/stg (which never had that container).

## Cascade plan
develop → release → main. Merging to main will re-trigger \`Deploy to prod\` which should now succeed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)