### PR TITLE
stg 승격: 트위터 OAuth scope %20 + Edge Config PATCH (develop→release)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/auth/adapter/out/external/config/OAuth2Properties.java
+++ b/app/src/main/java/com/pfplaybackend/api/auth/adapter/out/external/config/OAuth2Properties.java
@@ -86,12 +86,17 @@ public class OAuth2Properties {
         // ===== 헬퍼 메서드 =====
 
         /**
-         * 스코프를 +로 구분된 문자열로 반환 (URL 파라미터용)
+         * 스코프를 공백(%20) 으로 구분된 URL 인코딩 문자열로 반환 (authorize URL scope 파라미터용).
          *
-         * @return 예: "openid+email+profile"
+         * 주의: 리터럴 '+' 로 join 하면 안 된다 — X(Twitter) OAuth2 authorize 는 query 의
+         * '+' 를 공백으로 디코딩하지 않고 리터럴 처리하므로 "a+b" 가 단일 무효 스코프가 되어
+         * 토큰 스코프 실효 0 → /2/users/me 403. 공백은 '%20' 으로 인코딩한다.
+         * (bugs/2026-05-17-twitter-oauth-login-401.md, pfplay-platform#214)
+         *
+         * @return 예: "users.read%20tweet.read"
          */
         public String getScopesAsUrlEncoded() {
-            return scopes != null ? String.join("+", scopes) : "";
+            return scopes != null ? String.join("%20", scopes) : "";
         }
 
         /**

--- a/app/src/test/java/com/pfplaybackend/api/auth/application/service/OAuthUrlServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/auth/application/service/OAuthUrlServiceTest.java
@@ -153,6 +153,28 @@ class OAuthUrlServiceTest {
     }
 
     @Test
+    @DisplayName("generateAuthUrl — Twitter scope는 공백을 %20으로 인코딩한다 (리터럴 + 금지: X가 +를 리터럴 처리해 무효 스코프가 되어 /2/users/me 403)")
+    void generateAuthUrlTwitterScopeIsSpaceEncodedNotPlus() {
+        // given
+        OAuth2Properties.Provider twitterConfig = new OAuth2Properties.Provider();
+        twitterConfig.setClientId("twitter-client-id");
+        twitterConfig.setRedirectUri("http://localhost/twitter/callback");
+        twitterConfig.setAuthorizationUri("https://twitter.com/i/oauth2/authorize");
+        twitterConfig.setScopes(java.util.List.of("users.read", "tweet.read"));
+
+        when(oAuth2Properties.getProviders()).thenReturn(Map.of(TWITTER, twitterConfig));
+        when(stateStorePort.generateAndStoreState(TWITTER)).thenReturn("twitter-state");
+
+        // when
+        OAuthUrlResult result = oAuthUrlService.generateAuthUrl(OAuthProvider.TWITTER, TEST_VERIFIER);
+
+        // then
+        assertThat(result.authUrl())
+                .contains("scope=users.read%20tweet.read")
+                .doesNotContain("scope=users.read+tweet.read");
+    }
+
+    @Test
     @DisplayName("generateAuthUrl — 설정되지 않은 provider이면 예외가 발생한다")
     void generateAuthUrlUnconfiguredProviderThrows() {
         // given

--- a/common/src/main/java/com/pfplaybackend/api/common/config/rest/RestTemplateConfig.java
+++ b/common/src/main/java/com/pfplaybackend/api/common/config/rest/RestTemplateConfig.java
@@ -2,12 +2,20 @@ package com.pfplaybackend.api.common.config.rest;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class RestTemplateConfig {
+
+    /**
+     * 기본 SimpleClientHttpRequestFactory(HttpURLConnection)는 PATCH 미지원이라
+     * Vercel Edge Config 쓰기(PATCH)가 영구 실패한다. Java 11+ HttpClient 기반
+     * JdkClientHttpRequestFactory 는 PATCH 를 native 지원한다.
+     * (bugs/2026-05-15-vercel-edge-config-patch-method.md, pfplay-platform#211)
+     */
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        return new RestTemplate(new JdkClientHttpRequestFactory());
     }
 }

--- a/common/src/test/java/com/pfplaybackend/api/common/config/rest/RestTemplateConfigTest.java
+++ b/common/src/test/java/com/pfplaybackend/api/common/config/rest/RestTemplateConfigTest.java
@@ -1,0 +1,24 @@
+package com.pfplaybackend.api.common.config.rest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RestTemplateConfigTest {
+
+    /**
+     * 근본 원인 회귀 방지: 기본 SimpleClientHttpRequestFactory(HttpURLConnection)는
+     * PATCH 미지원이라 Vercel Edge Config 쓰기가 영구 실패한다
+     * (bugs/2026-05-15-vercel-edge-config-patch-method.md, #211).
+     * RestTemplate 빈은 PATCH 지원 팩토리(JdkClientHttpRequestFactory, Java 11+)를 써야 한다.
+     */
+    @Test
+    void restTemplateBean_usesPatchCapableJdkClientHttpRequestFactory() {
+        RestTemplate restTemplate = new RestTemplateConfig().restTemplate();
+
+        assertThat(restTemplate.getRequestFactory())
+                .isInstanceOf(JdkClientHttpRequestFactory.class);
+    }
+}


### PR DESCRIPTION
## 개요
develop 누적 2건을 stg(release) 로 승격. 범위 확인 완료 — release..develop = 아래 2 fix 만, 무관 커밋 없음. main..release 는 비어있어 이후 release→main 시 prod 엔 이 2건만 반영.

## 포함 (정확히 2건)
1. **트위터 OAuth 로그인 401 수정 (#214/#215)** — `getScopesAsUrlEncoded()` `+`→`%20`. X 가 authorize scope 의 `+` 를 리터럴 처리 → 무효 스코프 → `/2/users/me` 403 → 401. **prod 트위터 로그인 전면 차단 상태 → 최우선.**
2. **Vercel Edge Config PATCH 수정 (#211/#213)** — `RestTemplate` → `JdkClientHttpRequestFactory`. 기본 팩토리 PATCH 미지원으로 점검모드 강제차단(Path A) 영구 미동작.

## stg 검증 (release 머지 후, main 승격 전 필수)
- [ ] **트위터 로그인** stg 에서 정상 (authorize scope `users.read%20tweet.read`, `/2/users/me` 200, 콜백·세션쿠키 OK) — 우선
- [ ] 구글 로그인 회귀 없음
- [ ] Edge Config: 점검공지 등록→시각 도래→새로고침 시 `/maintenance` redirect, 백엔드 `ProtocolException: PATCH` 로그 사라짐, Edge Config maintenance 키 set
- [ ] **Fix3**: 적용 전 stg DB 의 cancel 안 된 ACTIVE `system_announcement` row 점검/정리

## 다음
stg 검증 통과 → release→main(prod) 승격 PR.

관련: #214 #215 #211 #213 · 노트 bugs/2026-05-17-twitter-oauth-login-401.md, bugs/2026-05-15-vercel-edge-config-patch-method.md