### PR TITLE
fix(announcement): @JdbcTypeCode(VARCHAR) on enum columns (real fix)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/administration/domain/entity/data/SystemAnnouncementData.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/domain/entity/data/SystemAnnouncementData.java
@@ -6,6 +6,8 @@ import com.pfplaybackend.api.common.entity.BaseEntity;
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import java.time.*;
 
 @Entity
@@ -14,8 +16,8 @@ import java.time.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SystemAnnouncementData extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) private Long id;
-    @Enumerated(EnumType.STRING) @Column(nullable = false, length = 32) private AnnouncementType type;
-    @Enumerated(EnumType.STRING) @Column(nullable = false, length = 16) private AnnouncementSeverity severity;
+    @Enumerated(EnumType.STRING) @JdbcTypeCode(SqlTypes.VARCHAR) @Column(nullable = false, length = 32) private AnnouncementType type;
+    @Enumerated(EnumType.STRING) @JdbcTypeCode(SqlTypes.VARCHAR) @Column(nullable = false, length = 16) private AnnouncementSeverity severity;
     @Column(name = "title_ko", nullable = false, length = 200) private String titleKo;
     @Column(name = "title_en", nullable = false, length = 200) private String titleEn;
     @Column(name = "message_ko", nullable = false, length = 2000) private String messageKo;


### PR DESCRIPTION
## Summary

PR #186 (\`b76e6811\` application.yml \`hibernate.type.preferred_enum_jdbc_type=VARCHAR\`) 가 효력 없음 — Spring \`JpaProperties\` 가 nested map 의 dot-flatten 처리 누락. V14 boot 가 여전히 같은 에러로 실패:

\`\`\`
Schema-validation: wrong column type encountered in column [severity] in table [system_announcement];
found [varchar (Types#VARCHAR)], but expecting [enum ('info','warn','critical') (Types#ENUM)]
\`\`\`

## Real fix

Entity-level \`@JdbcTypeCode(SqlTypes.VARCHAR)\` 직접 주입 — property 우회.

\`\`\`java
@Enumerated(EnumType.STRING) @JdbcTypeCode(SqlTypes.VARCHAR) @Column(length = 32) AnnouncementType type;
@Enumerated(EnumType.STRING) @JdbcTypeCode(SqlTypes.VARCHAR) @Column(length = 16) AnnouncementSeverity severity;
\`\`\`

## Local 검증

\`\`\`
Tomcat started on port 8080
Started Application in 45.21 seconds
\`\`\`

V14 마이그레이션 적용 + Hibernate validate 통과.

## application.yml fix 는 남겨둠

\`b76e6811\` 의 4개 jpa 블록 추가 라인은 노이즈지만 무해 (다른 enum entity 미래 risk 에 대비한 fallback). Revert 안 함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)