### PR TITLE
fix(jpa): force enum→VARCHAR (Hibernate 6 dialect default)

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -31,6 +31,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        type:
+          preferred_enum_jdbc_type: VARCHAR
 
   sql:
     init:
@@ -202,6 +204,8 @@ spring:
     properties:
       hibernate:
         format_sql: false
+        type:
+          preferred_enum_jdbc_type: VARCHAR
 
   sql:
     init:
@@ -252,6 +256,8 @@ spring:
     properties:
       hibernate:
         format_sql: false
+        type:
+          preferred_enum_jdbc_type: VARCHAR
 
   sql:
     init:
@@ -305,6 +311,8 @@ spring:
     properties:
       hibernate:
         format_sql: false
+        type:
+          preferred_enum_jdbc_type: VARCHAR
 
   sql:
     init:


### PR DESCRIPTION
## Summary

Hotfix for V14 boot failure on dev (PR #185 후속).

Hibernate 6.x MySQL dialect 가 Java enum → native ENUM 컬럼 매핑이 default. V14 의 `system_announcement.severity` (VARCHAR(16)) + `@Enumerated(EnumType.STRING)` 가 `ddl-auto=validate` 에서 충돌 → dev backend 부팅 실패.

V1~V14 마이그레이션 자체는 모두 정상 적용. 실패 지점은 Hibernate validate 단계 한 곳.

## Fix

`hibernate.type.preferred_enum_jdbc_type=VARCHAR` 1 property 를 4개 jpa 블록 (common + dev + staging + prod) 에 추가. Hibernate 6 의 canonical 우회 — enum 컬럼 모두 VARCHAR 매핑 강제.

## Test plan

- [x] `:app:test` BUILD SUCCESSFUL post-change
- [ ] dev 자동 재배포 후 backend boot 성공 확인
- [ ] dev V14 endpoint (`/api/v1/admin/announcements`) 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)