### PR TITLE
chore: sync develop to release (admin-origin-guard staging fix)

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -159,7 +159,6 @@ app:
       allowed:
         - https://localhost:3000
         - http://localhost:3000
-        - https://admin.pfplay.xyz
     admin-csrf:
       enabled: true
       cookie-name: XSRF-TOKEN
@@ -296,6 +295,11 @@ app:
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS}
 
+  security:
+    admin-origin-guard:
+      allowed:
+        - https://stg-admin.pfplay.xyz
+
 ---
 
 # 🔴 운영 환경
@@ -350,6 +354,11 @@ app:
 
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS}
+
+  security:
+    admin-origin-guard:
+      allowed:
+        - https://admin.pfplay.xyz
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## Summary
Sync develop → release to deploy the admin-origin-guard fix to staging.

Includes:
- #190 fix(security): scope admin-origin-guard allowed origins per profile

## Why
stg-admin login currently fails with **403 FORBIDDEN_ORIGIN** because `https://stg-admin.pfplay.xyz` is not in the filter's allowed list. Merging unblocks staging admin access.

## Test plan
- [ ] `Deploy to stg` workflow runs on merge
- [ ] Admin login from stg-admin.pfplay.xyz succeeds (no 403)
- [ ] No regression on prod-bound flow (prod still allows only `admin.pfplay.xyz`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)