### PR TITLE
release: nickname/link_domain uniqueness guards (V15)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/admin/application/service/AdminPartyroomService.java
+++ b/app/src/main/java/com/pfplaybackend/api/admin/application/service/AdminPartyroomService.java
@@ -15,6 +15,7 @@ import com.pfplaybackend.api.party.domain.entity.data.*;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
 import com.pfplaybackend.api.party.domain.enums.ReactionType;
 import com.pfplaybackend.api.party.domain.enums.StageType;
+import com.pfplaybackend.api.party.domain.exception.PartyroomException;
 import com.pfplaybackend.api.party.domain.value.*;
 import com.pfplaybackend.api.user.domain.entity.data.MemberData;
 import lombok.RequiredArgsConstructor;
@@ -58,6 +59,8 @@ public class AdminPartyroomService {
         String linkDomain = command.linkDomain();
         if (linkDomain == null || linkDomain.isEmpty()) {
             linkDomain = generateUniqueLinkDomain();
+        } else if (isLinkDomainDuplicated(linkDomain)) {
+            throw ExceptionCreator.create(PartyroomException.LINK_DOMAIN_ALREADY_EXISTS);
         }
 
         PartyroomData partyroom = createPartyroom(

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomCommandService.java
@@ -34,6 +34,8 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class PartyroomCommandService {
 
+    private static final int LINK_DOMAIN_GENERATION_MAX_ATTEMPTS = 5;
+
     private final PartyroomAggregatePort aggregatePort;
     private final PartyroomAccessCommandService partyroomAccessCommandService;
     private final ApplicationEventPublisher eventPublisher;
@@ -55,14 +57,26 @@ public class PartyroomCommandService {
         if(optionalActive.isPresent()) throw ExceptionCreator.create(PartyroomException.ALREADY_HOST);
 
         String linkDomain = command.linkDomain();
-        if(linkDomain == null || linkDomain.isEmpty()) {
-            linkDomain = UUID.randomUUID().toString().replaceAll("-", "").substring(0, 12);
+        if (linkDomain == null || linkDomain.isEmpty()) {
+            linkDomain = generateUniqueLinkDomain();
+        } else if (aggregatePort.findByLinkDomain(LinkDomain.of(linkDomain)).isPresent()) {
+            throw ExceptionCreator.create(PartyroomException.LINK_DOMAIN_ALREADY_EXISTS);
         }
         PartyroomData createdPartyroom = createPartyroom(
                 new CreatePartyroomCommand(command.title(), command.introduction(), linkDomain, command.playbackTimeLimit()),
                 StageType.GENERAL, authContext.getUserId());
         partyroomAccessCommandService.enterByHost(authContext.getUserId(), createdPartyroom);
         return createdPartyroom;
+    }
+
+    private String generateUniqueLinkDomain() {
+        for (int attempt = 0; attempt < LINK_DOMAIN_GENERATION_MAX_ATTEMPTS; attempt++) {
+            String candidate = UUID.randomUUID().toString().replaceAll("-", "").substring(0, 12);
+            if (aggregatePort.findByLinkDomain(LinkDomain.of(candidate)).isEmpty()) {
+                return candidate;
+            }
+        }
+        throw ExceptionCreator.create(PartyroomException.LINK_DOMAIN_ALREADY_EXISTS);
     }
 
     private PartyroomData createPartyroom(CreatePartyroomCommand command, StageType stageType, UserId hostId) {

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/exception/PartyroomException.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/exception/PartyroomException.java
@@ -12,7 +12,8 @@ public enum PartyroomException implements DomainException {
     ACTIVE_ANOTHER_ROOM("PTR-004", "이미 다른 파티룸에 입장 중입니다", ErrorType.FORBIDDEN),
     RESTRICTED_AUTHORITY("PTR-005", "권한이 부족합니다", ErrorType.FORBIDDEN),
     ALREADY_HOST("PTR-006", "이미 다른 파티룸의 호스트입니다", ErrorType.FORBIDDEN),
-    ILLEGAL_STATE_TRANSITION("PTR-007", "허용되지 않은 파티룸 상태 전이입니다", ErrorType.CONFLICT);
+    ILLEGAL_STATE_TRANSITION("PTR-007", "허용되지 않은 파티룸 상태 전이입니다", ErrorType.CONFLICT),
+    LINK_DOMAIN_ALREADY_EXISTS("PTR-008", "이미 사용 중인 파티룸 주소입니다", ErrorType.CONFLICT);
 
     private final String errorCode;
     private final String message;

--- a/app/src/main/resources/db/migration/V15__add_unique_constraints.sql
+++ b/app/src/main/resources/db/migration/V15__add_unique_constraints.sql
@@ -1,0 +1,10 @@
+-- Enforce uniqueness for user-facing identifiers that previously allowed
+-- silent collisions (no DB constraint, no service-level pre-check).
+-- Pre-deploy step: stg/dev data must be wiped of duplicates before this
+-- migration runs, otherwise the ALTER will fail.
+
+ALTER TABLE user_profile
+    ADD CONSTRAINT uk_user_profile_nickname UNIQUE (nickname);
+
+ALTER TABLE partyroom
+    ADD CONSTRAINT uk_partyroom_link_domain UNIQUE (link_domain);

--- a/app/src/test/java/com/pfplaybackend/api/admin/application/service/AdminPartyroomServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/admin/application/service/AdminPartyroomServiceTest.java
@@ -5,6 +5,7 @@ import com.pfplaybackend.api.admin.application.dto.result.AdminPartyroomResult;
 import com.pfplaybackend.api.admin.application.port.out.AdminPartyroomPort;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.exception.http.BadRequestException;
+import com.pfplaybackend.api.common.exception.http.ConflictException;
 import com.pfplaybackend.api.common.exception.http.NotFoundException;
 import com.pfplaybackend.api.party.application.service.PartyroomAccessCommandService;
 import com.pfplaybackend.api.party.application.service.PlaybackQueryService;
@@ -93,6 +94,7 @@ class AdminPartyroomServiceTest {
 
         PartyroomData savedPartyroom = createTestPartyroom("Test Room", "testdomain01");
 
+        when(adminPartyroomPort.findPartyroomByLinkDomain(LinkDomain.of("testdomain01"))).thenReturn(Optional.empty());
         when(adminPartyroomPort.savePartyroom(any(PartyroomData.class))).thenReturn(savedPartyroom);
 
         // when
@@ -102,6 +104,22 @@ class AdminPartyroomServiceTest {
         assertThat(result.title()).isEqualTo("Test Room");
         assertThat(result.linkDomain()).isEqualTo("testdomain01");
         verify(partyroomAccessCommandService).enterByHost(any(UserId.class), eq(savedPartyroom));
+    }
+
+    @Test
+    @DisplayName("createPartyroomWithHost — 사용자가 지정한 linkDomain이 이미 존재하면 CONFLICT(409)을 던진다")
+    void createPartyroomWithHostRejectsDuplicateLinkDomain() {
+        // given
+        AdminCreatePartyroomCommand command = new AdminCreatePartyroomCommand(
+                "100", "Test Room", "Welcome", "taken", 5);
+        PartyroomData existing = createTestPartyroom("Existing", "taken");
+        when(adminPartyroomPort.findPartyroomByLinkDomain(LinkDomain.of("taken"))).thenReturn(Optional.of(existing));
+
+        // when & then
+        assertThatThrownBy(() -> adminPartyroomService.createPartyroomWithHost(command))
+                .isInstanceOf(ConflictException.class);
+        verify(adminPartyroomPort, never()).savePartyroom(any());
+        verify(partyroomAccessCommandService, never()).enterByHost(any(), any());
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomCommandServiceTest.java
@@ -4,6 +4,7 @@ import com.pfplaybackend.api.common.ThreadLocalContext;
 import com.pfplaybackend.api.common.aspect.context.AuthContext;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.enums.AuthorityTier;
+import com.pfplaybackend.api.common.exception.http.ConflictException;
 import com.pfplaybackend.api.common.exception.http.ForbiddenException;
 import com.pfplaybackend.api.common.exception.http.NotFoundException;
 import com.pfplaybackend.api.party.application.dto.command.CreatePartyroomCommand;
@@ -72,6 +73,7 @@ class PartyroomCommandServiceTest {
         // given
         CreatePartyroomCommand command = new CreatePartyroomCommand("My Room", "Intro", "mylink", 10);
         when(aggregatePort.findNonTerminatedHostRoom(userId)).thenReturn(Optional.empty());
+        when(aggregatePort.findByLinkDomain(LinkDomain.of("mylink"))).thenReturn(Optional.empty());
         when(aggregatePort.savePartyroom(any(PartyroomData.class))).thenAnswer(invocation -> {
             PartyroomData p = invocation.getArgument(0);
             return PartyroomData.builder()
@@ -113,6 +115,7 @@ class PartyroomCommandServiceTest {
         // given
         CreatePartyroomCommand command = new CreatePartyroomCommand("My Room", "Intro", "", 10);
         when(aggregatePort.findNonTerminatedHostRoom(userId)).thenReturn(Optional.empty());
+        when(aggregatePort.findByLinkDomain(any(LinkDomain.class))).thenReturn(Optional.empty());
 
         ArgumentCaptor<PartyroomData> captor = ArgumentCaptor.forClass(PartyroomData.class);
         when(aggregatePort.savePartyroom(any(PartyroomData.class))).thenAnswer(invocation -> {
@@ -131,6 +134,37 @@ class PartyroomCommandServiceTest {
         verify(aggregatePort).savePartyroom(captor.capture());
         assertThat(captor.getValue().getLinkDomain().getValue()).isNotEmpty();
         assertThat(captor.getValue().getLinkDomain().getValue()).hasSize(12);
+    }
+
+    @Test
+    @DisplayName("createGeneralPartyRoom — 사용자가 지정한 linkDomain이 이미 존재하면 CONFLICT(409)을 던진다")
+    void createGeneralPartyRoomRejectsDuplicateLinkDomain() {
+        // given
+        CreatePartyroomCommand command = new CreatePartyroomCommand("My Room", "Intro", "taken", 10);
+        when(aggregatePort.findNonTerminatedHostRoom(userId)).thenReturn(Optional.empty());
+        PartyroomData existing = PartyroomData.builder().id(99L).hostId(new UserId(99L)).build();
+        when(aggregatePort.findByLinkDomain(LinkDomain.of("taken"))).thenReturn(Optional.of(existing));
+
+        // when & then
+        assertThatThrownBy(() -> partyroomCommandService.createGeneralPartyRoom(command))
+                .isInstanceOf(ConflictException.class);
+        verify(aggregatePort, never()).savePartyroom(any());
+        verify(partyroomAccessCommandService, never()).enterByHost(any(), any());
+    }
+
+    @Test
+    @DisplayName("createGeneralPartyRoom — 자동 생성된 linkDomain이 매번 충돌하면 CONFLICT(409)을 던진다")
+    void createGeneralPartyRoomAutoGenExhausted() {
+        // given
+        CreatePartyroomCommand command = new CreatePartyroomCommand("My Room", "Intro", "", 10);
+        when(aggregatePort.findNonTerminatedHostRoom(userId)).thenReturn(Optional.empty());
+        PartyroomData existing = PartyroomData.builder().id(99L).hostId(new UserId(99L)).build();
+        when(aggregatePort.findByLinkDomain(any(LinkDomain.class))).thenReturn(Optional.of(existing));
+
+        // when & then
+        assertThatThrownBy(() -> partyroomCommandService.createGeneralPartyRoom(command))
+                .isInstanceOf(ConflictException.class);
+        verify(aggregatePort, never()).savePartyroom(any());
     }
 
     // ========== updatePartyroom ==========

--- a/user/src/main/java/com/pfplaybackend/api/user/adapter/out/persistence/UserProfileRepository.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/adapter/out/persistence/UserProfileRepository.java
@@ -2,11 +2,20 @@ package com.pfplaybackend.api.user.adapter.out.persistence;
 
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.user.domain.entity.data.ProfileData;
+import com.pfplaybackend.api.user.domain.value.Nickname;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface UserProfileRepository extends JpaRepository<ProfileData, Long> {
     List<ProfileData> findAllByUserIdIn(List<UserId> userIds);
     ProfileData findByUserId(UserId userId);
+
+    @Query("SELECT COUNT(p) > 0 FROM ProfileData p WHERE p.bio.nickname = :nickname")
+    boolean existsByNickname(@Param("nickname") Nickname nickname);
+
+    @Query("SELECT COUNT(p) > 0 FROM ProfileData p WHERE p.bio.nickname = :nickname AND p.userId <> :userId")
+    boolean existsByNicknameAndUserIdNot(@Param("nickname") Nickname nickname, @Param("userId") UserId userId);
 }

--- a/user/src/main/java/com/pfplaybackend/api/user/application/service/UserBioCommandService.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/service/UserBioCommandService.java
@@ -3,11 +3,15 @@ package com.pfplaybackend.api.user.application.service;
 import com.pfplaybackend.api.common.ThreadLocalContext;
 import com.pfplaybackend.api.common.aspect.context.AuthContext;
 import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.exception.ExceptionCreator;
 import com.pfplaybackend.api.user.adapter.out.persistence.MemberRepository;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserProfileRepository;
 import com.pfplaybackend.api.user.application.dto.command.UpdateBioCommand;
 import com.pfplaybackend.api.user.domain.entity.data.MemberData;
 import com.pfplaybackend.api.user.domain.enums.ProfileChangeType;
 import com.pfplaybackend.api.user.domain.event.UserProfileChangedEvent;
+import com.pfplaybackend.api.user.domain.exception.UserException;
+import com.pfplaybackend.api.user.domain.value.Nickname;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -18,12 +22,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserBioCommandService {
 
     private final MemberRepository memberRepository;
+    private final UserProfileRepository userProfileRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void updateMyBio(UpdateBioCommand updateBioCommand) {
         AuthContext authContext = ThreadLocalContext.getAuthContext();
         UserId userId = authContext.getUserId();
+        Nickname requested = new Nickname(updateBioCommand.nickName());
+        if (userProfileRepository.existsByNicknameAndUserIdNot(requested, userId)) {
+            throw ExceptionCreator.create(UserException.NICKNAME_ALREADY_EXISTS);
+        }
         MemberData memberData = memberRepository.findByUserAccountId(userId.getUid()).orElseThrow();
         memberData.updateProfileBio(updateBioCommand.nickName(), updateBioCommand.introduction());
         memberRepository.save(memberData);

--- a/user/src/main/java/com/pfplaybackend/api/user/application/service/UserProfileCommandService.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/service/UserProfileCommandService.java
@@ -3,6 +3,7 @@ package com.pfplaybackend.api.user.application.service;
 import com.pfplaybackend.api.avatar.application.dto.AvatarBodyDto;
 import com.pfplaybackend.api.common.domain.enums.AvatarCompositionType;
 import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserProfileRepository;
 import com.pfplaybackend.api.user.domain.entity.data.ProfileData;
 import com.pfplaybackend.api.user.domain.enums.FaceSourceType;
 import com.pfplaybackend.api.user.domain.value.Nickname;
@@ -14,13 +15,16 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 public class UserProfileCommandService {
+    private static final int GUEST_NICKNAME_MAX_ATTEMPTS = 5;
+
     private final UserAvatarQueryService userAvatarQueryService;
+    private final UserProfileRepository userProfileRepository;
 
     public ProfileData createProfileDataForGuest(UserId userId) {
         AvatarBodyDto avatarBodyResource = userAvatarQueryService.getDefaultAvatarBody();
         return ProfileData.builder()
                 .userId(userId)
-                .nickname(new Nickname(generateGuestNickname()))
+                .nickname(new Nickname(generateUniqueGuestNickname()))
                 .avatarCompositionType(AvatarCompositionType.BODY_WITH_FACE)
                 .faceSourceType(FaceSourceType.INTERNAL_IMAGE)
                 .avatarBodyUri(userAvatarQueryService.getDefaultAvatarBodyUri())
@@ -52,7 +56,13 @@ public class UserProfileCommandService {
                 .build();
     }
 
-    private String generateGuestNickname() {
-        return "Guest_" + UUID.randomUUID().toString().replace("-", "").substring(0, 6);
+    private String generateUniqueGuestNickname() {
+        for (int attempt = 0; attempt < GUEST_NICKNAME_MAX_ATTEMPTS; attempt++) {
+            String candidate = "Guest_" + UUID.randomUUID().toString().replace("-", "").substring(0, 6);
+            if (!userProfileRepository.existsByNickname(new Nickname(candidate))) {
+                return candidate;
+            }
+        }
+        return "Guest_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
     }
 }

--- a/user/src/main/java/com/pfplaybackend/api/user/domain/exception/UserException.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/domain/exception/UserException.java
@@ -1,0 +1,21 @@
+package com.pfplaybackend.api.user.domain.exception;
+
+import com.pfplaybackend.api.common.exception.DomainException;
+import com.pfplaybackend.api.common.exception.ErrorType;
+import lombok.Getter;
+
+@Getter
+public enum UserException implements DomainException {
+
+    NICKNAME_ALREADY_EXISTS("USR-001", "이미 사용 중인 닉네임입니다", ErrorType.CONFLICT);
+
+    private final String errorCode;
+    private final String message;
+    private final ErrorType errorType;
+
+    UserException(String errorCode, String message, ErrorType errorType) {
+        this.message = message;
+        this.errorCode = errorCode;
+        this.errorType = errorType;
+    }
+}

--- a/user/src/test/java/com/pfplaybackend/api/user/application/service/UserBioCommandServiceTest.java
+++ b/user/src/test/java/com/pfplaybackend/api/user/application/service/UserBioCommandServiceTest.java
@@ -3,10 +3,13 @@ package com.pfplaybackend.api.user.application.service;
 import com.pfplaybackend.api.common.ThreadLocalContext;
 import com.pfplaybackend.api.common.aspect.context.AuthContext;
 import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.exception.http.ConflictException;
 import com.pfplaybackend.api.user.adapter.out.persistence.MemberRepository;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserProfileRepository;
 import com.pfplaybackend.api.user.application.dto.command.UpdateBioCommand;
 import com.pfplaybackend.api.user.domain.entity.data.MemberData;
 import com.pfplaybackend.api.user.domain.event.UserProfileChangedEvent;
+import com.pfplaybackend.api.user.domain.value.Nickname;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +30,7 @@ import static org.mockito.Mockito.*;
 class UserBioCommandServiceTest {
 
     @Mock MemberRepository memberRepository;
+    @Mock UserProfileRepository userProfileRepository;
     @Mock ApplicationEventPublisher eventPublisher;
     @InjectMocks UserBioCommandService userBioService;
 
@@ -50,6 +54,7 @@ class UserBioCommandServiceTest {
     void updateMyBioSuccess() {
         // given
         MemberData member = mock(MemberData.class);
+        when(userProfileRepository.existsByNicknameAndUserIdNot(new Nickname("NewNick"), userId)).thenReturn(false);
         when(memberRepository.findByUserAccountId(userId.getUid())).thenReturn(Optional.of(member));
         UpdateBioCommand command = new UpdateBioCommand("NewNick", "Hello World");
 
@@ -63,9 +68,25 @@ class UserBioCommandServiceTest {
     }
 
     @Test
+    @DisplayName("updateMyBio — 다른 사용자가 같은 닉네임을 쓰고 있으면 CONFLICT(409)을 던진다")
+    void updateMyBioRejectsDuplicateNickname() {
+        // given
+        when(userProfileRepository.existsByNicknameAndUserIdNot(new Nickname("Taken"), userId)).thenReturn(true);
+        UpdateBioCommand command = new UpdateBioCommand("Taken", "Bio");
+
+        // when & then
+        assertThatThrownBy(() -> userBioService.updateMyBio(command))
+                .isInstanceOf(ConflictException.class);
+        verify(memberRepository, never()).findByUserAccountId(anyLong());
+        verify(memberRepository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
     @DisplayName("updateMyBio — 회원을 찾을 수 없으면 NoSuchElementException이 발생한다")
     void updateMyBioMemberNotFound() {
         // given
+        when(userProfileRepository.existsByNicknameAndUserIdNot(new Nickname("Nick"), userId)).thenReturn(false);
         when(memberRepository.findByUserAccountId(userId.getUid())).thenReturn(Optional.empty());
         UpdateBioCommand command = new UpdateBioCommand("Nick", "Bio");
 

--- a/user/src/test/java/com/pfplaybackend/api/user/application/service/UserProfileCommandServiceTest.java
+++ b/user/src/test/java/com/pfplaybackend/api/user/application/service/UserProfileCommandServiceTest.java
@@ -2,11 +2,13 @@ package com.pfplaybackend.api.user.application.service;
 
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.avatar.application.dto.AvatarBodyDto;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserProfileRepository;
 import com.pfplaybackend.api.user.domain.entity.data.ProfileData;
 import com.pfplaybackend.api.avatar.domain.enums.ObtainmentType;
 import com.pfplaybackend.api.avatar.domain.value.AvatarBodyUri;
 import com.pfplaybackend.api.avatar.domain.value.AvatarFaceUri;
 import com.pfplaybackend.api.avatar.domain.value.AvatarIconUri;
+import com.pfplaybackend.api.user.domain.value.Nickname;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +17,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -23,6 +28,7 @@ class UserProfileCommandServiceTest {
     private static final String DEFAULT_BODY = "default-body";
 
     @Mock UserAvatarQueryService userAvatarQueryService;
+    @Mock UserProfileRepository userProfileRepository;
     @InjectMocks UserProfileCommandService userProfileCommandService;
 
     @Test
@@ -40,6 +46,7 @@ class UserProfileCommandServiceTest {
         when(userAvatarQueryService.getDefaultAvatarBodyUri()).thenReturn(new AvatarBodyUri(DEFAULT_BODY));
         when(userAvatarQueryService.getDefaultAvatarFaceUri()).thenReturn(new AvatarFaceUri("default-face"));
         when(userAvatarQueryService.getDefaultAvatarIconUri()).thenReturn(new AvatarIconUri("default-icon"));
+        when(userProfileRepository.existsByNickname(any(Nickname.class))).thenReturn(false);
 
         // when
         ProfileData profile = userProfileCommandService.createProfileDataForGuest(userId);
@@ -48,6 +55,33 @@ class UserProfileCommandServiceTest {
         assertThat(profile.getUserId()).isEqualTo(userId);
         assertThat(profile.getNicknameValue()).startsWith("Guest_");
         assertThat(profile.getAvatarSetting().getAvatarBodyUri().getValue()).isEqualTo(DEFAULT_BODY);
+    }
+
+    @Test
+    @DisplayName("createProfileDataForGuest — 닉네임 충돌 시 새 후보로 재시도한다")
+    void createProfileDataForGuestRetriesOnCollision() {
+        // given
+        UserId userId = new UserId(2L);
+        AvatarBodyDto defaultBody = AvatarBodyDto.builder()
+                .id(1L).name("default").resourceUri(DEFAULT_BODY)
+                .obtainableType(ObtainmentType.BASIC).obtainableScore(0)
+                .combinable(true).defaultSetting(true)
+                .combinePositionX(50).combinePositionY(100)
+                .build();
+        when(userAvatarQueryService.getDefaultAvatarBody()).thenReturn(defaultBody);
+        when(userAvatarQueryService.getDefaultAvatarBodyUri()).thenReturn(new AvatarBodyUri(DEFAULT_BODY));
+        when(userAvatarQueryService.getDefaultAvatarFaceUri()).thenReturn(new AvatarFaceUri("default-face"));
+        when(userAvatarQueryService.getDefaultAvatarIconUri()).thenReturn(new AvatarIconUri("default-icon"));
+        when(userProfileRepository.existsByNickname(any(Nickname.class)))
+                .thenReturn(true)
+                .thenReturn(false);
+
+        // when
+        ProfileData profile = userProfileCommandService.createProfileDataForGuest(userId);
+
+        // then
+        assertThat(profile.getNicknameValue()).startsWith("Guest_");
+        verify(userProfileRepository, times(2)).existsByNickname(any(Nickname.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Promotes #192 (uniqueness guards + V15 migration) to release for auto-deploy.

- DB unique indexes on `user_profile.nickname` and `partyroom.link_domain`.
- Service-level pre-checks with HTTP 409 (USR-001 / PTR-008) and retry loops for auto-generated values.
- Pre-deploy data wipe **already executed** on stg + dev (Redis FLUSHDB included), so V15 will apply against a clean schema.

## Pre-deploy state (verified)

| | stg | dev |
|---|---|---|
| user_account / user_profile / member | 0 / 0 / 0 | 0 / 0 / 0 |
| crew / partyroom | 0 / **1** (Main Stage) | 0 / **1** (Main Stage) |
| dj / dj_queue / playback / playlist / track | 0 each | 0 each |
| administrator / avatar_body_resource / system_config / flyway_schema_history | 1 / 15 / 2 / 14 | 1 / 15 / 2 / 14 |
| Redis DBSIZE | 0 | 0 |

Main Stage row preserved with reset state (`host_id=NULL`, `crew_count=0`, `is_activated=0`).

## Frontend coordination

pfplay-web E2E flows must be updated before next E2E run:
1. Generate unique nickname per test run (literal `\"nickname\"` will now 409).
2. Either omit `linkDomain` (server auto-gens) or generate unique value.
3. Call `PUT /api/v1/users/me/profile/avatar` after signup (composition_type non-NULL).

## Related

- PR #192 (this content, merged to develop)
- Issue #193 (separate: crew re-entry leaves stale exited_at — out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)