### PR TITLE
fix(timezone): JVM TZ를 KST로 고정 (LocalDateTime 9시간 어긋남 fix)

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,6 @@
 FROM eclipse-temurin:21-jre-alpine
+RUN apk add --no-cache tzdata
+ENV TZ=Asia/Seoul
 WORKDIR /opt/api
 COPY app/build/libs/*.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/common/src/main/java/com/pfplaybackend/api/common/config/ClockConfig.java
+++ b/common/src/main/java/com/pfplaybackend/api/common/config/ClockConfig.java
@@ -4,11 +4,23 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.time.Clock;
+import java.time.ZoneId;
 
+/**
+ * 모든 LocalDateTime / Instant 시각은 KST 기준으로 통일.
+ *
+ * 이 zone은 Dockerfile 의 TZ=Asia/Seoul 과 함께 동작 — 컨테이너 OS TZ 가
+ * 우연히 KST 가 아니어도 Clock 자체가 KST 를 보장한다 (방어적 명시).
+ *
+ * 주의: LocalDateTime.now() (Clock 인자 없음) 호출은 여전히 JVM default zone 을
+ * 따른다. 새 코드는 LocalDateTime.now(clock) 를 주입받아 사용할 것.
+ */
 @Configuration
 public class ClockConfig {
+    public static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
     @Bean
     public Clock clock() {
-        return Clock.systemDefaultZone();
+        return Clock.system(KST);
     }
 }

--- a/common/src/test/java/com/pfplaybackend/api/common/config/ClockConfigTest.java
+++ b/common/src/test/java/com/pfplaybackend/api/common/config/ClockConfigTest.java
@@ -1,0 +1,22 @@
+package com.pfplaybackend.api.common.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ClockConfigTest {
+
+    @Test
+    void clockBean_hasKstZone() {
+        Clock clock = new ClockConfig().clock();
+        assertThat(clock.getZone()).isEqualTo(ZoneId.of("Asia/Seoul"));
+    }
+
+    @Test
+    void kstConstant_matchesAsiaSeoul() {
+        assertThat(ClockConfig.KST).isEqualTo(ZoneId.of("Asia/Seoul"));
+    }
+}


### PR DESCRIPTION
## Summary

운영 중 admin 콘솔에서 lastLoginAt 등 모든 시각이 정확히 9시간 어긋나는 증상 발생. 진단 결과 backend root cause 확정.

## Root Cause

- `app/Dockerfile`: TZ env 미설정 → JVM default zone = container OS TZ = **UTC**
- `ClockConfig#clock()`: `Clock.systemDefaultZone()` → UTC clock 반환
- `LocalDateTime.now()` 사용 위치 **27개 파일** (lastLoginAt, createdAt, sentAt, withdrawnAt 등) 모두 UTC 시각으로 저장
- MySQL은 `--default-time-zone=+09:00` (KST) 이지만 LocalDateTime 은 timezone 없는 raw value 라 KST DB 설정과 무관하게 UTC 시각이 그대로 저장됨
- 결과: KST 환경 frontend 가 timezone 없는 LocalDateTime 을 KST 로 해석 → 정확히 9시간 어긋남
  - 예: KST 16:40 로그인이 화면에는 `07:40 KST` 로 표시

## Fix

1. `app/Dockerfile`:
   - `apk add --no-cache tzdata` (Alpine 은 tzdata 미포함이라 TZ env 만으로는 zone 못 찾음)
   - `ENV TZ=Asia/Seoul`
2. `common/.../ClockConfig.java`:
   - `Clock.system(ZoneId.of(\"Asia/Seoul\"))` 명시
   - 컨테이너 OS TZ 와 무관하게 Clock 자체가 KST 보장 (방어적 명시)
   - `KST` public constant 노출 (다른 위치에서 재사용 가능)
3. `ClockConfigTest`: zone 검증 단위 테스트

## ⚠️ BREAKING — 기존 데이터 영향

본 변경 ship 시점부터 새로 저장되는 LocalDateTime 은 KST. 기존 dev/stg DB 에는 UTC 로 저장된 timestamp 가 그대로 남아 있어 화면 표시가 9시간 어긋난 채 유지됨.

**대응 정책 (사용자 합의):** dev/stg DB **reset** (마이그레이션 SQL 대신).
- 영향 컬럼 예: `user_account.last_login_at`, `user_account.withdrawn_at`, `system_announcement.sent_at`, `crew_penalty_history.*_at`, 기타 모든 `*_at` LocalDateTime 컬럼

**prod 영향:** 없음 (admin 콘솔 prod ship 전이라 lastLoginAt 등 사용 화면이 prod 에 노출되지 않음)

## Ship 순서

1. PR merge → develop
2. dev 배포 + dev DB reset
3. release PR → stg 배포 + stg DB reset
4. main PR → prod 배포 (prod DB reset 불필요)

## 잔존 위험

- `LocalDateTime.now()` (Clock 인자 없음) 호출은 여전히 JVM default zone 사용 → Dockerfile TZ env 가 fallback 역할. 향후 `LocalDateTime.now(clock)` 으로 점진 마이그레이션 권장 (별도 follow-up)

## Test plan

- [x] `:common:test` 그린 (ClockConfigTest 포함)
- [ ] dev 배포 후 admin 콘솔에서 새 로그인 → lastLoginAt 이 현재 KST 시각과 일치하는지 확인
- [ ] prod 컨테이너 진입 후 `date` 명령으로 KST 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)