### PR TITLE
release: V15 호환 temp-user fix + prod 가드 (PR #196)

### DIFF
--- a/user/src/main/java/com/pfplaybackend/api/user/adapter/in/web/EasyUserManagementController.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/adapter/in/web/EasyUserManagementController.java
@@ -14,15 +14,24 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * Dev/test 전용 임시 회원 생성 endpoint. prod profile에서는 bean 자체가
+ * 생성되지 않으므로 path 매핑이 없고 404가 반환된다. SecurityConfig의
+ * `/api/v1/users/members/sign/**` permitAll matcher는 prod에서도 그대로
+ * 남아있지만, 핸들러가 없으므로 인증 우회만 의미할 뿐 외부에서 임시
+ * 계정을 만들 수 없다.
+ */
 @Tag(name = "User Sign API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
+@Profile("!prod")
 public class EasyUserManagementController {
 
     private final SharedSessionCookieWriter sharedSessionCookieWriter;

--- a/user/src/main/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeService.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeService.java
@@ -1,21 +1,28 @@
 package com.pfplaybackend.api.user.application.service.initialize;
 
+import com.pfplaybackend.api.avatar.application.dto.AvatarBodyDto;
 import com.pfplaybackend.api.common.config.security.enums.ProviderType;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.user.adapter.out.persistence.GuestRepository;
 import com.pfplaybackend.api.user.adapter.out.persistence.MemberRepository;
 import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserProfileRepository;
 import com.pfplaybackend.api.user.application.port.out.PlaylistSetupPort;
 import com.pfplaybackend.api.user.application.service.UserActivityCommandService;
+import com.pfplaybackend.api.user.application.service.UserAvatarQueryService;
 import com.pfplaybackend.api.user.application.service.UserProfileCommandService;
 import com.pfplaybackend.api.user.domain.entity.data.GuestData;
 import com.pfplaybackend.api.user.domain.entity.data.MemberData;
 import com.pfplaybackend.api.user.domain.entity.data.ProfileData;
 import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
+import com.pfplaybackend.api.user.domain.enums.FaceSourceType;
+import com.pfplaybackend.api.user.domain.value.Nickname;
 import com.pfplaybackend.api.user.domain.value.WalletAddress;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -24,13 +31,16 @@ public class TemporaryUserInitializeService {
     private final UserAccountRepository userAccountRepository;
     private final GuestRepository guestRepository;
     private final MemberRepository memberRepository;
+    private final UserProfileRepository userProfileRepository;
     private final UserProfileCommandService userProfileCommandService;
     private final UserActivityCommandService userActivityCommandService;
+    private final UserAvatarQueryService userAvatarQueryService;
     private final PlaylistSetupPort playlistSetupPort;
 
     private static final long GUEST_FIXED_ID = 1000000000000001L;
     private static final long ASSOCIATE_MEMBER_FIXED_ID = 1000000000000002L;
     private static final long FULL_MEMBER_FIXED_ID = 1000000000000003L;
+    private static final int TEMP_NICKNAME_MAX_ATTEMPTS = 5;
 
     @Transactional
     public void addTemporaryUsers() {
@@ -105,12 +115,35 @@ public class TemporaryUserInitializeService {
     }
 
     public MemberData upgradeMember(MemberData member) {
-        // 1. Profile Update
-        member.updateProfileBio("nickname", "introduction");
+        // 1. Profile Update — V15 unique 제약 대응으로 nickname 마다 UUID 접미사
+        member.updateProfileBio(generateUniqueTemporaryNickname(), "introduction");
         memberRepository.save(member);
         // 2. Wallet Update
         member.updateWalletAddress(new WalletAddress("wallet-address"));
         memberRepository.save(member);
+        // 3. Avatar Default Attach — broadcaster/응답 빌더가 avatar를 dereferencing할 때
+        //    NPE를 일으키지 않도록 BASIC seed (V3) 리소스를 attach한다.
+        AvatarBodyDto bodyResource = userAvatarQueryService.getDefaultAvatarBody();
+        member.updateAvatarBody(
+                userAvatarQueryService.getDefaultAvatarBodyUri(),
+                bodyResource.getCombinePositionX(),
+                bodyResource.getCombinePositionY());
+        member.updateAvatarFace(
+                userAvatarQueryService.getDefaultAvatarFaceUri(),
+                FaceSourceType.INTERNAL_IMAGE,
+                0.0, 0.0, 100.0);
+        member.updateAvatarIcon(userAvatarQueryService.getDefaultAvatarIconUri());
+        memberRepository.save(member);
         return member;
+    }
+
+    private String generateUniqueTemporaryNickname() {
+        for (int attempt = 0; attempt < TEMP_NICKNAME_MAX_ATTEMPTS; attempt++) {
+            String candidate = "nickname-" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+            if (!userProfileRepository.existsByNickname(new Nickname(candidate))) {
+                return candidate;
+            }
+        }
+        return "nickname-" + UUID.randomUUID().toString().replace("-", "").substring(0, 11);
     }
 }

--- a/user/src/test/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeServiceTest.java
+++ b/user/src/test/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeServiceTest.java
@@ -1,24 +1,35 @@
 package com.pfplaybackend.api.user.application.service.initialize;
 
+import com.pfplaybackend.api.avatar.application.dto.AvatarBodyDto;
+import com.pfplaybackend.api.avatar.domain.value.AvatarBodyUri;
+import com.pfplaybackend.api.avatar.domain.value.AvatarFaceUri;
+import com.pfplaybackend.api.avatar.domain.value.AvatarIconUri;
 import com.pfplaybackend.api.common.config.security.jwt.JwtService;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.user.adapter.out.persistence.GuestRepository;
 import com.pfplaybackend.api.user.adapter.out.persistence.MemberRepository;
 import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserProfileRepository;
 import com.pfplaybackend.api.user.application.port.out.PlaylistSetupPort;
 import com.pfplaybackend.api.user.application.service.UserActivityCommandService;
+import com.pfplaybackend.api.user.application.service.UserAvatarQueryService;
 import com.pfplaybackend.api.user.application.service.UserProfileCommandService;
 import com.pfplaybackend.api.user.domain.entity.data.GuestData;
 import com.pfplaybackend.api.user.domain.entity.data.MemberData;
 import com.pfplaybackend.api.user.domain.entity.data.ProfileData;
+import com.pfplaybackend.api.user.domain.enums.FaceSourceType;
+import com.pfplaybackend.api.user.domain.value.Nickname;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -27,8 +38,10 @@ class TemporaryUserInitializeServiceTest {
     @Mock UserAccountRepository userAccountRepository;
     @Mock GuestRepository guestRepository;
     @Mock MemberRepository memberRepository;
+    @Mock UserProfileRepository userProfileRepository;
     @Mock UserProfileCommandService userProfileCommandService;
     @Mock UserActivityCommandService userActivityCommandService;
+    @Mock UserAvatarQueryService userAvatarQueryService;
     @Mock PlaylistSetupPort playlistSetupPort;
     @Mock JwtService jwtService;
 
@@ -71,17 +84,63 @@ class TemporaryUserInitializeServiceTest {
     }
 
     @Test
-    @DisplayName("upgradeMember — 회원이 FM으로 업그레이드된다")
+    @DisplayName("upgradeMember — nickname unique 생성 + default avatar attach + 3회 save")
     void upgradeMemberSuccess() {
         // given
         MemberData member = mock(MemberData.class);
+        AvatarBodyDto bodyResource = mock(AvatarBodyDto.class);
+        AvatarBodyUri bodyUri = new AvatarBodyUri("https://cdn/body.png");
+        AvatarFaceUri faceUri = new AvatarFaceUri("https://cdn/face.png");
+        AvatarIconUri iconUri = new AvatarIconUri("https://cdn/icon.png");
+        when(userProfileRepository.existsByNickname(any(Nickname.class))).thenReturn(false);
+        when(userAvatarQueryService.getDefaultAvatarBody()).thenReturn(bodyResource);
+        when(bodyResource.getCombinePositionX()).thenReturn(60);
+        when(bodyResource.getCombinePositionY()).thenReturn(41);
+        when(userAvatarQueryService.getDefaultAvatarBodyUri()).thenReturn(bodyUri);
+        when(userAvatarQueryService.getDefaultAvatarFaceUri()).thenReturn(faceUri);
+        when(userAvatarQueryService.getDefaultAvatarIconUri()).thenReturn(iconUri);
 
         // when
         temporaryUserInitializeService.upgradeMember(member);
 
-        // then
-        verify(member).updateProfileBio("nickname", "introduction");
+        // then — V15 unique 제약 우회: nickname-<8자 hex>로 매번 다른 값
+        ArgumentCaptor<String> nickCaptor = ArgumentCaptor.forClass(String.class);
+        verify(member).updateProfileBio(nickCaptor.capture(), eq("introduction"));
+        assertThat(nickCaptor.getValue())
+                .startsWith("nickname-")
+                .hasSize("nickname-".length() + 8)
+                .matches("nickname-[0-9a-f]{8}");
+        verify(userProfileRepository).existsByNickname(any(Nickname.class));
         verify(member).updateWalletAddress(any());
-        verify(memberRepository, times(2)).save(member);
+        // avatar default attach (broadcaster NPE 방지)
+        verify(member).updateAvatarBody(eq(bodyUri), eq(60), eq(41));
+        verify(member).updateAvatarFace(eq(faceUri), eq(FaceSourceType.INTERNAL_IMAGE),
+                eq(0.0), eq(0.0), eq(100.0));
+        verify(member).updateAvatarIcon(eq(iconUri));
+        // profile / wallet / avatar 각각 save
+        verify(memberRepository, times(3)).save(member);
+    }
+
+    @Test
+    @DisplayName("upgradeMember — nickname 충돌 시 재시도 후 unique 후보를 채택한다")
+    void upgradeMemberRetriesOnNicknameCollision() {
+        // given
+        MemberData member = mock(MemberData.class);
+        AvatarBodyDto bodyResource = mock(AvatarBodyDto.class);
+        // 첫 시도는 충돌, 두 번째 시도는 성공
+        when(userProfileRepository.existsByNickname(any(Nickname.class)))
+                .thenReturn(true)
+                .thenReturn(false);
+        when(userAvatarQueryService.getDefaultAvatarBody()).thenReturn(bodyResource);
+        when(userAvatarQueryService.getDefaultAvatarBodyUri()).thenReturn(new AvatarBodyUri("u"));
+        when(userAvatarQueryService.getDefaultAvatarFaceUri()).thenReturn(new AvatarFaceUri("u"));
+        when(userAvatarQueryService.getDefaultAvatarIconUri()).thenReturn(new AvatarIconUri("u"));
+
+        // when
+        temporaryUserInitializeService.upgradeMember(member);
+
+        // then — 두 번째 후보가 nickname으로 채택됨
+        verify(userProfileRepository, times(2)).existsByNickname(any(Nickname.class));
+        verify(member).updateProfileBio(any(String.class), eq("introduction"));
     }
 }


### PR DESCRIPTION
## Summary

develop → release(stg) 동기화. PR #196의 2 commit만 포함 (다른 작업 섞임 X).

## Includes

- `ef347560` fix(temp-user): make createFullMember V15-compatible
  - V15(`uk_user_profile_nickname`) 적용 후 두 번째 호출부터 USR-001 실패 → unique nickname 생성 + default avatar attach
- `9fcc4637` fix(security): gate temporary member endpoints to non-prod profiles
  - `EasyUserManagementController` `@Profile("!prod")` — 도입 시점부터의 prod 잠재 노출 정리

원본 PR: #196 (이미 develop으로 머지됨)

## Why now

backend `release`에 V15가 이미 ship된 상태(PR #194). 이 호환 fix가 stg에 들어가야 pfplay-web 이슈 #282의 e2e가 stg에서 통과.

## Test plan

- [x] PR #196에서 `:user:test` PASS, `:app:bootJar` 빌드, 로컬 docker createFullMember 200 × 4 + DB 검증, 로컬 e2e 6/6 PASS 모두 완료
- [ ] release 머지 → stg 자동 배포 확인
- [ ] stg에서 frontend e2e 통과 확인 (frontend 새 배포 trigger 별도 필요 — 본 PR로는 자동 검증 X)

## prod ship

V15 자체가 prod 미배포 상태이므로 본 fix도 prod ship 긴급도 없음. release → main 끌어올림은 admin platform M5/M6 prod ship 묶음과 함께 정리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)