### PR TITLE
fix(auth): authorize scope %20 인코딩 — 트위터 OAuth 로그인 401 수정 (#214)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/auth/adapter/out/external/config/OAuth2Properties.java
+++ b/app/src/main/java/com/pfplaybackend/api/auth/adapter/out/external/config/OAuth2Properties.java
@@ -86,12 +86,17 @@ public class OAuth2Properties {
         // ===== 헬퍼 메서드 =====
 
         /**
-         * 스코프를 +로 구분된 문자열로 반환 (URL 파라미터용)
+         * 스코프를 공백(%20) 으로 구분된 URL 인코딩 문자열로 반환 (authorize URL scope 파라미터용).
          *
-         * @return 예: "openid+email+profile"
+         * 주의: 리터럴 '+' 로 join 하면 안 된다 — X(Twitter) OAuth2 authorize 는 query 의
+         * '+' 를 공백으로 디코딩하지 않고 리터럴 처리하므로 "a+b" 가 단일 무효 스코프가 되어
+         * 토큰 스코프 실효 0 → /2/users/me 403. 공백은 '%20' 으로 인코딩한다.
+         * (bugs/2026-05-17-twitter-oauth-login-401.md, pfplay-platform#214)
+         *
+         * @return 예: "users.read%20tweet.read"
          */
         public String getScopesAsUrlEncoded() {
-            return scopes != null ? String.join("+", scopes) : "";
+            return scopes != null ? String.join("%20", scopes) : "";
         }
 
         /**

--- a/app/src/test/java/com/pfplaybackend/api/auth/application/service/OAuthUrlServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/auth/application/service/OAuthUrlServiceTest.java
@@ -153,6 +153,28 @@ class OAuthUrlServiceTest {
     }
 
     @Test
+    @DisplayName("generateAuthUrl — Twitter scope는 공백을 %20으로 인코딩한다 (리터럴 + 금지: X가 +를 리터럴 처리해 무효 스코프가 되어 /2/users/me 403)")
+    void generateAuthUrlTwitterScopeIsSpaceEncodedNotPlus() {
+        // given
+        OAuth2Properties.Provider twitterConfig = new OAuth2Properties.Provider();
+        twitterConfig.setClientId("twitter-client-id");
+        twitterConfig.setRedirectUri("http://localhost/twitter/callback");
+        twitterConfig.setAuthorizationUri("https://twitter.com/i/oauth2/authorize");
+        twitterConfig.setScopes(java.util.List.of("users.read", "tweet.read"));
+
+        when(oAuth2Properties.getProviders()).thenReturn(Map.of(TWITTER, twitterConfig));
+        when(stateStorePort.generateAndStoreState(TWITTER)).thenReturn("twitter-state");
+
+        // when
+        OAuthUrlResult result = oAuthUrlService.generateAuthUrl(OAuthProvider.TWITTER, TEST_VERIFIER);
+
+        // then
+        assertThat(result.authUrl())
+                .contains("scope=users.read%20tweet.read")
+                .doesNotContain("scope=users.read+tweet.read");
+    }
+
+    @Test
     @DisplayName("generateAuthUrl — 설정되지 않은 provider이면 예외가 발생한다")
     void generateAuthUrlUnconfiguredProviderThrows() {
         // given


### PR DESCRIPTION
## 개요
트위터(X) OAuth 로그인 전면 실패(`auth/oauth/callback` 401). 구글은 정상.

## 근본 원인 (코드+prod로그+재현 datum 확정)
`OAuth2Properties.getScopesAsUrlEncoded()` = `String.join("+", scopes)` → 트위터 authorize URL 이 `scope=users.read+tweet.read`(리터럴 `+`) 로 전송. X OAuth2 authorize 는 query `scope` 의 `+` 를 공백으로 디코딩하지 않고 **리터럴 처리** → `users.read+tweet.read` = 단일 무효 스코프 → 토큰은 발급되나 `users.read`/`tweet.read` 실효 0 → `GET /2/users/me` **403**(prod 로그 확인) → `OAuthException` → `AuthService` catch → `AuthenticationException` → **401**. 구글은 스코프 1개(`email`, 구분자 無)라 영향 없음 → provider 비대칭 설명.

## 변경
- `getScopesAsUrlEncoded()`: `+` → `%20` (공백 percent-encoded). 스코프 토큰(`users.read`,`tweet.read`,`email`,`offline.access`)엔 추가 인코딩 필요 문자 없음.
- TDD: `OAuthUrlServiceTest.generateAuthUrlTwitterScopeIsSpaceEncodedNotPlus` — authorize URL scope 가 `%20`(리터럴 `+` 아님) 검증. RED→GREEN.

## blast radius
`getScopesAsUrlEncoded()` 사용처 = `OAuthUrlService` Google/Twitter authorize 빌더 2곳뿐. 구글 단일 스코프 영향 없음.

## 테스트
- `:app:test OAuthUrlServiceTest` 8/8 (신규 포함) · `OAuthClientServiceTest` · `AuthControllerTest` PASS, BUILD SUCCESSFUL

## 배포 후 확인
- [ ] staging/prod 에서 트위터 로그인 → `/2/users/me` 200, 콜백 정상, 세션 쿠키 발급
- [ ] 트위터 authorize URL 의 `scope` 가 `users.read%20tweet.read`

## 범위 밖 (별 개선)
`AuthService` catch-all 이 외부 provider 에러(OAuthException, 본래 502)를 `AuthenticationException`(401)로 뭉개 원인 은닉 — 에러 구분/로깅 개선은 별 작업.

관련 이슈: #214 · 노트 `bugs/2026-05-17-twitter-oauth-login-401.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)