### PR TITLE
release → main: Vercel Edge Config PATCH 픽스 prod 반영 (#213, #215)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/auth/adapter/out/external/config/OAuth2Properties.java
+++ b/app/src/main/java/com/pfplaybackend/api/auth/adapter/out/external/config/OAuth2Properties.java
@@ -86,12 +86,17 @@ public class OAuth2Properties {
         // ===== 헬퍼 메서드 =====
 
         /**
-         * 스코프를 +로 구분된 문자열로 반환 (URL 파라미터용)
+         * 스코프를 공백(%20) 으로 구분된 URL 인코딩 문자열로 반환 (authorize URL scope 파라미터용).
          *
-         * @return 예: "openid+email+profile"
+         * 주의: 리터럴 '+' 로 join 하면 안 된다 — X(Twitter) OAuth2 authorize 는 query 의
+         * '+' 를 공백으로 디코딩하지 않고 리터럴 처리하므로 "a+b" 가 단일 무효 스코프가 되어
+         * 토큰 스코프 실효 0 → /2/users/me 403. 공백은 '%20' 으로 인코딩한다.
+         * (bugs/2026-05-17-twitter-oauth-login-401.md, pfplay-platform#214)
+         *
+         * @return 예: "users.read%20tweet.read"
          */
         public String getScopesAsUrlEncoded() {
-            return scopes != null ? String.join("+", scopes) : "";
+            return scopes != null ? String.join("%20", scopes) : "";
         }
 
         /**

--- a/app/src/test/java/com/pfplaybackend/api/auth/application/service/OAuthUrlServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/auth/application/service/OAuthUrlServiceTest.java
@@ -153,6 +153,28 @@ class OAuthUrlServiceTest {
     }
 
     @Test
+    @DisplayName("generateAuthUrl — Twitter scope는 공백을 %20으로 인코딩한다 (리터럴 + 금지: X가 +를 리터럴 처리해 무효 스코프가 되어 /2/users/me 403)")
+    void generateAuthUrlTwitterScopeIsSpaceEncodedNotPlus() {
+        // given
+        OAuth2Properties.Provider twitterConfig = new OAuth2Properties.Provider();
+        twitterConfig.setClientId("twitter-client-id");
+        twitterConfig.setRedirectUri("http://localhost/twitter/callback");
+        twitterConfig.setAuthorizationUri("https://twitter.com/i/oauth2/authorize");
+        twitterConfig.setScopes(java.util.List.of("users.read", "tweet.read"));
+
+        when(oAuth2Properties.getProviders()).thenReturn(Map.of(TWITTER, twitterConfig));
+        when(stateStorePort.generateAndStoreState(TWITTER)).thenReturn("twitter-state");
+
+        // when
+        OAuthUrlResult result = oAuthUrlService.generateAuthUrl(OAuthProvider.TWITTER, TEST_VERIFIER);
+
+        // then
+        assertThat(result.authUrl())
+                .contains("scope=users.read%20tweet.read")
+                .doesNotContain("scope=users.read+tweet.read");
+    }
+
+    @Test
     @DisplayName("generateAuthUrl — 설정되지 않은 provider이면 예외가 발생한다")
     void generateAuthUrlUnconfiguredProviderThrows() {
         // given

--- a/common/src/main/java/com/pfplaybackend/api/common/config/rest/RestTemplateConfig.java
+++ b/common/src/main/java/com/pfplaybackend/api/common/config/rest/RestTemplateConfig.java
@@ -2,12 +2,20 @@ package com.pfplaybackend.api.common.config.rest;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class RestTemplateConfig {
+
+    /**
+     * 기본 SimpleClientHttpRequestFactory(HttpURLConnection)는 PATCH 미지원이라
+     * Vercel Edge Config 쓰기(PATCH)가 영구 실패한다. Java 11+ HttpClient 기반
+     * JdkClientHttpRequestFactory 는 PATCH 를 native 지원한다.
+     * (bugs/2026-05-15-vercel-edge-config-patch-method.md, pfplay-platform#211)
+     */
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        return new RestTemplate(new JdkClientHttpRequestFactory());
     }
 }

--- a/common/src/test/java/com/pfplaybackend/api/common/config/rest/RestTemplateConfigTest.java
+++ b/common/src/test/java/com/pfplaybackend/api/common/config/rest/RestTemplateConfigTest.java
@@ -1,0 +1,24 @@
+package com.pfplaybackend.api.common.config.rest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RestTemplateConfigTest {
+
+    /**
+     * 근본 원인 회귀 방지: 기본 SimpleClientHttpRequestFactory(HttpURLConnection)는
+     * PATCH 미지원이라 Vercel Edge Config 쓰기가 영구 실패한다
+     * (bugs/2026-05-15-vercel-edge-config-patch-method.md, #211).
+     * RestTemplate 빈은 PATCH 지원 팩토리(JdkClientHttpRequestFactory, Java 11+)를 써야 한다.
+     */
+    @Test
+    void restTemplateBean_usesPatchCapableJdkClientHttpRequestFactory() {
+        RestTemplate restTemplate = new RestTemplateConfig().restTemplate();
+
+        assertThat(restTemplate.getRequestFactory())
+                .isInstanceOf(JdkClientHttpRequestFactory.class);
+    }
+}


### PR DESCRIPTION
## 요약

stg(`release`)에 검증된 #216(= #213 + #215)을 prod(`main`)로 승격한다.

- **#213 — Vercel Edge Config PATCH 픽스 (핵심)**: `RestTemplate` 기본 `SimpleClientHttpRequestFactory`(HttpURLConnection)는 PATCH 미지원이라 점검 공지의 Edge Config 쓰기가 **영구 실패**해 왔다(Path A 강제 차단 미동작). Java 11+ `JdkClientHttpRequestFactory`로 교체해 PATCH native 지원. (`bugs/2026-05-15-vercel-edge-config-patch-method.md`)
- **#215 — OAuth authorize scope `%20` 인코딩 (동반, 무해)**: 트위터 401의 진짜 원인은 아님(외부 X 정책). 무해 위생 변경이라 동반 승격. 트위터 로그인 UI는 별도 작업으로 제거 예정.

변경 파일 4개:
- `common/.../RestTemplateConfig.java` (+ `RestTemplateConfigTest`)
- `auth/.../OAuth2Properties.java` (+ `OAuthUrlServiceTest`)

## prod 승격 선결 조건 (완료)

#213이 PATCH를 정상 동작시키므로, prod `system_announcement`에 남아 있던 stale ACTIVE row(`maintenance_started_at` NOT NULL, `cancelled_at` NULL)를 **배포 전 cancel 처리 완료**. 미처리 시 배포 직후 cron tick이 prod Edge Config를 ACTIVE PATCH → prod 전면 `/maintenance` 잠금 위험이 있었음.

## 배포 후 검증

- [ ] backend 로그에서 `Invalid HTTP method: PATCH` ERROR 소멸
- [ ] Vercel prod Edge Config에 `maintenance` 키 set 안 됨 (stale row cancel 했으므로 비어 있어야 정상)
- [ ] prod 페이지 정상 (`/maintenance` rewrite 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)