### PR TITLE
feat(presence): grace window for transient disconnects

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/operations/application/service/SystemConfigCache.java
+++ b/app/src/main/java/com/pfplaybackend/api/operations/application/service/SystemConfigCache.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * In-memory snapshot cache for SystemConfig (maintenance mode keys).
+ * In-memory snapshot cache for SystemConfig.
  *
  * 30-second TTL. Per-instance — no distributed invalidation in PR 3.
  * Tolerated staleness window matches spec (§9.3 "system_config 캐시 stale: 캐시 TTL 30~60초").
@@ -25,6 +25,8 @@ public class SystemConfigCache {
 
     static final Duration SNAPSHOT_TTL = Duration.ofSeconds(30);
     static final String DEFAULT_MAINTENANCE_MESSAGE = "시스템 점검 중입니다.";
+    static final int DEFAULT_DJ_GRACE_SECONDS = 30;
+    static final int DEFAULT_LISTENER_GRACE_SECONDS = 10;
 
     private final SystemConfigRepository repository;
     private final Clock clock;
@@ -41,6 +43,14 @@ public class SystemConfigCache {
 
     public String getMaintenanceMessage() {
         return current().maintenanceMessage;
+    }
+
+    public int getDjGraceSeconds() {
+        return current().djGraceSeconds;
+    }
+
+    public int getListenerGraceSeconds() {
+        return current().listenerGraceSeconds;
     }
 
     /** Public so PR 6's event listener can force-invalidate after admin toggle. */
@@ -62,7 +72,9 @@ public class SystemConfigCache {
     private Snapshot fetch(Instant now) {
         boolean enabled = readBool(ConfigKey.MAINTENANCE_ENABLED, false);
         String message = readString(ConfigKey.MAINTENANCE_MESSAGE, DEFAULT_MAINTENANCE_MESSAGE);
-        return new Snapshot(enabled, message, now);
+        int djGrace = readInt(ConfigKey.PRESENCE_DJ_GRACE_SECONDS, DEFAULT_DJ_GRACE_SECONDS);
+        int listenerGrace = readInt(ConfigKey.PRESENCE_LISTENER_GRACE_SECONDS, DEFAULT_LISTENER_GRACE_SECONDS);
+        return new Snapshot(enabled, message, djGrace, listenerGrace, now);
     }
 
     /**
@@ -87,5 +99,24 @@ public class SystemConfigCache {
             .orElse(fallback);
     }
 
-    private record Snapshot(boolean maintenanceEnabled, String maintenanceMessage, Instant fetchedAt) {}
+    /**
+     * Fail-open: missing rows, blank values, non-numeric values, or non-positive integers
+     * fall back to {@code fallback}. A typo must not brick presence semantics.
+     */
+    private int readInt(ConfigKey key, int fallback) {
+        Optional<SystemConfigData> row = repository.findByConfigKey(key.value());
+        if (row.isEmpty()) return fallback;
+        String v = row.get().getConfigValue();
+        if (v == null || v.isBlank()) return fallback;
+        try {
+            int parsed = Integer.parseInt(v.trim());
+            return parsed > 0 ? parsed : fallback;
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    private record Snapshot(boolean maintenanceEnabled, String maintenanceMessage,
+                            int djGraceSeconds, int listenerGraceSeconds,
+                            Instant fetchedAt) {}
 }

--- a/app/src/main/java/com/pfplaybackend/api/operations/domain/value/ConfigKey.java
+++ b/app/src/main/java/com/pfplaybackend/api/operations/domain/value/ConfigKey.java
@@ -38,4 +38,6 @@ public record ConfigKey(String value) {
     // Well-known keys
     public static final ConfigKey MAINTENANCE_ENABLED = new ConfigKey("maintenance.enabled");
     public static final ConfigKey MAINTENANCE_MESSAGE = new ConfigKey("maintenance.message");
+    public static final ConfigKey PRESENCE_DJ_GRACE_SECONDS = new ConfigKey("presence.dj_grace_seconds");
+    public static final ConfigKey PRESENCE_LISTENER_GRACE_SECONDS = new ConfigKey("presence.listener_grace_seconds");
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/PresenceExpirationListener.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/PresenceExpirationListener.java
@@ -1,0 +1,60 @@
+package com.pfplaybackend.api.party.adapter.in.listener;
+
+import com.pfplaybackend.api.party.application.service.PartyroomPresenceService;
+import com.pfplaybackend.api.party.application.service.PartyroomPresenceService.ParsedPresenceKey;
+import com.pfplaybackend.api.party.application.service.lock.DistributedLockExecutor;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+
+/**
+ * Subscribes to Redis {@code __keyevent@*__:expired} pattern and dispatches
+ * {@code PRESENCE:PENDING:<roomId>:<crewId>} expirations to
+ * {@link PartyroomPresenceService#forceOffline}.
+ *
+ * <p>Co-exists with {@link PlaybackDurationWaitTopicListener} on the same pattern;
+ * each filters by its own key prefix. Spring Redis delivers every expired event
+ * to all subscribers, so both run for every expiration but only act on matching
+ * keys.
+ *
+ * <p>If this listener is not subscribed at the moment a key expires (e.g., app
+ * restart spans the TTL), the event is permanently lost — Redis pub/sub does not
+ * buffer (Issue #195). Mitigated by the reconcile cron that periodically scans
+ * stale {@code crew.pending_exit_at} rows and calls {@code forceOffline}
+ * idempotently.
+ */
+@Slf4j
+@AllArgsConstructor
+public class PresenceExpirationListener implements MessageListener {
+
+    private static final String KEY_PREFIX = "PRESENCE:PENDING:";
+
+    private final PartyroomPresenceService presenceService;
+    private final DistributedLockExecutor distributedLockExecutor;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String expiredKey = message.toString();
+        if (!expiredKey.startsWith(KEY_PREFIX)) {
+            return;
+        }
+        ParsedPresenceKey parsed = PartyroomPresenceService.parseKey(expiredKey);
+        if (parsed == null) {
+            log.warn("[presence] malformed expired key: {}", expiredKey);
+            return;
+        }
+        // Lock per crew so the reconcile cron and this listener cannot race on
+        // the same row. forceOffline is itself idempotent, but the lock keeps the
+        // event-publishing path single-shot.
+        String lockKey = "presence:" + parsed.crewId().getId();
+        try {
+            distributedLockExecutor.performTaskWithLock(lockKey, () -> {
+                presenceService.forceOffline(parsed.partyroomId(), parsed.crewId());
+                return null;
+            });
+        } catch (Exception e) {
+            log.warn("[presence] failed to process expired key={} : {}", expiredKey, e.getMessage());
+        }
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/config/RedisListenerConfig.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/config/RedisListenerConfig.java
@@ -5,9 +5,11 @@ import com.pfplaybackend.api.common.config.redis.RedisMessagePublisher;
 import com.pfplaybackend.api.party.adapter.in.listener.CrewProfilePreCheckTopicListener;
 import com.pfplaybackend.api.party.adapter.in.listener.GroupBroadcastTopicListener;
 import com.pfplaybackend.api.party.adapter.in.listener.PlaybackDurationWaitTopicListener;
+import com.pfplaybackend.api.party.adapter.in.listener.PresenceExpirationListener;
 import com.pfplaybackend.api.party.adapter.in.listener.message.*;
 import com.pfplaybackend.api.party.application.port.out.ExpirationTaskPort;
 import com.pfplaybackend.api.party.application.service.CrewProfileChangeEventHandler;
+import com.pfplaybackend.api.party.application.service.PartyroomPresenceService;
 import com.pfplaybackend.api.party.application.service.PlaybackCommandService;
 import com.pfplaybackend.api.party.application.service.lock.DistributedLockExecutor;
 import com.pfplaybackend.realtime.sender.SimpMessageSender;
@@ -35,6 +37,7 @@ public class RedisListenerConfig {
                                                         DistributedLockExecutor distributedLockExecutor,
                                                         CrewProfileChangeEventHandler crewProfileService,
                                                         PlaybackCommandService playbackCommandService,
+                                                        PartyroomPresenceService presenceService,
                                                         ExpirationTaskPort expirationTaskPort,
                                                         RedisMessagePublisher messagePublisher,
                                                         ObjectMapper objectMapper) {
@@ -63,6 +66,7 @@ public class RedisListenerConfig {
         // Special listeners with business logic
         container.addMessageListener(new CrewProfilePreCheckTopicListener(objectMapper, distributedLockExecutor, crewProfileService, messagePublisher), new ChannelTopic("crew_profile_pre_check"));
         container.addMessageListener(new PlaybackDurationWaitTopicListener(expirationTaskPort, distributedLockExecutor, playbackCommandService), new PatternTopic("__keyevent@*__:expired"));
+        container.addMessageListener(new PresenceExpirationListener(presenceService, distributedLockExecutor), new PatternTopic("__keyevent@*__:expired"));
         return container;
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/CrewRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/CrewRepository.java
@@ -22,14 +22,50 @@ public interface CrewRepository extends JpaRepository<CrewData, Long> {
      *  - 반환 1: is_active=false → true 전이 발생 (호출자는 ENTER 이벤트 발행 의무)
      *  - 반환 0: row 없거나 이미 active (호출자는 후속 분기 — 새 INSERT 또는 idempotent return)
      * Race B-reentry 차단: 동시 호출 중 정확히 한 호출자만 1 반환.
+     *
+     * Resets exited_at and pending_exit_at to NULL so stale values from prior sessions
+     * do not poison the new active row (fixes Issue #193).
      */
     @Modifying(clearAutomatically = true)
     @Query("UPDATE CrewData c " +
-           "SET c.isActive = true, c.enteredAt = :now " +
+           "SET c.isActive = true, c.enteredAt = :now, c.exitedAt = NULL, c.pendingExitAt = NULL " +
            "WHERE c.partyroomId = :partyroomId AND c.userId = :userId AND c.isActive = false")
     int activateCrew(@Param("partyroomId") PartyroomId partyroomId,
                      @Param("userId") UserId userId,
                      @Param("now") LocalDateTime now);
+
+    /**
+     * Crew rows stuck in PENDING_EXIT past the threshold. Used by reconcile cron to
+     * recover from lost Redis expired events (Issue #195) and process them as OFFLINE.
+     */
+    @Query("SELECT c FROM CrewData c " +
+           "WHERE c.isActive = true AND c.pendingExitAt IS NOT NULL AND c.pendingExitAt < :threshold")
+    List<CrewData> findStalePending(@Param("threshold") LocalDateTime threshold);
+
+    /**
+     * Conditional clear of pending_exit_at on reconnect. Returns 1 when the transition
+     * PENDING_EXIT → ONLINE actually occurred (caller is the unique winner; race losers
+     * see 0 and return idempotently).
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE CrewData c SET c.pendingExitAt = NULL " +
+           "WHERE c.partyroomId = :partyroomId AND c.userId = :userId " +
+           "AND c.isActive = true AND c.pendingExitAt IS NOT NULL")
+    int clearPending(@Param("partyroomId") PartyroomId partyroomId,
+                     @Param("userId") UserId userId);
+
+    /**
+     * Conditional set of pending_exit_at on disconnect. Returns 1 when the transition
+     * ONLINE → PENDING_EXIT actually occurred. Idempotent: returns 0 if already pending
+     * (so the original timestamp/grace is not extended) or if crew is already inactive.
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE CrewData c SET c.pendingExitAt = :now " +
+           "WHERE c.partyroomId = :partyroomId AND c.userId = :userId " +
+           "AND c.isActive = true AND c.pendingExitAt IS NULL")
+    int markPending(@Param("partyroomId") PartyroomId partyroomId,
+                    @Param("userId") UserId userId,
+                    @Param("now") LocalDateTime now);
 
     /**
      * crew row를 inactive로 조건부 toggle.

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomAggregateAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomAggregateAdapter.java
@@ -95,6 +95,21 @@ public class PartyroomAggregateAdapter implements PartyroomAggregatePort, Partyr
         return crewRepository.deactivateCrew(partyroomId, userId, now);
     }
 
+    @Override
+    public int markCrewPending(PartyroomId partyroomId, UserId userId, LocalDateTime now) {
+        return crewRepository.markPending(partyroomId, userId, now);
+    }
+
+    @Override
+    public int clearCrewPending(PartyroomId partyroomId, UserId userId) {
+        return crewRepository.clearPending(partyroomId, userId);
+    }
+
+    @Override
+    public List<CrewData> findStalePendingCrews(LocalDateTime threshold) {
+        return crewRepository.findStalePending(threshold);
+    }
+
     // ===== DJ: DjData =====
 
     @Override

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/realtime/PresencePortAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/realtime/PresencePortAdapter.java
@@ -1,0 +1,53 @@
+package com.pfplaybackend.api.party.adapter.out.realtime;
+
+import com.pfplaybackend.api.party.application.dto.partyroom.PartyroomSessionDto;
+import com.pfplaybackend.api.party.application.service.PartyroomPresenceService;
+import com.pfplaybackend.realtime.port.PresencePort;
+import com.pfplaybackend.realtime.port.SessionCachePort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+/**
+ * Bridges STOMP session events (in the realtime module) to the partyroom presence
+ * service (in the app module). The realtime listener fires with only a sessionId;
+ * we resolve it to {@code (partyroomId, userId)} via the session cache that
+ * {@code SubscriptionEventListener} populates on subscribe.
+ *
+ * <p>If the session cache lookup misses (e.g., disconnect arrives before subscribe
+ * completed, or for a non-partyroom subscription), both methods are silent no-ops.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PresencePortAdapter implements PresencePort {
+
+    private final SessionCachePort sessionCachePort;
+    private final PartyroomPresenceService presenceService;
+
+    @Override
+    public void onSessionConnected(String sessionId) {
+        resolve(sessionId).ifPresent(dto ->
+                presenceService.clearPending(dto.partyroomId(), dto.userId()));
+    }
+
+    @Override
+    public void onSessionDisconnected(String sessionId) {
+        resolve(sessionId).ifPresent(dto ->
+                presenceService.markPending(dto.partyroomId(), dto.userId()));
+    }
+
+    private Optional<PartyroomSessionDto> resolve(String sessionId) {
+        Optional<Object> cached = sessionCachePort.getSessionCache(sessionId);
+        if (cached.isEmpty()) return Optional.empty();
+        Object obj = cached.get();
+        if (!(obj instanceof PartyroomSessionDto dto)) {
+            log.debug("[presence] session cache for {} is not a PartyroomSessionDto: {}",
+                    sessionId, obj.getClass().getSimpleName());
+            return Optional.empty();
+        }
+        return Optional.of(dto);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
@@ -202,6 +202,17 @@ public class PartyroomAccessCommandService {
     public void exit(PartyroomId partyroomId) {
         AuthContext authContext = ThreadLocalContext.getAuthContext();
         UserId userId = authContext.getUserId();
+        exitInternal(partyroomId, userId);
+    }
+
+    /**
+     * exit() body extracted so non-HTTP callers (presence grace expiration listener,
+     * reconcile cron) can run the same flow without ThreadLocal AuthContext setup.
+     * Strict invariant: callers MUST already have authority to act on this user/room
+     * (e.g., the user themselves, or system-level recovery actions).
+     */
+    @Transactional
+    public void exitInternal(PartyroomId partyroomId, UserId userId) {
         log.info("[exit] START - userId={}, partyroomId={}", userId, partyroomId.getId());
 
         PartyroomData partyroom = partyroomQueryService.getPartyroomById(partyroomId);

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomPresenceService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomPresenceService.java
@@ -1,0 +1,202 @@
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.operations.application.service.SystemConfigCache;
+import com.pfplaybackend.api.party.application.service.lock.DistributedLockExecutor;
+import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
+import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
+import com.pfplaybackend.api.party.domain.value.CrewId;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Presence grace state machine.
+ *
+ * <pre>
+ *   ONLINE ──[disconnect]──► PENDING_EXIT ──[grace TTL]──► OFFLINE
+ *      ▲                          │
+ *      └──[reconnect within grace]┘
+ * </pre>
+ *
+ * <p>DB column {@code crew.pending_exit_at} is the source of truth. Redis key
+ * {@code PRESENCE:PENDING:<roomId>:<crewId>} with TTL = grace_seconds drives the
+ * timer (event consumed by {@code PresenceExpirationListener}). A reconcile cron
+ * provides safety against lost expired events (Issue #195).
+ *
+ * <p>All transitions other than {@code forceOffline} are silent — no domain events
+ * published, no STOMP broadcast. The room is unaware until OFFLINE actually fires.
+ *
+ * <p>See {@code docs/superpowers/specs/2026-05-09-presence-grace-window-design.md}.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PartyroomPresenceService {
+
+    private static final String PRESENCE_KEY_PREFIX = "PRESENCE:PENDING:";
+    /** Reconcile look-back: max possible grace + buffer for Redis delivery skew. */
+    private static final long RECONCILE_BUFFER_SECONDS = 30;
+
+    private final PartyroomAggregatePort aggregatePort;
+    private final PartyroomAccessCommandService partyroomAccessCommandService;
+    private final SystemConfigCache systemConfigCache;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final DistributedLockExecutor distributedLockExecutor;
+    private final Clock clock;
+
+    /**
+     * ONLINE → PENDING_EXIT. Idempotent: re-firing while already pending is a no-op
+     * (original timestamp preserved, grace not extended). Returns silently if the
+     * crew row is missing or already inactive.
+     */
+    @Transactional
+    public void markPending(PartyroomId partyroomId, UserId userId) {
+        Optional<CrewData> optCrew = aggregatePort.findCrew(partyroomId, userId);
+        if (optCrew.isEmpty() || !optCrew.get().isActive()) {
+            return;
+        }
+        CrewData crew = optCrew.get();
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        int updated = aggregatePort.markCrewPending(partyroomId, userId, now);
+        if (updated == 0) {
+            // Already pending or already inactive; do not overwrite Redis TTL.
+            return;
+        }
+
+        int graceSeconds = pickGraceSeconds(partyroomId, new CrewId(crew.getId()));
+        String key = presenceKey(partyroomId, new CrewId(crew.getId()));
+        redisTemplate.opsForValue().set(key, "", graceSeconds, TimeUnit.SECONDS);
+        log.info("[presence] PENDING_EXIT - userId={}, partyroomId={}, graceSeconds={}",
+                userId, partyroomId.getId(), graceSeconds);
+    }
+
+    /**
+     * PENDING_EXIT → ONLINE. No-op if not currently pending. Returns silently —
+     * this transition is invisible to the room.
+     */
+    @Transactional
+    public void clearPending(PartyroomId partyroomId, UserId userId) {
+        int cleared = aggregatePort.clearCrewPending(partyroomId, userId);
+        if (cleared == 0) {
+            return;
+        }
+        Optional<CrewData> crew = aggregatePort.findCrew(partyroomId, userId);
+        crew.ifPresent(c -> redisTemplate.delete(presenceKey(partyroomId, new CrewId(c.getId()))));
+        log.info("[presence] ONLINE restored - userId={}, partyroomId={}",
+                userId, partyroomId.getId());
+    }
+
+    /**
+     * PENDING_EXIT → OFFLINE by crewId. Used by the Redis expiration listener
+     * (which only has the parsed key) and by the reconcile cron.
+     *
+     * <p>Re-reads DB to confirm the crew is still PENDING_EXIT — if they reconnected
+     * before this handler ran, returns without side effects. Otherwise delegates to
+     * {@link PartyroomAccessCommandService#exitInternal} which performs the
+     * authoritative deactivation, DJ-queue cleanup, and {@code crew_exited}
+     * broadcast.
+     */
+    @Transactional
+    public void forceOffline(PartyroomId partyroomId, CrewId crewId) {
+        Optional<CrewData> optCrew = aggregatePort.findCrewById(crewId.getId());
+        if (optCrew.isEmpty()) {
+            redisTemplate.delete(presenceKey(partyroomId, crewId));
+            return;
+        }
+        CrewData crew = optCrew.get();
+        if (!crew.isActive() || !crew.isPendingExit()) {
+            // Already exited (race with explicit Exit) or reconnected before this
+            // handler arrived — nothing to do beyond cleaning up the Redis key.
+            redisTemplate.delete(presenceKey(partyroomId, crewId));
+            return;
+        }
+        log.info("[presence] OFFLINE promotion - userId={}, partyroomId={}, pendingSince={}",
+                crew.getUserId(), partyroomId.getId(), crew.getPendingExitAt());
+
+        partyroomAccessCommandService.exitInternal(partyroomId, crew.getUserId());
+        redisTemplate.delete(presenceKey(partyroomId, crewId));
+    }
+
+    private int pickGraceSeconds(PartyroomId partyroomId, CrewId crewId) {
+        PartyroomPlaybackData playbackState = aggregatePort.findPlaybackState(partyroomId);
+        boolean isCurrentDj = playbackState != null
+                && playbackState.isActivated()
+                && playbackState.isCurrentDj(crewId);
+        return isCurrentDj
+                ? systemConfigCache.getDjGraceSeconds()
+                : systemConfigCache.getListenerGraceSeconds();
+    }
+
+    static String presenceKey(PartyroomId partyroomId, CrewId crewId) {
+        return PRESENCE_KEY_PREFIX + partyroomId.getId() + ":" + crewId.getId();
+    }
+
+    /**
+     * Parses a Redis presence key back into (partyroomId, crewId). Returns null on
+     * malformed input — caller logs and skips.
+     */
+    public static ParsedPresenceKey parseKey(String key) {
+        if (key == null || !key.startsWith(PRESENCE_KEY_PREFIX)) return null;
+        String suffix = key.substring(PRESENCE_KEY_PREFIX.length());
+        int sep = suffix.indexOf(':');
+        if (sep <= 0 || sep == suffix.length() - 1) return null;
+        try {
+            long partyroomId = Long.parseLong(suffix.substring(0, sep));
+            long crewId = Long.parseLong(suffix.substring(sep + 1));
+            return new ParsedPresenceKey(new PartyroomId(partyroomId), new CrewId(crewId));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    public record ParsedPresenceKey(PartyroomId partyroomId, CrewId crewId) {}
+
+    /**
+     * Reconciliation safety net for Issue #195: Redis pub/sub does not buffer
+     * expired-key events, so any TTL that elapses while the listener is not
+     * subscribed (app restart, network blip on the Redis connection) is lost
+     * forever. This cron sweeps DB rows whose {@code pending_exit_at} is older
+     * than the maximum possible grace and forces them OFFLINE.
+     *
+     * <p>Doubles as startup recovery — the first tick after boot catches anything
+     * stranded during downtime.
+     *
+     * <p>Idempotent w.r.t. the Redis listener path: both call {@code forceOffline},
+     * which re-checks DB and returns early if the row no longer qualifies. The
+     * per-crew distributed lock prevents simultaneous publish of the EXIT event.
+     */
+    @Scheduled(fixedDelay = 60_000)
+    public void reconcileStalePending() {
+        long maxGrace = Math.max(systemConfigCache.getDjGraceSeconds(),
+                                 systemConfigCache.getListenerGraceSeconds());
+        LocalDateTime threshold = LocalDateTime.now(clock).minusSeconds(maxGrace + RECONCILE_BUFFER_SECONDS);
+        List<CrewData> stale = aggregatePort.findStalePendingCrews(threshold);
+        if (stale.isEmpty()) return;
+
+        log.info("[presence] reconcile sweep found {} stale PENDING_EXIT crew(s)", stale.size());
+        for (CrewData crew : stale) {
+            try {
+                String lockKey = "presence:" + crew.getId();
+                distributedLockExecutor.performTaskWithLock(lockKey, () -> {
+                    forceOffline(crew.getPartyroomId(), new CrewId(crew.getId()));
+                    return null;
+                });
+            } catch (Exception e) {
+                log.warn("[presence] reconcile failed for crewId={} : {}", crew.getId(), e.getMessage());
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/CrewData.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/CrewData.java
@@ -58,6 +58,9 @@ public class CrewData extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime enteredAt;
     private LocalDateTime exitedAt;
+    // Presence grace window: when set, the crew row is in PENDING_EXIT (still is_active=1
+    // but client signal lost). Cleared on reconnect; promoted to OFFLINE when grace elapses.
+    private LocalDateTime pendingExitAt;
     // 입장 시점에 프론트엔드가 전달한 국가 코드 (ISO 3166-1 alpha-2). 전달되지 않으면 null.
     @Column(name = "country_code", length = 2)
     @Convert(converter = CountryCodeConverter.class)
@@ -69,6 +72,7 @@ public class CrewData extends BaseEntity {
     @Builder
     public CrewData(Long id, PartyroomId partyroomId, UserId userId, GradeType gradeType,
                     boolean isActive, boolean isBanned, LocalDateTime enteredAt, LocalDateTime exitedAt,
+                    LocalDateTime pendingExitAt,
                     CountryCode countryCode,
                     LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
@@ -79,6 +83,7 @@ public class CrewData extends BaseEntity {
         this.isBanned = isBanned;
         this.enteredAt = enteredAt;
         this.exitedAt = exitedAt;
+        this.pendingExitAt = pendingExitAt;
         this.countryCode = countryCode;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
@@ -107,19 +112,40 @@ public class CrewData extends BaseEntity {
     public void deactivatePresence(LocalDateTime now) {
         this.isActive = false;
         this.exitedAt = now;
+        this.pendingExitAt = null;
     }
 
     public void deactivatePresence() {
         deactivatePresence(LocalDateTime.now());
     }
 
+    /**
+     * Re-entry path: clears prior exited_at and pending_exit_at so a stale value from a
+     * previous session does not poison the new active row. Fixes Issue #193.
+     */
     public void activatePresence(LocalDateTime now) {
         this.isActive = true;
         this.enteredAt = now;
+        this.exitedAt = null;
+        this.pendingExitAt = null;
     }
 
     public void activatePresence() {
         activatePresence(LocalDateTime.now());
+    }
+
+    public void markPending(LocalDateTime now) {
+        if (this.pendingExitAt == null) {
+            this.pendingExitAt = now;
+        }
+    }
+
+    public void clearPending() {
+        this.pendingExitAt = null;
+    }
+
+    public boolean isPendingExit() {
+        return this.pendingExitAt != null;
     }
 
     public void updateGrade(GradeType gradeType) {

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/port/PartyroomAggregatePort.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/port/PartyroomAggregatePort.java
@@ -29,6 +29,12 @@ public interface PartyroomAggregatePort {
     /** 조건부 atomic toggle. 반환값: 1 (전이 발생) / 0 (미전이). 자세한 시맨틱은 CrewRepository javadoc. */
     int activateCrew(PartyroomId partyroomId, UserId userId, LocalDateTime now);
     int deactivateCrew(PartyroomId partyroomId, UserId userId, LocalDateTime now);
+    /** Presence grace: ONLINE → PENDING_EXIT atomic toggle. 1 = transition occurred, 0 = no-op. */
+    int markCrewPending(PartyroomId partyroomId, UserId userId, LocalDateTime now);
+    /** Presence grace: PENDING_EXIT → ONLINE atomic toggle. 1 = transition occurred, 0 = no-op. */
+    int clearCrewPending(PartyroomId partyroomId, UserId userId);
+    /** Presence grace reconciliation: rows whose pending_exit_at is older than threshold. */
+    List<CrewData> findStalePendingCrews(LocalDateTime threshold);
 
     // ===== DJ: DjData =====
     List<DjData> findDjsOrdered(PartyroomId partyroomId);

--- a/app/src/main/resources/db/migration/V16__add_presence.sql
+++ b/app/src/main/resources/db/migration/V16__add_presence.sql
@@ -1,0 +1,11 @@
+-- Presence grace window: distinguish "client disconnected briefly" (PENDING_EXIT)
+-- from "client confirmed gone" (OFFLINE). DB row is the source of truth; Redis
+-- TTL key drives the grace timer (with cron safety net for app-restart durability).
+
+ALTER TABLE crew
+    ADD COLUMN pending_exit_at DATETIME(6) NULL,
+    ADD INDEX idx_crew_pending_exit (pending_exit_at);
+
+INSERT INTO system_config (config_key, config_value, description) VALUES
+    ('presence.dj_grace_seconds',       '30', '현재 DJ가 끊겼을 때 OFFLINE 판정까지의 유예(초)'),
+    ('presence.listener_grace_seconds', '10', '일반 listener가 끊겼을 때 OFFLINE 판정까지의 유예(초)');

--- a/app/src/test/java/com/pfplaybackend/api/operations/application/service/SystemConfigCacheTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/operations/application/service/SystemConfigCacheTest.java
@@ -48,14 +48,58 @@ class SystemConfigCacheTest {
     void second_call_within_ttl_does_not_hit_repo() {
         when(repository.findByConfigKey(anyString()))
             .thenReturn(Optional.of(seed("maintenance.enabled", "false")))
-            .thenReturn(Optional.of(seed("maintenance.message", "")));
+            .thenReturn(Optional.of(seed("maintenance.message", "")))
+            .thenReturn(Optional.of(seed("presence.dj_grace_seconds", "30")))
+            .thenReturn(Optional.of(seed("presence.listener_grace_seconds", "10")));
 
         cache.isMaintenanceMode();
         clock.advanceSeconds(29);
         cache.isMaintenanceMode();
         cache.getMaintenanceMessage();
+        cache.getDjGraceSeconds();
+        cache.getListenerGraceSeconds();
 
-        verify(repository, times(2)).findByConfigKey(anyString()); // initial pair only
+        // One snapshot fetch loads all four keys; further reads within TTL hit no repo.
+        verify(repository, times(4)).findByConfigKey(anyString());
+    }
+
+    @Test
+    void readInt_returns_value_for_valid_int() {
+        when(repository.findByConfigKey(ConfigKey.MAINTENANCE_ENABLED.value()))
+            .thenReturn(Optional.empty());
+        when(repository.findByConfigKey(ConfigKey.MAINTENANCE_MESSAGE.value()))
+            .thenReturn(Optional.empty());
+        when(repository.findByConfigKey(ConfigKey.PRESENCE_DJ_GRACE_SECONDS.value()))
+            .thenReturn(Optional.of(seed("presence.dj_grace_seconds", "45")));
+        when(repository.findByConfigKey(ConfigKey.PRESENCE_LISTENER_GRACE_SECONDS.value()))
+            .thenReturn(Optional.of(seed("presence.listener_grace_seconds", "  15  ")));
+
+        assertThat(cache.getDjGraceSeconds()).isEqualTo(45);
+        assertThat(cache.getListenerGraceSeconds()).isEqualTo(15);
+    }
+
+    @Test
+    void readInt_falls_back_on_garbage() {
+        when(repository.findByConfigKey(ConfigKey.MAINTENANCE_ENABLED.value()))
+            .thenReturn(Optional.empty());
+        when(repository.findByConfigKey(ConfigKey.MAINTENANCE_MESSAGE.value()))
+            .thenReturn(Optional.empty());
+        when(repository.findByConfigKey(ConfigKey.PRESENCE_DJ_GRACE_SECONDS.value()))
+            .thenReturn(Optional.of(seed("presence.dj_grace_seconds", "thirty")));
+        when(repository.findByConfigKey(ConfigKey.PRESENCE_LISTENER_GRACE_SECONDS.value()))
+            .thenReturn(Optional.of(seed("presence.listener_grace_seconds", "-5")));
+
+        // Defaults: 30 / 10
+        assertThat(cache.getDjGraceSeconds()).isEqualTo(30);
+        assertThat(cache.getListenerGraceSeconds()).isEqualTo(10);
+    }
+
+    @Test
+    void readInt_falls_back_on_missing_row() {
+        when(repository.findByConfigKey(anyString())).thenReturn(Optional.empty());
+
+        assertThat(cache.getDjGraceSeconds()).isEqualTo(30);
+        assertThat(cache.getListenerGraceSeconds()).isEqualTo(10);
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomPresenceServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomPresenceServiceTest.java
@@ -1,0 +1,242 @@
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.operations.application.service.SystemConfigCache;
+import com.pfplaybackend.api.party.application.service.lock.DistributedLockExecutor;
+import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
+import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
+import com.pfplaybackend.api.party.domain.value.CrewId;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PartyroomPresenceServiceTest {
+
+    private static final long PARTY_ID = 100L;
+    private static final long USER_UID = 200L;
+    private static final long CREW_ID = 300L;
+
+    @Mock PartyroomAggregatePort aggregatePort;
+    @Mock PartyroomAccessCommandService partyroomAccessCommandService;
+    @Mock SystemConfigCache systemConfigCache;
+    @Mock RedisTemplate<String, Object> redisTemplate;
+    @Mock ValueOperations<String, Object> valueOps;
+    @Mock DistributedLockExecutor distributedLockExecutor;
+
+    PartyroomPresenceService service;
+    Clock clock;
+
+    @BeforeEach
+    void setUp() {
+        clock = Clock.fixed(Instant.parse("2026-05-09T12:00:00Z"), ZoneId.of("UTC"));
+        service = new PartyroomPresenceService(aggregatePort, partyroomAccessCommandService,
+                systemConfigCache, redisTemplate, distributedLockExecutor, clock);
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    }
+
+    private PartyroomId roomId() { return new PartyroomId(PARTY_ID); }
+    private UserId userId() { return new UserId(USER_UID); }
+    private CrewId crewId() { return new CrewId(CREW_ID); }
+
+    private CrewData activeCrew(boolean pending) {
+        return CrewData.builder()
+                .id(CREW_ID)
+                .partyroomId(roomId())
+                .userId(userId())
+                .isActive(true)
+                .pendingExitAt(pending ? LocalDateTime.now(clock) : null)
+                .enteredAt(LocalDateTime.now(clock).minusMinutes(5))
+                .build();
+    }
+
+    @Test
+    @DisplayName("markPending — listener인 사용자에게 listener grace로 Redis 키 SET")
+    void markPendingListener() {
+        when(aggregatePort.findCrew(roomId(), userId())).thenReturn(Optional.of(activeCrew(false)));
+        when(aggregatePort.markCrewPending(eq(roomId()), eq(userId()), any(LocalDateTime.class))).thenReturn(1);
+        PartyroomPlaybackData playback = mockPlayback(false);
+        when(aggregatePort.findPlaybackState(roomId())).thenReturn(playback);
+        when(systemConfigCache.getListenerGraceSeconds()).thenReturn(10);
+
+        service.markPending(roomId(), userId());
+
+        verify(valueOps).set(eq("PRESENCE:PENDING:" + PARTY_ID + ":" + CREW_ID), eq(""), eq(10L), eq(TimeUnit.SECONDS));
+    }
+
+    @Test
+    @DisplayName("markPending — 현재 DJ에게는 DJ grace로 Redis 키 SET")
+    void markPendingCurrentDj() {
+        when(aggregatePort.findCrew(roomId(), userId())).thenReturn(Optional.of(activeCrew(false)));
+        when(aggregatePort.markCrewPending(eq(roomId()), eq(userId()), any(LocalDateTime.class))).thenReturn(1);
+        PartyroomPlaybackData playback = mockPlayback(true);
+        when(aggregatePort.findPlaybackState(roomId())).thenReturn(playback);
+        when(systemConfigCache.getDjGraceSeconds()).thenReturn(30);
+
+        service.markPending(roomId(), userId());
+
+        verify(valueOps).set(anyString(), eq(""), eq(30L), eq(TimeUnit.SECONDS));
+    }
+
+    @Test
+    @DisplayName("markPending — 이미 PENDING인 경우 Redis SET 안 함 (grace 연장 방지)")
+    void markPendingAlreadyPending() {
+        when(aggregatePort.findCrew(roomId(), userId())).thenReturn(Optional.of(activeCrew(true)));
+        when(aggregatePort.markCrewPending(eq(roomId()), eq(userId()), any(LocalDateTime.class))).thenReturn(0);
+
+        service.markPending(roomId(), userId());
+
+        verify(valueOps, never()).set(anyString(), any(), anyLong(), any(TimeUnit.class));
+    }
+
+    @Test
+    @DisplayName("markPending — crew가 inactive면 no-op")
+    void markPendingInactiveCrew() {
+        CrewData inactive = CrewData.builder().id(CREW_ID).partyroomId(roomId()).userId(userId())
+                .isActive(false).enteredAt(LocalDateTime.now(clock).minusHours(1)).build();
+        when(aggregatePort.findCrew(roomId(), userId())).thenReturn(Optional.of(inactive));
+
+        service.markPending(roomId(), userId());
+
+        verify(aggregatePort, never()).markCrewPending(any(), any(), any());
+        verify(valueOps, never()).set(anyString(), any(), anyLong(), any(TimeUnit.class));
+    }
+
+    @Test
+    @DisplayName("clearPending — 전이 발생 시 Redis 키 DEL")
+    void clearPendingTransitions() {
+        when(aggregatePort.clearCrewPending(roomId(), userId())).thenReturn(1);
+        when(aggregatePort.findCrew(roomId(), userId())).thenReturn(Optional.of(activeCrew(false)));
+
+        service.clearPending(roomId(), userId());
+
+        verify(redisTemplate).delete("PRESENCE:PENDING:" + PARTY_ID + ":" + CREW_ID);
+    }
+
+    @Test
+    @DisplayName("clearPending — 전이 없으면 no-op (Redis 건드리지 않음)")
+    void clearPendingNoTransition() {
+        when(aggregatePort.clearCrewPending(roomId(), userId())).thenReturn(0);
+
+        service.clearPending(roomId(), userId());
+
+        verify(redisTemplate, never()).delete(anyString());
+    }
+
+    @Test
+    @DisplayName("forceOffline — PENDING이면 exitInternal 위임 + Redis 키 DEL")
+    void forceOfflinePromotes() {
+        when(aggregatePort.findCrewById(CREW_ID)).thenReturn(Optional.of(activeCrew(true)));
+
+        service.forceOffline(roomId(), crewId());
+
+        verify(partyroomAccessCommandService).exitInternal(roomId(), userId());
+        verify(redisTemplate).delete("PRESENCE:PENDING:" + PARTY_ID + ":" + CREW_ID);
+    }
+
+    @Test
+    @DisplayName("forceOffline — 이미 reconnect한 (pending=false) 크루는 no-op (race)")
+    void forceOfflineAlreadyReconnected() {
+        when(aggregatePort.findCrewById(CREW_ID)).thenReturn(Optional.of(activeCrew(false)));
+
+        service.forceOffline(roomId(), crewId());
+
+        verify(partyroomAccessCommandService, never()).exitInternal(any(), any());
+        verify(redisTemplate).delete(anyString()); // cleanup only
+    }
+
+    @Test
+    @DisplayName("forceOffline — 이미 inactive한 크루는 no-op")
+    void forceOfflineAlreadyInactive() {
+        CrewData inactive = CrewData.builder().id(CREW_ID).partyroomId(roomId()).userId(userId())
+                .isActive(false).pendingExitAt(null).enteredAt(LocalDateTime.now(clock).minusHours(1)).build();
+        when(aggregatePort.findCrewById(CREW_ID)).thenReturn(Optional.of(inactive));
+
+        service.forceOffline(roomId(), crewId());
+
+        verify(partyroomAccessCommandService, never()).exitInternal(any(), any());
+    }
+
+    @Test
+    @DisplayName("forceOffline — crew row가 사라졌으면 Redis 키만 정리")
+    void forceOfflineMissingCrew() {
+        when(aggregatePort.findCrewById(CREW_ID)).thenReturn(Optional.empty());
+
+        service.forceOffline(roomId(), crewId());
+
+        verify(partyroomAccessCommandService, never()).exitInternal(any(), any());
+        verify(redisTemplate).delete(anyString());
+    }
+
+    @Test
+    @DisplayName("parseKey — 정상 키 파싱")
+    void parseKeyValid() {
+        PartyroomPresenceService.ParsedPresenceKey parsed =
+                PartyroomPresenceService.parseKey("PRESENCE:PENDING:42:99");
+        assertThat(parsed).isNotNull();
+        assertThat(parsed.partyroomId().getId()).isEqualTo(42L);
+        assertThat(parsed.crewId().getId()).isEqualTo(99L);
+    }
+
+    @Test
+    @DisplayName("parseKey — 잘못된 prefix면 null")
+    void parseKeyWrongPrefix() {
+        assertThat(PartyroomPresenceService.parseKey("TASK:WAIT:1")).isNull();
+        assertThat(PartyroomPresenceService.parseKey(null)).isNull();
+        assertThat(PartyroomPresenceService.parseKey("PRESENCE:PENDING:notnum:99")).isNull();
+        assertThat(PartyroomPresenceService.parseKey("PRESENCE:PENDING:42")).isNull();
+    }
+
+    @Test
+    @DisplayName("reconcileStalePending — stale 행을 forceOffline로 처리")
+    void reconcileSweep() {
+        when(systemConfigCache.getDjGraceSeconds()).thenReturn(30);
+        when(systemConfigCache.getListenerGraceSeconds()).thenReturn(10);
+        when(aggregatePort.findStalePendingCrews(any(LocalDateTime.class)))
+                .thenReturn(java.util.List.of(activeCrew(true)));
+        when(aggregatePort.findCrewById(CREW_ID)).thenReturn(Optional.of(activeCrew(true)));
+        // distributed lock executes the action immediately
+        org.mockito.Mockito.doAnswer(invocation -> {
+            java.util.function.Supplier<Void> action = invocation.getArgument(1);
+            action.get();
+            return null;
+        }).when(distributedLockExecutor).performTaskWithLock(anyString(), any());
+
+        service.reconcileStalePending();
+
+        verify(partyroomAccessCommandService, times(1)).exitInternal(roomId(), userId());
+    }
+
+    private PartyroomPlaybackData mockPlayback(boolean currentDj) {
+        PartyroomPlaybackData playback = org.mockito.Mockito.mock(PartyroomPlaybackData.class);
+        lenient().when(playback.isActivated()).thenReturn(currentDj);
+        lenient().when(playback.isCurrentDj(any(CrewId.class))).thenReturn(currentDj);
+        return playback;
+    }
+}

--- a/docs/superpowers/specs/2026-05-09-presence-grace-window-design.md
+++ b/docs/superpowers/specs/2026-05-09-presence-grace-window-design.md
@@ -310,6 +310,34 @@ otherwise the negotiated value falls back to `0,0` and only TCP keepalive
 detects disconnects (much slower). This is captured in the pfplay-web E2E
 contract issue.
 
+### STOMP heartbeat does NOT replace the LB keep-alive heartbeat
+
+The application-level custom heartbeat in pfplay-web (`/pub/heartbeat`, 4s
+interval, handled by `HeartbeatController` on the server) stays in place
+permanently as a separate concern: it keeps the GCP HTTP(S) Load Balancer
+backend service connection alive. The configured backend service timeout
+is **30 seconds** (the GCP Classic ALB default; verified via
+`gcloud compute backend-services describe <name> --global` — value
+`timeoutSec: 30`).
+
+A previous attempt to rely on STOMP built-in heartbeat alone for this
+purpose did not keep the LB connection alive in practice. The exact
+mechanism is unverified — possible explanations include Spring Boot
+heartbeat configuration pitfalls (e.g.,
+[spring-boot#30872](https://github.com/spring-projects/spring-boot/issues/30872)
+where missing `TaskScheduler` causes negotiation to silently fall back to
+`heart-beat:0,0`), client-side opt-in not being set, or LB-specific
+treatment of small heartbeat frames. None of these has been narrowed down
+to a single root cause, and a controlled reproducer is hard to run because
+stg does not sit behind GCP LB (only prod does).
+
+Bottom line: two heartbeats coexist with separate jobs.
+
+| Heartbeat | Frequency | Purpose | Owner |
+|---|---|---|---|
+| `/pub/heartbeat` (PING/PONG STOMP message) | 4s client → server | Keep GCP LB backend connection alive (30s timeout) | `HeartbeatController` (server) + pfplay-web custom interval (client) |
+| STOMP built-in heartbeat (newline frame) | 5s/10s bidirectional | Fast disconnect detection for presence model | Spring SimpleBroker + pfplay-web stomp client opt-in |
+
 ## Open questions for review
 
 1. **Pagehide proactive ping**: do we want to add a small endpoint that the

--- a/docs/superpowers/specs/2026-05-09-presence-grace-window-design.md
+++ b/docs/superpowers/specs/2026-05-09-presence-grace-window-design.md
@@ -264,8 +264,11 @@ Coupled enough that splitting hurts review:
    Pattern matches existing `PlaybackDurationWaitTopicListener`.
 8. **STOMP DISCONNECT hook**: existing STOMP session listener (`SubscriptionEventListener`
    was seen in logs) gains a disconnect handler → `markPending` for each subscribed room.
-9. **Heartbeat timeout**: configure STOMP heartbeat in WebSocket config; on timeout
-   server-side, fire same path as DISCONNECT.
+9. **Heartbeat timeout**: STOMP heartbeat configured in `WebSocketConfig` —
+   `setHeartbeatValue([10_000, 5_000])` + dedicated `ThreadPoolTaskScheduler`.
+   Server-side timeout fires `SessionDisconnectEvent` automatically, which
+   the existing `DisconnectionEventListener` already routes to
+   `presencePort.onSessionDisconnected`.
 10. **Reconcile cron** (`@Scheduled(fixedDelay = 60_000)`): scan stale PENDING_EXIT, call
     `forceOffline`. Doubles as startup recovery.
 11. **Issue #193 fix in same PR**: `activatePresence` and `activateCrew` JPQL clear
@@ -286,20 +289,42 @@ Coupled enough that splitting hurts review:
 - Integration: re-entry after OFFLINE → both `exited_at` and `pending_exit_at` cleared
   (Issue #193 regression).
 
+## STOMP heartbeat (resolved)
+
+Configured in `WebSocketConfig`:
+
+```
+server → client:  10000 ms  (server emits heartbeat every 10s)
+client → server:   5000 ms  (server expects client heartbeat every 5s)
+```
+
+With STOMP's 1.5x grace, a missing client heartbeat triggers DISCONNECT within
+~7.5s of the actual disconnect. That leaves ~2.5s of headroom inside the default
+10s `listener_grace_seconds` before `forceOffline` fires — so a brief blip
+(<10s total: detection + grace) does not disturb the room. A dedicated
+single-thread `ThreadPoolTaskScheduler` bean drives the heartbeats.
+
+Note: heartbeat is negotiated at CONNECT. The pfplay-web stomp client must
+opt in (e.g., `client.heartbeatIncoming = 10000; client.heartbeatOutgoing = 5000`)
+otherwise the negotiated value falls back to `0,0` and only TCP keepalive
+detects disconnects (much slower). This is captured in the pfplay-web E2E
+contract issue.
+
 ## Open questions for review
 
-1. **STOMP heartbeat values**: what client/server intervals do we want? Need to align
-   with grace defaults (heartbeat timeout should be < listener_grace_seconds, otherwise
-   timeout itself eats most of the grace). Suggested: client→server 5s, server→client
-   10s, server timeout 8s.
-2. **Pagehide proactive ping**: do we want to add the new `mode=pending` to the existing
-   exit endpoint in this PR, or leave to a follow-up? The model works without it — STOMP
-   DISCONNECT alone is enough trigger. Adding it just shaves a few seconds off perceived
-   latency for the disconnecting user (no functional difference for others).
-3. **Multi-instance considerations**: deployment is currently single-instance per env.
-   When/if we go multi-instance, `PRESENCE:PENDING:*` Redis keys are shared so the listener
-   on any instance handles the expired event. The reconcile cron would need leader election
-   to avoid duplicate processing. Out of scope for this PR; flag for future.
+1. **Pagehide proactive ping**: do we want to add a small endpoint that the
+   client can hit during the browser `pagehide` event (e.g., via
+   `navigator.sendBeacon`) to enter PENDING_EXIT immediately rather than
+   waiting for STOMP heartbeat timeout? The model works without it — STOMP
+   DISCONNECT alone is enough trigger. Adding it shaves the ~7.5s detection
+   gap off the disconnecting user's perceived recovery window. Defer until
+   we measure real-world cases of "user reconnected within 10s but was
+   already broadcast as exited".
+2. **Multi-instance considerations**: deployment is currently single-instance
+   per env. When/if we go multi-instance, `PRESENCE:PENDING:*` Redis keys are
+   shared so the listener on any instance handles the expired event. The
+   reconcile cron would need leader election to avoid duplicate processing.
+   Out of scope for this PR; flag for future.
 
 ## Out of scope (deferred)
 

--- a/docs/superpowers/specs/2026-05-09-presence-grace-window-design.md
+++ b/docs/superpowers/specs/2026-05-09-presence-grace-window-design.md
@@ -1,0 +1,309 @@
+# Presence Grace Window — Design
+
+**Status**: draft
+**Author**: backend
+**Date**: 2026-05-09
+**Related**: Issue #193 (re-entry exited_at), Issue #195 (Redis expired-event loss)
+
+## Problem
+
+When a user in a partyroom briefly disconnects (mobile background, screen lock, transient
+network blip), the current system treats the disconnect as a hard exit: crew row goes
+inactive, `crew_exited` broadcasts, and if they were the current DJ, `skipPlayback` cuts
+their track and rotates the queue. When the same user comes back ~5–10s later, they
+re-enter as a fresh crew row, triggering `crew_entered`. To other crew members the user's
+avatar disappears and reappears; to the user, their listening session is interrupted; to
+the room, the music may have been needlessly skipped.
+
+Goal: absorb sub-grace-window disconnects silently while keeping the visible/audible
+state stable. Make the perceived experience match what would happen if the network blip
+had not occurred.
+
+## Non-goals
+
+- Detecting *why* the disconnect happened (heartbeat vs pagehide vs crash) — handled the same.
+- Multi-tab presence dedup — out of scope. One tab per user is the assumed model.
+- Cross-room state — multi-room invariant ("one user, one active room") still enforced as today.
+- Redis pub/sub durability fix — tracked separately as Issue #195. This spec uses DB as
+  source of truth so it does *not* depend on that fix landing first.
+
+## Design overview
+
+Three-state presence machine per crew row:
+
+```
+ONLINE ──[disconnect signal]──► PENDING_EXIT ──[grace TTL elapses]──► OFFLINE
+   ▲                                  │
+   └──────[reconnect within grace]────┘
+```
+
+- **ONLINE**: normal. `crew.is_active = 1`, no `pending_exit_at`.
+- **PENDING_EXIT**: client gone but unconfirmed. `crew.is_active = 1`, `pending_exit_at = T`.
+  No event broadcast to the room. Grace clock ticking.
+- **OFFLINE**: confirmed gone. Existing `exit()` flow runs (deactivate crew + skipPlayback if
+  current DJ + `crew_exited` broadcast).
+
+Only the transition `PENDING_EXIT → OFFLINE` produces user-visible side effects in the room.
+Both `ONLINE → PENDING_EXIT` and `PENDING_EXIT → ONLINE` are silent.
+
+## State storage
+
+### DB (truth)
+
+New nullable column on `crew`:
+
+```sql
+ALTER TABLE crew ADD COLUMN pending_exit_at DATETIME(6) NULL;
+ALTER TABLE crew ADD INDEX idx_crew_pending_exit (pending_exit_at);
+```
+
+- `pending_exit_at IS NULL`  AND `is_active = 1` → ONLINE
+- `pending_exit_at IS NOT NULL` AND `is_active = 1` → PENDING_EXIT
+- `is_active = 0` → OFFLINE (and historically possibly never PENDING_EXIT — old rows OK)
+
+### Redis (timing trigger, not truth)
+
+Per-crew expirable key whose only job is to fire a `__keyevent@*__:expired` notification
+when grace elapses:
+
+```
+PRESENCE:PENDING:<partyroomId>:<crewId>   TTL=grace_seconds
+```
+
+- Value: irrelevant (DB has the truth). Empty string is fine.
+- The expired event triggers the OFFLINE handler. Handler re-reads DB, confirms still
+  PENDING_EXIT, then runs `exit()`-equivalent.
+
+### Why both?
+
+DB-only with a periodic cron is robust but introduces 5–10s jitter on grace expiration.
+Redis TTL gives second-precision in normal operation. DB persistence + a low-frequency
+recovery cron handles the Issue #195 failure mode (event lost during app restart) without
+making this design block on #195 being fixed.
+
+## Trigger paths
+
+### Disconnect → PENDING_EXIT
+
+Three signals can fire this transition. All three converge on a single domain method
+`PartyroomPresenceService.markPending(partyroomId, userId)`:
+
+1. **STOMP DISCONNECT frame** received by server. Existing session listener; needs to
+   look up which partyroom the user was subscribed to.
+2. **Heartbeat timeout** — server-side timer per session (existing STOMP heartbeat
+   contract). When N seconds pass without heartbeat, treat as DISCONNECT.
+3. **Explicit pagehide ping** from client (existing exit endpoint, but with a new
+   `mode=pending` query param). Optimization: client knows it's about to background and
+   tells the server proactively, reducing perceived disconnect latency.
+
+`markPending` is idempotent: setting `pending_exit_at` when already set is a no-op (keep
+the original timestamp so grace doesn't extend). Re-firing the Redis key is fine.
+
+### Reconnect → ONLINE
+
+Two signals:
+
+1. **STOMP CONNECT** with same userId while a `PRESENCE:PENDING:<crewId>` key exists →
+   `clearPending(partyroomId, userId)`.
+2. (No second signal needed for now. STOMP re-subscribe is the canonical "I'm back".)
+
+`clearPending`:
+- DB: `UPDATE crew SET pending_exit_at = NULL WHERE crew_id = ?`
+- Redis: `DEL PRESENCE:PENDING:<partyroomId>:<crewId>`
+- Broadcasts: none. The room never knew this crew left.
+
+### Grace expires → OFFLINE
+
+`PresenceExpirationListener` (new) subscribes to `__keyevent@*__:expired` filtered for
+`PRESENCE:PENDING:*`. On fire:
+
+```java
+1. Parse partyroomId + crewId from the key.
+2. Re-read crew row. If pending_exit_at IS NULL → user already reconnected → return.
+3. If is_active = 0 → already offline (race with explicit exit) → return.
+4. Run exit-equivalent: deactivateCrew + handleDjQueueOnLeave + crew_exited broadcast.
+5. Clear pending_exit_at as part of the same TX.
+```
+
+Step 4 reuses existing logic by delegating to `PartyroomAccessCommandService.exitInternal`
+(extract the body of `exit()` so both the user-initiated DELETE endpoint and the presence
+listener can call it without ThreadLocal AuthContext setup).
+
+### Explicit user exit during PENDING_EXIT
+
+User clicks "leave room" while their previous session was already PENDING_EXIT (e.g., one
+tab silently disconnected, another tab clicks Exit):
+
+- DELETE endpoint runs `exitInternal` → goes straight to OFFLINE
+- `clearPending` runs as part of `exitInternal` to clean Redis key
+- No double broadcast (atomic toggle on `is_active` already enforces single EXIT — see
+  existing `deactivateCrew` returning row-count)
+
+## Grace duration policy
+
+Differentiated by role at the moment of disconnect:
+
+| Role at disconnect | Grace | Source |
+|---|---|---|
+| Currently the playing DJ (`partyroom_playback.current_dj_crew_id == crewId`) | 30s | `system_config: presence.dj_grace_seconds` |
+| Anyone else (including queued-but-not-current DJs) | 10s | `system_config: presence.listener_grace_seconds` |
+
+Defaults seeded in `V16__add_presence_config.sql`. `SystemConfigCache` (already present)
+caches values with 30s TTL. New `readInt` helper added; admin-driven changes can
+`invalidate()` for instant propagation if/when an admin endpoint is added.
+
+Grace is set **at the moment of disconnect** based on role at that instant. If the user
+becomes/stops being current DJ during PENDING_EXIT (only possible via track-end rotation
+during their grace), the grace is not retroactively adjusted. Simpler and adequate.
+
+## Interaction with existing flows
+
+### Track end during grace
+
+If the current DJ is PENDING_EXIT and the track's `TASK:WAIT` expires naturally:
+- `complete()` → `tryProceed()` → queue rotates → next DJ's track starts.
+- The PENDING_EXIT user is still in queue (not removed yet). They'd be eligible for the
+  next rotation, but they're now no longer "current DJ" — just queued.
+- If their grace then expires, `exitInternal` runs and removes them from the queue. No
+  visible churn because they were no longer the current DJ at that moment.
+- DJ point award (`updateDjPointScore`) still fires for the just-completed track. Correct:
+  the user did finish that track, even if disconnected.
+
+### Multi-room invariant
+
+Existing `tryEnter` calls `exit()` on the previous room before entering the new one. With
+the presence model, this stays the same: explicit room-switch is an explicit signal, no
+grace applied. The previous-room crew row goes straight to OFFLINE.
+
+This means if a user is PENDING_EXIT in room A and a *different* device of theirs enters
+room B, they'll be hard-exited from A (existing `exit()` runs). Acceptable.
+
+### Re-entry after OFFLINE
+
+After OFFLINE the crew row stays `is_active=0` with `exited_at` set. If the same user
+later enters again (within or beyond presence grace expiration), the existing `tryEnter`
+path runs. Note: Issue #193 (re-entry leaves stale `exited_at`) needs to be fixed in the
+same PR that lands this presence model — otherwise the new `pending_exit_at` field would
+similarly need explicit reset on re-entry. Reusing the fix is cheap.
+
+## Recovery (Issue #195 hedge)
+
+App restart between Redis key SET and TTL expiration loses the expired event. To prevent
+permanent PENDING_EXIT zombies:
+
+```java
+@Scheduled(fixedDelay = 60_000) // every 60s
+public void reconcilePendingExits() {
+    LocalDateTime threshold = LocalDateTime.now(clock).minusSeconds(MAX_GRACE_SECONDS);
+    crewRepository.findStalePending(threshold).forEach(crew ->
+        presenceService.forceOffline(crew.getPartyroomId(), crew.getUserId()));
+}
+```
+
+`MAX_GRACE_SECONDS` = max(djGrace, listenerGrace) + 10s buffer. Idempotent with the Redis
+listener (both call `exitInternal`, which is itself idempotent via atomic toggle).
+
+Same cron also acts as a startup recovery — first tick after boot catches anything
+stranded during downtime.
+
+## Race conditions handled
+
+| Race | Resolution |
+|---|---|
+| Reconnect arrives while OFFLINE handler is mid-tx | Handler re-reads `pending_exit_at`; if NULL, returns. No double-broadcast. |
+| Two disconnect signals (STOMP + heartbeat timeout) for same user | `markPending` is idempotent; `pending_exit_at` set once, Redis SET is overwrite-safe. Grace not extended. |
+| Explicit Exit during PENDING_EXIT | `exitInternal` clears `pending_exit_at` and Redis key; OFFLINE handler later finds NULL and bails. |
+| Recovery cron + Redis listener fire on same crew | Both call `exitInternal` → atomic toggle returns 0 on the second one → idempotent. |
+| User PENDING_EXIT in room A, joins room B from different device | `tryEnter` for B calls `exitInternal` for A first → goes straight to OFFLINE, clears pending state. |
+
+## Config
+
+```sql
+-- V16__add_presence_config.sql
+INSERT INTO system_config (config_key, config_value, description) VALUES
+  ('presence.dj_grace_seconds',       '30', '현재 DJ가 끊겼을 때 OFFLINE 판정까지의 유예(초)'),
+  ('presence.listener_grace_seconds', '10', '일반 listener가 끊겼을 때 OFFLINE 판정까지의 유예(초)');
+```
+
+`ConfigKey` enum: `PRESENCE_DJ_GRACE_SECONDS`, `PRESENCE_LISTENER_GRACE_SECONDS`.
+`SystemConfigCache.readInt(ConfigKey, int fallback)` helper added.
+
+## Schema migration
+
+```sql
+-- V16__add_presence.sql (combine config + crew column)
+ALTER TABLE crew
+  ADD COLUMN pending_exit_at DATETIME(6) NULL,
+  ADD INDEX idx_crew_pending_exit (pending_exit_at);
+
+INSERT INTO system_config (config_key, config_value, description) VALUES
+  ('presence.dj_grace_seconds',       '30', '현재 DJ가 끊겼을 때 OFFLINE 판정까지의 유예(초)'),
+  ('presence.listener_grace_seconds', '10', '일반 listener가 끊겼을 때 OFFLINE 판정까지의 유예(초)');
+```
+
+No data backfill needed — column is nullable, all existing rows default to NULL = ONLINE
+or OFFLINE depending on `is_active`.
+
+## Implementation plan (single PR)
+
+Coupled enough that splitting hurts review:
+
+1. **V16 migration** — column + index + config seeds.
+2. **`SystemConfigCache.readInt`** + presence ConfigKeys + Snapshot extension.
+3. **`CrewData.pendingExitAt`** field + JPA mapping. Domain methods `markPending()`,
+   `clearPending()`, `isPendingExit()`.
+4. **`CrewRepository`**: `findStalePending(threshold)` query.
+5. **Refactor `PartyroomAccessCommandService.exit()`**: extract body to
+   `exitInternal(partyroomId, userId)` taking explicit args (no ThreadLocal). Public
+   `exit()` becomes a thin wrapper. Also extract `expel()` body the same way for
+   consistency.
+6. **`PartyroomPresenceService`** (new): `markPending`, `clearPending`, `forceOffline`.
+   Encapsulates DB write + Redis key SET/DEL.
+7. **`PresenceExpirationListener`** (new): subscribes to `__keyevent@*__:expired`
+   filtered for `PRESENCE:PENDING:*`. Delegates to `presenceService.forceOffline`.
+   Pattern matches existing `PlaybackDurationWaitTopicListener`.
+8. **STOMP DISCONNECT hook**: existing STOMP session listener (`SubscriptionEventListener`
+   was seen in logs) gains a disconnect handler → `markPending` for each subscribed room.
+9. **Heartbeat timeout**: configure STOMP heartbeat in WebSocket config; on timeout
+   server-side, fire same path as DISCONNECT.
+10. **Reconcile cron** (`@Scheduled(fixedDelay = 60_000)`): scan stale PENDING_EXIT, call
+    `forceOffline`. Doubles as startup recovery.
+11. **Issue #193 fix in same PR**: `activatePresence` and `activateCrew` JPQL clear
+    `exitedAt` AND `pendingExitAt` on re-entry.
+12. **Tests**: see below.
+
+## Test plan
+
+- Unit: presence service state transitions (mark, clear, force-offline idempotency).
+- Unit: `SystemConfigCache.readInt` (parse, fallback on garbage).
+- Integration: full disconnect → reconnect within grace → no broadcast.
+- Integration: full disconnect → grace expires → `crew_exited` fires once.
+- Integration: current DJ disconnect → grace expires → `skipPlayback` fires once
+  (verify track actually advances).
+- Integration: track end during grace of current DJ → rotation proceeds, point awarded.
+- Integration: explicit Exit during PENDING_EXIT → no double broadcast.
+- Integration: stale PENDING_EXIT (older than max grace) → reconcile cron processes it.
+- Integration: re-entry after OFFLINE → both `exited_at` and `pending_exit_at` cleared
+  (Issue #193 regression).
+
+## Open questions for review
+
+1. **STOMP heartbeat values**: what client/server intervals do we want? Need to align
+   with grace defaults (heartbeat timeout should be < listener_grace_seconds, otherwise
+   timeout itself eats most of the grace). Suggested: client→server 5s, server→client
+   10s, server timeout 8s.
+2. **Pagehide proactive ping**: do we want to add the new `mode=pending` to the existing
+   exit endpoint in this PR, or leave to a follow-up? The model works without it — STOMP
+   DISCONNECT alone is enough trigger. Adding it just shaves a few seconds off perceived
+   latency for the disconnecting user (no functional difference for others).
+3. **Multi-instance considerations**: deployment is currently single-instance per env.
+   When/if we go multi-instance, `PRESENCE:PENDING:*` Redis keys are shared so the listener
+   on any instance handles the expired event. The reconcile cron would need leader election
+   to avoid duplicate processing. Out of scope for this PR; flag for future.
+
+## Out of scope (deferred)
+
+- Visible "(reconnecting…)" UI indicator. Decided against (silence over noise).
+- Per-user variable grace (e.g., longer for paid users). YAGNI.
+- Connection quality awareness (slow vs flaky). Beyond v1.
+- Cross-room presence (showing "user X is in room Y" to friends). Different feature.

--- a/realtime/src/main/java/com/pfplaybackend/realtime/config/WebSocketConfig.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/config/WebSocketConfig.java
@@ -2,9 +2,12 @@ package com.pfplaybackend.realtime.config;
 
 import com.pfplaybackend.realtime.interceptor.WebSocketHandshakeInterceptor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -19,11 +22,29 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    // STOMP heartbeat targeted at the presence grace window.
+    // Server expects a client heartbeat every 5s; with the STOMP 1.5x grace this
+    // means a disconnect is detected within ~7.5s, leaving headroom inside the
+    // 10s default listener_grace_seconds before forceOffline fires.
+    private static final long SERVER_TO_CLIENT_HEARTBEAT_MS = 10_000L;
+    private static final long CLIENT_TO_SERVER_HEARTBEAT_MS = 5_000L;
+
     private final WebSocketHandshakeInterceptor webSocketHandshakeInterceptor;
+
+    @Bean
+    public TaskScheduler stompHeartbeatScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(1);
+        scheduler.setThreadNamePrefix("stomp-heartbeat-");
+        scheduler.initialize();
+        return scheduler;
+    }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry brokerRegistry) {
-        brokerRegistry.enableSimpleBroker("/sub");
+        brokerRegistry.enableSimpleBroker("/sub")
+                .setHeartbeatValue(new long[] { SERVER_TO_CLIENT_HEARTBEAT_MS, CLIENT_TO_SERVER_HEARTBEAT_MS })
+                .setTaskScheduler(stompHeartbeatScheduler());
         brokerRegistry.setApplicationDestinationPrefixes("/pub");
         brokerRegistry.setUserDestinationPrefix("/user");
     }

--- a/realtime/src/main/java/com/pfplaybackend/realtime/config/WebSocketConfig.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/config/WebSocketConfig.java
@@ -22,10 +22,17 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-    // STOMP heartbeat targeted at the presence grace window.
-    // Server expects a client heartbeat every 5s; with the STOMP 1.5x grace this
-    // means a disconnect is detected within ~7.5s, leaving headroom inside the
-    // 10s default listener_grace_seconds before forceOffline fires.
+    // STOMP heartbeat — used for fast disconnect detection only. Server expects a
+    // client heartbeat every 5s; with the STOMP 1.5x grace this means a disconnect
+    // is detected within ~7.5s, leaving headroom inside the 10s default
+    // listener_grace_seconds before forceOffline fires.
+    //
+    // NOTE: this does NOT replace the existing application-level heartbeat
+    // (`/pub/heartbeat`, 4s interval) which is responsible for keeping the GCP
+    // HTTP(S) LB connection alive (backend service timeout = 30s, confirmed via
+    // `gcloud compute backend-services describe`). Past attempts to rely on STOMP
+    // heartbeat alone for LB keep-alive did not work in practice — root cause not
+    // verified, so the application heartbeat stays for keep-alive duties.
     private static final long SERVER_TO_CLIENT_HEARTBEAT_MS = 10_000L;
     private static final long CLIENT_TO_SERVER_HEARTBEAT_MS = 5_000L;
 

--- a/realtime/src/main/java/com/pfplaybackend/realtime/event/DisconnectionEventListener.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/event/DisconnectionEventListener.java
@@ -1,5 +1,6 @@
 package com.pfplaybackend.realtime.event;
 
+import com.pfplaybackend.realtime.port.PresencePort;
 import com.pfplaybackend.realtime.port.SessionCachePort;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -15,11 +16,15 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 public class DisconnectionEventListener implements ApplicationListener<SessionDisconnectEvent> {
     private static final Logger logger = LoggerFactory.getLogger(DisconnectionEventListener.class);
     private final SessionCachePort sessionCachePort;
+    private final PresencePort presencePort;
 
     @Override
     public void onApplicationEvent(SessionDisconnectEvent event) {
         StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
         String sessionId = headerAccessor.getSessionId();
+        // PRESENCE: enter grace before deleting session cache (adapter still needs it
+        // to look up partyroomId/userId).
+        presencePort.onSessionDisconnected(sessionId);
         sessionCachePort.deleteSessionCache(sessionId);
         logger.info("Web socket connection closed: {}", sessionId);
 

--- a/realtime/src/main/java/com/pfplaybackend/realtime/event/SubscriptionEventListener.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/event/SubscriptionEventListener.java
@@ -1,5 +1,6 @@
 package com.pfplaybackend.realtime.event;
 
+import com.pfplaybackend.realtime.port.PresencePort;
 import com.pfplaybackend.realtime.port.SessionCachePort;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -17,6 +18,7 @@ import java.security.Principal;
 public class SubscriptionEventListener implements ApplicationListener<SessionSubscribeEvent> {
     private static final Logger logger = LoggerFactory.getLogger(SubscriptionEventListener.class);
     private final SessionCachePort sessionCachePort;
+    private final PresencePort presencePort;
 
     @Override
     public void onApplicationEvent(SessionSubscribeEvent event) {
@@ -30,6 +32,9 @@ public class SubscriptionEventListener implements ApplicationListener<SessionSub
         }
         String userId = principal.getName();
         sessionCachePort.saveSessionCache(sessionId, userId, destination);
+        // PRESENCE: subscribe to a partyroom topic = user is back. Clear any
+        // PENDING_EXIT for their associated room (no-op if not pending).
+        presencePort.onSessionConnected(sessionId);
 
         logger.info("Session has subscribed, sessionId : {}, userId : {}, destination : {}", sessionId, userId, destination);
     }

--- a/realtime/src/main/java/com/pfplaybackend/realtime/port/PresencePort.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/port/PresencePort.java
@@ -1,0 +1,25 @@
+package com.pfplaybackend.realtime.port;
+
+/**
+ * Bridges realtime STOMP session events to the partyroom presence model in the app
+ * module. Implementation lives in app and translates a sessionId into the associated
+ * (partyroomId, userId) before calling the domain service.
+ *
+ * <p>Both methods MUST be idempotent — STOMP can deliver duplicate connect/disconnect
+ * frames under reconnection storms, and the listener fires for every subscribe.
+ */
+public interface PresencePort {
+
+    /**
+     * Called when a STOMP session for a partyroom subscription is established or
+     * re-established. Implementation cancels any PENDING_EXIT for the user/room.
+     */
+    void onSessionConnected(String sessionId);
+
+    /**
+     * Called when a STOMP session disconnects (clean close, abnormal close, or
+     * heartbeat timeout). Implementation marks the user PENDING_EXIT in the
+     * associated partyroom and starts the grace timer.
+     */
+    void onSessionDisconnected(String sessionId);
+}

--- a/realtime/src/test/java/com/pfplaybackend/realtime/event/DisconnectionEventListenerTest.java
+++ b/realtime/src/test/java/com/pfplaybackend/realtime/event/DisconnectionEventListenerTest.java
@@ -1,5 +1,6 @@
 package com.pfplaybackend.realtime.event;
 
+import com.pfplaybackend.realtime.port.PresencePort;
 import com.pfplaybackend.realtime.port.SessionCachePort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,11 +24,14 @@ class DisconnectionEventListenerTest {
     @Mock
     private SessionCachePort sessionCachePort;
 
+    @Mock
+    private PresencePort presencePort;
+
     @InjectMocks
     private DisconnectionEventListener listener;
 
     @Test
-    @DisplayName("정상 종료(1000) 시 세션 캐시를 삭제한다")
+    @DisplayName("정상 종료(1000) 시 presence를 PENDING으로 표시하고 세션 캐시를 삭제한다")
     void onApplicationEventNormalCloseDeletesSessionCache() {
         // given
         String sessionId = "session-normal";
@@ -37,11 +41,12 @@ class DisconnectionEventListenerTest {
         listener.onApplicationEvent(event);
 
         // then
+        verify(presencePort).onSessionDisconnected(sessionId);
         verify(sessionCachePort).deleteSessionCache(sessionId);
     }
 
     @Test
-    @DisplayName("비정상 종료(1006) 시에도 세션 캐시를 삭제한다")
+    @DisplayName("비정상 종료(1006) 시에도 presence와 세션 캐시 정리가 동일하게 일어난다")
     void onApplicationEventAbnormalCloseDeletesSessionCache() {
         // given
         String sessionId = "session-abnormal";
@@ -52,6 +57,7 @@ class DisconnectionEventListenerTest {
         listener.onApplicationEvent(event);
 
         // then
+        verify(presencePort).onSessionDisconnected(sessionId);
         verify(sessionCachePort).deleteSessionCache(sessionId);
     }
 

--- a/realtime/src/test/java/com/pfplaybackend/realtime/event/SubscriptionEventListenerTest.java
+++ b/realtime/src/test/java/com/pfplaybackend/realtime/event/SubscriptionEventListenerTest.java
@@ -1,5 +1,6 @@
 package com.pfplaybackend.realtime.event;
 
+import com.pfplaybackend.realtime.port.PresencePort;
 import com.pfplaybackend.realtime.port.SessionCachePort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,9 @@ class SubscriptionEventListenerTest {
     @Mock
     private SessionCachePort sessionCachePort;
 
+    @Mock
+    private PresencePort presencePort;
+
     @InjectMocks
     private SubscriptionEventListener listener;
 
@@ -53,6 +57,7 @@ class SubscriptionEventListenerTest {
 
         // then
         verify(sessionCachePort).saveSessionCache(sessionId, userId, destination);
+        verify(presencePort).onSessionConnected(sessionId);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Three-state presence machine (ONLINE → PENDING_EXIT → OFFLINE) that absorbs brief mobile disconnects (background, screen lock, network jitter) without flapping the room. Role-aware grace: 30s for the active DJ, 10s for everyone else, both tunable via \`system_config\`.

## Why

Today, any STOMP disconnect immediately runs the full \`exit()\` flow — crew row goes inactive, \`crew_exited\` broadcasts, and if the user happened to be the current DJ, \`skipPlayback\` cuts their track and rotates the queue. A 5s pocket-lock or push notification cuts the song. Reconnects then trigger a fresh \`crew_entered\`, so other crew see avatars disappear and reappear constantly. This is loud and disruptive.

## Design (full spec at \`docs/superpowers/specs/2026-05-09-presence-grace-window-design.md\`)

- **State**: \`crew.pending_exit_at\` (V16 column) is source of truth. Redis \`PRESENCE:PENDING:<roomId>:<crewId>\` with TTL drives the grace timer.
- **Silent grace**: \`ONLINE → PENDING_EXIT\` and \`PENDING_EXIT → ONLINE\` broadcast nothing. The room is unaware until OFFLINE actually fires.
- **OFFLINE handler**: delegates to existing \`PartyroomAccessCommandService.exitInternal\` (extracted from \`exit()\` so non-HTTP callers can reuse it). Same skipPlayback + crew_exited path as today.
- **Triggers**: STOMP DISCONNECT or heartbeat timeout → \`presencePort.onSessionDisconnected\` → \`markPending\`. STOMP SUBSCRIBE → \`onSessionConnected\` → \`clearPending\`.
- **Two converging paths to OFFLINE**: \`PresenceExpirationListener\` on Redis \`__keyevent expired\` (precise), plus a 60s reconcile cron that sweeps stale \`pending_exit_at\` rows. The cron also hedges against Issue #195 (Redis fire-and-forget) without blocking on its fix.

## Config (V16 seeds)

| Key | Default | Tunable |
|---|---|---|
| \`presence.dj_grace_seconds\` | 30 | system_config |
| \`presence.listener_grace_seconds\` | 10 | system_config |

\`SystemConfigCache\` extended with \`readInt\` helper, fail-open on missing/garbage values.

## Bundled fix: Issue #193

\`activateCrew\` JPQL and \`CrewData.activatePresence\` now reset both \`exited_at\` and the new \`pending_exit_at\` on re-entry, so stale values from a prior session don't poison the new active row.

## Files

20 files changed, +1106/-8. Highlights:
- \`app/src/main/resources/db/migration/V16__add_presence.sql\`
- \`PartyroomPresenceService\` + \`PresencePortAdapter\` + \`PresenceExpirationListener\`
- \`PartyroomAggregatePort\` extended with \`markCrewPending\` / \`clearCrewPending\` / \`findStalePendingCrews\`
- \`PartyroomAccessCommandService.exitInternal\` extraction
- \`SystemConfigCache.readInt\` + presence ConfigKeys
- \`realtime\` module: \`PresencePort\` interface + listener wiring
- Unit tests for service state transitions, key parsing, reconcile cron

## Risk / rollback

- V16 is additive (nullable column + 2 config rows). Backfill not required. Rollback = drop column + delete config rows.
- Behavior change is opt-in by trigger path — if no STOMP disconnect/subscribe events fire (e.g., during test runs that bypass websocket), no presence rows are written and code paths are dormant.
- Cron is idempotent and shares the per-crew distributed lock with the Redis listener — no duplicate broadcasts.

## Open questions for review

1. STOMP heartbeat values (client→server 5s, server→client 10s, server timeout 8s) — proposed but not yet wired into WebSocket config. Spec notes this as a separate question; could be a follow-up PR or added here. Without explicit heartbeat tuning, the system relies on TCP keepalive, which is much slower to detect disconnects.
2. Pagehide proactive ping — not in this PR. Marked as deferred. STOMP DISCONNECT alone covers the trigger; pagehide would just shave latency for the disconnecting user.

## Test plan
- [x] \`./gradlew :realtime:test :app:test :user:test\` — green
- [ ] Manual: open two browser tabs as different crew, force-close one, verify \`crew_exited\` does NOT fire within 10s and DOES fire after 10s
- [ ] Manual: as the current DJ, lock screen briefly (<30s) — track keeps playing, no skip
- [ ] Manual: as the current DJ, fully exit — track skips immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)