### PR TITLE
fix(common): RestTemplate PATCH 지원 — Vercel Edge Config 점검모드 복구 (#211)

### DIFF
--- a/common/src/main/java/com/pfplaybackend/api/common/config/rest/RestTemplateConfig.java
+++ b/common/src/main/java/com/pfplaybackend/api/common/config/rest/RestTemplateConfig.java
@@ -2,12 +2,20 @@ package com.pfplaybackend.api.common.config.rest;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class RestTemplateConfig {
+
+    /**
+     * 기본 SimpleClientHttpRequestFactory(HttpURLConnection)는 PATCH 미지원이라
+     * Vercel Edge Config 쓰기(PATCH)가 영구 실패한다. Java 11+ HttpClient 기반
+     * JdkClientHttpRequestFactory 는 PATCH 를 native 지원한다.
+     * (bugs/2026-05-15-vercel-edge-config-patch-method.md, pfplay-platform#211)
+     */
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        return new RestTemplate(new JdkClientHttpRequestFactory());
     }
 }

--- a/common/src/test/java/com/pfplaybackend/api/common/config/rest/RestTemplateConfigTest.java
+++ b/common/src/test/java/com/pfplaybackend/api/common/config/rest/RestTemplateConfigTest.java
@@ -1,0 +1,24 @@
+package com.pfplaybackend.api.common.config.rest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RestTemplateConfigTest {
+
+    /**
+     * 근본 원인 회귀 방지: 기본 SimpleClientHttpRequestFactory(HttpURLConnection)는
+     * PATCH 미지원이라 Vercel Edge Config 쓰기가 영구 실패한다
+     * (bugs/2026-05-15-vercel-edge-config-patch-method.md, #211).
+     * RestTemplate 빈은 PATCH 지원 팩토리(JdkClientHttpRequestFactory, Java 11+)를 써야 한다.
+     */
+    @Test
+    void restTemplateBean_usesPatchCapableJdkClientHttpRequestFactory() {
+        RestTemplate restTemplate = new RestTemplateConfig().restTemplate();
+
+        assertThat(restTemplate.getRequestFactory())
+                .isInstanceOf(JdkClientHttpRequestFactory.class);
+    }
+}


### PR DESCRIPTION
## 개요
`RestTemplate` 기본 팩토리 `SimpleClientHttpRequestFactory`(HttpURLConnection)가 PATCH 미지원이라 `VercelEdgeConfigAdapter.writeMaintenance` 의 PATCH 호출이 영구 실패 → Edge Config maintenance 키 미설정 → 점검 모드 강제 차단(middleware page rewrite, Path A) 영구 미동작(reload 한 방으로 우회 가능). Java 11+ `HttpClient` 기반 `JdkClientHttpRequestFactory`(PATCH native 지원)로 교체.

## 변경
- `common` `RestTemplateConfig`: `new RestTemplate(new JdkClientHttpRequestFactory())` (의존성 추가 0, JDK21 환경)
- TDD: `RestTemplateConfigTest` — 빈의 요청 팩토리가 PATCH 지원 타입인지 검증(근본원인 회귀 방지). RED(SimpleClientHttpRequestFactory) → GREEN.

## blast radius (공유 @Bean)
`RestTemplate` 빈 사용처 grep 결과 `VercelEdgeConfigAdapter`(PATCH) + `PytubeSearchService`(GET) 둘뿐.
- `VercelEdgeConfigAdapterTest` 통과
- `PytubeSearchServiceTest` 통과 (GET, JSON, 리다이렉트 의존 없음)
- 잔여 리스크(낮음): `java.net.http.HttpClient` 기본 redirect=NEVER (HttpURLConnection 은 follow). 두 사용처 모두 리다이렉트 의존 없음.

## 테스트
- `:common:test RestTemplateConfigTest` GREEN
- 회귀 `:app:test VercelEdgeConfigAdapterTest`, `:playlist:test PytubeSearchServiceTest` PASS
- BUILD SUCCESSFUL

## 배포 후 확인 (코드 외)
- [ ] staging 점검공지 등록 → 시각 도래 후 새로고침 → URL `/maintenance` redirect (Path A 정상)
- [ ] backend 로그에서 `[EdgeConfig] write failed` + `ProtocolException: Invalid HTTP method: PATCH` 사라짐
- [ ] Vercel Edge Config items 에 `maintenance`(prod)/`maintenance_preview`(staging) 키 set
- [ ] **Fix 3 (필수)**: 적용 전 staging DB 의 cancel 안 된 ACTIVE `system_announcement` row 점검/정리 (노트 §Fix 3)

## 범위 밖 (별 작업)
- Path B(`MaintenanceModeFilter`/system_config) dead code 정리 ADR
- `scheduled_end_at` 자동 종료/deadman switch 검토

관련 이슈: #211 · 노트 `bugs/2026-05-15-vercel-edge-config-patch-method.md` · 로드맵 Cluster F/Tier1

🤖 Generated with [Claude Code](https://claude.com/claude-code)