### PR TITLE
release: JVM TZ를 KST로 고정 (timezone fix → stg)

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,6 @@
 FROM eclipse-temurin:21-jre-alpine
+RUN apk add --no-cache tzdata
+ENV TZ=Asia/Seoul
 WORKDIR /opt/api
 COPY app/build/libs/*.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/common/src/main/java/com/pfplaybackend/api/common/config/ClockConfig.java
+++ b/common/src/main/java/com/pfplaybackend/api/common/config/ClockConfig.java
@@ -4,11 +4,23 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.time.Clock;
+import java.time.ZoneId;
 
+/**
+ * 모든 LocalDateTime / Instant 시각은 KST 기준으로 통일.
+ *
+ * 이 zone은 Dockerfile 의 TZ=Asia/Seoul 과 함께 동작 — 컨테이너 OS TZ 가
+ * 우연히 KST 가 아니어도 Clock 자체가 KST 를 보장한다 (방어적 명시).
+ *
+ * 주의: LocalDateTime.now() (Clock 인자 없음) 호출은 여전히 JVM default zone 을
+ * 따른다. 새 코드는 LocalDateTime.now(clock) 를 주입받아 사용할 것.
+ */
 @Configuration
 public class ClockConfig {
+    public static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
     @Bean
     public Clock clock() {
-        return Clock.systemDefaultZone();
+        return Clock.system(KST);
     }
 }

--- a/common/src/test/java/com/pfplaybackend/api/common/config/ClockConfigTest.java
+++ b/common/src/test/java/com/pfplaybackend/api/common/config/ClockConfigTest.java
@@ -1,0 +1,22 @@
+package com.pfplaybackend.api.common.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ClockConfigTest {
+
+    @Test
+    void clockBean_hasKstZone() {
+        Clock clock = new ClockConfig().clock();
+        assertThat(clock.getZone()).isEqualTo(ZoneId.of("Asia/Seoul"));
+    }
+
+    @Test
+    void kstConstant_matchesAsiaSeoul() {
+        assertThat(ClockConfig.KST).isEqualTo(ZoneId.of("Asia/Seoul"));
+    }
+}


### PR DESCRIPTION
## Summary

PR #202 (`fix(timezone): JVM TZ를 KST로 고정`)을 stg로 ship.

develop → release 차이는 본 timezone fix 단건.

## 변경 범위

- `app/Dockerfile`: tzdata + `ENV TZ=Asia/Seoul`
- `common/.../ClockConfig.java`: `Clock.system(ZoneId.of(\"Asia/Seoul\"))` 명시 + `KST` constant
- `common/.../ClockConfigTest.java`: zone 검증

## ⚠️ stg DB reset 필수

기존 stg DB에 UTC 로 저장된 timestamp 가 있어 화면 표시가 9시간 어긋난 채 유지됨.

**권장 순서 (사용자 의견 반영 — ship 전에 reset 이 깔끔):**

1. **release merge 직전** stg VM 에서 미리 reset 준비
   ```bash
   cd /home/eisen/PFPlay/pfplay-platform
   docker compose -f docker-compose.stg.yml -p pfplay-stg down
   docker volume rm pfplay-stg_mysql-data pfplay-stg_redis-data
   ```
2. release merge → GHA `deploy-stg.yml` 트리거 → 새 image pull + `up -d --no-deps app`
3. 빈 volume + 새 KST backend 첫 부팅 → Flyway V1~V16 + admin seed 자동
4. 검증
   ```bash
   docker compose -f docker-compose.stg.yml -p pfplay-stg exec app date
   # → KST 출력
   ```

다만 deploy.sh 가 `--no-deps app` 으로 mysql 컨테이너를 건드리지 않는 모델이라, 1단계에서 mysql/redis 컨테이너까지 down 시켰다면 release merge 트리거된 GHA 가 mysql 을 다시 띄우지 않을 수 있음. 그 경우 사용자가 별도로 `up -d` 한 번 더 실행 필요.

## prod 영향

없음 (admin 콘솔 prod ship 전이라 lastLoginAt 등 timestamp 표시 화면이 prod 노출 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)