### PR TITLE
feat: Amplitude backend asks L1/L4/L2/L5 (analytics data accuracy)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/auth/adapter/in/web/AuthController.java
+++ b/app/src/main/java/com/pfplaybackend/api/auth/adapter/in/web/AuthController.java
@@ -86,6 +86,7 @@ public class AuthController {
                 .tokenType(authResult.tokenType())
                 .expiresIn(authResult.expiresIn())
                 .issuedAt(authResult.issuedAt())
+                .isNewUser(authResult.isNewUser())
                 .build();
 
         return ResponseEntity.ok(ApiCommonResponse.success(loginResponse));

--- a/app/src/main/java/com/pfplaybackend/api/auth/adapter/in/web/payload/response/LoginOAuthResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/auth/adapter/in/web/payload/response/LoginOAuthResponse.java
@@ -1,6 +1,8 @@
 package com.pfplaybackend.api.auth.adapter.in.web.payload.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -21,4 +23,18 @@ public class LoginOAuthResponse {
     private Long expiresIn;
 
     private LocalDateTime issuedAt;
+
+    /**
+     * True iff this OAuth callback created a new {@code UserAccount} row
+     * (fresh provider identity), false if an existing user logged in.
+     *
+     * <p>Frontend uses this to fire {@code User Signed Up} on actual signup
+     * only — replacing the previous localStorage UID heuristic which broke
+     * across incognito, cache-clear, and multi-device first-login.
+     *
+     * <p>Amplitude L4 (see {@code amplitude-backend-asks.md}).
+     */
+    @JsonProperty("isNewUser")
+    @Schema(example = "false", description = "True if this call created a new user record (signup), false for returning login.")
+    private boolean isNewUser;
 }

--- a/app/src/main/java/com/pfplaybackend/api/auth/application/dto/result/AuthResult.java
+++ b/app/src/main/java/com/pfplaybackend/api/auth/application/dto/result/AuthResult.java
@@ -2,5 +2,11 @@ package com.pfplaybackend.api.auth.application.dto.result;
 
 import java.time.LocalDateTime;
 
-public record AuthResult(String accessToken, String tokenType, Long expiresIn, LocalDateTime issuedAt) {
+public record AuthResult(
+        String accessToken,
+        String tokenType,
+        Long expiresIn,
+        LocalDateTime issuedAt,
+        boolean isNewUser
+) {
 }

--- a/app/src/main/java/com/pfplaybackend/api/auth/application/service/AuthService.java
+++ b/app/src/main/java/com/pfplaybackend/api/auth/application/service/AuthService.java
@@ -12,8 +12,8 @@ import com.pfplaybackend.api.common.config.security.jwt.properties.JwtProperties
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.exception.AuthenticationException;
 import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.application.dto.result.MemberSignResult;
 import com.pfplaybackend.api.user.application.service.MemberSignService;
-import com.pfplaybackend.api.user.domain.entity.data.MemberData;
 import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -57,7 +57,9 @@ public class AuthService {
             );
 
             ProviderType providerType = ProviderType.valueOf(provider.name());
-            MemberData member = memberSignService.getMemberOrCreate(userProfile.email(), providerType);
+            MemberSignResult signResult =
+                    memberSignService.getMemberOrCreateWithStatus(userProfile.email(), providerType);
+            var member = signResult.member();
 
             UserAccountData userAccount = userAccountRepository
                     .findByUserId(new UserId(member.getUserAccountId()))
@@ -78,7 +80,12 @@ public class AuthService {
                     member.getAuthorityTier()
             ));
 
-            return new AuthResult(token, "Cookie", jwtProperties.getSharedSessionTokenExpirationMs(), LocalDateTime.now(clock));
+            return new AuthResult(
+                    token,
+                    "Cookie",
+                    jwtProperties.getSharedSessionTokenExpirationMs(),
+                    LocalDateTime.now(clock),
+                    signResult.isNewUser());
 
         } catch (Exception e) {
             log.error("OAuth login failed: {}", e.getMessage(), e);

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/PlaylistCommandAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/PlaylistCommandAdapter.java
@@ -2,7 +2,9 @@ package com.pfplaybackend.api.party.adapter.out.external;
 
 import com.pfplaybackend.api.common.domain.value.PlaylistId;
 import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.application.port.out.AddedTrackInfo;
 import com.pfplaybackend.api.party.application.port.out.PlaylistCommandPort;
+import com.pfplaybackend.api.playlist.application.dto.GrabbedTrackDto;
 import com.pfplaybackend.api.playlist.application.dto.PlaybackTrackDto;
 import com.pfplaybackend.api.playlist.application.service.GrabTrackService;
 import com.pfplaybackend.api.playlist.application.service.TrackCommandService;
@@ -17,8 +19,9 @@ public class PlaylistCommandAdapter implements PlaylistCommandPort {
     private final TrackCommandService trackCommandService;
 
     @Override
-    public void grabTrack(UserId userId, String linkId) {
-        grabTrackService.grabTrack(userId, linkId);
+    public AddedTrackInfo grabTrack(UserId userId, String linkId) {
+        GrabbedTrackDto grabbed = grabTrackService.grabTrack(userId, linkId);
+        return new AddedTrackInfo(grabbed.trackId(), grabbed.playlistId());
     }
 
     @Override

--- a/app/src/main/java/com/pfplaybackend/api/party/application/dto/playback/AddedTrackDto.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/dto/playback/AddedTrackDto.java
@@ -1,0 +1,9 @@
+package com.pfplaybackend.api.party.application.dto.playback;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "GRAB 리액션으로 사용자 GRABLIST에 추가된 트랙 정보")
+public record AddedTrackDto(
+        @Schema(description = "추가된 트랙 ID", example = "12345") Long trackId,
+        @Schema(description = "추가된 GRABLIST 플레이리스트 ID", example = "67") Long playlistId
+) {}

--- a/app/src/main/java/com/pfplaybackend/api/party/application/dto/playback/ReactionHistoryDto.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/dto/playback/ReactionHistoryDto.java
@@ -8,17 +8,23 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record ReactionHistoryDto(
         @Schema(description = "좋아요 여부", example = "false") boolean isLiked,
         @Schema(description = "싫어요 여부", example = "false") boolean isDisliked,
-        @Schema(description = "그랩 여부", example = "false") boolean isGrabbed
+        @Schema(description = "그랩 여부", example = "false") boolean isGrabbed,
+        @Schema(description = "GRAB 성공 시 사용자 GRABLIST에 신규 추가된 트랙 정보 (LIKE/DISLIKE/이미 그랩 상태에서 토글 off → null)", nullable = true)
+        AddedTrackDto addedTrack
 ) {
     public static ReactionHistoryDto empty() {
-        return new ReactionHistoryDto(false, false, false);
+        return new ReactionHistoryDto(false, false, false, null);
     }
 
     public static ReactionHistoryDto from(ReactionState state) {
-        return new ReactionHistoryDto(state.liked(), state.disliked(), state.grabbed());
+        return new ReactionHistoryDto(state.liked(), state.disliked(), state.grabbed(), null);
+    }
+
+    public static ReactionHistoryDto from(ReactionState state, AddedTrackDto addedTrack) {
+        return new ReactionHistoryDto(state.liked(), state.disliked(), state.grabbed(), addedTrack);
     }
 
     public static ReactionHistoryDto from(PlaybackReactionHistoryData data) {
-        return new ReactionHistoryDto(data.isLiked(), data.isDisliked(), data.isGrabbed());
+        return new ReactionHistoryDto(data.isLiked(), data.isDisliked(), data.isGrabbed(), null);
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/port/out/AddedTrackInfo.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/port/out/AddedTrackInfo.java
@@ -1,0 +1,7 @@
+package com.pfplaybackend.api.party.application.port.out;
+
+/**
+ * Result of a successful GRAB operation: identifies the new playlist entry.
+ * Used by analytics to fire `Track Added(source='grab')` from the client side.
+ */
+public record AddedTrackInfo(Long trackId, Long playlistId) {}

--- a/app/src/main/java/com/pfplaybackend/api/party/application/port/out/PlaylistCommandPort.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/port/out/PlaylistCommandPort.java
@@ -5,6 +5,6 @@ import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.playlist.application.dto.PlaybackTrackDto;
 
 public interface PlaylistCommandPort {
-    void grabTrack(UserId userId, String linkId);
+    AddedTrackInfo grabTrack(UserId userId, String linkId);
     PlaybackTrackDto getFirstTrack(PlaylistId playlistId);
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackReactionCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackReactionCommandService.java
@@ -6,6 +6,7 @@ import com.pfplaybackend.api.common.enums.AuthorityTier;
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
 import com.pfplaybackend.api.party.adapter.out.persistence.PlaybackReactionHistoryRepository;
 import com.pfplaybackend.api.party.application.dto.partyroom.ActivePartyroomDto;
+import com.pfplaybackend.api.party.application.port.out.AddedTrackInfo;
 import com.pfplaybackend.api.party.domain.entity.data.CrewData;
 import com.pfplaybackend.api.party.domain.entity.data.history.PlaybackReactionHistoryData;
 import com.pfplaybackend.api.party.domain.enums.ReactionType;
@@ -13,6 +14,7 @@ import com.pfplaybackend.api.party.domain.exception.ReactionException;
 import com.pfplaybackend.api.party.domain.model.ReactionPostProcessResult;
 import com.pfplaybackend.api.party.domain.model.ReactionState;
 import com.pfplaybackend.api.party.domain.service.PlaybackReactionDomainService;
+import com.pfplaybackend.api.party.application.dto.playback.AddedTrackDto;
 import com.pfplaybackend.api.party.application.dto.playback.ReactionHistoryDto;
 import com.pfplaybackend.api.party.domain.value.CrewId;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
@@ -49,8 +51,13 @@ public class PlaybackReactionCommandService {
         ReactionPostProcessResult reactionPostProcessDto = executeProcess(historyData, existingState, targetState);
         Optional<CrewData> optional = partyroomQueryService.getCrewByUserId(partyroomId, authContext.getUserId());
         CrewData crew = optional.orElseThrow();
-        playbackReactionPostProcessCommandService.postProcess(reactionPostProcessDto, reactionType, partyroomId, playbackId, new CrewId(crew.getId()));
-        return ReactionHistoryDto.from(targetState);
+        AddedTrackInfo addedTrack = playbackReactionPostProcessCommandService.postProcess(
+                reactionPostProcessDto, reactionType, partyroomId, playbackId, new CrewId(crew.getId()));
+        return ReactionHistoryDto.from(targetState, toAddedTrackDto(addedTrack));
+    }
+
+    private AddedTrackDto toAddedTrackDto(AddedTrackInfo info) {
+        return info == null ? null : new AddedTrackDto(info.trackId(), info.playlistId());
     }
 
     private PlaybackReactionHistoryData getValidReactionHistoryData(AuthContext authContext, PlaybackId playbackId) {

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackReactionPostProcessCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackReactionPostProcessCommandService.java
@@ -3,6 +3,7 @@ package com.pfplaybackend.api.party.application.service;
 import com.pfplaybackend.api.common.ThreadLocalContext;
 import com.pfplaybackend.api.common.aspect.context.AuthContext;
 import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.application.port.out.AddedTrackInfo;
 import com.pfplaybackend.api.party.application.port.out.PlaylistCommandPort;
 import com.pfplaybackend.api.party.application.port.out.UserActivityPort;
 import com.pfplaybackend.api.party.domain.entity.data.PlaybackAggregationData;
@@ -28,11 +29,15 @@ public class PlaybackReactionPostProcessCommandService {
     private final PlaylistCommandPort playlistCommandPort;
     private final UserActivityPort userActivityPort;
 
-    public void postProcess(ReactionPostProcessResult postProcessDto, ReactionType reactionType, PartyroomId partyroomId, PlaybackId playbackId, CrewId crewId) {
+    /**
+     * @return AddedTrackInfo when this call materialised a new GRABLIST entry, otherwise null.
+     */
+    public AddedTrackInfo postProcess(ReactionPostProcessResult postProcessDto, ReactionType reactionType, PartyroomId partyroomId, PlaybackId playbackId, CrewId crewId) {
         AuthContext authContext = ThreadLocalContext.getAuthContext();
         PlaybackData playback = playbackQueryService.getPlaybackById(playbackId);
+        AddedTrackInfo addedTrack = null;
         if(postProcessDto.grabStatusChanged()) {
-            grabTrack(authContext.getUserId(), playback);
+            addedTrack = grabTrack(authContext.getUserId(), playback);
         }
         if(postProcessDto.djActivityScoreChanged()) {
             updateDjActivityScore(playback.getUserId(), postProcessDto.deltaScore());
@@ -42,6 +47,7 @@ public class PlaybackReactionPostProcessCommandService {
             publishAggregationChangedEvent(partyroomId, aggregation);
         }
         publishMotionChangedEvent(partyroomId, reactionType, postProcessDto.determinedMotionType(), crewId);
+        return addedTrack;
     }
 
     public void publishMotionChangedEvent(PartyroomId partyroomId, ReactionType reactionType, MotionType motionType, CrewId crewId) {
@@ -57,8 +63,8 @@ public class PlaybackReactionPostProcessCommandService {
                 partyroomId, aggregation.getLikeCount(), aggregation.getDislikeCount(), aggregation.getGrabCount()));
     }
 
-    public void grabTrack(UserId userId, PlaybackData playback) {
+    public AddedTrackInfo grabTrack(UserId userId, PlaybackData playback) {
         // TODO 이미 동일한 LinkId를 보유하고 있다면 예외 발생
-        playlistCommandPort.grabTrack(userId, playback.getLinkId());
+        return playlistCommandPort.grabTrack(userId, playback.getLinkId());
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/partyview/adapter/in/web/PartyroomSetupController.java
+++ b/app/src/main/java/com/pfplaybackend/api/partyview/adapter/in/web/PartyroomSetupController.java
@@ -34,6 +34,6 @@ public class PartyroomSetupController {
             @Parameter(description = "파티룸 ID") @PathVariable Long partyroomId) {
         PartyroomSetupResult result = partyroomSetupQueryService.getSetupInfo(new PartyroomId(partyroomId));
         return ResponseEntity.ok().body(
-                ApiCommonResponse.success(QueryPartyroomSetupResponse.from(result.crews(), result.display())));
+                ApiCommonResponse.success(QueryPartyroomSetupResponse.from(result.stageType(), result.crews(), result.display())));
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/partyview/adapter/in/web/payload/response/QueryPartyroomSetupResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/partyview/adapter/in/web/payload/response/QueryPartyroomSetupResponse.java
@@ -1,7 +1,9 @@
 package com.pfplaybackend.api.partyview.adapter.in.web.payload.response;
 
+import com.pfplaybackend.api.party.domain.enums.StageType;
 import com.pfplaybackend.api.partyview.application.dto.CrewSetupDto;
 import com.pfplaybackend.api.partyview.application.dto.DisplayDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -10,10 +12,17 @@ import java.util.List;
 @Builder
 @Data
 public class QueryPartyroomSetupResponse {
+
+    // Amplitude L1: 클라이언트가 lobby 캐시에 의존하지 않고 입장 시점에서
+    // canonical stage_type 값을 받을 수 있도록 응답 최상위에 노출.
+    @Schema(description = "파티룸 스테이지 타입 (Amplitude `Partyroom Entered`의 stage_type 프로퍼티 source)",
+            example = "MAIN")
+    private StageType stageType;
+
     private List<CrewSetupDto> crews;
     private DisplayDto display;
 
-    public static QueryPartyroomSetupResponse from(List<CrewSetupDto> crews, DisplayDto display) {
-        return new QueryPartyroomSetupResponse(crews, display);
+    public static QueryPartyroomSetupResponse from(StageType stageType, List<CrewSetupDto> crews, DisplayDto display) {
+        return new QueryPartyroomSetupResponse(stageType, crews, display);
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/partyview/application/dto/result/PartyroomSetupResult.java
+++ b/app/src/main/java/com/pfplaybackend/api/partyview/application/dto/result/PartyroomSetupResult.java
@@ -1,11 +1,13 @@
 package com.pfplaybackend.api.partyview.application.dto.result;
 
+import com.pfplaybackend.api.party.domain.enums.StageType;
 import com.pfplaybackend.api.partyview.application.dto.CrewSetupDto;
 import com.pfplaybackend.api.partyview.application.dto.DisplayDto;
 
 import java.util.List;
 
 public record PartyroomSetupResult(
+    StageType stageType,
     List<CrewSetupDto> crews,
     DisplayDto display
 ) {}

--- a/app/src/main/java/com/pfplaybackend/api/partyview/application/service/PartyroomSetupQueryService.java
+++ b/app/src/main/java/com/pfplaybackend/api/partyview/application/service/PartyroomSetupQueryService.java
@@ -13,6 +13,7 @@ import com.pfplaybackend.api.party.application.service.PartyroomQueryService;
 import com.pfplaybackend.api.party.application.service.PlaybackQueryService;
 import com.pfplaybackend.api.party.application.service.PlaybackReactionQueryService;
 import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
 import com.pfplaybackend.api.party.domain.entity.data.PlaybackAggregationData;
 import com.pfplaybackend.api.party.domain.entity.data.PlaybackData;
 import com.pfplaybackend.api.party.domain.entity.data.history.PlaybackReactionHistoryData;
@@ -45,9 +46,12 @@ public class PartyroomSetupQueryService {
 
     @Transactional(readOnly = true)
     public PartyroomSetupResult getSetupInfo(PartyroomId partyroomId) {
+        // Amplitude L1: stageType은 partyroom aggregate의 canonical 필드.
+        // 클라이언트가 lobby 캐시 lookup 없이도 입장 시점에서 받을 수 있도록 응답에 포함.
+        PartyroomData partyroom = partyroomQueryService.getPartyroomById(partyroomId);
         List<CrewSetupDto> crews = getCrewsForSetup(partyroomId);
         DisplayDto display = getDisplayInfo();
-        return new PartyroomSetupResult(crews, display);
+        return new PartyroomSetupResult(partyroom.getStageType(), crews, display);
     }
 
     private List<CrewSetupDto> getCrewsForSetup(PartyroomId partyroomId) {

--- a/app/src/test/java/com/pfplaybackend/api/auth/adapter/in/web/AuthControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/auth/adapter/in/web/AuthControllerTest.java
@@ -101,7 +101,7 @@ class AuthControllerTest {
         when(oAuthUrlService.validateAndConsumeState(eq("valid-state"), any(OAuthProvider.class), anyString()))
                 .thenReturn(true);
         when(authService.processOAuthLogin(any(OAuthLoginCommand.class)))
-                .thenReturn(new AuthResult("access-token", "Cookie", 3600L, LocalDateTime.now()));
+                .thenReturn(new AuthResult("access-token", "Cookie", 3600L, LocalDateTime.now(), true));
 
         // when & then
         mockMvc.perform(post("/api/v1/auth/oauth/callback")
@@ -110,9 +110,39 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.tokenType").value("Cookie"));
+                .andExpect(jsonPath("$.data.tokenType").value("Cookie"))
+                .andExpect(jsonPath("$.data.isNewUser").value(true));
 
         verify(sharedSessionCookieWriter).write(any(), eq("access-token"));
+    }
+
+    @Test
+    @DisplayName("oauthCallback — 기존 사용자 재로그인 시 isNewUser=false (Amplitude L4)")
+    void oauthCallbackReturningUserExposesIsNewUserFalse() throws Exception {
+        // given — same call shape but service signals returning user
+        String codeVerifier = "a".repeat(43);
+        String body = """
+                {
+                    "provider": "google",
+                    "code": "auth-code-123",
+                    "codeVerifier": "%s",
+                    "state": "valid-state"
+                }
+                """.formatted(codeVerifier);
+
+        when(oAuthUrlService.validateAndConsumeState(eq("valid-state"), any(OAuthProvider.class), anyString()))
+                .thenReturn(true);
+        when(authService.processOAuthLogin(any(OAuthLoginCommand.class)))
+                .thenReturn(new AuthResult("access-token", "Cookie", 3600L, LocalDateTime.now(), false));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/oauth/callback")
+                        .with(jwt())
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isNewUser").value(false));
     }
 
     @Test
@@ -155,7 +185,7 @@ class AuthControllerTest {
                 """.formatted(codeVerifier);
 
         when(authService.processOAuthLogin(any(OAuthLoginCommand.class)))
-                .thenReturn(new AuthResult("access-token", "Cookie", 3600L, LocalDateTime.now()));
+                .thenReturn(new AuthResult("access-token", "Cookie", 3600L, LocalDateTime.now(), false));
 
         // when & then
         mockMvc.perform(post("/api/v1/auth/oauth/callback")

--- a/app/src/test/java/com/pfplaybackend/api/auth/application/service/AuthServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/auth/application/service/AuthServiceTest.java
@@ -14,6 +14,7 @@ import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.enums.AuthorityTier;
 import com.pfplaybackend.api.common.exception.AuthenticationException;
 import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.application.dto.result.MemberSignResult;
 import com.pfplaybackend.api.user.application.service.MemberSignService;
 import com.pfplaybackend.api.user.domain.entity.data.MemberData;
 import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
@@ -79,8 +80,8 @@ class AuthServiceTest {
         MemberData member = mock(MemberData.class);
         when(member.getUserAccountId()).thenReturn(1L);
         when(member.getAuthorityTier()).thenReturn(AuthorityTier.FM);
-        when(memberSignService.getMemberOrCreate("test@gmail.com", ProviderType.GOOGLE))
-                .thenReturn(member);
+        when(memberSignService.getMemberOrCreateWithStatus("test@gmail.com", ProviderType.GOOGLE))
+                .thenReturn(new MemberSignResult(member, false));
 
         UserAccountData userAccount = mock(UserAccountData.class);
         when(userAccount.getEmail()).thenReturn("test@gmail.com");
@@ -100,6 +101,45 @@ class AuthServiceTest {
         assertThat(result.tokenType()).isEqualTo("Cookie");
         assertThat(result.expiresIn()).isEqualTo(3600L);
         assertThat(result.issuedAt()).isNotNull();
+        // Returning user — MemberSignResult.isNewUser=false above propagates here.
+        assertThat(result.isNewUser()).isFalse();
+    }
+
+    @Test
+    @DisplayName("OAuth 로그인 — 신규 UserAccount INSERT 시 isNewUser=true가 응답으로 전파된다 (Amplitude L4)")
+    void processOAuthLoginNewUserPropagatesIsNewUserTrue() {
+        // given — same setup as success test but MemberSignService reports a brand new UA was created
+        OAuthLoginCommand command = new OAuthLoginCommand("google", "auth-code", "verifier");
+
+        OAuthTokenDto tokenResponse = new OAuthTokenDto("access-token", "Bearer", 3600, null, "email");
+        when(oAuthClientService.exchangeCodeForToken(OAuthProvider.GOOGLE, "auth-code", "verifier"))
+                .thenReturn(tokenResponse);
+
+        OAuthUserProfileDto userProfile = new OAuthUserProfileDto("google-id", "newbie@gmail.com", "Newbie", null);
+        when(oAuthClientService.getUserProfile(OAuthProvider.GOOGLE, "access-token"))
+                .thenReturn(userProfile);
+
+        MemberData member = mock(MemberData.class);
+        when(member.getUserAccountId()).thenReturn(42L);
+        when(member.getAuthorityTier()).thenReturn(AuthorityTier.FM);
+        when(memberSignService.getMemberOrCreateWithStatus("newbie@gmail.com", ProviderType.GOOGLE))
+                .thenReturn(new MemberSignResult(member, true));
+
+        UserAccountData userAccount = mock(UserAccountData.class);
+        when(userAccount.getEmail()).thenReturn("newbie@gmail.com");
+        when(userAccount.getUserId()).thenReturn(new UserId(42L));
+        when(userAccount.getProviderType()).thenReturn(ProviderType.GOOGLE);
+        when(userAccountRepository.findByUserId(any(UserId.class)))
+                .thenReturn(Optional.of(userAccount));
+
+        when(jwtService.mintSharedSessionToken(any())).thenReturn("jwt-token");
+        when(jwtProperties.getSharedSessionTokenExpirationMs()).thenReturn(3600L);
+
+        // when
+        AuthResult result = authService.processOAuthLogin(command);
+
+        // then
+        assertThat(result.isNewUser()).isTrue();
     }
 
     @Test
@@ -118,8 +158,8 @@ class AuthServiceTest {
 
         MemberData member = mock(MemberData.class);
         when(member.getUserAccountId()).thenReturn(99L);
-        when(memberSignService.getMemberOrCreate("test@gmail.com", ProviderType.GOOGLE))
-                .thenReturn(member);
+        when(memberSignService.getMemberOrCreateWithStatus("test@gmail.com", ProviderType.GOOGLE))
+                .thenReturn(new MemberSignResult(member, false));
 
         when(userAccountRepository.findByUserId(any(UserId.class)))
                 .thenReturn(Optional.empty());
@@ -173,8 +213,8 @@ class AuthServiceTest {
         MemberData member = mock(MemberData.class);
         when(member.getUserAccountId()).thenReturn(7L);
         when(member.getAuthorityTier()).thenReturn(AuthorityTier.FM);
-        when(memberSignService.getMemberOrCreate("test@gmail.com", ProviderType.GOOGLE))
-                .thenReturn(member);
+        when(memberSignService.getMemberOrCreateWithStatus("test@gmail.com", ProviderType.GOOGLE))
+                .thenReturn(new MemberSignResult(member, false));
 
         UserAccountData userAccount = mock(UserAccountData.class);
         when(userAccount.getEmail()).thenReturn("test@gmail.com");
@@ -227,8 +267,8 @@ class AuthServiceTest {
 
         MemberData member = mock(MemberData.class);
         when(member.getUserAccountId()).thenReturn(99L);
-        when(memberSignService.getMemberOrCreate("test@gmail.com", ProviderType.GOOGLE))
-                .thenReturn(member);
+        when(memberSignService.getMemberOrCreateWithStatus("test@gmail.com", ProviderType.GOOGLE))
+                .thenReturn(new MemberSignResult(member, false));
 
         when(userAccountRepository.findByUserId(any(UserId.class)))
                 .thenReturn(Optional.empty());

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/PlaybackReactionCommandControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/PlaybackReactionCommandControllerTest.java
@@ -1,21 +1,24 @@
 package com.pfplaybackend.api.party.adapter.in.web;
 
+import com.pfplaybackend.api.party.application.dto.playback.AddedTrackDto;
 import com.pfplaybackend.api.party.application.dto.playback.ReactionHistoryDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class PlaybackReactionCommandControllerTest extends AbstractPartyCommandWebMvcTest {
 
     @Test
-    @DisplayName("reactToPlayback — 200 OK")
+    @DisplayName("reactToPlayback LIKE — 200 OK, addedTrack null")
     void reactToPlaybackReturns200() throws Exception {
         // given
         String body = """
@@ -24,7 +27,7 @@ class PlaybackReactionCommandControllerTest extends AbstractPartyCommandWebMvcTe
                 }
                 """;
         when(playbackReactionCommandService.reactToCurrentPlayback(any(), any()))
-                .thenReturn(new ReactionHistoryDto(true, false, false));
+                .thenReturn(new ReactionHistoryDto(true, false, false, null));
 
         // when & then
         mockMvc.perform(post("/api/v1/partyrooms/1/playbacks/reaction")
@@ -32,7 +35,32 @@ class PlaybackReactionCommandControllerTest extends AbstractPartyCommandWebMvcTe
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.addedTrack").value(nullValue()));
+    }
+
+    @Test
+    @DisplayName("reactToPlayback GRAB 성공 — 응답 body에 addedTrack {trackId, playlistId} 포함")
+    void reactToPlaybackGrabIncludesAddedTrack() throws Exception {
+        // given
+        String body = """
+                {
+                    "reactionType": "GRAB"
+                }
+                """;
+        when(playbackReactionCommandService.reactToCurrentPlayback(any(), any()))
+                .thenReturn(new ReactionHistoryDto(true, false, true, new AddedTrackDto(12345L, 67L)));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/partyrooms/1/playbacks/reaction")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.addedTrack.trackId").value(12345))
+                .andExpect(jsonPath("$.data.addedTrack.playlistId").value(67))
+                .andExpect(jsonPath("$.data.isGrabbed").value(true));
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceTest.java
@@ -196,6 +196,73 @@ class PartyroomAccessCommandServiceTest {
     }
 
     @Test
+    @DisplayName("exit — 이미 inactive인 crew에 대한 후속 DELETE는 예외 없이 no-op 반환 (Amplitude L2 mobile pagehide 멱등성)")
+    void exitOnAlreadyInactiveCrewShouldBeIdempotentNoOp() {
+        // given — crew row가 존재하지만 이미 isActive=false (이전 exit 호출로 deactivate됨)
+        CrewData inactiveCrew = CrewData.builder()
+                .id(42L)
+                .userId(userId)
+                .gradeType(GradeType.LISTENER)
+                .isActive(false)
+                .build();
+
+        PartyroomData partyroomData = PartyroomData.builder()
+                .id(1L)
+                .partyroomId(partyroomId)
+                .status(PartyroomStatus.ACTIVE)
+                .build();
+
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroomData);
+        when(aggregatePort.findCrew(partyroomId, userId)).thenReturn(Optional.of(inactiveCrew));
+        // 멱등 toggle: 이미 inactive → UPDATE WHERE is_active=true는 0 row 영향
+        when(aggregatePort.deactivateCrew(eq(partyroomId), eq(userId), any(LocalDateTime.class)))
+                .thenReturn(0);
+
+        // when — 후속 DELETE /crews/me 호출 (mobile pagehide + visibilitychange 등 다중 fire 시나리오)
+        partyroomAccessCommandService.exit(partyroomId);
+
+        // then — 예외 없이 정상 반환 + EXIT event 미발행 + DJ queue 처리도 skip (이미 종료된 effect를 또 일으키면 안 됨)
+        verifyNoInteractions(eventPublisher);
+        verify(aggregatePort, never()).findDj(any(), any());
+        verify(aggregatePort, never()).findPlaybackState(any());
+        verify(partyroomAggregateService, never()).removeDjFromQueue(any(), any());
+        verify(playbackControlPort, never()).skipPlayback(any());
+    }
+
+    @Test
+    @DisplayName("exit — 첫 호출은 deactivate 1 → EXIT 이벤트 발행 (멱등성 분기와 대비되는 baseline)")
+    void exitFirstCallShouldDeactivateAndPublishEvent() {
+        // given — 정상 active crew
+        CrewData activeCrew = CrewData.builder()
+                .id(42L)
+                .userId(userId)
+                .gradeType(GradeType.LISTENER)
+                .isActive(true)
+                .build();
+
+        PartyroomData partyroomData = PartyroomData.builder()
+                .id(1L)
+                .partyroomId(partyroomId)
+                .status(PartyroomStatus.ACTIVE)
+                .build();
+
+        PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroomData);
+        when(aggregatePort.findCrew(partyroomId, userId)).thenReturn(Optional.of(activeCrew));
+        when(aggregatePort.deactivateCrew(eq(partyroomId), eq(userId), any(LocalDateTime.class)))
+                .thenReturn(1);
+        when(aggregatePort.findDj(eq(partyroomId), any(CrewId.class))).thenReturn(Optional.empty());
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+
+        // when
+        partyroomAccessCommandService.exit(partyroomId);
+
+        // then — EXIT 이벤트 1회 발행
+        verify(eventPublisher, times(1)).publishEvent(any(CrewAccessedEvent.class));
+    }
+
+    @Test
     @DisplayName("tryEnter INSERT race 패배자는 winner를 별 트랜잭션에서 조회하고 ENTER 이벤트를 발행하지 않는다")
     void tryEnterConcurrentInsertLoserShouldNotPublishEnter() {
         // given

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackReactionCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackReactionCommandServiceTest.java
@@ -7,6 +7,7 @@ import com.pfplaybackend.api.common.enums.AuthorityTier;
 import com.pfplaybackend.api.common.exception.http.ForbiddenException;
 import com.pfplaybackend.api.party.adapter.out.persistence.PlaybackReactionHistoryRepository;
 import com.pfplaybackend.api.party.application.dto.partyroom.ActivePartyroomDto;
+import com.pfplaybackend.api.party.application.port.out.AddedTrackInfo;
 import com.pfplaybackend.api.party.domain.entity.data.CrewData;
 import com.pfplaybackend.api.party.domain.entity.data.history.PlaybackReactionHistoryData;
 import com.pfplaybackend.api.party.domain.enums.ReactionType;
@@ -62,7 +63,7 @@ class PlaybackReactionCommandServiceTest {
     }
 
     @Test
-    @DisplayName("LIKE 반응 시 정상적으로 후처리가 호출되고 결과가 반환된다")
+    @DisplayName("LIKE 반응 시 정상적으로 후처리가 호출되고 addedTrack=null로 결과가 반환된다")
     void reactToCurrentPlaybackLikeSuccess() {
         // given
         ActivePartyroomDto activePartyroom = new ActivePartyroomDto(
@@ -86,6 +87,9 @@ class PlaybackReactionCommandServiceTest {
         CrewData crew = CrewData.builder().id(5L).userId(userId).build();
         when(partyroomQueryService.getCrewByUserId(partyroomId, userId)).thenReturn(Optional.of(crew));
 
+        when(playbackReactionPostProcessCommandService.postProcess(any(), any(), any(), any(), any()))
+                .thenReturn(null);
+
         // when
         ReactionHistoryDto result = playbackReactionCommandService.reactToCurrentPlayback(partyroomId, ReactionType.LIKE);
 
@@ -93,8 +97,91 @@ class PlaybackReactionCommandServiceTest {
         assertThat(result.isLiked()).isTrue();
         assertThat(result.isDisliked()).isFalse();
         assertThat(result.isGrabbed()).isFalse();
+        assertThat(result.addedTrack()).isNull();
         verify(playbackReactionPostProcessCommandService).postProcess(
                 postProcessResult, ReactionType.LIKE, partyroomId, playbackId, new CrewId(5L));
+    }
+
+    @Test
+    @DisplayName("GRAB 반응 시 응답에 addedTrack(trackId, playlistId)이 포함된다")
+    void reactToCurrentPlaybackGrabSuccessIncludesAddedTrack() {
+        // given
+        ActivePartyroomDto activePartyroom = new ActivePartyroomDto(
+                partyroomId.getId(), false, 5L, true, playbackId, new CrewId(5L));
+        when(partyroomQueryService.getMyActivePartyroom()).thenReturn(Optional.of(activePartyroom));
+
+        PlaybackReactionHistoryData historyData = new PlaybackReactionHistoryData(userId, playbackId);
+        when(playbackReactionQueryService.findPrevHistoryData(playbackId, userId))
+                .thenReturn(Optional.empty());
+
+        ReactionState baseState = ReactionState.createBaseState();
+        ReactionState targetState = new ReactionState(true, false, true);
+        when(playbackReactionDomainService.getTargetReactionState(baseState, ReactionType.GRAB))
+                .thenReturn(targetState);
+
+        ReactionPostProcessResult postProcessResult = new ReactionPostProcessResult(true, true, true, true, null, 3, null);
+        when(playbackReactionDomainService.determinePostProcessing(baseState, targetState))
+                .thenReturn(postProcessResult);
+        when(playbackReactionHistoryRepository.save(any())).thenReturn(historyData);
+
+        CrewData crew = CrewData.builder().id(5L).userId(userId).build();
+        when(partyroomQueryService.getCrewByUserId(partyroomId, userId)).thenReturn(Optional.of(crew));
+
+        AddedTrackInfo addedTrackInfo = new AddedTrackInfo(12345L, 67L);
+        when(playbackReactionPostProcessCommandService.postProcess(
+                postProcessResult, ReactionType.GRAB, partyroomId, playbackId, new CrewId(5L)))
+                .thenReturn(addedTrackInfo);
+
+        // when
+        ReactionHistoryDto result = playbackReactionCommandService.reactToCurrentPlayback(partyroomId, ReactionType.GRAB);
+
+        // then
+        assertThat(result.isLiked()).isTrue();
+        assertThat(result.isGrabbed()).isTrue();
+        assertThat(result.addedTrack()).isNotNull();
+        assertThat(result.addedTrack().trackId()).isEqualTo(12345L);
+        assertThat(result.addedTrack().playlistId()).isEqualTo(67L);
+    }
+
+    @Test
+    @DisplayName("GRAB 토글 off (이미 grab 상태에서 다시 GRAB → un-grab) 시 addedTrack=null")
+    void reactToCurrentPlaybackGrabToggleOffReturnsNullAddedTrack() {
+        // given
+        ActivePartyroomDto activePartyroom = new ActivePartyroomDto(
+                partyroomId.getId(), false, 5L, true, playbackId, new CrewId(5L));
+        when(partyroomQueryService.getMyActivePartyroom()).thenReturn(Optional.of(activePartyroom));
+
+        PlaybackReactionHistoryData historyData = mock(PlaybackReactionHistoryData.class);
+        when(historyData.getId()).thenReturn(99L);
+        when(historyData.applyReactionState(any())).thenReturn(historyData);
+        when(playbackReactionQueryService.findPrevHistoryData(playbackId, userId))
+                .thenReturn(Optional.of(historyData));
+
+        // already-grabbed → GRAB toggle leaves grab false (per ReactionStateResolver: (true,false,true) -GRAB-> (true,false,true);
+        // we still verify the contract: when post-process reports no grab status change, addedTrack must be null.
+        ReactionState existingState = new ReactionState(true, false, true);
+        when(playbackReactionDomainService.getReactionStateByHistory(historyData)).thenReturn(existingState);
+
+        ReactionState targetState = new ReactionState(true, false, true);
+        when(playbackReactionDomainService.getTargetReactionState(existingState, ReactionType.GRAB))
+                .thenReturn(targetState);
+
+        ReactionPostProcessResult postProcessResult = new ReactionPostProcessResult(false, false, false, false, null, 0, null);
+        when(playbackReactionDomainService.determinePostProcessing(existingState, targetState))
+                .thenReturn(postProcessResult);
+        when(playbackReactionHistoryRepository.save(any())).thenReturn(historyData);
+
+        CrewData crew = CrewData.builder().id(5L).userId(userId).build();
+        when(partyroomQueryService.getCrewByUserId(partyroomId, userId)).thenReturn(Optional.of(crew));
+
+        when(playbackReactionPostProcessCommandService.postProcess(any(), any(), any(), any(), any()))
+                .thenReturn(null);
+
+        // when
+        ReactionHistoryDto result = playbackReactionCommandService.reactToCurrentPlayback(partyroomId, ReactionType.GRAB);
+
+        // then
+        assertThat(result.addedTrack()).isNull();
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackReactionPostProcessCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackReactionPostProcessCommandServiceTest.java
@@ -3,6 +3,7 @@ package com.pfplaybackend.api.party.application.service;
 import com.pfplaybackend.api.common.ThreadLocalContext;
 import com.pfplaybackend.api.common.aspect.context.AuthContext;
 import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.application.port.out.AddedTrackInfo;
 import com.pfplaybackend.api.party.application.port.out.PlaylistCommandPort;
 import com.pfplaybackend.api.party.application.port.out.UserActivityPort;
 import com.pfplaybackend.api.party.domain.entity.data.PlaybackAggregationData;
@@ -27,6 +28,7 @@ import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -59,7 +61,7 @@ class PlaybackReactionPostProcessCommandServiceTest {
     }
 
     @Test
-    @DisplayName("grab 상태 변경 시 grabTrack이 호출된다")
+    @DisplayName("grab 상태 변경 시 grabTrack이 호출되고 AddedTrackInfo가 반환된다")
     void postProcessGrabStatusChangedCallsGrabTrack() {
         // given
         ReactionPostProcessResult dto = new ReactionPostProcessResult(
@@ -70,12 +72,35 @@ class PlaybackReactionPostProcessCommandServiceTest {
         when(playback.getLinkId()).thenReturn("link-123");
         when(playbackQueryService.getPlaybackById(playbackId)).thenReturn(playback);
 
+        AddedTrackInfo addedTrack = new AddedTrackInfo(555L, 67L);
+        when(playlistCommandPort.grabTrack(userId, "link-123")).thenReturn(addedTrack);
+
         // when
-        service.postProcess(dto, ReactionType.GRAB, partyroomId, playbackId, crewId);
+        AddedTrackInfo result = service.postProcess(dto, ReactionType.GRAB, partyroomId, playbackId, crewId);
 
         // then
+        assertThat(result).isEqualTo(addedTrack);
         verify(playlistCommandPort).grabTrack(userId, "link-123");
         verify(eventPublisher).publishEvent(any(ReactionMotionChangedEvent.class));
+    }
+
+    @Test
+    @DisplayName("grab 상태 변경이 없으면 AddedTrackInfo로 null이 반환된다")
+    void postProcessGrabStatusUnchangedReturnsNull() {
+        // given
+        ReactionPostProcessResult dto = new ReactionPostProcessResult(
+                false, false, false, false, null, 0, MotionType.NONE);
+
+        PlaybackData playback = mock(PlaybackData.class);
+        lenient().when(playback.getUserId()).thenReturn(new UserId(2L));
+        when(playbackQueryService.getPlaybackById(playbackId)).thenReturn(playback);
+
+        // when
+        AddedTrackInfo result = service.postProcess(dto, ReactionType.LIKE, partyroomId, playbackId, crewId);
+
+        // then
+        assertThat(result).isNull();
+        verify(playlistCommandPort, never()).grabTrack(any(), any());
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/partyview/adapter/in/web/PartyroomSetupControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/partyview/adapter/in/web/PartyroomSetupControllerTest.java
@@ -1,6 +1,7 @@
 package com.pfplaybackend.api.partyview.adapter.in.web;
 
 import com.pfplaybackend.api.party.adapter.in.web.AbstractPartyQueryWebMvcTest;
+import com.pfplaybackend.api.party.domain.enums.StageType;
 import com.pfplaybackend.api.partyview.application.dto.DisplayDto;
 import com.pfplaybackend.api.partyview.application.dto.result.PartyroomSetupResult;
 import org.junit.jupiter.api.DisplayName;
@@ -8,11 +9,13 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class PartyroomSetupControllerTest extends AbstractPartyQueryWebMvcTest {
@@ -21,13 +24,27 @@ class PartyroomSetupControllerTest extends AbstractPartyQueryWebMvcTest {
     @DisplayName("getSetupInfo — 200 OK")
     void getSetupInfoReturns200() throws Exception {
         // given
-        PartyroomSetupResult result = new PartyroomSetupResult(List.of(), mock(DisplayDto.class));
+        PartyroomSetupResult result = new PartyroomSetupResult(StageType.MAIN, List.of(), mock(DisplayDto.class));
         when(partyroomSetupQueryService.getSetupInfo(any())).thenReturn(result);
 
         // when & then
         mockMvc.perform(get("/api/v1/partyrooms/1/setup")
                         .with(jwt().authorities(() -> "ROLE_MEMBER")))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("getSetupInfo — 응답 본문에 stageType 필드가 포함된다 (Amplitude L1)")
+    void getSetupInfoIncludesStageType() throws Exception {
+        // given — service가 GENERAL 스테이지 룸을 반환
+        PartyroomSetupResult result = new PartyroomSetupResult(StageType.GENERAL, List.of(), mock(DisplayDto.class));
+        when(partyroomSetupQueryService.getSetupInfo(any())).thenReturn(result);
+
+        // when & then — stageType이 응답 최상위에 enum-name 문자열로 노출되어야 한다
+        mockMvc.perform(get("/api/v1/partyrooms/1/setup")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.stageType", equalTo("GENERAL")));
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/partyview/application/service/PartyroomSetupQueryServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/partyview/application/service/PartyroomSetupQueryServiceTest.java
@@ -13,9 +13,11 @@ import com.pfplaybackend.api.party.application.service.PartyroomQueryService;
 import com.pfplaybackend.api.party.application.service.PlaybackQueryService;
 import com.pfplaybackend.api.party.application.service.PlaybackReactionQueryService;
 import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
 import com.pfplaybackend.api.party.domain.entity.data.PlaybackAggregationData;
 import com.pfplaybackend.api.party.domain.entity.data.PlaybackData;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
+import com.pfplaybackend.api.party.domain.enums.StageType;
 import com.pfplaybackend.api.party.domain.value.CrewId;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import com.pfplaybackend.api.party.domain.value.PlaybackId;
@@ -70,6 +72,25 @@ class PartyroomSetupQueryServiceTest {
                 "body_uri", "face_uri", "icon_uri", 0, 0, 0.0, 0.0, 1.0);
     }
 
+    /**
+     * Build a {@link PartyroomData} mock with the given stageType.
+     *
+     * <p>Two gotchas worth flagging:
+     * <ul>
+     *   <li>Do NOT inline this inside {@code when(...).thenReturn(...)} — the inner stubbing
+     *       will collide with the outer one and Mockito throws UnfinishedStubbingException.
+     *       Always assign the return value to a local first, then pass it to thenReturn.</li>
+     *   <li>{@code lenient()} is required because some tests stub a partyroom but the service
+     *       throws before reaching the stageType lookup (e.g. no-active-room path). Strict
+     *       mode would flag the unused stub.</li>
+     * </ul>
+     */
+    private PartyroomData partyroomDataWith(StageType stageType) {
+        PartyroomData partyroom = mock(PartyroomData.class);
+        lenient().when(partyroom.getStageType()).thenReturn(stageType);
+        return partyroom;
+    }
+
     @Test
     @DisplayName("getSetupInfo — 활성 재생이 있을 때 DisplayDto에 재생 정보가 포함된다")
     void getSetupInfoActivePlayback() {
@@ -89,6 +110,8 @@ class PartyroomSetupQueryServiceTest {
 
         PlaybackAggregationData aggregation = PlaybackAggregationData.createFor(playbackId);
 
+        PartyroomData partyroom = partyroomDataWith(StageType.MAIN);
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
         when(partyroomQueryService.getActiveCrews(partyroomId)).thenReturn(List.of(crew1, djCrew));
         when(userProfileQueryPort.getUsersProfileSetting(any()))
                 .thenReturn(Map.of(
@@ -105,6 +128,7 @@ class PartyroomSetupQueryServiceTest {
         PartyroomSetupResult result = partyroomSetupQueryService.getSetupInfo(partyroomId);
 
         // then
+        assertThat(result.stageType()).isEqualTo(StageType.MAIN);
         assertThat(result.display().playbackActivated()).isTrue();
         assertThat(result.display().playback()).isNotNull();
         assertThat(result.display().playback().getName()).isEqualTo("Song");
@@ -119,6 +143,8 @@ class PartyroomSetupQueryServiceTest {
         ActivePartyroomDto activeDto = new ActivePartyroomDto(partyroomId.getId(), false, 1L, false, null, null);
         CrewData crew = CrewData.builder().id(1L).userId(userId).gradeType(GradeType.CLUBBER).build();
 
+        PartyroomData partyroom = partyroomDataWith(StageType.GENERAL);
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
         when(partyroomQueryService.getActiveCrews(partyroomId)).thenReturn(List.of(crew));
         when(userProfileQueryPort.getUsersProfileSetting(any()))
                 .thenReturn(Map.of(userId, createProfileSetting("User1")));
@@ -128,6 +154,7 @@ class PartyroomSetupQueryServiceTest {
         PartyroomSetupResult result = partyroomSetupQueryService.getSetupInfo(partyroomId);
 
         // then
+        assertThat(result.stageType()).isEqualTo(StageType.GENERAL);
         assertThat(result.display().playbackActivated()).isFalse();
         assertThat(result.display().playback()).isNull();
         assertThat(result.display().reaction()).isNull();
@@ -144,6 +171,8 @@ class PartyroomSetupQueryServiceTest {
         CrewData crew1 = CrewData.builder().id(1L).userId(userId).gradeType(GradeType.HOST).build();
         CrewData crew2 = CrewData.builder().id(2L).userId(user2).gradeType(GradeType.CLUBBER).build();
 
+        PartyroomData partyroom = partyroomDataWith(StageType.MAIN);
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
         when(partyroomQueryService.getActiveCrews(partyroomId)).thenReturn(List.of(crew1, crew2));
         when(userProfileQueryPort.getUsersProfileSetting(any()))
                 .thenReturn(Map.of(
@@ -164,7 +193,9 @@ class PartyroomSetupQueryServiceTest {
     @Test
     @DisplayName("getSetupInfo — 활성 파티룸이 없으면 예외가 발생한다")
     void getSetupInfoNoActiveRoomThrows() {
-        // given
+        // given — partyroom 자체는 존재(stageType lookup 통과)하지만 호출자의 active crew 세션은 없음
+        PartyroomData partyroom = partyroomDataWith(StageType.MAIN);
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
         when(partyroomQueryService.getActiveCrews(partyroomId)).thenReturn(List.of());
         when(userProfileQueryPort.getUsersProfileSetting(any()))
                 .thenReturn(Map.of());

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/dto/GrabbedTrackDto.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/dto/GrabbedTrackDto.java
@@ -1,0 +1,8 @@
+package com.pfplaybackend.api.playlist.application.dto;
+
+/**
+ * Identifies the new track entry created by a successful GRAB.
+ * Returned by GrabTrackService so callers can surface trackId / playlistId
+ * (e.g. for client-side analytics).
+ */
+public record GrabbedTrackDto(Long trackId, Long playlistId) {}

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/GrabTrackService.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/GrabTrackService.java
@@ -3,6 +3,7 @@ package com.pfplaybackend.api.playlist.application.service;
 import com.pfplaybackend.api.common.domain.value.PlaylistId;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
+import com.pfplaybackend.api.playlist.application.dto.GrabbedTrackDto;
 import com.pfplaybackend.api.playlist.application.dto.command.AddTrackCommand;
 import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
 import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
@@ -23,7 +24,7 @@ public class GrabTrackService {
     private final TrackCommandService trackCommandService;
 
     @Transactional
-    public void grabTrack(UserId userId, String linkId) {
+    public GrabbedTrackDto grabTrack(UserId userId, String linkId) {
         TrackData targetTrackData = aggregatePort.findFirstTrackByLink(linkId);
         if (targetTrackData == null) throw ExceptionCreator.create(TrackException.NOT_FOUND_TRACK);
 
@@ -38,6 +39,7 @@ public class GrabTrackService {
                 targetTrackData.getDuration().toDisplayString(),
                 targetTrackData.getThumbnailImage()
         );
-        trackCommandService.addTrackInPlaylist(playlistData.getId(), command);
+        Long trackId = trackCommandService.addTrackInPlaylist(playlistData.getId(), command);
+        return new GrabbedTrackDto(trackId, playlistData.getId());
     }
 }

--- a/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/GrabTrackServiceTest.java
+++ b/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/GrabTrackServiceTest.java
@@ -5,6 +5,7 @@ import com.pfplaybackend.api.common.domain.value.PlaylistId;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.exception.http.ConflictException;
 import com.pfplaybackend.api.common.exception.http.NotFoundException;
+import com.pfplaybackend.api.playlist.application.dto.GrabbedTrackDto;
 import com.pfplaybackend.api.playlist.application.dto.command.AddTrackCommand;
 import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
 import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
@@ -56,7 +57,7 @@ class GrabTrackServiceTest {
     }
 
     @Test
-    @DisplayName("grabTrack — 정상 그랩 시 트랙이 GRABLIST에 추가된다")
+    @DisplayName("grabTrack — 정상 그랩 시 트랙이 GRABLIST에 추가되고 GrabbedTrackDto가 반환된다")
     void grabTrackSuccess() {
         // given
         TrackData track = createTrackData();
@@ -65,12 +66,15 @@ class GrabTrackServiceTest {
         when(aggregatePort.findFirstTrackByLink(LINK_ID)).thenReturn(track);
         when(aggregatePort.findPlaylistByOwnerAndType(USER_ID, PlaylistType.GRABLIST)).thenReturn(grablist);
         when(aggregatePort.findTrackByPlaylistAndLink(new PlaylistId(grablist.getId()), LINK_ID)).thenReturn(Optional.empty());
+        when(trackCommandService.addTrackInPlaylist(eq(grablist.getId()), any(AddTrackCommand.class))).thenReturn(777L);
 
         // when
-        grabTrackService.grabTrack(USER_ID, LINK_ID);
+        GrabbedTrackDto result = grabTrackService.grabTrack(USER_ID, LINK_ID);
 
         // then
         verify(trackCommandService).addTrackInPlaylist(eq(grablist.getId()), any(AddTrackCommand.class));
+        assertThat(result.trackId()).isEqualTo(777L);
+        assertThat(result.playlistId()).isEqualTo(grablist.getId());
     }
 
     @Test

--- a/user/src/main/java/com/pfplaybackend/api/user/application/dto/result/MemberSignResult.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/dto/result/MemberSignResult.java
@@ -1,0 +1,19 @@
+package com.pfplaybackend.api.user.application.dto.result;
+
+import com.pfplaybackend.api.user.domain.entity.data.MemberData;
+
+/**
+ * Result of {@link com.pfplaybackend.api.user.application.service.MemberSignService#getMemberOrCreateWithStatus}.
+ *
+ * <p>{@code isNewUser} reflects whether the {@code UserAccount} row was newly
+ * INSERTed during this call. It is the authoritative signal used by the OAuth
+ * callback response (Amplitude L4) to distinguish a true sign-up from a
+ * returning login — replacing the client's brittle localStorage UID heuristic.
+ *
+ * <p>"New user" specifically means a new {@code UserAccount} (the
+ * provider-identity row), not a recovery of a missing {@code Member} for an
+ * existing account. The latter is a returning user from the analytics
+ * perspective.
+ */
+public record MemberSignResult(MemberData member, boolean isNewUser) {
+}

--- a/user/src/main/java/com/pfplaybackend/api/user/application/service/MemberSignService.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/service/MemberSignService.java
@@ -5,6 +5,7 @@ import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.user.adapter.out.persistence.MemberRepository;
 import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
 import com.pfplaybackend.api.user.application.dto.command.SignMemberCommand;
+import com.pfplaybackend.api.user.application.dto.result.MemberSignResult;
 import com.pfplaybackend.api.user.application.port.out.OAuth2RedirectPort;
 import com.pfplaybackend.api.user.application.port.out.PlaylistSetupPort;
 import com.pfplaybackend.api.user.domain.entity.data.MemberData;
@@ -46,17 +47,42 @@ public class MemberSignService {
      * <p>When a new Member is created, profile / default-playlist / event
      * side-effects fire (matches pre-V4 behavior). Activity-row initialization
      * is deferred to Task 11 (see {@link #initializeNewMember} TODO).
+     *
+     * <p>Backward-compat shim — callers that don't need the {@code isNewUser}
+     * flag stay on this method. New callers (Amplitude L4 OAuth callback)
+     * should use {@link #getMemberOrCreateWithStatus}.
      */
     @Transactional
     public MemberData getMemberOrCreate(String email, ProviderType providerType) {
-        UserAccountData userAccount = userAccountRepository
-                .findByEmailAndProviderType(email, providerType)
-                .orElseGet(() -> userAccountRepository.save(
-                        UserAccountData.createForSocial(new UserId(), email, providerType)));
+        return getMemberOrCreateWithStatus(email, providerType).member();
+    }
+
+    /**
+     * Same flow as {@link #getMemberOrCreate} but additionally reports whether
+     * the {@code UserAccount} row was newly INSERTed during this call.
+     *
+     * <p>Used by the OAuth callback (Amplitude L4) so the client's
+     * {@code User Signed Up} event can fire only on actual sign-up rather than
+     * relying on a localStorage UID heuristic that breaks across incognito,
+     * cache-clear, and multi-device scenarios.
+     *
+     * <p>{@code isNewUser=true} iff no {@code UserAccount} existed for the
+     * {@code (email, providerType)} pair before this call — i.e. a fresh
+     * provider identity. The "UA exists, Member missing" recovery path is
+     * {@code isNewUser=false}: it's a returning user whose Member row was
+     * regenerated.
+     */
+    @Transactional
+    public MemberSignResult getMemberOrCreateWithStatus(String email, ProviderType providerType) {
+        var existing = userAccountRepository.findByEmailAndProviderType(email, providerType);
+        boolean isNewUser = existing.isEmpty();
+
+        UserAccountData userAccount = existing.orElseGet(() -> userAccountRepository.save(
+                UserAccountData.createForSocial(new UserId(), email, providerType)));
 
         userAccount.recordLogin();
 
-        return getOrCreateMemberFor(userAccount);
+        return new MemberSignResult(getOrCreateMemberFor(userAccount), isNewUser);
     }
 
     /**

--- a/user/src/test/java/com/pfplaybackend/api/user/application/service/MemberSignServiceTest.java
+++ b/user/src/test/java/com/pfplaybackend/api/user/application/service/MemberSignServiceTest.java
@@ -5,6 +5,7 @@ import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.user.adapter.out.persistence.MemberRepository;
 import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
 import com.pfplaybackend.api.user.application.dto.command.SignMemberCommand;
+import com.pfplaybackend.api.user.application.dto.result.MemberSignResult;
 import com.pfplaybackend.api.user.application.port.out.OAuth2RedirectPort;
 import com.pfplaybackend.api.user.application.port.out.PlaylistSetupPort;
 import com.pfplaybackend.api.user.domain.entity.data.MemberData;
@@ -214,6 +215,74 @@ class MemberSignServiceTest {
         assertThat(adminAccount.getLastLoginAt()).isNull();
         // mustChangePassword stays true; no flag mutation in this method
         assertThat(adminAccount.isMustChangePassword()).isTrue();
+    }
+
+    @Test
+    @DisplayName("getMemberOrCreateWithStatus — UserAccount 미존재 시 isNewUser=true (Amplitude L4)")
+    void getMemberOrCreateWithStatusReturnsTrueWhenUserAccountMissing() {
+        // given
+        when(userAccountRepository.findByEmailAndProviderType(EMAIL, ProviderType.GOOGLE))
+                .thenReturn(Optional.empty());
+        when(userAccountRepository.save(any(UserAccountData.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(memberRepository.findByUserAccountId(any(Long.class)))
+                .thenReturn(Optional.empty());
+        when(memberRepository.save(any(MemberData.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(userProfileCommandService.createProfileDataForMember(any(UserId.class)))
+                .thenReturn(mock(ProfileData.class));
+
+        // when
+        MemberSignResult result = memberSignService.getMemberOrCreateWithStatus(EMAIL, ProviderType.GOOGLE);
+
+        // then
+        assertThat(result.isNewUser()).isTrue();
+        assertThat(result.member()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("getMemberOrCreateWithStatus — 기존 UserAccount + 기존 Member 시 isNewUser=false (Amplitude L4)")
+    void getMemberOrCreateWithStatusReturnsFalseWhenBothPresent() {
+        // given
+        UserAccountData existingAccount = UserAccountData.createForSocial(
+                new UserId(123L), EMAIL, ProviderType.GOOGLE);
+        MemberData existingMember = mock(MemberData.class);
+
+        when(userAccountRepository.findByEmailAndProviderType(EMAIL, ProviderType.GOOGLE))
+                .thenReturn(Optional.of(existingAccount));
+        when(memberRepository.findByUserAccountId(123L))
+                .thenReturn(Optional.of(existingMember));
+
+        // when
+        MemberSignResult result = memberSignService.getMemberOrCreateWithStatus(EMAIL, ProviderType.GOOGLE);
+
+        // then
+        assertThat(result.isNewUser()).isFalse();
+        assertThat(result.member()).isSameAs(existingMember);
+    }
+
+    @Test
+    @DisplayName("getMemberOrCreateWithStatus — UserAccount는 있고 Member만 복구되는 경우 isNewUser=false (returning user from analytics 관점)")
+    void getMemberOrCreateWithStatusReturnsFalseOnMemberRecovery() {
+        // given — UA exists (returning user), but Member row was lost; recovery is NOT a sign-up
+        UserAccountData existingAccount = UserAccountData.createForSocial(
+                new UserId(456L), EMAIL, ProviderType.GOOGLE);
+
+        when(userAccountRepository.findByEmailAndProviderType(EMAIL, ProviderType.GOOGLE))
+                .thenReturn(Optional.of(existingAccount));
+        when(memberRepository.findByUserAccountId(456L))
+                .thenReturn(Optional.empty());
+        when(memberRepository.save(any(MemberData.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(userProfileCommandService.createProfileDataForMember(any(UserId.class)))
+                .thenReturn(mock(ProfileData.class));
+
+        // when
+        MemberSignResult result = memberSignService.getMemberOrCreateWithStatus(EMAIL, ProviderType.GOOGLE);
+
+        // then — Member was newly saved, but UserAccount was not, so isNewUser=false
+        assertThat(result.isNewUser()).isFalse();
+        verify(memberRepository).save(any(MemberData.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Frontend `amplitude-backend-asks.md` 의 4건 backend enhancement. 모두 backwards-compatible (필드 추가 또는 동작 보장만), 4 commit 시리즈 (ROI 우선순위).

## Commits

| Commit | ID | 내용 | 분석 효과 |
|---|---|---|---|
| `8d61ba50` | **L1** | `GET /v1/partyrooms/{id}/setup` 응답에 `stageType` 추가 | `stage_type` 100% coverage (link/direct 진입자 누락 해소) |
| `17bd542e` | **L4** | OAuth callback 응답에 `isNewUser: boolean` 추가 (`@JsonProperty("isNewUser")`) | `User Signed Up` 절대값 정확도 (localStorage 휴리스틱 제거) |
| `6fa87ed7` | **L2** | exit endpoint 멱등성 — 검증 결과 이미 멱등, IT 2건 추가로 contract lock | 모바일 `pagehide` 리스너 가능, exit 데이터 수신율 |
| `35b9a747` | **L5** | GRAB 응답에 `addedTrack: { trackId, playlistId } \| null` 추가 | grab 경로 `Track Added` 가시화 |

## Backwards compatibility

- L1/L4/L5: 모두 nullable additive 필드. 기존 client 영향 0
- L2: production 코드 변경 0 — 검증 + 테스트만

## Test plan

- [x] 모든 commit 후 `:app:test` BUILD SUCCESSFUL
- [x] L5 `./gradlew test` (전 모듈) BUILD SUCCESSFUL
- [ ] dev 자동 재배포 후 frontend 통합 검증:
  - L1: lobby 거치지 않는 직접 링크 진입 시 `stage_type` 채워짐
  - L4: 신규 OAuth signup `isNewUser=true`, 재로그인 `false`
  - L2: mobile `pagehide` 시 DELETE 중복 호출에 200 응답 (404/409 미반환)
  - L5: GRAB 시 응답 `addedTrack` 채워져 `Track Added` 발화

## Frontend 후속

각 항목별 `Client 측 후속` 가이드는 `amplitude-backend-asks.md` 참조. 각 frontend PR 은 독립적으로 진행 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)