### PR TITLE
test(party): skip→플레이리스트 최하단·DJ큐 밀림 invariant 회귀 잠금 (#222)

### DIFF
--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackCommandServiceTest.java
@@ -206,6 +206,100 @@ class PlaybackCommandServiceTest {
         verify(userActivityPort).updateDjPointScore(userId, 1);
     }
 
+    // ── #222 회귀 잠금: skip(자의/타의) 시 DJ큐 회전 + 본인 플레이리스트 회전이 함께 wiring 되는지 ──
+    // DJ큐 산술(#1→맨뒤)은 PartyroomAggregateServiceTest.rotatesCorrectly,
+    // 트랙 회전 SQL(orderNumber=1→total)은 TrackRepositoryReorderIntegrationTest 가 별도로 잠금.
+    // 여기서는 "skip 경로가 rotateDjQueue + getFirstTrack(현재 DJ 플레이리스트) 양쪽을 호출한다"는
+    // 수렴 지점의 invariant 를 잠근다.
+
+    private DjData stubDoStartWithQueuedDj(PlaybackTimeLimit timeLimit, Duration trackDuration) {
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(partyroomId.getId()).partyroomId(partyroomId)
+                .playbackTimeLimit(timeLimit)
+                .build();
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+
+        PlaylistId playlistId = new PlaylistId(100L);
+        DjData djData = DjData.builder()
+                .id(1L).partyroomId(partyroomId).crewId(new CrewId(1L))
+                .playlistId(playlistId).orderNumber(1).build();
+        when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(List.of(djData));
+        when(partyroomAggregateService.rotateDjQueue(partyroomId)).thenReturn(List.of(djData));
+
+        CrewData djCrew = CrewData.builder()
+                .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+        when(aggregatePort.findCrewById(1L)).thenReturn(Optional.of(djCrew));
+
+        PlaybackTrackDto trackDto = new PlaybackTrackDto("linkId", "Song", "thumb.jpg", trackDuration, 1);
+        when(playlistCommandPort.getFirstTrack(playlistId)).thenReturn(trackDto);
+        return djData;
+    }
+
+    @Test
+    @DisplayName("#222 skipPlayback — 큐에 DJ가 있으면 DJ큐 회전과 현재 DJ 플레이리스트 회전(getFirstTrack)이 함께 호출된다")
+    void skipPlaybackWithQueuedDjRotatesQueueAndPlaylist() {
+        // given — 트랙 길이가 제한 이내(재생됨)
+        DjData dj = stubDoStartWithQueuedDj(PlaybackTimeLimit.ofMinutes(10), Duration.fromString("3:30"));
+
+        PlaybackData savedPlayback = mock(PlaybackData.class);
+        lenient().when(savedPlayback.getId()).thenReturn(1L);
+        lenient().when(savedPlayback.getDuration()).thenReturn(Duration.ofSeconds(210));
+        when(playbackRepository.save(any(PlaybackData.class))).thenReturn(savedPlayback);
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(PartyroomPlaybackData.createFor(partyroomId));
+
+        // when — 자의 skip (DELETE /playbacks/current → skipPlayback)
+        playbackCommandService.skipPlayback(partyroomId);
+
+        // then — 스케줄 취소 + DJ큐 밀림 + 트랙 회전 양쪽 wiring
+        verify(expirationTaskPort).cancelExpiration(String.valueOf(partyroomId.getId()));
+        verify(partyroomAggregateService).rotateDjQueue(partyroomId);
+        verify(playlistCommandPort).getFirstTrack(dj.getPlaylistId());
+    }
+
+    @Test
+    @DisplayName("#222 skipByManager — MODERATOR 타의 skip 도 DJ큐 회전 + 플레이리스트 회전을 함께 호출한다")
+    void skipByManagerWithQueuedDjRotatesQueueAndPlaylist() {
+        // given — MODERATOR 권한 컨텍스트
+        ActivePartyroomDto activeDto = new ActivePartyroomDto(partyroomId.getId(), false, 1L, true, new PlaybackId(1L), new CrewId(1L));
+        CrewData adjuster = CrewData.builder().id(1L).userId(userId).gradeType(GradeType.MODERATOR).build();
+        when(partyroomQueryService.getMyActivePartyroom(userId)).thenReturn(Optional.of(activeDto));
+        when(partyroomQueryService.getCrewOrThrow(new PartyroomId(activeDto.id()), userId)).thenReturn(adjuster);
+
+        DjData dj = stubDoStartWithQueuedDj(PlaybackTimeLimit.ofMinutes(10), Duration.fromString("3:30"));
+
+        PlaybackData savedPlayback = mock(PlaybackData.class);
+        lenient().when(savedPlayback.getId()).thenReturn(1L);
+        lenient().when(savedPlayback.getDuration()).thenReturn(Duration.ofSeconds(210));
+        when(playbackRepository.save(any(PlaybackData.class))).thenReturn(savedPlayback);
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(PartyroomPlaybackData.createFor(partyroomId));
+
+        // when — 타의 skip
+        playbackCommandService.skipByManager(partyroomId);
+
+        // then
+        verify(expirationTaskPort).cancelExpiration(String.valueOf(partyroomId.getId()));
+        verify(partyroomAggregateService).rotateDjQueue(partyroomId);
+        verify(playlistCommandPort).getFirstTrack(dj.getPlaylistId());
+    }
+
+    @Test
+    @DisplayName("#222 time-limit edge — 트랙이 제한을 초과하면 재생되지 않아도 getFirstTrack(플레이리스트 회전)은 이미 호출된다 (의도된 동작)")
+    void timeLimitExceededStillRotatesPlaylistBeforeCheck() {
+        // given — 단일 DJ, 트랙 길이(3:30=210s)가 제한(1분=60s)을 초과 → 재생 안 됨
+        // doStart 는 getFirstTrack(플레이리스트 회전) 호출 '후' time-limit 검사 → 회전은 이미 발생.
+        // remainingAttempts(=큐 size=1) <= 1 이므로 deactivate. 첫 DJ silent deactivate 패턴과 정렬된 의도 동작.
+        DjData dj = stubDoStartWithQueuedDj(PlaybackTimeLimit.ofMinutes(1), Duration.fromString("3:30"));
+
+        // when — 자의 skip
+        playbackCommandService.skipPlayback(partyroomId);
+
+        // then — 트랙은 재생 안 됨(save 미호출)이나 플레이리스트 회전은 이미 발생, 큐도 회전, 이후 deactivate
+        verify(playlistCommandPort).getFirstTrack(dj.getPlaylistId());
+        verify(partyroomAggregateService).rotateDjQueue(partyroomId);
+        verify(playbackRepository, never()).save(any(PlaybackData.class));
+        verify(partyroomAggregateService).deactivatePlayback(partyroomId);
+    }
+
     @Test
     @DisplayName("updatePlaybackAggregation — atomic delta 적용 후 reload된 aggregation 반환")
     void updatePlaybackAggregationUpdatesSuccessfully() {

--- a/app/src/test/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepositoryReorderIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepositoryReorderIntegrationTest.java
@@ -1,0 +1,126 @@
+package com.pfplaybackend.api.playlist.adapter.out.persistence;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.Duration;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #222 회귀 잠금 — skip(자의/타의/time-limit) 시 "재생된 트랙이 본인 플레이리스트 최하단으로" invariant 의
+ * 산술 핵심인 {@link TrackRepository#reorderTracks} 의 SQL 동작을 잠근다.
+ *
+ * <p>이 동작은 명시적 "skip→재정렬" 로직이 아니라 재생 시작(getFirstTrack)의 부수효과라
+ * 회귀 테스트로 묶지 않으면 재생/큐 로직 리팩터 시 조용히 깨질 수 있다.
+ * DJ 큐 회전 산술은 PartyroomAggregateServiceTest.rotatesCorrectly,
+ * getFirstTrack wiring 은 TrackCommandServiceTest.getFirstTrackReturnsFirstTrackAndRotates 가 별도로 잠금.
+ */
+@Transactional
+class TrackRepositoryReorderIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private TrackRepository trackRepository;
+
+    private TrackData saveTrack(long playlistId, int orderNumber, String linkId) {
+        return trackRepository.save(TrackData.builder()
+                .playlistId(new PlaylistId(playlistId))
+                .orderNumber(orderNumber)
+                .name("track-" + orderNumber)
+                .linkId(linkId)
+                .duration(Duration.fromString("3:30"))
+                .thumbnailImage("thumb.jpg")
+                .build());
+    }
+
+    @Test
+    @DisplayName("reorderTracks — orderNumber=1 트랙은 맨 뒤(total)로, 나머지는 한 칸씩 앞으로 이동한다")
+    void rotatesFirstTrackToBottom() {
+        // given — 한 플레이리스트의 트랙 순서 [1,2,3,4]
+        long playlistId = 9001L;
+        TrackData t1 = saveTrack(playlistId, 1, "link-1");
+        TrackData t2 = saveTrack(playlistId, 2, "link-2");
+        TrackData t3 = saveTrack(playlistId, 3, "link-3");
+        TrackData t4 = saveTrack(playlistId, 4, "link-4");
+        flushAndClear();
+
+        // when — 재생 시작 시점에 호출되는 회전 (total=4)
+        trackRepository.reorderTracks(playlistId, 4L);
+        flushAndClear();
+
+        // then — 재생된 #1 트랙이 최하단으로, 나머지는 -1
+        assertThat(trackRepository.findById(t1.getId()).orElseThrow().getOrderNumber()).isEqualTo(4);
+        assertThat(trackRepository.findById(t2.getId()).orElseThrow().getOrderNumber()).isEqualTo(1);
+        assertThat(trackRepository.findById(t3.getId()).orElseThrow().getOrderNumber()).isEqualTo(2);
+        assertThat(trackRepository.findById(t4.getId()).orElseThrow().getOrderNumber()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("reorderTracks — 다른 플레이리스트의 트랙 순서는 영향받지 않는다 (playlist_id 격리)")
+    void doesNotAffectOtherPlaylists() {
+        // given
+        long target = 9100L;
+        long other = 9200L;
+        TrackData targetFirst = saveTrack(target, 1, "t-link-1");
+        TrackData targetSecond = saveTrack(target, 2, "t-link-2");
+        TrackData otherFirst = saveTrack(other, 1, "o-link-1");
+        TrackData otherSecond = saveTrack(other, 2, "o-link-2");
+        flushAndClear();
+
+        // when
+        trackRepository.reorderTracks(target, 2L);
+        flushAndClear();
+
+        // then — target 만 회전, other 는 불변
+        assertThat(trackRepository.findById(targetFirst.getId()).orElseThrow().getOrderNumber()).isEqualTo(2);
+        assertThat(trackRepository.findById(targetSecond.getId()).orElseThrow().getOrderNumber()).isEqualTo(1);
+        assertThat(trackRepository.findById(otherFirst.getId()).orElseThrow().getOrderNumber()).isEqualTo(1);
+        assertThat(trackRepository.findById(otherSecond.getId()).orElseThrow().getOrderNumber()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("reorderTracks — 단일 트랙(total=1)이면 orderNumber=1 그대로 (skip 후 같은 트랙 재생, 의도된 동작)")
+    void singleTrackStaysAtOne() {
+        // given
+        long playlistId = 9300L;
+        TrackData only = saveTrack(playlistId, 1, "only-link");
+        flushAndClear();
+
+        // when
+        trackRepository.reorderTracks(playlistId, 1L);
+        flushAndClear();
+
+        // then — CASE WHEN orderNumber=1 THEN 1: 그대로. 트랙이 하나면 skip 해도 같은 트랙
+        assertThat(trackRepository.findById(only.getId()).orElseThrow().getOrderNumber()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("reorderTracks — 회전을 두 번 적용하면 #1·#2가 차례로 최하단으로 (skip 누적 시 순서 보존)")
+    void repeatedRotationPreservesCyclicOrder() {
+        // given — [1,2,3]
+        long playlistId = 9400L;
+        TrackData a = saveTrack(playlistId, 1, "a");
+        TrackData b = saveTrack(playlistId, 2, "b");
+        TrackData c = saveTrack(playlistId, 3, "c");
+        flushAndClear();
+
+        // when — 연속 skip 2회
+        trackRepository.reorderTracks(playlistId, 3L); // a:1->3, b:2->1, c:3->2
+        flushAndClear();
+        trackRepository.reorderTracks(playlistId, 3L); // b:1->3, c:2->1, a:3->2
+        flushAndClear();
+
+        // then — 순환 순서 보존 (b가 최하단, c가 다음 재생 대상)
+        List<Integer> orders = List.of(
+                trackRepository.findById(a.getId()).orElseThrow().getOrderNumber(),
+                trackRepository.findById(b.getId()).orElseThrow().getOrderNumber(),
+                trackRepository.findById(c.getId()).orElseThrow().getOrderNumber());
+        assertThat(orders).containsExactly(2, 3, 1);
+    }
+}


### PR DESCRIPTION
## 배경

사용자 검증 요청(#222): DJ 대기열에서 skip(자의/타의 무관) 시 ① 트랙이 그 사람 플레이리스트 최하단으로 ② 해당 DJ가 DJ큐 뒤로 밀리는지.

코드 추적 결과 **이미 정상 동작**한다. 단, 명시적 "skip→재정렬" 로직이 아니라 `getFirstTrack`(재생 시작)의 `rotateTrackOrder` 부수효과 + `doStart` 진입 시 `rotateDjQueue` 조합으로만 성립 → **회귀 테스트로 잠겨 있지 않아** 재생/큐 로직 리팩터 시 조용히 깨질 수 있다. 이 PR은 invariant를 테스트로 잠근다. **프로덕션 코드 변경 없음.**

## 변경

- **`TrackRepositoryReorderIntegrationTest`** (신규, Testcontainers): `reorderTracks` SQL 산술 잠금 — `orderNumber=1`→맨뒤(`total`)·나머지 `-1`, `playlist_id` 격리, 단일 트랙 그대로(=skip 후 같은 트랙·의도), 연속 회전 시 순환 순서 보존. 이 SQL이 "트랙→플레이리스트 최하단"의 산술 핵심이며 그간 어디에도 안 잠겨 있었음.
- **`PlaybackCommandServiceTest`** (+3): 
  - `skipPlayback`(자의) + 큐에 DJ → `rotateDjQueue` + `getFirstTrack(현재 DJ 플레이리스트)` 양쪽 호출 wiring 잠금
  - `skipByManager`(MODERATOR 타의) + 큐에 DJ → 동일 wiring 잠금
  - time-limit 초과 트랙: 재생 안 돼도 `getFirstTrack`(플레이리스트 회전)은 `doStart`에서 검사 *전* 이미 호출됨 → **의도된 동작**으로 명시 문서화 (첫 DJ silent deactivate 패턴과 정렬)

## 중복 회피

- DJ큐 회전 산술(#1→맨뒤): 기존 `PartyroomAggregateServiceTest.rotatesCorrectly` 가 이미 잠금
- `getFirstTrack` wiring(old#1 반환 + rotateTrackOrder 호출): 기존 `TrackCommandServiceTest.getFirstTrackReturnsFirstTrackAndRotates` 가 이미 잠금
- 본 PR은 미잠금 갭(SQL 산술 / skip 수렴 wiring / time-limit edge)만 보강

## 테스트 결과

- `TrackRepositoryReorderIntegrationTest`: 4/4 PASS (Testcontainers MySQL)
- `PlaybackCommandServiceTest`: 10/10 PASS (신규 #222 3건 포함)
- 의존 락 회귀 확인: `PartyroomAggregateServiceTest` · `TrackCommandServiceTest` green

Closes #222