### PR TITLE
release: hot-fix enterPartyroom optional body (PR #200)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/PartyroomAccessCommandController.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/PartyroomAccessCommandController.java
@@ -30,15 +30,17 @@ public class PartyroomAccessCommandController {
 
     private final PartyroomAccessCommandService partyroomAccessCommandService;
 
-    @Operation(summary = "파티룸 입장", description = "파티룸에 입장합니다. 입장 시 크루(Crew)로 등록되며, 크루 정보가 반환됩니다. 요청 본문의 countryCode(ISO 3166-1 alpha-2)는 선택값으로, 주어진 경우 해당 입장 시점의 국가 코드로 저장되고 생략/null이면 비워집니다.")
+    @Operation(summary = "파티룸 입장", description = "파티룸에 입장합니다. 입장 시 크루(Crew)로 등록되며, 크루 정보가 반환됩니다. 요청 본문 자체와 본문의 countryCode(ISO 3166-1 alpha-2)는 모두 선택값으로, 주어진 경우 해당 입장 시점의 국가 코드로 저장되고 본문 생략 또는 countryCode 생략/null이면 비워집니다.")
     @ApiResponse(responseCode = "201", description = "파티룸 입장 성공")
     @SecurityRequirement(name = "cookieAuth")
     @ApiErrorCodes({PartyroomException.class, PenaltyException.class})
     @PostMapping("/{partyroomId}/crews")
     public ResponseEntity<ApiCommonResponse<EnterPartyroomResponse>> enterPartyroom(
             @Parameter(description = "파티룸 ID") @PathVariable Long partyroomId,
-            @Valid @RequestBody EnterPartyroomRequest request) {
-        CountryCode countryCode = request.countryCode() == null ? null : CountryCode.of(request.countryCode());
+            @Valid @RequestBody(required = false) EnterPartyroomRequest request) {
+        CountryCode countryCode = (request == null || request.countryCode() == null)
+                ? null
+                : CountryCode.of(request.countryCode());
         CrewData crew = partyroomAccessCommandService.tryEnter(new PartyroomId(partyroomId), countryCode);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiCommonResponse.success(EnterPartyroomResponse.from(crew)));
     }

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/PartyroomAccessCommandControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/PartyroomAccessCommandControllerTest.java
@@ -54,6 +54,40 @@ class PartyroomAccessCommandControllerTest extends AbstractPartyCommandWebMvcTes
     }
 
     @Test
+    @DisplayName("enterPartyroom — body 자체 생략 시에도 201 Created (frontend가 국기 기능 비활성화 케이스)")
+    void enterPartyroomWithoutBodyReturns201() throws Exception {
+        // given
+        CrewData crew = mock(CrewData.class);
+        when(crew.getId()).thenReturn(1L);
+        when(crew.getGradeType()).thenReturn(GradeType.CLUBBER);
+        when(partyroomAccessCommandService.tryEnter(any(), any())).thenReturn(crew);
+
+        // when & then — no .content(), no .contentType()
+        mockMvc.perform(post("/api/v1/partyrooms/1/crews")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf()))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("enterPartyroom — Content-Type만 있고 body가 빈 경우에도 201 Created")
+    void enterPartyroomWithEmptyBodyReturns201() throws Exception {
+        // given
+        CrewData crew = mock(CrewData.class);
+        when(crew.getId()).thenReturn(1L);
+        when(crew.getGradeType()).thenReturn(GradeType.CLUBBER);
+        when(partyroomAccessCommandService.tryEnter(any(), any())).thenReturn(crew);
+
+        // when & then — empty JSON object
+        mockMvc.perform(post("/api/v1/partyrooms/1/crews")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
     @DisplayName("enterPartyroom — 잘못된 countryCode 형식은 400")
     void enterPartyroomWithInvalidCountryCodeReturns400() throws Exception {
         mockMvc.perform(post("/api/v1/partyrooms/1/crews")


### PR DESCRIPTION
## Summary

Promotes the enterPartyroom hot-fix (PR #200) to release for stg/dev auto-deploy.

Fixes 400 \"Required request body is missing\" on \`POST /api/v1/partyrooms/{id}/crews\` when the client omits the body — surfaced after pfplay-web disabled the country flag feature and stopped sending any body.

## Risk

Low. Pure widening of accepted input; previous valid requests unchanged. No DB/migration impact.

## Test plan
- [x] CI green on develop
- [ ] Manual on stg post-deploy: \`POST /api/v1/partyrooms/1/crews\` (Main Stage) with no body → 201

🤖 Generated with [Claude Code](https://claude.com/claude-code)