### PR TITLE
fix(security): scope admin-origin-guard allowed origins per profile

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -159,7 +159,6 @@ app:
       allowed:
         - https://localhost:3000
         - http://localhost:3000
-        - https://admin.pfplay.xyz
     admin-csrf:
       enabled: true
       cookie-name: XSRF-TOKEN
@@ -296,6 +295,11 @@ app:
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS}
 
+  security:
+    admin-origin-guard:
+      allowed:
+        - https://stg-admin.pfplay.xyz
+
 ---
 
 # 🔴 운영 환경
@@ -350,6 +354,11 @@ app:
 
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS}
+
+  security:
+    admin-origin-guard:
+      allowed:
+        - https://admin.pfplay.xyz
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## Summary
- Move env-specific admin origins out of `common` into `staging`/`prod` profile blocks
- Add `https://stg-admin.pfplay.xyz` (staging); keep `https://admin.pfplay.xyz` (prod)
- `local` / `dev` continue to inherit common (localhost only)

## Why
stg-admin login was returning **403 FORBIDDEN_ORIGIN**. `AdminOriginGuardFilter`'s allowed list only contained the prod admin host (`admin.pfplay.xyz`), so requests from `https://stg-admin.pfplay.xyz` were rejected before reaching the auth handler.

Observed in stg-app logs:
```
WARN c.p.a.c.c.s.web.AdminOriginGuardFilter : admin_origin_guard.deny
  path=/api/v1/auth/admin/login origin=https://stg-admin.pfplay.xyz
```

## Test plan
- [ ] Rebuild stg image, redeploy stg-app, verify admin login succeeds from stg-admin
- [ ] Confirm prod build resolves to `admin.pfplay.xyz` only (no regression)
- [ ] `AdminOriginGuardFilterTest` / `AdminAuthControllerTest` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)