### PR TITLE
feat(presence): PR-1 user-session 레지스트리 — presence 권위 전환 (#209 #225)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/RedisSessionCacheAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/RedisSessionCacheAdapter.java
@@ -6,21 +6,50 @@ import com.pfplaybackend.api.party.application.dto.partyroom.PartyroomSessionDto
 import com.pfplaybackend.api.party.application.port.out.PartyroomQueryPort;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import com.pfplaybackend.realtime.port.SessionCachePort;
-import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
+/**
+ * Chat-only session cache: {@code sessionId → (partyroom, user, crew)} written on
+ * STOMP SUBSCRIBE and read by {@code PartyroomChatCommandService.sendMessage}.
+ *
+ * <p><b>Two parallel, deliberately distinct session-tracking mechanisms.</b>
+ * Presence authority is the user-session <i>registry</i> driven by WS
+ * CONNECT/DISCONNECT (#209 #31, {@code RedisUserSessionStoreAdapter}). This
+ * session <i>cache</i> is a SEPARATE chat-only mechanism keyed on SUBSCRIBE
+ * write / UNSUBSCRIBE delete / TTL backstop. Do NOT collapse them: routing
+ * presence back through this subscribe-timed cache would reintroduce the #31 bug.
+ */
 @Service
-@RequiredArgsConstructor
 public class RedisSessionCacheAdapter implements SessionCachePort {
     private static final Logger logger = LoggerFactory.getLogger(RedisSessionCacheAdapter.class);
     private final RedisTemplate<String, Object> redisTemplate;
     private final PartyroomQueryPort partyroomQueryPort;
+
+    /**
+     * Self-healing backstop TTL (seconds) applied on every {@link #saveSessionCache}.
+     * The clean path still deletes on UNSUBSCRIBE; this only bounds abnormal-close
+     * orphans (1006, no UNSUBSCRIBE — DisconnectionEventListener correctly does not
+     * delete since Task 1.5). Default 24h — far longer than any realistic live
+     * subscribed session, and a re-SUBSCRIBE rewrites/refreshes the row.
+     */
+    private final long ttlSeconds;
+
+    public RedisSessionCacheAdapter(
+            RedisTemplate<String, Object> redisTemplate,
+            PartyroomQueryPort partyroomQueryPort,
+            @Value("${presence.session-cache.ttl-seconds:86400}") long ttlSeconds) {
+        this.redisTemplate = redisTemplate;
+        this.partyroomQueryPort = partyroomQueryPort;
+        this.ttlSeconds = ttlSeconds;
+    }
 
     @Transactional
     public void saveSessionCache(String sessionId, String userId, String destination) {
@@ -36,7 +65,9 @@ public class RedisSessionCacheAdapter implements SessionCachePort {
                     return;
                 }
                 PartyroomSessionDto sessionData = partyroomSessionDto.get();
-                redisTemplate.opsForValue().set(sessionId, sessionData);
+                // TTL 백스톱: clean path는 UNSUBSCRIBE에서 delete하지만, 비정상 종료
+                // orphan(1006, UNSUBSCRIBE 없음)은 이 TTL로만 self-heal된다.
+                redisTemplate.opsForValue().set(sessionId, sessionData, ttlSeconds, TimeUnit.SECONDS);
             }
         }
     }

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/RedisUserSessionStoreAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/RedisUserSessionStoreAdapter.java
@@ -1,14 +1,15 @@
 package com.pfplaybackend.api.party.adapter.out.persistence;
 
 import com.pfplaybackend.api.party.application.service.UserSessionRegistry;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Redis-backed {@link UserSessionRegistry.SessionStore} adapter (Cluster A PR-1).
@@ -27,10 +28,23 @@ import java.util.List;
  * {@code SREM usersessions} then {@code SCARD usersessions}, executed as a single
  * server-side Lua script so two concurrent disconnects for the same user cannot
  * both observe a non-empty set (exactly one sees {@code 0} ⇒ wasLastSession).
+ *
+ * <p><b>Self-healing TTL backstop.</b> The authoritative cleanup is
+ * {@link #unbindSessionAndCount} on STOMP DISCONNECT. But DISCONNECT is not
+ * guaranteed (network partition, pod kill, broker crash, ungraceful client
+ * teardown); a missed DISCONNECT would otherwise leave an orphan sid in
+ * {@code presence:usersessions:{uid}} forever, permanently keeping that user's
+ * {@code SCARD} ≥ 1 so {@code wasLastSession} can never again be true and the
+ * presence grace timer can never fire for them again. The DB-crew
+ * reconcile-cron sweeps {@code crew.pending_exit_at} rows only — it does NOT
+ * touch this Redis user-session registry, so the registry must bound its own
+ * leak. Therefore both keys carry a (configurable, default 24h) TTL refreshed
+ * on every {@link #bindSession} (a reconnect re-CONNECT naturally refreshes it);
+ * the TTL is deliberately far longer than any realistic continuous live session
+ * so it never expires an actually-live tab, while still self-expiring orphans.
  */
 @Slf4j
 @Repository
-@RequiredArgsConstructor
 public class RedisUserSessionStoreAdapter implements UserSessionRegistry.SessionStore {
 
     private static final String SESSION_KEY_PREFIX = "presence:session:";
@@ -50,10 +64,29 @@ public class RedisUserSessionStoreAdapter implements UserSessionRegistry.Session
 
     private final StringRedisTemplate stringRedisTemplate;
 
+    /**
+     * Self-healing backstop TTL (seconds) applied to both registry keys on every
+     * {@link #bindSession}. Default 24h — generously longer than any realistic
+     * continuous live session so a live tab is never expired, while bounding a
+     * missed-DISCONNECT orphan to at most this window.
+     */
+    private final long ttlSeconds;
+
+    public RedisUserSessionStoreAdapter(
+            StringRedisTemplate stringRedisTemplate,
+            @Value("${presence.user-session.ttl-seconds:86400}") long ttlSeconds) {
+        this.stringRedisTemplate = stringRedisTemplate;
+        this.ttlSeconds = ttlSeconds;
+    }
+
     @Override
     public void bindSession(String sessionId, String userId) {
-        stringRedisTemplate.opsForValue().set(sessionKey(sessionId), userId);
-        stringRedisTemplate.opsForSet().add(userSessionsKey(userId), sessionId);
+        // Refresh TTL on every bind: a reconnect re-CONNECT re-binds and thus
+        // naturally pushes the self-heal expiry forward for a still-live session.
+        stringRedisTemplate.opsForValue().set(sessionKey(sessionId), userId, ttlSeconds, TimeUnit.SECONDS);
+        String userSetKey = userSessionsKey(userId);
+        stringRedisTemplate.opsForSet().add(userSetKey, sessionId);
+        stringRedisTemplate.expire(userSetKey, ttlSeconds, TimeUnit.SECONDS);
     }
 
     @Override

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/RedisUserSessionStoreAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/RedisUserSessionStoreAdapter.java
@@ -1,0 +1,80 @@
+package com.pfplaybackend.api.party.adapter.out.persistence;
+
+import com.pfplaybackend.api.party.application.service.UserSessionRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * Redis-backed {@link UserSessionRegistry.SessionStore} adapter (Cluster A PR-1).
+ *
+ * <p>Keys (per {@link UserSessionRegistry} Javadoc):
+ * <ul>
+ *   <li>{@code presence:session:{sid}} → uid (STRING, session → user binding)</li>
+ *   <li>{@code presence:usersessions:{uid}} → Set&lt;sid&gt; (user → live sessions)</li>
+ * </ul>
+ *
+ * <p>Values are plain strings (no JSON wrapping) via {@link StringRedisTemplate} so
+ * the Lua script can compare/return them directly — consistent with V16 presence
+ * which also uses {@code RedisTemplate} string semantics for control keys.
+ *
+ * <p>{@link #unbindSessionAndCount} is the atomic pair {@code DEL session} +
+ * {@code SREM usersessions} then {@code SCARD usersessions}, executed as a single
+ * server-side Lua script so two concurrent disconnects for the same user cannot
+ * both observe a non-empty set (exactly one sees {@code 0} ⇒ wasLastSession).
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class RedisUserSessionStoreAdapter implements UserSessionRegistry.SessionStore {
+
+    private static final String SESSION_KEY_PREFIX = "presence:session:";
+    private static final String USER_SESSIONS_KEY_PREFIX = "presence:usersessions:";
+
+    /**
+     * KEYS[1] = presence:session:{sid}, KEYS[2] = presence:usersessions:{uid},
+     * ARGV[1] = sid. Atomically removes the session binding and reports the
+     * remaining live session count for that user. SCARD on a now-empty set
+     * returns 0 (Redis auto-deletes the empty set), so 0 ⇒ that was the last.
+     */
+    private static final RedisScript<Long> UNBIND_AND_COUNT = new DefaultRedisScript<>(
+            "redis.call('DEL', KEYS[1]) "
+                    + "redis.call('SREM', KEYS[2], ARGV[1]) "
+                    + "return redis.call('SCARD', KEYS[2])",
+            Long.class);
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Override
+    public void bindSession(String sessionId, String userId) {
+        stringRedisTemplate.opsForValue().set(sessionKey(sessionId), userId);
+        stringRedisTemplate.opsForSet().add(userSessionsKey(userId), sessionId);
+    }
+
+    @Override
+    public String getUserBySession(String sessionId) {
+        return stringRedisTemplate.opsForValue().get(sessionKey(sessionId));
+    }
+
+    @Override
+    public long unbindSessionAndCount(String sessionId, String userId) {
+        Long remaining = stringRedisTemplate.execute(
+                UNBIND_AND_COUNT,
+                List.of(sessionKey(sessionId), userSessionsKey(userId)),
+                sessionId);
+        return remaining == null ? 0L : remaining;
+    }
+
+    private static String sessionKey(String sessionId) {
+        return SESSION_KEY_PREFIX + sessionId;
+    }
+
+    private static String userSessionsKey(String userId) {
+        return USER_SESSIONS_KEY_PREFIX + userId;
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/realtime/PresencePortAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/realtime/PresencePortAdapter.java
@@ -44,9 +44,18 @@ public class PresencePortAdapter implements PresencePort {
 
     @Override
     public void onSessionConnected(String sessionId) {
-        userSessionRegistry.findUserBySession(sessionId).ifPresent(userId ->
-                resolveActiveRoom(userId).ifPresent(roomId ->
-                        presenceService.clearPending(roomId, userId)));
+        Optional<UserId> user = userSessionRegistry.findUserBySession(sessionId);
+        if (user.isEmpty()) {
+            log.debug("[presence] onSessionConnected no-op: no user for sessionId={}", sessionId);
+            return;
+        }
+        UserId userId = user.get();
+        Optional<PartyroomId> roomId = resolveActiveRoom(userId);
+        if (roomId.isEmpty()) {
+            log.debug("[presence] onSessionConnected no-op: no active room for userId={}", userId);
+            return;
+        }
+        presenceService.clearPending(roomId.get(), userId);
     }
 
     @Override
@@ -55,16 +64,28 @@ public class PresencePortAdapter implements PresencePort {
         if (!result.wasLastSession()) {
             // Multi-tab: another live session for this user remains (or the session
             // was unknown). Closing one tab must not start the grace timer.
+            log.debug("[presence] onSessionDisconnected no-op: not last session, sessionId={}", sessionId);
             return;
         }
-        result.userId().ifPresent(userId ->
-                resolveActiveRoom(userId).ifPresent(roomId ->
-                        presenceService.markPending(roomId, userId)));
+        if (result.userId().isEmpty()) {
+            log.debug("[presence] onSessionDisconnected no-op: last session but no userId, sessionId={}", sessionId);
+            return;
+        }
+        UserId userId = result.userId().get();
+        Optional<PartyroomId> roomId = resolveActiveRoom(userId);
+        if (roomId.isEmpty()) {
+            log.debug("[presence] onSessionDisconnected no-op: last session but no active room, userId={}", userId);
+            return;
+        }
+        presenceService.markPending(roomId.get(), userId);
     }
 
     private Optional<PartyroomId> resolveActiveRoom(UserId userId) {
         return partyroomQueryPort.getActivePartyroomByUserId(userId)
                 .map(ActivePartyroomDto::id)
-                .map(PartyroomId::new);
+                // ActivePartyroomDto.id() is the partyroom PK — non-null by query contract
+                // (locked by ClusterAPresenceIntegrationTest); a null here is a broken
+                // invariant and must fail loudly, not be silently filtered.
+                .map(PartyroomId::of);
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/realtime/PresencePortAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/realtime/PresencePortAdapter.java
@@ -1,9 +1,13 @@
 package com.pfplaybackend.api.party.adapter.out.realtime;
 
-import com.pfplaybackend.api.party.application.dto.partyroom.PartyroomSessionDto;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.application.dto.partyroom.ActivePartyroomDto;
+import com.pfplaybackend.api.party.application.port.out.PartyroomQueryPort;
 import com.pfplaybackend.api.party.application.service.PartyroomPresenceService;
+import com.pfplaybackend.api.party.application.service.UserSessionRegistry;
+import com.pfplaybackend.api.party.application.service.UserSessionRegistry.UnregisterResult;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import com.pfplaybackend.realtime.port.PresencePort;
-import com.pfplaybackend.realtime.port.SessionCachePort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,41 +17,54 @@ import java.util.Optional;
 /**
  * Bridges STOMP session events (in the realtime module) to the partyroom presence
  * service (in the app module). The realtime listener fires with only a sessionId;
- * we resolve it to {@code (partyroomId, userId)} via the session cache that
- * {@code SubscriptionEventListener} populates on subscribe.
+ * we resolve it to {@code (partyroomId, userId)} using the server-side authority,
+ * not the subscribe-timing session cache:
  *
- * <p>If the session cache lookup misses (e.g., disconnect arrives before subscribe
- * completed, or for a non-partyroom subscription), both methods are silent no-ops.
+ * <ul>
+ *   <li>{@code userId} ← {@link UserSessionRegistry} (live STOMP session registry)</li>
+ *   <li>active room ← {@link PartyroomQueryPort#getActivePartyroomByUserId} (DB authority)</li>
+ * </ul>
+ *
+ * <p>If the user cannot be resolved via the registry, or has no active room, both
+ * methods are silent no-ops (preserving the original cache-miss contract — now
+ * "not resolvable via registry/DB" is the silent no-op).
+ *
+ * <p>On disconnect we only mark PENDING_EXIT when the user's <em>last</em> live
+ * session is gone; if other sessions remain (multi-tab) the disconnect is a silent
+ * no-op so a closed tab does not start the grace timer for an still-present user.
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class PresencePortAdapter implements PresencePort {
 
-    private final SessionCachePort sessionCachePort;
+    private final UserSessionRegistry userSessionRegistry;
+    private final PartyroomQueryPort partyroomQueryPort;
     private final PartyroomPresenceService presenceService;
 
     @Override
     public void onSessionConnected(String sessionId) {
-        resolve(sessionId).ifPresent(dto ->
-                presenceService.clearPending(dto.partyroomId(), dto.userId()));
+        userSessionRegistry.findUserBySession(sessionId).ifPresent(userId ->
+                resolveActiveRoom(userId).ifPresent(roomId ->
+                        presenceService.clearPending(roomId, userId)));
     }
 
     @Override
     public void onSessionDisconnected(String sessionId) {
-        resolve(sessionId).ifPresent(dto ->
-                presenceService.markPending(dto.partyroomId(), dto.userId()));
+        UnregisterResult result = userSessionRegistry.unregister(sessionId);
+        if (!result.wasLastSession()) {
+            // Multi-tab: another live session for this user remains (or the session
+            // was unknown). Closing one tab must not start the grace timer.
+            return;
+        }
+        result.userId().ifPresent(userId ->
+                resolveActiveRoom(userId).ifPresent(roomId ->
+                        presenceService.markPending(roomId, userId)));
     }
 
-    private Optional<PartyroomSessionDto> resolve(String sessionId) {
-        Optional<Object> cached = sessionCachePort.getSessionCache(sessionId);
-        if (cached.isEmpty()) return Optional.empty();
-        Object obj = cached.get();
-        if (!(obj instanceof PartyroomSessionDto dto)) {
-            log.debug("[presence] session cache for {} is not a PartyroomSessionDto: {}",
-                    sessionId, obj.getClass().getSimpleName());
-            return Optional.empty();
-        }
-        return Optional.of(dto);
+    private Optional<PartyroomId> resolveActiveRoom(UserId userId) {
+        return partyroomQueryPort.getActivePartyroomByUserId(userId)
+                .map(ActivePartyroomDto::id)
+                .map(PartyroomId::new);
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/realtime/SessionRegistryPortAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/realtime/SessionRegistryPortAdapter.java
@@ -1,0 +1,29 @@
+package com.pfplaybackend.api.party.adapter.out.realtime;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.application.service.UserSessionRegistry;
+import com.pfplaybackend.realtime.port.SessionRegistryPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Bridges the realtime CONNECT event (in the realtime module) to the live
+ * {@link UserSessionRegistry} (in the app module). The realtime listener fires
+ * with the authenticated {@code (sessionId, userId)} pair; we translate the
+ * userId String into the {@link UserId} domain value and record the live
+ * session so that subsequent presence resolution can map a bare sessionId back
+ * to its user.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SessionRegistryPortAdapter implements SessionRegistryPort {
+
+    private final UserSessionRegistry userSessionRegistry;
+
+    @Override
+    public void register(String sessionId, String userId) {
+        userSessionRegistry.register(sessionId, UserId.fromString(userId));
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/realtime/SessionRegistryPortAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/realtime/SessionRegistryPortAdapter.java
@@ -5,7 +5,7 @@ import com.pfplaybackend.api.party.application.service.UserSessionRegistry;
 import com.pfplaybackend.realtime.port.SessionRegistryPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 /**
  * Bridges the realtime CONNECT event (in the realtime module) to the live
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
  * to its user.
  */
 @Slf4j
-@Component
+@Service
 @RequiredArgsConstructor
 public class SessionRegistryPortAdapter implements SessionRegistryPort {
 

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
@@ -109,7 +109,11 @@ public class PartyroomAccessCommandService {
                 // constructor cycle via forceOffline→exitInternal). Any stale Redis
                 // presence-timer key is safely no-op'd by forceOffline's
                 // !isPendingExit() guard, which also deletes the leftover key.
-                aggregatePort.clearCrewPending(partyroomId, userId);
+                int graceCancelled = aggregatePort.clearCrewPending(partyroomId, userId);
+                if (graceCancelled > 0) {
+                    log.debug("[presence] grace cancelled via REST same-room re-entry — userId={}, partyroomId={}",
+                            userId, partyroomId.getId());
+                }
                 enforceHostInvariant(partyroom, userId, saved);
                 return saved;
             }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
@@ -100,6 +100,16 @@ public class PartyroomAccessCommandService {
                         ExceptionCreator.create(CrewException.INVALID_ACTIVE_ROOM));
                 crew.updateCountryCode(countryCode);
                 CrewData saved = aggregatePort.saveCrew(crew);
+                // SE4 defense-in-depth — REST same-room re-entry cancels grace: a page
+                // refresh sets pending_exit_at on STOMP DISCONNECT, and "REST enter = user
+                // is here" so we clear it immediately rather than relying solely on the
+                // STOMP CONNECT-time clearPending (closes the SE4 race even if the reconnect
+                // is delayed). DB-only clear via the already-injected aggregatePort keeps
+                // this cycle-free (injecting PartyroomPresenceService would form a
+                // constructor cycle via forceOffline→exitInternal). Any stale Redis
+                // presence-timer key is safely no-op'd by forceOffline's
+                // !isPendingExit() guard, which also deletes the leftover key.
+                aggregatePort.clearCrewPending(partyroomId, userId);
                 enforceHostInvariant(partyroom, userId, saved);
                 return saved;
             }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/UserSessionRegistry.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/UserSessionRegistry.java
@@ -1,0 +1,90 @@
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+/**
+ * Server-side authority for live STOMP sessions per user (Cluster A PR-1).
+ *
+ * <p>Tracks which STOMP sessions are alive for each user so that on DISCONNECT we
+ * can answer: "does this user still have any live session?" Only when the last
+ * session is gone should the presence grace timer start
+ * ({@link PartyroomPresenceService#markPending}).
+ *
+ * <p>State lives in Redis behind the injected {@link SessionStore} port:
+ * <ul>
+ *   <li>{@code presence:session:{sid}} → uid (session → user binding)</li>
+ *   <li>{@code presence:usersessions:{uid}} → Set&lt;sid&gt; (user → live sessions)</li>
+ * </ul>
+ *
+ * <p>The "was this the last session" decision is the atomic pair
+ * {@code SREM} then {@code SCARD == 0}; the port exposes it as a single
+ * {@link SessionStore#unbindSessionAndCount} operation so a real Redis adapter
+ * can make it atomic (Lua / pipeline). The unit test uses an in-memory fake.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserSessionRegistry {
+
+    private final SessionStore sessionStore;
+
+    /** Binds a live STOMP session to its user. */
+    public void register(String sessionId, UserId userId) {
+        sessionStore.bindSession(sessionId, String.valueOf(userId.getUid()));
+    }
+
+    /**
+     * Removes a session. Returns the owning user (if the session was known) and
+     * whether this removed the user's last live session.
+     */
+    public UnregisterResult unregister(String sessionId) {
+        String userIdValue = sessionStore.getUserBySession(sessionId);
+        if (userIdValue == null) {
+            return new UnregisterResult(Optional.empty(), false);
+        }
+        long remaining = sessionStore.unbindSessionAndCount(sessionId, userIdValue);
+        return new UnregisterResult(
+                Optional.of(UserId.fromString(userIdValue)),
+                remaining == 0);
+    }
+
+    /** Resolves the user that owns a session, if it is currently registered. */
+    public Optional<UserId> findUserBySession(String sessionId) {
+        String userIdValue = sessionStore.getUserBySession(sessionId);
+        return Optional.ofNullable(userIdValue).map(UserId::fromString);
+    }
+
+    /**
+     * Outcome of {@link #unregister}. {@code userId} is empty when the session
+     * was unknown; {@code wasLastSession} is true only when removal emptied the
+     * user's session set.
+     */
+    public record UnregisterResult(Optional<UserId> userId, boolean wasLastSession) {}
+
+    /**
+     * Redis operations behind a port so the unit can use an in-memory fake.
+     * The concrete adapter is {@code RedisTemplate}-backed (covered by a later
+     * integration test).
+     */
+    public interface SessionStore {
+
+        /** {@code SET presence:session:{sid} uid} + {@code SADD presence:usersessions:{uid} sid}. */
+        void bindSession(String sessionId, String userId);
+
+        /** {@code GET presence:session:{sid}} — null if absent. */
+        String getUserBySession(String sessionId);
+
+        /**
+         * {@code DEL presence:session:{sid}} + {@code SREM presence:usersessions:{uid} sid}
+         * then {@code SCARD presence:usersessions:{uid}}. Returns the remaining
+         * session count (0 ⇒ that was the last session). Must be atomic in the
+         * real adapter.
+         */
+        long unbindSessionAndCount(String sessionId, String userId);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/UserSessionRegistry.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/UserSessionRegistry.java
@@ -33,9 +33,15 @@ public class UserSessionRegistry {
 
     private final SessionStore sessionStore;
 
-    /** Binds a live STOMP session to its user. */
+    /**
+     * Binds a live STOMP session to its user. Encodes the uid with
+     * {@link UserId#toString()} so it is exactly symmetric with the
+     * {@link UserId#fromString(String)} decode used by {@link #unregister} /
+     * {@link #findUserBySession} ({@code UserId.toString()} returns
+     * {@code String.valueOf(uid)} — same stored form as before).
+     */
     public void register(String sessionId, UserId userId) {
-        sessionStore.bindSession(sessionId, String.valueOf(userId.getUid()));
+        sessionStore.bindSession(sessionId, userId.toString());
     }
 
     /**

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/chat/PartyroomChatCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/chat/PartyroomChatCommandService.java
@@ -31,8 +31,9 @@ public class PartyroomChatCommandService {
     private final ObjectMapper objectMapper;
 
     public void sendMessage(String sessionId, String content) {
-        // 세션캐시 read는 채팅(비-presence) 용도로만 생존한다. presence는 WS CONNECT/DISCONNECT가
-        // 권위이며(#209 #31) SUBSCRIBE 트리거는 디커미션됨. (write 경로 부재는 PR-1 범위 밖)
+        // 세션캐시는 채팅 전용 source다: SUBSCRIBE에서 sessionId→(partyroom,user,crew)를
+        // write하고 UNSUBSCRIBE에서 delete한다. presence는 WS CONNECT/DISCONNECT가 권위로
+        // 세션캐시와 분리됨 (#209 #31).
         Optional<Object> optional = sessionCachePort.getSessionCache(sessionId);
 
         if (optional.isEmpty()) {

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/chat/PartyroomChatCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/chat/PartyroomChatCommandService.java
@@ -31,6 +31,8 @@ public class PartyroomChatCommandService {
     private final ObjectMapper objectMapper;
 
     public void sendMessage(String sessionId, String content) {
+        // 세션캐시 read는 채팅(비-presence) 용도로만 생존한다. presence는 WS CONNECT/DISCONNECT가
+        // 권위이며(#209 #31) SUBSCRIBE 트리거는 디커미션됨. (write 경로 부재는 PR-1 범위 밖)
         Optional<Object> optional = sessionCachePort.getSessionCache(sessionId);
 
         if (optional.isEmpty()) {

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/chat/PartyroomChatCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/chat/PartyroomChatCommandService.java
@@ -32,8 +32,8 @@ public class PartyroomChatCommandService {
 
     public void sendMessage(String sessionId, String content) {
         // 세션캐시는 채팅 전용 source다: SUBSCRIBE에서 sessionId→(partyroom,user,crew)를
-        // write하고 UNSUBSCRIBE에서 delete한다. presence는 WS CONNECT/DISCONNECT가 권위로
-        // 세션캐시와 분리됨 (#209 #31).
+        // write(24h TTL 백스톱 포함)하고 UNSUBSCRIBE에서 delete한다. 비정상 종료 orphan은
+        // 그 TTL로 self-heal된다. presence는 WS CONNECT/DISCONNECT가 권위로 분리됨 (#209 #31).
         Optional<Object> optional = sessionCachePort.getSessionCache(sessionId);
 
         if (optional.isEmpty()) {

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/RedisSessionCacheAdapterTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/RedisSessionCacheAdapterTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -77,9 +76,8 @@ class RedisSessionCacheAdapterTest {
         redisSessionCacheAdapter.saveSessionCache(sessionId, userIdStr, destination);
 
         // then — clean path는 UNSUBSCRIBE에서 delete하지만, 비정상 종료(1006, UNSUBSCRIBE 없음)
-        // orphan은 이 TTL로만 만료된다. TTL은 양수이며 24h 백스톱 이내여야 한다.
+        // orphan은 이 TTL로만 만료된다. set(...) 에 TTL 인자가 실제로 전달되는지 검증한다.
         verify(valueOperations).set(eq(sessionId), any(), eq(TTL_SECONDS), eq(TimeUnit.SECONDS));
-        assertThat(TTL_SECONDS).isPositive().isLessThanOrEqualTo(86400L);
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/RedisSessionCacheAdapterTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/RedisSessionCacheAdapterTest.java
@@ -16,9 +16,9 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -26,15 +26,18 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class RedisSessionCacheAdapterTest {
 
+    private static final long TTL_SECONDS = 86400L;
+
     @Mock RedisTemplate<String, Object> redisTemplate;
     @Mock ValueOperations<String, Object> valueOperations;
     @Mock PartyroomQueryPort partyroomQueryPort;
 
-    @InjectMocks RedisSessionCacheAdapter redisSessionCacheAdapter;
+    RedisSessionCacheAdapter redisSessionCacheAdapter;
 
     @BeforeEach
     void setUp() {
         lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        redisSessionCacheAdapter = new RedisSessionCacheAdapter(redisTemplate, partyroomQueryPort, TTL_SECONDS);
     }
 
     @Test
@@ -54,7 +57,29 @@ class RedisSessionCacheAdapterTest {
         redisSessionCacheAdapter.saveSessionCache(sessionId, userIdStr, destination);
 
         // then
-        verify(valueOperations).set(eq(sessionId), any());
+        verify(valueOperations).set(eq(sessionId), any(), eq(TTL_SECONDS), eq(TimeUnit.SECONDS));
+    }
+
+    @Test
+    @DisplayName("saveSessionCache — 비정상 종료 orphan self-heal을 위한 TTL 백스톱이 적용된다")
+    void saveSessionCacheAppliesTtlBackstop() {
+        // given
+        String sessionId = "session-123";
+        String userIdStr = "1";
+        String destination = "/sub/partyrooms/1";
+        UserId userId = UserId.fromString(userIdStr);
+        ActivePartyroomDto activeDto = new ActivePartyroomDto(
+                1L, false, 10L, true, new PlaybackId(1L), new CrewId(5L)
+        );
+        when(partyroomQueryPort.getActivePartyroomByUserId(userId)).thenReturn(Optional.of(activeDto));
+
+        // when
+        redisSessionCacheAdapter.saveSessionCache(sessionId, userIdStr, destination);
+
+        // then — clean path는 UNSUBSCRIBE에서 delete하지만, 비정상 종료(1006, UNSUBSCRIBE 없음)
+        // orphan은 이 TTL로만 만료된다. TTL은 양수이며 24h 백스톱 이내여야 한다.
+        verify(valueOperations).set(eq(sessionId), any(), eq(TTL_SECONDS), eq(TimeUnit.SECONDS));
+        assertThat(TTL_SECONDS).isPositive().isLessThanOrEqualTo(86400L);
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/RedisUserSessionStoreAdapterIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/RedisUserSessionStoreAdapterIntegrationTest.java
@@ -1,0 +1,116 @@
+package com.pfplaybackend.api.party.adapter.out.persistence;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.party.application.service.UserSessionRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("integration")
+@DisplayName("RedisUserSessionStoreAdapter — 실제 Redis 대상 SessionStore 포트 동작/원자성")
+class RedisUserSessionStoreAdapterIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private UserSessionRegistry.SessionStore sessionStore;
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    @BeforeEach
+    void flush() {
+        stringRedisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+    }
+
+    @Test
+    @DisplayName("bindSession 후 getUserBySession 은 바인딩된 유저를 반환한다")
+    void bindThenLookupReturnsUser() {
+        sessionStore.bindSession("sid-1", "1001");
+
+        assertThat(sessionStore.getUserBySession("sid-1")).isEqualTo("1001");
+    }
+
+    @Test
+    @DisplayName("같은 유저의 두 세션 중 하나를 unbind 하면 남은 세션 수는 1 (마지막 아님)")
+    void unbindOneOfTwoReturnsRemainingCount() {
+        sessionStore.bindSession("sid-a", "2002");
+        sessionStore.bindSession("sid-b", "2002");
+
+        long remaining = sessionStore.unbindSessionAndCount("sid-a", "2002");
+
+        assertThat(remaining).isEqualTo(1L);
+        // unbound session no longer resolves; sibling still does
+        assertThat(sessionStore.getUserBySession("sid-a")).isNull();
+        assertThat(sessionStore.getUserBySession("sid-b")).isEqualTo("2002");
+    }
+
+    @Test
+    @DisplayName("마지막 세션을 unbind 하면 남은 세션 수는 0 (마지막)")
+    void unbindLastReturnsZero() {
+        sessionStore.bindSession("sid-only", "3003");
+
+        long remaining = sessionStore.unbindSessionAndCount("sid-only", "3003");
+
+        assertThat(remaining).isZero();
+        assertThat(sessionStore.getUserBySession("sid-only")).isNull();
+    }
+
+    @Test
+    @DisplayName("알 수 없는 세션을 unbind 해도 안전하다 (0 반환, 예외 없음)")
+    void unbindUnknownSessionIsSafe() {
+        long remaining = sessionStore.unbindSessionAndCount("ghost", "4004");
+
+        assertThat(remaining).isZero();
+        assertThat(sessionStore.getUserBySession("ghost")).isNull();
+    }
+
+    @Test
+    @DisplayName("동일 유저의 두 세션을 두 스레드가 동시에 unbind — 정확히 한 스레드만 마지막(0)을 관측한다")
+    void concurrentUnbindExactlyOneObservesLast() throws InterruptedException {
+        String userId = "5005";
+        sessionStore.bindSession("sid-x", userId);
+        sessionStore.bindSession("sid-y", userId);
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(2);
+        ConcurrentLinkedQueue<Long> results = new ConcurrentLinkedQueue<>();
+
+        for (String sid : new String[]{"sid-x", "sid-y"}) {
+            pool.submit(() -> {
+                try {
+                    start.await();
+                    results.add(sessionStore.unbindSessionAndCount(sid, userId));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        start.countDown();
+        assertThat(done.await(10, TimeUnit.SECONDS)).isTrue();
+        pool.shutdownNow();
+
+        AtomicInteger zeroCount = new AtomicInteger();
+        results.forEach(r -> {
+            if (r == 0L) zeroCount.incrementAndGet();
+        });
+        assertThat(results).hasSize(2);
+        assertThat(zeroCount.get())
+                .as("exactly one disconnect must observe wasLast (count==0)")
+                .isEqualTo(1);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/RedisUserSessionStoreAdapterIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/RedisUserSessionStoreAdapterIntegrationTest.java
@@ -42,6 +42,26 @@ class RedisUserSessionStoreAdapterIntegrationTest extends AbstractIntegrationTes
     }
 
     @Test
+    @DisplayName("bindSession 후 두 키 모두 양수 TTL 을 갖는다 (missed-DISCONNECT self-heal 백스톱)")
+    void bindSessionAppliesPositiveTtlToBothKeys() {
+        sessionStore.bindSession("sid-ttl", "9009");
+
+        Long sessionTtl = stringRedisTemplate.getExpire("presence:session:sid-ttl");
+        Long userSetTtl = stringRedisTemplate.getExpire("presence:usersessions:9009");
+
+        assertThat(sessionTtl)
+                .as("session 키는 양수 TTL 을 가져야 한다")
+                .isNotNull()
+                .isGreaterThan(0L)
+                .isLessThanOrEqualTo(86400L);
+        assertThat(userSetTtl)
+                .as("usersessions 키는 양수 TTL 을 가져야 한다")
+                .isNotNull()
+                .isGreaterThan(0L)
+                .isLessThanOrEqualTo(86400L);
+    }
+
+    @Test
     @DisplayName("같은 유저의 두 세션 중 하나를 unbind 하면 남은 세션 수는 1 (마지막 아님)")
     void unbindOneOfTwoReturnsRemainingCount() {
         sessionStore.bindSession("sid-a", "2002");

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/out/realtime/PresencePortAdapterTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/out/realtime/PresencePortAdapterTest.java
@@ -1,0 +1,131 @@
+package com.pfplaybackend.api.party.adapter.out.realtime;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.application.dto.partyroom.ActivePartyroomDto;
+import com.pfplaybackend.api.party.application.port.out.PartyroomQueryPort;
+import com.pfplaybackend.api.party.application.service.PartyroomPresenceService;
+import com.pfplaybackend.api.party.application.service.UserSessionRegistry;
+import com.pfplaybackend.api.party.application.service.UserSessionRegistry.UnregisterResult;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.realtime.port.SessionCachePort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PresencePortAdapterTest {
+
+    @Mock UserSessionRegistry userSessionRegistry;
+    @Mock PartyroomQueryPort partyroomQueryPort;
+    @Mock PartyroomPresenceService presenceService;
+    @Mock SessionCachePort sessionCachePort;
+
+    @InjectMocks PresencePortAdapter adapter;
+
+    private static final String SID = "sess-1";
+    private static final UserId UID = new UserId(42L);
+    private static final long ROOM_ID = 777L;
+
+    private ActivePartyroomDto activeRoom() {
+        return new ActivePartyroomDto(ROOM_ID, false, 1L, false, null, null);
+    }
+
+    @Test
+    @DisplayName("connected: 레지스트리 uid resolve + 활성 룸 있으면 clearPending")
+    void onSessionConnected_resolvesViaRegistryAndQueryPort_clearsPending() {
+        when(userSessionRegistry.findUserBySession(SID)).thenReturn(Optional.of(UID));
+        when(partyroomQueryPort.getActivePartyroomByUserId(UID)).thenReturn(Optional.of(activeRoom()));
+
+        adapter.onSessionConnected(SID);
+
+        verify(presenceService).clearPending(new PartyroomId(ROOM_ID), UID);
+        verifyNoInteractions(sessionCachePort);
+    }
+
+    @Test
+    @DisplayName("connected: 레지스트리에 uid 없으면 silent no-op")
+    void onSessionConnected_unknownSession_isSilentNoOp() {
+        when(userSessionRegistry.findUserBySession(SID)).thenReturn(Optional.empty());
+
+        adapter.onSessionConnected(SID);
+
+        verifyNoInteractions(presenceService);
+        verifyNoInteractions(partyroomQueryPort);
+        verifyNoInteractions(sessionCachePort);
+    }
+
+    @Test
+    @DisplayName("connected: uid는 있지만 활성 룸 없으면 silent no-op")
+    void onSessionConnected_noActiveRoom_isSilentNoOp() {
+        when(userSessionRegistry.findUserBySession(SID)).thenReturn(Optional.of(UID));
+        when(partyroomQueryPort.getActivePartyroomByUserId(UID)).thenReturn(Optional.empty());
+
+        adapter.onSessionConnected(SID);
+
+        verify(presenceService, never()).clearPending(any(), any());
+        verifyNoInteractions(sessionCachePort);
+    }
+
+    @Test
+    @DisplayName("disconnected: 마지막 세션이면 활성 룸 resolve 후 markPending")
+    void onSessionDisconnected_lastSession_marksPending() {
+        when(userSessionRegistry.unregister(SID))
+                .thenReturn(new UnregisterResult(Optional.of(UID), true));
+        when(partyroomQueryPort.getActivePartyroomByUserId(UID)).thenReturn(Optional.of(activeRoom()));
+
+        adapter.onSessionDisconnected(SID);
+
+        verify(presenceService).markPending(new PartyroomId(ROOM_ID), UID);
+        verifyNoInteractions(sessionCachePort);
+    }
+
+    @Test
+    @DisplayName("disconnected: 마지막 세션 아니면 멀티탭 → no-op")
+    void onSessionDisconnected_notLastSession_isSilentNoOp() {
+        when(userSessionRegistry.unregister(SID))
+                .thenReturn(new UnregisterResult(Optional.of(UID), false));
+
+        adapter.onSessionDisconnected(SID);
+
+        verifyNoInteractions(presenceService);
+        verifyNoInteractions(partyroomQueryPort);
+        verifyNoInteractions(sessionCachePort);
+    }
+
+    @Test
+    @DisplayName("disconnected: 알 수 없는 세션이면 silent no-op")
+    void onSessionDisconnected_unknownSession_isSilentNoOp() {
+        when(userSessionRegistry.unregister(SID))
+                .thenReturn(new UnregisterResult(Optional.empty(), false));
+
+        adapter.onSessionDisconnected(SID);
+
+        verifyNoInteractions(presenceService);
+        verifyNoInteractions(partyroomQueryPort);
+        verifyNoInteractions(sessionCachePort);
+    }
+
+    @Test
+    @DisplayName("disconnected: 마지막 세션이지만 활성 룸 없으면 silent no-op")
+    void onSessionDisconnected_lastSessionNoActiveRoom_isSilentNoOp() {
+        when(userSessionRegistry.unregister(SID))
+                .thenReturn(new UnregisterResult(Optional.of(UID), true));
+        when(partyroomQueryPort.getActivePartyroomByUserId(UID)).thenReturn(Optional.empty());
+
+        adapter.onSessionDisconnected(SID);
+
+        verify(presenceService, never()).markPending(any(), any());
+        verifyNoInteractions(sessionCachePort);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/out/realtime/SessionRegistryPortAdapterTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/out/realtime/SessionRegistryPortAdapterTest.java
@@ -1,0 +1,30 @@
+package com.pfplaybackend.api.party.adapter.out.realtime;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.application.service.UserSessionRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SessionRegistryPortAdapterTest {
+
+    @Mock UserSessionRegistry userSessionRegistry;
+
+    @InjectMocks SessionRegistryPortAdapter adapter;
+
+    @Test
+    @DisplayName("register 는 userId 문자열을 UserId 로 변환해 레지스트리에 위임한다")
+    void registerDelegatesToRegistry() {
+        // when
+        adapter.register("s1", "123");
+
+        // then
+        verify(userSessionRegistry).register("s1", UserId.fromString("123"));
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/ClusterAPresenceIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/ClusterAPresenceIntegrationTest.java
@@ -1,0 +1,124 @@
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.application.dto.partyroom.ActivePartyroomDto;
+import com.pfplaybackend.api.party.application.port.out.PartyroomQueryPort;
+import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
+import com.pfplaybackend.api.party.domain.enums.GradeType;
+import com.pfplaybackend.api.party.domain.enums.StageType;
+import com.pfplaybackend.api.party.domain.value.LinkDomain;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Cluster A PR-1 특성화(characterization) 회귀 잠금.
+ *
+ * presence 경로는 사용자의 권위 있는(authoritative) active 룸을 STOMP subscribe 타이밍이 아니라
+ * 기존 {@link PartyroomQueryPort#getActivePartyroomByUserId(UserId)} 계약으로 resolve 한다.
+ * 신규 포트 메서드를 추가하지 않고 이 기존 계약을 잠가, 후속 presence 리팩터링이
+ * 룸-resolve 진실 원천을 조용히 깨뜨리지 못하게 한다.
+ *
+ * 프로덕션 코드 변경 없음 — 작성·배선만으로 GREEN 인 것이 정상(이것이 곧 잠금).
+ */
+@Transactional
+class ClusterAPresenceIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private PartyroomQueryPort partyroomQueryPort;
+
+    private PartyroomId persistFullActivePartyroom(UserId hostId) {
+        // 1) PartyroomData (root) — IDENTITY 생성 PK 확보
+        PartyroomData partyroom = PartyroomData.create(
+                "Cluster A 파티룸", "presence resolve 잠금용 파티룸",
+                LinkDomain.of("cluster-a-presence-" + hostId.getUid()),
+                PlaybackTimeLimit.ofMinutes(5),
+                StageType.GENERAL, hostId);
+        entityManager.persist(partyroom);
+        entityManager.flush();
+        PartyroomId partyroomId = new PartyroomId(partyroom.getId());
+
+        // 2) getActivePartyroomByUserId QueryDSL 은 PARTYROOM_PLAYBACK / DJ_QUEUE 와
+        //    inner join 하므로 두 상태 행이 반드시 존재해야 한다.
+        entityManager.persist(PartyroomPlaybackData.createFor(partyroomId));
+        entityManager.persist(DjQueueData.createFor(partyroomId));
+
+        return partyroomId;
+    }
+
+    @Test
+    @DisplayName("getActivePartyroomByUserId — active crew 사용자는 그 파티룸의 ActivePartyroomDto 를 반환하고 dto.id() 는 PartyroomId 로 매핑된다")
+    void activeCrewUserResolvesActivePartyroom() {
+        // given
+        UserId hostId = new UserId(900L);
+        UserId crewUserId = new UserId(901L);
+        PartyroomId partyroomId = persistFullActivePartyroom(hostId);
+
+        CrewData activeCrew = CrewData.create(
+                partyroomId, crewUserId, GradeType.CLUBBER, null);
+        entityManager.persist(activeCrew);
+        flushAndClear();
+
+        // when
+        Optional<ActivePartyroomDto> result =
+                partyroomQueryPort.getActivePartyroomByUserId(crewUserId);
+
+        // then
+        assertThat(result).isPresent();
+        ActivePartyroomDto dto = result.get();
+        assertThat(dto.id()).isEqualTo(partyroomId.getId());
+        // 후속 presence resolve 가 사용하는 DTO → 도메인 값 매핑이 유효함을 잠근다.
+        assertThat(new PartyroomId(dto.id())).isEqualTo(partyroomId);
+        assertThat(dto.crewId()).isEqualTo(activeCrew.getId());
+    }
+
+    @Test
+    @DisplayName("getActivePartyroomByUserId — 비active crew 사용자는 Optional.empty() 를 반환한다")
+    void inactiveCrewUserResolvesEmpty() {
+        // given
+        UserId hostId = new UserId(910L);
+        UserId crewUserId = new UserId(911L);
+        PartyroomId partyroomId = persistFullActivePartyroom(hostId);
+
+        CrewData inactiveCrew = CrewData.create(
+                partyroomId, crewUserId, GradeType.CLUBBER, null);
+        inactiveCrew.deactivatePresence();
+        entityManager.persist(inactiveCrew);
+        flushAndClear();
+
+        // when
+        Optional<ActivePartyroomDto> result =
+                partyroomQueryPort.getActivePartyroomByUserId(crewUserId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getActivePartyroomByUserId — crew 행이 없는 사용자는 Optional.empty() 를 반환한다")
+    void absentCrewUserResolvesEmpty() {
+        // given
+        UserId hostId = new UserId(920L);
+        UserId unknownUserId = new UserId(921L);
+        persistFullActivePartyroom(hostId);
+        flushAndClear();
+
+        // when
+        Optional<ActivePartyroomDto> result =
+                partyroomQueryPort.getActivePartyroomByUserId(unknownUserId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/ClusterAPresenceIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/ClusterAPresenceIntegrationTest.java
@@ -1,42 +1,110 @@
 package com.pfplaybackend.api.party.application.service;
 
 import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.aspect.context.AuthContext;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.party.application.dto.partyroom.ActivePartyroomDto;
 import com.pfplaybackend.api.party.application.port.out.PartyroomQueryPort;
+import com.pfplaybackend.api.party.application.port.out.UserProfileQueryPort;
 import com.pfplaybackend.api.party.domain.entity.data.CrewData;
 import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
 import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
 import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
 import com.pfplaybackend.api.party.domain.enums.StageType;
+import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
+import com.pfplaybackend.api.party.domain.value.CrewId;
 import com.pfplaybackend.api.party.domain.value.LinkDomain;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
+import com.pfplaybackend.realtime.port.PresencePort;
+import com.pfplaybackend.realtime.port.SessionRegistryPort;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Cluster A PR-1 특성화(characterization) 회귀 잠금.
  *
- * presence 경로는 사용자의 권위 있는(authoritative) active 룸을 STOMP subscribe 타이밍이 아니라
- * 기존 {@link PartyroomQueryPort#getActivePartyroomByUserId(UserId)} 계약으로 resolve 한다.
- * 신규 포트 메서드를 추가하지 않고 이 기존 계약을 잠가, 후속 presence 리팩터링이
+ * <p>전반부 3건 — presence 경로는 사용자의 권위 있는(authoritative) active 룸을 STOMP subscribe
+ * 타이밍이 아니라 기존 {@link PartyroomQueryPort#getActivePartyroomByUserId(UserId)} 계약으로
+ * resolve 한다. 신규 포트 메서드를 추가하지 않고 이 기존 계약을 잠가, 후속 presence 리팩터링이
  * 룸-resolve 진실 원천을 조용히 깨뜨리지 못하게 한다.
  *
- * 프로덕션 코드 변경 없음 — 작성·배선만으로 GREEN 인 것이 정상(이것이 곧 잠금).
+ * <p>후반부 시나리오 — PR-1(Task 1.1~1.7)으로 통합된 presence 흐름을 실제 Redis(user-session
+ * registry) + MySQL(crew.pending_exit_at 권위) 로 끝까지 구동해 #31 / SE4(경로 A·B) / 멀티탭(E1) /
+ * grace 만료 5개 행위를 잠근다. 구동 시seam 은 리스너가 호출하는 그대로:
+ * {@code sessionRegistryPort.register(sid, uid)} → {@code presencePort.onSessionConnected(sid)}
+ * (CONNECT), {@code presencePort.onSessionDisconnected(sid)} (DISCONNECT).
+ *
+ * <p>{@link UserProfileQueryPort} 만 MockBean — tryEnter 의 프로필 보유 invariant 가드는 presence
+ * 행위와 직교하는 주변 게이트이므로(실제 ProfileData/AvatarSetting 행 구성은 잠금 대상이 아님)
+ * 통과시킨다. presence DB 전이(pending_exit_at / is_active / exited_at)는 전부 실제 빈으로 구동·검증.
+ *
+ * <p>프로덕션 코드 변경 없음 — 작성·배선만으로 GREEN 인 것이 정상(이것이 곧 잠금).
  */
 @Transactional
 class ClusterAPresenceIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired
     private PartyroomQueryPort partyroomQueryPort;
+    @Autowired
+    private SessionRegistryPort sessionRegistryPort;
+    @Autowired
+    private PresencePort presencePort;
+    @Autowired
+    private PartyroomPresenceService presenceService;
+    @Autowired
+    private PartyroomAccessCommandService partyroomAccessCommandService;
+    @Autowired
+    private PartyroomAggregatePort aggregatePort;
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    /**
+     * tryEnter 의 프로필 보유 invariant 게이트만 무력화 — presence 흐름과 직교.
+     * (실제 ProfileData 행 구성은 PR-1 잠금 대상이 아니며 fragile.)
+     */
+    @MockBean
+    private UserProfileQueryPort userProfileQueryPort;
+
+    @BeforeEach
+    void seedProfileGate() {
+        // 어떤 userId 든 프로필 보유 상태로 — assertHasProfile 통과.
+        lenient().when(userProfileQueryPort.getUsersProfileSetting(any()))
+                .thenAnswer(inv -> {
+                    List<UserId> ids = inv.getArgument(0);
+                    Map<UserId, ProfileSettingDto> result = new java.util.HashMap<>();
+                    for (UserId id : ids) {
+                        result.put(id, mock(ProfileSettingDto.class));
+                    }
+                    return result;
+                });
+        // registry/presence Redis 키는 tx 밖이므로 케이스 간 격리를 위해 비운다.
+        stringRedisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+    }
+
+    @AfterEach
+    void clearAuthContext() {
+        ThreadLocalContext.clearContext();
+    }
 
     private PartyroomId persistFullActivePartyroom(UserId hostId) {
         // 1) PartyroomData (root) — IDENTITY 생성 PK 확보
@@ -56,6 +124,27 @@ class ClusterAPresenceIntegrationTest extends AbstractIntegrationTest {
 
         return partyroomId;
     }
+
+    private CrewData persistActiveCrew(PartyroomId partyroomId, UserId userId) {
+        CrewData crew = CrewData.create(partyroomId, userId, GradeType.CLUBBER, null);
+        entityManager.persist(crew);
+        flushAndClear();
+        return crew;
+    }
+
+    /** 벌크 JPQL(markPending/clearPending) 은 영속성 컨텍스트를 우회 → flush+clear 후 재조회. */
+    private CrewData refetchCrew(PartyroomId partyroomId, UserId userId) {
+        flushAndClear();
+        return aggregatePort.findCrew(partyroomId, userId).orElseThrow();
+    }
+
+    private void setAuthContext(UserId userId) {
+        AuthContext authContext = mock(AuthContext.class);
+        lenient().when(authContext.getUserId()).thenReturn(userId);
+        ThreadLocalContext.setContext(authContext);
+    }
+
+    // ───────────────────────── 기존 특성화 3건 (유지) ─────────────────────────
 
     @Test
     @DisplayName("getActivePartyroomByUserId — active crew 사용자는 그 파티룸의 ActivePartyroomDto 를 반환하고 dto.id() 는 PartyroomId 로 매핑된다")
@@ -120,5 +209,155 @@ class ClusterAPresenceIntegrationTest extends AbstractIntegrationTest {
 
         // then
         assertThat(result).isEmpty();
+    }
+
+    // ─────────────── PR-1 통합 시나리오 잠금 (#31 / SE4 / 멀티탭 / grace) ───────────────
+
+    @Test
+    @DisplayName("#31 — subscribe 여부 무관: 마지막 세션 DISCONNECT 가 항상 pending_exit_at 을 SET 한다 (registry 권위, subscribe-타이밍 캐시 비의존)")
+    void disconnectAlwaysMarksPendingViaRegistry_31() {
+        // given — 사용자가 룸에 ACTIVE (crew is_active=true, pending_exit_at NULL)
+        UserId hostId = new UserId(1000L);
+        UserId userId = new UserId(1001L);
+        PartyroomId partyroomId = persistFullActivePartyroom(hostId);
+        CrewData crew = persistActiveCrew(partyroomId, userId);
+        assertThat(refetchCrew(partyroomId, userId).isPendingExit()).isFalse();
+
+        // when — CONNECT 시 세션 등록(STOMP SUBSCRIBE 는 한 번도 없음) → 그 단일 세션 DISCONNECT
+        String sid = "sid-31-only";
+        sessionRegistryPort.register(sid, String.valueOf(userId.getUid()));
+        presencePort.onSessionDisconnected(sid);
+
+        // then — subscribe 캐시와 무관하게 grace 시작: pending_exit_at SET
+        CrewData after = refetchCrew(partyroomId, userId);
+        assertThat(after.isPendingExit())
+                .as("#31: 탭 종료/DISCONNECT 는 subscribe 캐시 게이팅 없이 항상 registry 경로로 pending 마크")
+                .isTrue();
+        assertThat(after.isActive()).isTrue();
+        assertThat(after.getExitedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("SE4 경로 A — DISCONNECT(pending) 후 동일 유저 새 세션 CONNECT 시 pending_exit_at 이 해제된다")
+    void se4PathA_connectTimeClearsPending() {
+        // given — active → 세션 등록 → DISCONNECT 로 pending SET
+        UserId hostId = new UserId(1010L);
+        UserId userId = new UserId(1011L);
+        PartyroomId partyroomId = persistFullActivePartyroom(hostId);
+        persistActiveCrew(partyroomId, userId);
+
+        String sid1 = "sid-se4a-1";
+        sessionRegistryPort.register(sid1, String.valueOf(userId.getUid()));
+        presencePort.onSessionDisconnected(sid1);
+        assertThat(refetchCrew(partyroomId, userId).isPendingExit()).isTrue();
+
+        // when — 재접속: 새 세션을 CONNECT 시점에 등록 + onSessionConnected
+        String sid2 = "sid-se4a-2";
+        sessionRegistryPort.register(sid2, String.valueOf(userId.getUid()));
+        presencePort.onSessionConnected(sid2);
+
+        // then — pending 해제 (ONLINE 복원)
+        CrewData after = refetchCrew(partyroomId, userId);
+        assertThat(after.isPendingExit())
+                .as("SE4 경로 A: CONNECT-time clearPending 으로 grace 취소")
+                .isFalse();
+        assertThat(after.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("SE4 경로 B (end-to-end) — DISCONNECT(pending) 후 REST 같은-룸 재입장으로 pending 해제 + 늦게 만료된 stale 키의 forceOffline 은 NO-OP")
+    void se4PathB_restReentryClears_thenLateExpiryIsNoOp() {
+        // given — active → 세션 등록 → DISCONNECT 로 pending SET
+        UserId hostId = new UserId(1020L);
+        UserId userId = new UserId(1021L);
+        PartyroomId partyroomId = persistFullActivePartyroom(hostId);
+        CrewData crew = persistActiveCrew(partyroomId, userId);
+        long crewId = crew.getId();
+
+        String sid = "sid-se4b";
+        sessionRegistryPort.register(sid, String.valueOf(userId.getUid()));
+        presencePort.onSessionDisconnected(sid);
+        assertThat(refetchCrew(partyroomId, userId).isPendingExit()).isTrue();
+
+        // when (1) — REST 같은-룸 재입장 (페이지 새로고침 흐름)
+        setAuthContext(userId);
+        partyroomAccessCommandService.tryEnter(partyroomId, null);
+
+        // then (1) — DB pending_exit_at 해제
+        CrewData afterReentry = refetchCrew(partyroomId, userId);
+        assertThat(afterReentry.isPendingExit())
+                .as("SE4 경로 B: REST 같은-룸 재입장이 grace 를 이중방어로 취소")
+                .isFalse();
+        assertThat(afterReentry.isActive()).isTrue();
+
+        // when (2) — 늦게 도착한 expiration listener 가 stale Redis 타이머 키로 forceOffline 발화
+        presenceService.forceOffline(partyroomId, new CrewId(crewId));
+
+        // then (2) — !isPendingExit() 가드로 NO-OP: crew 는 여전히 active, exited_at NULL, OFFLINE 아님
+        CrewData afterLateExpiry = refetchCrew(partyroomId, userId);
+        assertThat(afterLateExpiry.isActive())
+                .as("T1.7 forward note: 재입장으로 pending 해제된 crew 는 늦은 만료에도 OFFLINE 되지 않아야 함")
+                .isTrue();
+        assertThat(afterLateExpiry.getExitedAt()).isNull();
+        assertThat(afterLateExpiry.isPendingExit()).isFalse();
+    }
+
+    @Test
+    @DisplayName("E1 멀티탭 — 두 세션 중 첫 DISCONNECT 는 pending 미발생, 마지막 DISCONNECT 에서만 pending SET (SE5 self-eviction 방지)")
+    void e1MultiTab_onlyLastSessionStartsGrace() {
+        // given — active, 같은 유저 두 세션 등록
+        UserId hostId = new UserId(1030L);
+        UserId userId = new UserId(1031L);
+        PartyroomId partyroomId = persistFullActivePartyroom(hostId);
+        persistActiveCrew(partyroomId, userId);
+
+        String s1 = "sid-e1-tab1";
+        String s2 = "sid-e1-tab2";
+        sessionRegistryPort.register(s1, String.valueOf(userId.getUid()));
+        sessionRegistryPort.register(s2, String.valueOf(userId.getUid()));
+
+        // when (1) — s1 만 DISCONNECT (마지막 세션 아님)
+        presencePort.onSessionDisconnected(s1);
+
+        // then (1) — pending 미발생 (다른 탭이 살아있음)
+        assertThat(refetchCrew(partyroomId, userId).isPendingExit())
+                .as("E1: 한 탭만 닫혔으므로 grace 타이머가 시작되면 안 됨 (SE5)")
+                .isFalse();
+
+        // when (2) — s2 DISCONNECT (마지막 세션)
+        presencePort.onSessionDisconnected(s2);
+
+        // then (2) — pending SET
+        assertThat(refetchCrew(partyroomId, userId).isPendingExit())
+                .as("E1: 마지막 세션 종료 시에만 grace 시작")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("#31 grace 만료 → exited — DISCONNECT(pending) 후 forceOffline(grace TTL 만료) 시 crew is_active=false, exited_at SET (고스트 정리)")
+    void graceExpiryPromotesToOffline_31EndState() {
+        // given — active → 세션 등록 → DISCONNECT 로 pending SET
+        UserId hostId = new UserId(1040L);
+        UserId userId = new UserId(1041L);
+        PartyroomId partyroomId = persistFullActivePartyroom(hostId);
+        CrewData crew = persistActiveCrew(partyroomId, userId);
+        long crewId = crew.getId();
+
+        String sid = "sid-31-expiry";
+        sessionRegistryPort.register(sid, String.valueOf(userId.getUid()));
+        presencePort.onSessionDisconnected(sid);
+        assertThat(refetchCrew(partyroomId, userId).isPendingExit()).isTrue();
+
+        // when — grace TTL 만료 시뮬레이션
+        presenceService.forceOffline(partyroomId, new CrewId(crewId));
+
+        // then — 고스트 최종 정리: is_active=false, exited_at SET (#31 종착 상태)
+        CrewData after = refetchCrew(partyroomId, userId);
+        assertThat(after.isActive())
+                .as("#31 end state: grace 만료 시 고스트 crew 가 비활성화되어야 함")
+                .isFalse();
+        assertThat(after.getExitedAt())
+                .as("#31 end state: exited_at 이 기록되어야 함")
+                .isNotNull();
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/ClusterAPresenceIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/ClusterAPresenceIntegrationTest.java
@@ -98,6 +98,7 @@ class ClusterAPresenceIntegrationTest extends AbstractIntegrationTest {
                     return result;
                 });
         // registry/presence Redis 키는 tx 밖이므로 케이스 간 격리를 위해 비운다.
+        // 주의: flushAll 은 단일 fork(integrationTest 직렬 실행) 전제 — 병렬 fork 시 키 간섭 가능.
         stringRedisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
     }
 
@@ -224,6 +225,7 @@ class ClusterAPresenceIntegrationTest extends AbstractIntegrationTest {
         assertThat(refetchCrew(partyroomId, userId).isPendingExit()).isFalse();
 
         // when — CONNECT 시 세션 등록(STOMP SUBSCRIBE 는 한 번도 없음) → 그 단일 세션 DISCONNECT
+        // String uid 인자는 realtime CONNECT-frame Principal 계약(리스너가 넘기는 형태)을 그대로 미러링.
         String sid = "sid-31-only";
         sessionRegistryPort.register(sid, String.valueOf(userId.getUid()));
         presencePort.onSessionDisconnected(sid);

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceTest.java
@@ -512,6 +512,126 @@ class PartyroomAccessCommandServiceTest {
     }
 
     @Test
+    @DisplayName("tryEnter: same-room 재입장 시 pending_exit_at을 해제한다 — SE4 레이스 이중방어 (#225)")
+    void tryEnter_sameRoomReentry_clearsPendingExit() {
+        // given — user already active in SAME room (page refresh: STOMP DISCONNECT set
+        // pending_exit_at; reload triggers REST tryEnter same-room path)
+        CrewData crew = CrewData.builder()
+                .id(10L)
+                .userId(userId)
+                .gradeType(GradeType.LISTENER)
+                .isActive(true)
+                .build();
+
+        PartyroomData partyroomData = PartyroomData.builder()
+                .id(1L)
+                .partyroomId(partyroomId)
+                .status(PartyroomStatus.ACTIVE)
+                .build();
+
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroomData);
+        when(aggregatePort.countActiveCrews(partyroomId)).thenReturn(10L);
+        when(aggregatePort.findCrew(partyroomId, userId)).thenReturn(Optional.of(crew));
+        when(aggregatePort.saveCrew(any(CrewData.class))).thenReturn(crew);
+
+        ActivePartyroomDto activeRoomInfo = mock(ActivePartyroomDto.class);
+        when(activeRoomInfo.id()).thenReturn(1L);
+        when(partyroomQueryService.getMyActivePartyroom(userId)).thenReturn(Optional.of(activeRoomInfo));
+
+        // when
+        partyroomAccessCommandService.tryEnter(partyroomId, null);
+
+        // then — SE4 defense-in-depth: REST same-room re-entry cancels grace exactly once
+        verify(aggregatePort, times(1)).clearCrewPending(partyroomId, userId);
+    }
+
+    @Test
+    @DisplayName("tryEnter: 신규 진입(fresh)에서는 pending 해제를 호출하지 않는다 — same-room 분기 전용")
+    void tryEnter_freshEntry_doesNotClearPending() {
+        // given — no existing active room, fresh entry path
+        PartyroomData partyroom = mock(PartyroomData.class);
+        when(partyroom.getPartyroomId()).thenReturn(partyroomId);
+        when(partyroom.getStatus()).thenReturn(PartyroomStatus.ACTIVE);
+        when(partyroom.isSuspended()).thenReturn(false);
+
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+        when(aggregatePort.countActiveCrews(partyroomId)).thenReturn(0L);
+        when(partyroomQueryService.getMyActivePartyroom(userId)).thenReturn(Optional.empty());
+        when(aggregatePort.findCrew(partyroomId, userId)).thenReturn(Optional.empty());
+        when(aggregatePort.activateCrew(eq(partyroomId), eq(userId), any())).thenReturn(0);
+        when(aggregatePort.saveCrew(any(CrewData.class)))
+                .thenAnswer(inv -> {
+                    CrewData input = inv.getArgument(0);
+                    ReflectionTestUtils.setField(input, "id", 100L);
+                    return input;
+                });
+
+        // when
+        partyroomAccessCommandService.tryEnter(partyroomId, null);
+
+        // then — pending clear belongs only to the same-room re-entry branch
+        verify(aggregatePort, never()).clearCrewPending(any(), any());
+    }
+
+    @Test
+    @DisplayName("tryEnter: 다른 룸에서 옮겨오는 신규 진입에서는 pending 해제를 호출하지 않는다 — same-room 분기 전용")
+    void tryEnter_otherRoomAutoExit_doesNotClearPending() {
+        // given — same scenario as tryEnterAnotherRoomActiveShouldAutoExitInsteadOfException
+        PartyroomId newRoomId = new PartyroomId(2L);
+        PartyroomId oldRoomId = new PartyroomId(1L);
+
+        CrewData newRoomCrew = CrewData.builder()
+                .id(20L)
+                .userId(userId)
+                .gradeType(GradeType.LISTENER)
+                .isActive(false)
+                .build();
+
+        PartyroomData newPartyroomData = PartyroomData.builder()
+                .id(2L)
+                .partyroomId(newRoomId)
+                .status(PartyroomStatus.ACTIVE)
+                .build();
+
+        when(partyroomQueryService.getPartyroomById(newRoomId)).thenReturn(newPartyroomData);
+        when(aggregatePort.countActiveCrews(newRoomId)).thenReturn(5L);
+        when(aggregatePort.findCrew(newRoomId, userId)).thenReturn(Optional.of(newRoomCrew));
+
+        ActivePartyroomDto activeRoomInfo = mock(ActivePartyroomDto.class);
+        when(activeRoomInfo.id()).thenReturn(oldRoomId.getId());
+        when(partyroomQueryService.getMyActivePartyroom(userId)).thenReturn(Optional.of(activeRoomInfo));
+
+        CrewData oldCrew = CrewData.builder()
+                .id(5L)
+                .userId(userId)
+                .gradeType(GradeType.LISTENER)
+                .isActive(true)
+                .build();
+
+        PartyroomData oldPartyroomData = PartyroomData.builder()
+                .id(1L)
+                .partyroomId(oldRoomId)
+                .status(PartyroomStatus.ACTIVE)
+                .build();
+
+        PartyroomPlaybackData oldPlaybackState = PartyroomPlaybackData.createFor(new PartyroomId(1L));
+
+        when(partyroomQueryService.getPartyroomById(oldRoomId)).thenReturn(oldPartyroomData);
+        when(aggregatePort.findCrew(oldRoomId, userId)).thenReturn(Optional.of(oldCrew));
+        when(aggregatePort.findDj(oldRoomId, new CrewId(5L))).thenReturn(Optional.empty());
+        when(aggregatePort.findPlaybackState(oldRoomId)).thenReturn(oldPlaybackState);
+        when(aggregatePort.deactivateCrew(eq(oldRoomId), eq(userId), any(LocalDateTime.class))).thenReturn(1);
+        when(aggregatePort.activateCrew(eq(newRoomId), eq(userId), any(LocalDateTime.class))).thenReturn(1);
+        when(aggregatePort.saveCrew(any(CrewData.class))).thenReturn(newRoomCrew);
+
+        // when
+        partyroomAccessCommandService.tryEnter(newRoomId, null);
+
+        // then — auto-exit-then-fresh-entry must NOT clear pending (not the same-room branch)
+        verify(aggregatePort, never()).clearCrewPending(any(), any());
+    }
+
+    @Test
     @DisplayName("tryEnter healing: grade promotion is silent — no CrewGradeChangedEvent published")
     void tryEnter_healing_doesNotPublishGradeChangeEvent() {
         // given — same setup pattern as Test #3 (LISTENER → HOST healing path via re-activate)

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/UserSessionRegistryTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/UserSessionRegistryTest.java
@@ -1,0 +1,126 @@
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("UserSessionRegistry — 세션 생존·마지막세션 판정 단위")
+class UserSessionRegistryTest {
+
+    /**
+     * In-memory fake of the {@link UserSessionRegistry.SessionStore} port.
+     * Mirrors the Redis semantics the real adapter must provide:
+     * a session→user key/value and a user→sessions Set with SREM-then-SCARD.
+     */
+    static class FakeSessionStore implements UserSessionRegistry.SessionStore {
+        final Map<String, String> sessionToUser = new HashMap<>();
+        final Map<String, Set<String>> userSessions = new HashMap<>();
+
+        @Override
+        public void bindSession(String sessionId, String userId) {
+            sessionToUser.put(sessionId, userId);
+            userSessions.computeIfAbsent(userId, k -> new HashSet<>()).add(sessionId);
+        }
+
+        @Override
+        public String getUserBySession(String sessionId) {
+            return sessionToUser.get(sessionId);
+        }
+
+        @Override
+        public long unbindSessionAndCount(String sessionId, String userId) {
+            sessionToUser.remove(sessionId);
+            Set<String> set = userSessions.get(userId);
+            if (set == null) {
+                return 0L;
+            }
+            set.remove(sessionId);
+            long remaining = set.size();
+            if (remaining == 0) {
+                userSessions.remove(userId);
+            }
+            return remaining;
+        }
+    }
+
+    private FakeSessionStore store;
+    private UserSessionRegistry registry;
+
+    private final UserId user = new UserId(42L);
+
+    @BeforeEach
+    void setUp() {
+        store = new FakeSessionStore();
+        registry = new UserSessionRegistry(store);
+    }
+
+    @Test
+    @DisplayName("register 후 findUserBySession 으로 uid 가 조회된다")
+    void registerThenFindUser() {
+        registry.register("sid-1", user);
+
+        Optional<UserId> found = registry.findUserBySession("sid-1");
+
+        assertThat(found).contains(user);
+    }
+
+    @Test
+    @DisplayName("findUserBySession — 등록되지 않은 세션은 빈 Optional")
+    void findUserByUnknownSession() {
+        assertThat(registry.findUserBySession("nope")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("동일 uid 2세션 중 1개 unregister → wasLastSession=false")
+    void unregisterOneOfTwoSessionsNotLast() {
+        registry.register("sid-1", user);
+        registry.register("sid-2", user);
+
+        UserSessionRegistry.UnregisterResult result = registry.unregister("sid-1");
+
+        assertThat(result.userId()).contains(user);
+        assertThat(result.wasLastSession()).isFalse();
+    }
+
+    @Test
+    @DisplayName("마지막 세션 unregister → wasLastSession=true")
+    void unregisterLastSessionIsLast() {
+        registry.register("sid-1", user);
+        registry.register("sid-2", user);
+        registry.unregister("sid-1");
+
+        UserSessionRegistry.UnregisterResult result = registry.unregister("sid-2");
+
+        assertThat(result.userId()).contains(user);
+        assertThat(result.wasLastSession()).isTrue();
+    }
+
+    @Test
+    @DisplayName("단일 세션 unregister → wasLastSession=true")
+    void unregisterSingleSessionIsLast() {
+        registry.register("sid-1", user);
+
+        UserSessionRegistry.UnregisterResult result = registry.unregister("sid-1");
+
+        assertThat(result.userId()).contains(user);
+        assertThat(result.wasLastSession()).isTrue();
+    }
+
+    @Test
+    @DisplayName("등록되지 않은 세션 unregister → userId 비어있고 wasLastSession=false")
+    void unregisterUnknownSession() {
+        UserSessionRegistry.UnregisterResult result = registry.unregister("ghost");
+
+        assertThat(result.userId()).isEmpty();
+        assertThat(result.wasLastSession()).isFalse();
+    }
+}

--- a/docs/superpowers/plans/2026-05-18-cluster-a-realtime-subscription-presence.md
+++ b/docs/superpowers/plans/2026-05-18-cluster-a-realtime-subscription-presence.md
@@ -1,0 +1,278 @@
+# Cluster A 실시간 구독·presence·세션→룸 통합 재설계 — 구현 계획
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (subagents 가용) 으로 실행. 스텝은 `- [ ]` 체크박스로 추적.
+
+**Goal:** #30·#31·#5·#225 4증상을 단일 뿌리에서 통합 제거 — 라이프사이클·presence·구독격리를 서버 권위(WS 연결생존) + 클라 단일진실원천으로 재설계.
+
+**Architecture:** L1 user-session 레지스트리(서버 presence 권위, subscribe-타이밍 의존 제거) / L2 클라 unload-exit 분리·제거 / L3 클라 `subscriptions[]` 단일진실원천 / L4 서버 단일룸 가드 + DJ큐 presence 통합. 스펙: `docs/superpowers/specs/2026-05-18-cluster-a-realtime-subscription-presence-design.md` (승인). piecemeal 금지 — 통합 1설계, 구현 4 PR.
+
+**Tech Stack:** pfplay-platform = Java/Spring Boot, JDK 21 (`JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7"` prefix 필수), JUnit5/Mockito/AssertJ, Testcontainers(`@Tag("integration")` → `:app:integrationTest`), Redis(V16 presence). pfplay-web = Next.js/React/TS, **vitest**(러너 — `package.json` `"test":"vitest run"`, `vitest.config.ts` include `src/**/*.test.{ts,tsx}`, jsdom, globals; **jest 아님**), 단일 파일: `yarn vitest run <path>`. `@stomp/stompjs`. 브랜치: 각 PR `feature/cluster-a-pr<n>-*` off `origin/develop`, develop 대상 한글 PR. 회귀잠금 = 각 PR 동반.
+
+**공통 규약:** TDD(red→green→commit). 마이크로 커밋 로컬 OK, push 전 논리단위 squash. 이슈/커밋/PR 한글. verification before completion(테스트 결과 XML 확인). `:app:test`는 `@Tag("integration")` 제외 → 통합테스트는 `:app:integrationTest`.
+
+---
+
+## 파일 구조 (생성/수정 + 책임)
+
+### PR-1 platform L1 (서버 권위)
+- Create `app/.../party/application/service/UserSessionRegistry.java` — Redis 백킹 sessionId↔userId / userId→Set<sessionId>. 책임: STOMP 세션 생존 추적, "마지막 세션" 판정.
+- Presence 룸 resolve: 기존 `PartyroomQueryPort.getActivePartyroomByUserId(UserId): Optional<ActivePartyroomDto>` 재사용(adapter `PartyroomAggregateAdapter:182`). **신규 포트 메서드 불요** — presence 경로에서 이 query port 호출 후 `dto.id()` → `new PartyroomId(...)` 매핑. (subscribe-타이밍 무관하게 DB crew 권위.)
+- Modify `realtime/.../event/ConnectionEventListener.java` — passive→레지스트리 등록 + reconnect clearPending(CONNECT 시점).
+- Modify `realtime/.../event/DisconnectionEventListener.java` — 레지스트리 제거 + 마지막세션→markPending(DB resolve).
+- Modify `realtime/.../event/SubscriptionEventListener.java` — presence 트리거(onSessionConnected/세션캐시) 제거.
+- Modify `app/.../party/adapter/out/realtime/PresencePortAdapter.java` — resolve를 세션캐시→레지스트리/DB 권위로 전환.
+- Modify `realtime/.../port/PresencePort.java` (필요시 시그니처) — sessionId 대신 (userId|room) 기반 onConnected/onDisconnected.
+- Modify `app/.../party/application/service/PartyroomAccessCommandService.java` — 같은-룸 재입장 분기에 `clearPending` 추가.
+- Tests: `app/src/test/.../UserSessionRegistryTest.java`(단위), `.../party/application/service/PartyroomPresenceServiceClusterATest.java` 또는 통합 `.../ClusterAPresenceIntegrationTest.java`(Testcontainers), `PartyroomAccessCommandServiceTest`(재입장 clearPending).
+
+### PR-2 platform L4 (단일룸 가드 + DJ큐 grace 잠금)
+- Modify `realtime/.../event/SubscriptionEventListener.java` — 서버 단일룸 가드(권위 룸 불일치 SUBSCRIBE 거부, no-op+log).
+- Modify `realtime/.../config/WebSocketConfig.java` — 7.5s 주석 정정(상한=reconcile cron 명기).
+- Tests: `SubscriptionEventListenerTest`(가드), `app/src/test/.../DjQueueGraceIntegrationTest.java`(통합: markPending DjData불변/grace내 보존/만료 제거/현재DJ 균일), `PartyroomPresenceServiceTest`(reconcile stale sweep).
+
+### PR-3 web L3 (클라 단일진실원천)
+- Modify `src/shared/api/websocket/client.ts` — `Subscription`에 callback, `subscriptions[]` desired-state, (re)connect reconcile, unsubscribe 무조건 제거.
+- Modify `src/entities/partyroom-client/lib/partyroom-client.ts` — `subscribe` replace 정책(throw 제거).
+- Tests: `src/shared/api/websocket/client.test.ts`, `src/entities/partyroom-client/lib/partyroom-client.test.ts`.
+
+### PR-4 web L2 (exit 분리)
+- Create `src/features/partyroom/exit/lib/use-teardown-partyroom.ts` — (3) 클라 정리만.
+- Modify `src/app/parties/(room)/[id]/layout.tsx` — unmount=teardown, beforeunload/pagehide 제거.
+- Modify `src/features/partyroom/exit/lib/use-exit-partyroom.ts` — 명시 exit 전용으로 축소.
+- Modify (정리) `exitedOnBackend`/`markExitedOnBackend` 사용처 — 불요처 제거.
+- Tests: `src/app/parties/(room)/[id]/layout.test.tsx`(신규 생성, 현재 부재)·`use-teardown-partyroom.test.ts`·`use-exit-partyroom.test.ts`.
+
+---
+
+## Chunk 1: PR-1 — platform L1 user-session 레지스트리 + 리스너 재배선
+
+브랜치: `git checkout -b feature/cluster-a-pr1-user-session-registry origin/develop`
+
+### Task 1.1: UserSessionRegistry 단위 — 등록/제거/마지막세션 판정
+
+**Files:** Create `app/src/main/java/com/pfplaybackend/api/party/application/service/UserSessionRegistry.java`; Test `app/src/test/java/com/pfplaybackend/api/party/application/service/UserSessionRegistryTest.java`
+
+- [ ] **Step 1: 실패 테스트** — `UserSessionRegistryTest`: (a) `register(sid,uid)` 후 `isLastSession` 판정, (b) 동일 uid 2세션 중 1개 `unregister`→`wasLastSession`=false, (c) 마지막 `unregister`→true, (d) `findUserBySession(sid)` 반환. Redis는 `@Mock RedisTemplate` 또는 임베디드. 우선 in-memory 추상화 인터페이스로 단위(Redis 어댑터는 통합에서).
+
+```java
+@ExtendWith(MockitoExtension.class)
+class UserSessionRegistryTest {
+  // given registry backed by a fake store
+  // when register("s1", U1); register("s2", U1)
+  // then unregister("s1") -> wasLast=false ; unregister("s2") -> wasLast=true
+  // and findUserBySession("s2")==U1 before unregister
+}
+```
+
+- [ ] **Step 2: 실패 확인** — `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "*UserSessionRegistryTest" --console=plain` → FAIL(클래스 없음).
+- [ ] **Step 3: 최소 구현** — `UserSessionRegistry`: `presence:session:{sid}`→uid, `presence:usersessions:{uid}`→Set<sid>. 메서드 `register(sid,uid)`, `unregister(sid)`→`UnregisterResult{userId, wasLastSession}`, `findUserBySession(sid)`. Redis 연산은 주입 포트 뒤. 원자성: usersessions Set `SREM` 후 `SCARD`==0 이면 wasLast=true(Lua 또는 파이프라인; 단위는 fake로).
+- [ ] **Step 4: 통과 확인** — 동일 명령 PASS. 결과 XML 확인 `app/build/test-results/test/TEST-*UserSessionRegistryTest.xml` tests>0 failures=0.
+- [ ] **Step 5: 커밋** — `git add` 신규 2파일; `git commit -m "feat(presence): user-session 레지스트리 — 세션 생존·마지막세션 판정 (#209)"`
+
+### Task 1.2: Presence 룸 resolve = 기존 PartyroomQueryPort 재사용 (신규 포트 불요)
+
+**Files:** 확인만 — `app/.../party/application/port/...PartyroomQueryPort.java` 의 `getActivePartyroomByUserId(UserId): Optional<ActivePartyroomDto>` 및 adapter `PartyroomAggregateAdapter` (~line 182). Test 통합 `ClusterAPresenceIntegrationTest`(`@Tag("integration")`, extends `AbstractIntegrationTest`).
+
+- [ ] **Step 1: 실패 테스트** — `ClusterAPresenceIntegrationTest`: active crew 1행 저장 후 `getActivePartyroomByUserId(userId)` 가 그 `ActivePartyroomDto`(`.id()`=partyroomId) 반환, 비active면 `Optional.empty()`. (presence 경로가 이 query port로 룸 권위 resolve 함을 잠금.)
+- [ ] **Step 2: 실패 확인** — `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:integrationTest --tests "*ClusterAPresenceIntegrationTest" --console=plain` → FAIL(클래스 없음/RED).
+- [ ] **Step 3: 구현** — 신규 포트 메서드 추가하지 말 것. presence resolve 헬퍼(Task 1.3 PresencePortAdapter 내부)가 `partyroomQueryPort.getActivePartyroomByUserId(userId)` 호출 → `dto -> new PartyroomId(dto.id())` 매핑. 의존 주입 추가(기존 query port 빈). 이 태스크 산출=통합테스트가 query port의 active-by-user 계약을 잠금(GREEN이 되도록 의존 배선은 Task 1.3에서 완성 — 본 태스크는 계약 characterization).
+- [ ] **Step 4: 통과 확인** — integrationTest PASS, XML `app/build/test-results/integrationTest/TEST-*ClusterAPresenceIntegrationTest.xml` tests>0 failures=0. (참고: 본 태스크는 기존 query-port 계약 characterization 잠금 — 곧바로 GREEN 정상, RED 강요 금지. 실제 resolve 배선은 Task 1.3에서 완성.)
+- [ ] **Step 5: 커밋** — `test(presence): 룸 권위 resolve = PartyroomQueryPort.getActivePartyroomByUserId 계약 잠금 (#209)`
+
+### Task 1.3: PresencePort/Adapter — sessionId 캐시 의존 제거, 레지스트리/DB 권위
+
+**Files:** Modify `realtime/.../port/PresencePort.java`, `app/.../adapter/out/realtime/PresencePortAdapter.java`; Test `PresencePortAdapterTest`(신규/수정, Mockito).
+
+- [ ] **Step 1: 실패 테스트** — `onSessionConnected(sessionId)`: 레지스트리에서 uid resolve → `partyroomQueryPort.getActivePartyroomByUserId(uid)` 있으면 `presenceService.clearPending(new PartyroomId(dto.id()),uid)`. `onSessionDisconnected(sessionId)`: 레지스트리 `unregister`→wasLast면 동일 query port로 룸 resolve→`markPending`. 세션캐시(`sessionCachePort`) resolve 미사용 검증(no interaction).
+- [ ] **Step 2: 실패 확인** — `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "*PresencePortAdapterTest" --console=plain` FAIL.
+- [ ] **Step 3: 구현** — `PresencePortAdapter`가 `UserSessionRegistry` + `partyroomQueryPort.getActivePartyroomByUserId`(→`new PartyroomId(dto.id())`) 사용. 세션캐시 기반 resolve 제거. `PresencePort` 시그니처 유지(sessionId in) — 내부 resolve만 교체(리스너 영향 최소, 리뷰 risk2 회피).
+- [ ] **Step 4: 통과 확인** — PASS + XML.
+- [ ] **Step 5: 커밋** — `refactor(presence): PresencePortAdapter resolve를 레지스트리·DB 권위로 (#209)`
+
+### Task 1.4: ConnectionEventListener — 등록 + reconnect clearPending(CONNECT 시점)
+
+**Files:** Modify `realtime/.../event/ConnectionEventListener.java`; Test `ConnectionEventListenerTest`(신규).
+
+- [ ] **Step 1: 실패 테스트** — `SessionConnectEvent`(Principal=uid, sessionId) → `registry.register(sid,uid)` 호출 + `presencePort.onSessionConnected(sid)` 호출. Principal null이면 무시(로그).
+- [ ] **Step 2: 실패 확인** FAIL.
+- [ ] **Step 3: 구현** — `ConnectionEventListener implements ApplicationListener<SessionConnectEvent>`: `StompHeaderAccessor`에서 `getUser()`(Principal=uid, WebSocketConfig.determineUser가 handshake서 바인딩)·sessionId 추출 → register + onSessionConnected.
+- [ ] **Step 4: 통과 확인** PASS + XML.
+- [ ] **Step 5: 커밋** — `feat(presence): ConnectionEventListener 레지스트리 등록 + CONNECT 시점 clearPending (#209 SE4)`
+
+### Task 1.5: DisconnectionEventListener — 레지스트리 제거 + 마지막세션 markPending
+
+**Files:** Modify `realtime/.../event/DisconnectionEventListener.java`; Test `DisconnectionEventListenerTest`(수정).
+
+- [ ] **Step 1: 실패 테스트** — DISCONNECT: `registry.unregister(sid)` 호출, wasLast=true면 `presencePort.onSessionDisconnected(sid)`→markPending 경로; wasLast=false면 markPending 미발생(멀티탭 E1). resolve-before 순서: 세션캐시 delete 제거(레지스트리가 진실).
+- [ ] **Step 2: 실패 확인** FAIL.
+- [ ] **Step 3: 구현** — 기존 `presencePort.onSessionDisconnected` 호출을 레지스트리 unregister 결과 게이트로(wasLast일 때만 진행). **세션캐시 delete 라인(`sessionCachePort.deleteSessionCache(sessionId)`, 현 `DisconnectionEventListener:28`) 제거** — PR-1에서 resolve가 레지스트리/DB 권위로 이동하므로 presence가 세션캐시를 더는 안 씀. 세션캐시는 presence 외 프로덕션 용도 없음(Subscription/Unsubscription/Disconnection만 presence 목적 사용) → 호출 완전 제거. (Subscription 쪽 save 제거는 Task 1.6, Unsubscription delete 잔존 제거는 Task 1.6에서 일괄.)
+- [ ] **Step 4: 통과 확인** PASS + XML.
+- [ ] **Step 5: 커밋** — `feat(presence): DisconnectionEventListener 마지막세션만 markPending, 멀티탭 자기축출 해소 (#209 SE5)`
+
+### Task 1.6: SubscriptionEventListener — presence 트리거 제거
+
+**Files:** Modify `realtime/.../event/SubscriptionEventListener.java`; Test `SubscriptionEventListenerTest`(수정).
+
+- [ ] **Step 1: 실패 테스트** — SUBSCRIBE 시 `presencePort.onSessionConnected` **미호출**(presence는 CONNECT 책임), presence용 `saveSessionCache` 미호출. (단일룸 가드는 PR-2.)
+- [ ] **Step 2: 실패 확인** FAIL.
+- [ ] **Step 3: 구현** — `SubscriptionEventListener`에서 `presencePort.onSessionConnected(...)` 및 presence 목적 `sessionCachePort.saveSessionCache(...)` 호출 제거(presence는 CONNECT 책임). 세션캐시는 presence 외 프로덕션 용도 없음(Task 1.5에서 확인) → 관련 호출 일괄 제거, 잔존 시 주석으로 비-presence 용도 명시. either/or 금지 — 제거가 기본.
+- [ ] **Step 4: 통과 확인** PASS + XML.
+- [ ] **Step 5: 커밋** — `refactor(presence): SubscriptionEventListener presence 트리거 제거 — subscribe-타이밍 의존 종결 (#209 #31)`
+
+### Task 1.7: REST 같은-룸 재입장 clearPending (SE4 이중방어)
+
+**Files:** Modify `app/.../party/application/service/PartyroomAccessCommandService.java` (같은-룸 재입장 분기, 검증된 ~lines 93-104); Test `PartyroomAccessCommandServiceTest`.
+
+- [ ] **Step 1: 실패 테스트** — 같은-룸 재입장(이미 active) 시 `presenceService.clearPending(partyroomId,userId)` 호출됨 verify. 다른-룸/신규 입장 분기엔 영향 없음.
+- [ ] **Step 2: 실패 확인** `:app:test --tests "*PartyroomAccessCommandServiceTest"` FAIL.
+- [ ] **Step 3: 구현** — 같은-룸 분기에 `presenceService.clearPending(partyroomId, userId);` 추가(countryCode 갱신 인접).
+- [ ] **Step 4: 통과 확인** PASS + XML.
+- [ ] **Step 5: 커밋** — `feat(presence): 같은-룸 REST 재입장 시 clearPending — SE4 레이스 이중방어 (#209 #225)`
+
+### Task 1.8: 통합 회귀잠금 — #31 / SE4 / 멀티탭
+
+**Files:** `app/src/test/.../ClusterAPresenceIntegrationTest.java`(확장, `@Tag("integration")`)
+
+- [ ] **Step 1: 실패 테스트** — 시나리오 통합: (#31) subscribe-before-enter 순서여도 disconnect→markPending(레지스트리 CONNECT 등록 기반, subscribe 타이밍 무관) → grace 만료 forceOffline→exited_at 갱신. (SE4) disconnect→markPending→CONNECT 재연결→clearPending(pending=NULL). (E1) 2세션 중 1 disconnect→markPending 미발생.
+- [ ] **Step 2: 실패 확인** `:app:integrationTest --tests "*ClusterAPresenceIntegrationTest"` FAIL(미구현 시) 또는 시나리오 RED.
+- [ ] **Step 3: 구현/보정** — 앞 태스크 통합으로 GREEN 되게 누락분 보정.
+- [ ] **Step 4: 통과 확인** integrationTest PASS, XML tests>0 failures=0.
+- [ ] **Step 5: 커밋** — `test(presence): #31·SE4·멀티탭 통합 회귀잠금 (#209)`
+
+### Task 1.9: PR-1 통합검증 + PR
+
+- [ ] **Step 1** — 영향 테스트 스위트 전체 GREEN: `:app:test` 관련 + `:app:integrationTest --tests "*ClusterA*" "*Presence*" "*EventListener*"`. 회귀 확인: 기존 `PartyroomPresenceServiceTest`,`SubscriptionEventListenerTest`,`PartyroomAccessCommandServiceTest`.
+- [ ] **Step 2** — 마이크로커밋 논리단위 squash(필요시).
+- [ ] **Step 3** — push `-u origin feature/cluster-a-pr1-user-session-registry`; `gh pr create --base develop` 한글 본문(스펙 §4 C1-C3, #209/#225, 회귀 #31/SE4/E1, 트레이드오프 §9). CI green 확인.
+- [ ] **Step 4** — 로드맵 LIVE + 메모리: A/#31·#225 "PR-1 develop" 갱신.
+
+---
+
+## Chunk 2: PR-2 — platform L4 서버 단일룸 가드 + DJ큐 grace 잠금 + SE10
+
+브랜치: `git checkout -b feature/cluster-a-pr2-single-room-guard origin/develop` (PR-1 머지 후 rebase 또는 develop 기준; presence 코드 충돌 시 PR-1 선행)
+
+### Task 2.1: 서버 단일룸 SUBSCRIBE 가드
+
+**Files:** Modify `realtime/.../event/SubscriptionEventListener.java`; Test `SubscriptionEventListenerTest`.
+
+- [ ] **Step 1: 실패 테스트** — SUBSCRIBE `/sub/partyrooms/{id}`에서 id가 `partyroomQueryPort.getActivePartyroomByUserId(uid)`의 `dto.id()`(권위 룸)와 불일치 → 등록 거부(no-op, WARN 로그), 일치 → 통과. 권위 룸 없음(미입장, `Optional.empty()`)인데 SUBSCRIBE → 거부(로그). negative-ACK 없음(클라 계약: 조용한 미등록).
+- [ ] **Step 2: 실패 확인** `:app:test --tests "*SubscriptionEventListenerTest"` FAIL.
+- [ ] **Step 3: 구현** — destination 파싱 partyroomId vs 권위 룸 비교. 불일치 시 early-return + `log.warn`. (subscribe 자체 STOMP 등록은 막을 수 없으니 서버측 처리/세션 연관만 거부 — broadcast 라우팅은 destination 기반이므로 추가 서버측 차단 필요 시 메시지 라우팅 단계 가드도 검토; 최소: 서버 부수효과/세션연관 미수행 + 로그. 스펙 §4 C2 계약 준수.)
+- [ ] **Step 4: 통과 확인** PASS + XML.
+- [ ] **Step 5: 커밋** — `feat(presence): 서버 단일룸 SUBSCRIBE 가드 — #30 백엔드 방어 (web#298)`
+
+### Task 2.2: DJ큐 grace 통합 회귀잠금
+
+**Files:** `app/src/test/.../DjQueueGraceIntegrationTest.java`(신규, `@Tag("integration")`). **성격: characterization 회귀잠금** — 설계상 PR-1 후 자연 도출이라 첫 작성에 곧바로 GREEN일 수 있음. 그게 정상(= invariant 잠금 성공). **RED를 억지로 찾아 루프 돌지 말 것**; 만약 RED면 그 시나리오가 실제 미보장 → 최소 보정.
+
+- [ ] **Step 1: 실패 테스트** — (a) `markPending` 호출 후 DjData 행 불변(orderNumber·존재). (b) DJ가 disconnect→markPending→grace내 재연결(clearPending)→DjData 자리·순서 보존. (c) grace 만료 forceOffline→exitInternal→handleDjQueueOnLeave→DjData 제거 + (wasCurrentDj면) skipPlayback. (d) 현재 DJ disconnect: grace 동안 doStart가 pending DJ 그대로 재생(스킵 안 함), 만료시에만 skip.
+- [ ] **Step 2: 실패 확인** `:app:integrationTest --tests "*DjQueueGraceIntegrationTest"` FAIL/RED.
+- [ ] **Step 3: 구현/보정** — 대부분 GREEN(설계상 자연 도출). pending DJ 체크를 doStart에 **추가하지 않음**(SE1). 누락 행위만 최소 보정.
+- [ ] **Step 4: 통과 확인** integrationTest PASS, XML.
+- [ ] **Step 5: 커밋** — `test(presence): DJ큐 라이프사이클 presence grace 통합 회귀잠금 (#225 SE1)`
+
+### Task 2.3: SE10 — 7.5s 주석 정정 + reconcile backstop 테스트
+
+**Files:** Modify `realtime/.../config/WebSocketConfig.java`(주석); Test `PartyroomPresenceServiceTest` 또는 통합 reconcile sweep.
+
+- [ ] **Step 1: 실패 테스트** — reconcile cron characterization: `pending_exit_at < threshold` stale crew → forceOffline 정리(이미 존재하면 회귀잠금만, 첫 작성 GREEN 정상 — RED 강요 금지). 신규 단언: 유령 상한 보장 주체가 cron(maxGrace+버퍼)임(heartbeat 미검출 시뮬레이션 → cron 정리).
+- [ ] **Step 2: 실패/통과 확인** — characterization이므로 GREEN이면 잠금 성공으로 진행. RED면 누락 보정.
+- [ ] **Step 3: 구현** — WebSocketConfig 7.5s 주석을 "실제 유령 상한 = reconcile cron(maxGrace+버퍼), heartbeat는 fast-path"로 정정. 로직 변경 없음(있다면 최소).
+- [ ] **Step 4: 통과 확인** PASS + XML.
+- [ ] **Step 5: 커밋** — `docs+test(presence): SE10 — 유령 상한=reconcile cron 명기 + backstop 회귀 (#225)`
+
+### Task 2.4: PR-2 통합검증 + PR
+
+- [ ] **Step 1** — `:app:test` 관련 + `:app:integrationTest --tests "*DjQueueGrace*" "*SubscriptionEventListener*"` GREEN. 기존 `PlaybackCommandServiceTest`·`TrackRepositoryReorderIntegrationTest`(#222) 회귀 확인.
+- [ ] **Step 2** — squash; push; `gh pr create --base develop` 한글(스펙 §4 C2가드/C4/C5, web#298 백엔드방어, #225, 회귀).
+- [ ] **Step 3** — 로드맵/메모리 갱신.
+
+---
+
+## Chunk 3: PR-3 — web L3 SocketClient 단일진실원천 + PartyroomClient replace
+
+레포: `pfplay-web`. 브랜치: `cd ../pfplay-web && git fetch origin && git checkout -b feature/cluster-a-pr3-subscriptions-sot origin/develop` (develop 기준 — web 환경 매핑 확인).
+
+### Task 3.1: SocketClient — subscriptions[]에 callback + 단일진실원천 reconcile
+
+**Files:** Modify `src/shared/api/websocket/client.ts`; Test `src/shared/api/websocket/client.test.ts`.
+
+- [ ] **Step 1: 실패 테스트**(vitest, `yarn vitest run src/shared/api/websocket/client.test.ts`) — (a) `subscribe(d,cb)` 후 `subscriptions`에 `{destination:d,callback:cb}` 동기 존재(connected/!connected 무관). (b) reconnect(handleConnect) 시 `subscriptions` 순회 재구독, `onConnectQueue`엔 subscribe 콜백 없음. (c) `unsubscribe(d)`가 `!connected`여도 `subscriptions`에서 제거 → 이후 reconnect 재구독 안 함. (d) A subscribe→unsubscribe→B subscribe→disconnect→connect ⇒ STOMP subscribe는 B만.
+- [ ] **Step 2: 실패 확인** — `cd "../pfplay-web" && yarn vitest run src/shared/api/websocket/client.test.ts` → FAIL.
+- [ ] **Step 3: 구현** — `interface Subscription { destination; callback; ... }`. `subscribe`: onConnect 래핑 제거 → `subscriptions.push({destination,callback})` 동기 + `if(connected) this.client.subscribe(...)`. `handleConnect`: `subscriptions` 순회하여 각 `this.client.subscribe(destination,callback)` 재바인딩(중복 없게 기존 STOMP핸들 정리). `unsubscribe`: `if(connected)` STOMP unsub, **무조건** `subscriptions=subscriptions.filter(...)`. `handleDisconnect`: 라이브 핸들만 해제, `subscriptions`(desired) 보존. `onConnectQueue`에서 subscribe 콜백 미적재(heartbeat 등만).
+- [ ] **Step 4: 통과 확인** vitest PASS.
+- [ ] **Step 5: 커밋** — `fix(websocket): subscriptions[] 단일진실원천 — reconnect stale 부활·!connected 누수 해소 (#5 #30)`
+
+### Task 3.2: PartyroomClient — replace 정책(throw 제거)
+
+**Files:** Modify `src/entities/partyroom-client/lib/partyroom-client.ts`; Test `partyroom-client.test.ts`.
+
+- [ ] **Step 1: 실패 테스트** — 기존 룸 구독 중 `subscribe(B)` → throw 안 함, 기존 룸 unsubscribe 후 B subscribe, `subscribedRoomId=B`, `socketClient.subscriptions` 길이 1(B). 기존 throw 케이스 테스트 제거/수정.
+- [ ] **Step 2: 실패 확인** vitest FAIL.
+- [ ] **Step 3: 구현** — `subscribe(partyroomId)`: `if(this.subscribedRoomId!=null && this.subscribedRoomId!==partyroomId) this.unsubscribeCurrentRoom();` 그 후 `socketClient.subscribe(...)` + `subscribedRoomId=partyroomId`. throw 제거.
+- [ ] **Step 4: 통과 확인** vitest PASS.
+- [ ] **Step 5: 커밋** — `fix(partyroom-client): subscribe replace 정책 — #30 throw→silent→push 증폭 발원 제거 (web#298)`
+
+### Task 3.3: PR-3 회귀 + PR
+
+- [ ] **Step 1** — web 테스트 스위트 GREEN(`client.test.ts`,`partyroom-client.test.ts`,`handle-subscription-event.test.ts` 등 영향분). A→B→offline/online→B만 수신 시나리오 잠금.
+- [ ] **Step 2** — squash; push; `gh pr create --base develop`(web) 한글(스펙 §4 C6/C7, #5/#30, 회귀 T8/T9).
+- [ ] **Step 3** — 로드맵/메모리 갱신(web#298 PR-3 develop).
+
+---
+
+## Chunk 4: PR-4 — web L2 exit() 분리 + unload/unmount backend-exit 제거
+
+레포: `pfplay-web`. 브랜치: `feature/cluster-a-pr4-exit-split` off develop (PR-3 후).
+
+### Task 4.1: useTeardownPartyroom 신규 (클라 정리만)
+
+**Files:** Create `src/features/partyroom/exit/lib/use-teardown-partyroom.ts`; Test `...use-teardown-partyroom.test.ts`.
+
+- [ ] **Step 1: 실패 테스트** — 호출 시 `unsubscribeCurrentRoom`+`resetPartyroomStore`+`trackPartyroomExited`만, 백엔드 mutation 미호출.
+- [ ] **Step 2: 실패 확인** vitest FAIL(없음).
+- [ ] **Step 3: 구현** — `useExitPartyroom` 본문에서 (3)만 추출한 훅.
+- [ ] **Step 4: 통과 확인** vitest PASS.
+- [ ] **Step 5: 커밋** — `feat(partyroom): useTeardownPartyroom — 클라 정리/백엔드 exit 분리 (web#298 #225)`
+
+### Task 4.2: layout.tsx — unmount=teardown, beforeunload/pagehide 제거
+
+**Files:** Modify `src/app/parties/(room)/[id]/layout.tsx`; **Create** `src/app/parties/(room)/[id]/layout.test.tsx`(현재 부재 확정 — 신규 생성. vitest include `src/**/*.test.{ts,tsx}` 가 `.tsx` 포함 확인됨, jsdom).
+
+- [ ] **Step 1: 실패 테스트** — `layout.test.tsx` 신규: unmount cleanup 시 teardown 호출·백엔드 exit 미호출. `window.addEventListener('beforeunload'|'pagehide', ...)` 미등록(spy).
+- [ ] **Step 2: 실패 확인** FAIL.
+- [ ] **Step 3: 구현** — `enter()` 유지. `beforeunload`/`pagehide` add/removeEventListener 제거. cleanup `return () => useTeardownPartyroom()` 사용.
+- [ ] **Step 4: 통과 확인** vitest PASS.
+- [ ] **Step 5: 커밋** — `fix(partyroom): unload/unmount 백엔드-exit 제거, unmount=teardown — #225a #30 증폭 종결 (web#298)`
+
+### Task 4.3: 명시 exit 경로 정리 + exitedOnBackend 단순화
+
+**Files:** Modify `src/features/partyroom/exit/lib/use-exit-partyroom.ts`(명시 전용), 사용처(`partyroom-card`·`use-penalty-alert`·`use-sign-out`·`use-enter-partyroom`) `markExitedOnBackend` 불요분 제거; Test 각 영향.
+
+- [ ] **Step 1: 실패 테스트** — sign-out은 명시 backend exit 유지(호출 verify). 룸전환은 서버 tryEnter auto-exit 의존(클라 DELETE 미호출, teardown만). penalty/expel은 서버 처리(클라 teardown만). `exitedOnBackend` 불요 분기 제거 후 회귀(이중 DELETE 없음).
+- [ ] **Step 2: 실패 확인** FAIL.
+- [ ] **Step 3: 구현** — `useExitPartyroom`을 명시 backend-exit 전용으로 축소. `markExitedOnBackend` workaround 사용처 정리(스펙 §4 C8). `MainPartyroomCard` 부수버그 자연 소멸 확인.
+- [ ] **Step 4: 통과 확인** vitest PASS.
+- [ ] **Step 5: 커밋** — `refactor(partyroom): exit 경로 명시-전용 축소 + exitedOnBackend workaround 정리 (web#298)`
+
+### Task 4.4: PR-4 회귀 + PR
+
+- [ ] **Step 1** — web 스위트 GREEN. 시나리오: 새고침 grace내→DJ자리 유지(서버 PR-1/2와 합쳐 수용테스트는 스테이징/수동), 룸전환 정상, sign-out exit 유지.
+- [ ] **Step 2** — squash; push; `gh pr create --base develop`(web) 한글(스펙 §4 C8/C9, #225a/#30, 회귀 T10/T11, §9 트레이드오프, C9 follow-up 이슈 링크).
+- [ ] **Step 3** — 로드맵/메모리: Cluster A 4 PR 상태 갱신. C9(SE3 애널리틱스) 별도 follow-up 이슈 등록.
+
+---
+
+## 완료 정의 (Cluster A)
+
+- PR-1~4 develop 머지, 각 회귀잠금 GREEN(XML 검증).
+- 4증상 수용: #30 입장튕김0 / #31 탭닫기→grace·cron 정리 / #5 A→B→offline/online→B만 / #225 새고침 grace내 DJ자리 유지·결정적.
+- 로드맵 LIVE Cluster A 행 갱신, 메모리 진입점 갱신. C9(SE3) follow-up 이슈 분리.
+- prod(main) 진입은 별도 release 게이트(스펙 §8).
+
+## 참조 스킬
+- @superpowers:test-driven-development (red→green)
+- @superpowers:subagent-driven-development (실행)
+- @superpowers:verification-before-completion (XML 증거)
+- @superpowers:finishing-a-development-branch (PR/머지)

--- a/docs/superpowers/specs/2026-05-18-cluster-a-realtime-subscription-presence-design.md
+++ b/docs/superpowers/specs/2026-05-18-cluster-a-realtime-subscription-presence-design.md
@@ -50,8 +50,10 @@
 
 **C2 리스너 재배선**
 - `ConnectionEventListener`(현 passive): `SessionConnectEvent`에서 Principal=uid+sessionId 레지스트리 등록. 유저 pending이면 `clearPending`(**CONNECT 시점 — SE4 fix, SUBSCRIBE 비의존**).
+  - **왜 CONNECT에 Principal이 있나(load-bearing 근거)**: `WebSocketConfig`의 `determineUser`가 handshake 단계에서 `attributes.get("uid")`로 Principal을 바인딩한다. 따라서 `SessionConnectEvent`(CONNECT 프레임)에 이미 `Principal=uid` 존재 — SUBSCRIBE를 기다릴 필요 없음. (현 `ConnectionEventListener`는 sessionId 로깅만 하고 `getUser()` 미사용이라 "CONNECT엔 인증 없음"으로 오해 금지.) 이 사실이 PR-1의 가장 load-bearing한 전제.
 - `DisconnectionEventListener`: 레지스트리에서 sessionId 제거. 유저의 **마지막** 세션이면 → 유저 active 룸을 `aggregatePort.findActiveRoomByUser`(DB 권위)로 resolve → `markPending`. resolve-before-cache-delete 순서 유지.
 - `SubscriptionEventListener`: presence 트리거 제거. **서버 단일룸 가드** 추가: SUBSCRIBE `/sub/partyrooms/{id}`의 id가 유저 권위 active 룸과 불일치 → 등록 거부(no-op, 로그). presence용 세션캐시 기록 제거.
+  - **거부 시 클라 관측 계약(명시)**: STOMP 브로커엔 SUBSCRIBE negative-ACK가 없으므로 거부=조용히 미등록(클라는 구독했다 믿지만 메시지 0). 클라는 **SUBSCRIBE 에러에 의존하지 않고** REST `tryEnter` 권위 + replace 정책으로 자신의 룸을 판단(E2 stale 탭은 tryEnter 시 prior auto-exit로 자연 정리, 메시지 미수신은 부차 신호). PR-2(서버 가드)와 PR-3(클라)이 이 계약으로 정렬 — 클라가 SUBSCRIBE 실패를 에러 처리하려 들지 말 것.
 - `UnsubscriptionEventListener`: presence 무관(연결 생존 기준). 세션캐시 정리만 잔존(타 용도 있으면 유지).
 
 **C3 REST 재입장 clearPending (SE4 이중방어)**
@@ -104,6 +106,7 @@
 - **E6 서버 가드 오거부 방지**: DB 권위 active 룸 일치시 통과, 크로스룸 불일치만 거부.
 - **E7 sign-out**: 명시 exit 경로 유지(impl PR 배선 검증).
 - **E8 호스트 끊김**: SE7 — 특수처리 없음(룸 지속, 호스트 슬롯 grace만료시 일반 crew처럼 비움). 기존 설계.
+- **E9 하드 unload 텔레메트리 갭(인지)**: C9 착수 전까지 하드 unload는 `trackPartyroomExited` 미발행(현재도 best-effort라 회귀 아님). C9 follow-up 담당자가 인지하도록 명시 — exit 이벤트·세션길이 분석 일시 누락.
 
 ## 7. 테스트 전략
 
@@ -134,6 +137,8 @@
 4. **PR-4 web L2**: exit() 분리 `useTeardownPartyroom`(C8) + unload/unmount backend-exit 제거 + `exitedOnBackend` 정리. 회귀: #225a, #30 증폭. (web#298)
 
 순서: PR-1→PR-2(platform 순차, 같은 presence 코드) ‖ PR-3→PR-4(web 순차). platform·web 트랙 병렬 가능. 4개 모두 §2 invariant로 수렴, 각 PR 회귀잠금 동반. 머지=develop(한글 PR), main 진입은 별도 release 게이트.
+
+**배포 인터리빙 안전성(병렬 트랙 명시)**: PR-2(서버 가드 live) 가 PR-3(클라 단일원천) 보다 먼저 떠 클라 누수가 아직 있는 상태여도 — reconnect 후 leaked stale-room SUBSCRIBE는 서버 가드가 조용히 거부(= 바라던 최종상태, benign). 역순(PR-3 먼저)도 안전(클라가 이미 단일룸). 따라서 platform/web 트랙 배포 순서 무관.
 
 ## 9. 트레이드오프 (수용 확정)
 

--- a/docs/superpowers/specs/2026-05-18-cluster-a-realtime-subscription-presence-design.md
+++ b/docs/superpowers/specs/2026-05-18-cluster-a-realtime-subscription-presence-design.md
@@ -51,7 +51,7 @@
 **C2 리스너 재배선**
 - `ConnectionEventListener`(현 passive): `SessionConnectEvent`에서 Principal=uid+sessionId 레지스트리 등록. 유저 pending이면 `clearPending`(**CONNECT 시점 — SE4 fix, SUBSCRIBE 비의존**).
   - **왜 CONNECT에 Principal이 있나(load-bearing 근거)**: `WebSocketConfig`의 `determineUser`가 handshake 단계에서 `attributes.get("uid")`로 Principal을 바인딩한다. 따라서 `SessionConnectEvent`(CONNECT 프레임)에 이미 `Principal=uid` 존재 — SUBSCRIBE를 기다릴 필요 없음. (현 `ConnectionEventListener`는 sessionId 로깅만 하고 `getUser()` 미사용이라 "CONNECT엔 인증 없음"으로 오해 금지.) 이 사실이 PR-1의 가장 load-bearing한 전제.
-- `DisconnectionEventListener`: 레지스트리에서 sessionId 제거. 유저의 **마지막** 세션이면 → 유저 active 룸을 `aggregatePort.findActiveRoomByUser`(DB 권위)로 resolve → `markPending`. resolve-before-cache-delete 순서 유지.
+- `DisconnectionEventListener`: 레지스트리에서 sessionId 제거. 유저의 **마지막** 세션이면 → 유저 active 룸을 `PartyroomQueryPort.getActivePartyroomByUserId(userId)`(DB 권위, `dto.id()`→`PartyroomId`)로 resolve → `markPending`. resolve-before-cache-delete 순서 유지.
 - `SubscriptionEventListener`: presence 트리거 제거. **서버 단일룸 가드** 추가: SUBSCRIBE `/sub/partyrooms/{id}`의 id가 유저 권위 active 룸과 불일치 → 등록 거부(no-op, 로그). presence용 세션캐시 기록 제거.
   - **거부 시 클라 관측 계약(명시)**: STOMP 브로커엔 SUBSCRIBE negative-ACK가 없으므로 거부=조용히 미등록(클라는 구독했다 믿지만 메시지 0). 클라는 **SUBSCRIBE 에러에 의존하지 않고** REST `tryEnter` 권위 + replace 정책으로 자신의 룸을 판단(E2 stale 탭은 tryEnter 시 prior auto-exit로 자연 정리, 메시지 미수신은 부차 신호). PR-2(서버 가드)와 PR-3(클라)이 이 계약으로 정렬 — 클라가 SUBSCRIBE 실패를 에러 처리하려 들지 말 것.
 - `UnsubscriptionEventListener`: presence 무관(연결 생존 기준). 세션캐시 정리만 잔존(타 용도 있으면 유지).

--- a/docs/superpowers/specs/2026-05-18-cluster-a-realtime-subscription-presence-design.md
+++ b/docs/superpowers/specs/2026-05-18-cluster-a-realtime-subscription-presence-design.md
@@ -1,0 +1,149 @@
+# Cluster A — 실시간 구독·presence·세션→룸 매핑 통합 재설계
+
+- **작성일**: 2026-05-18
+- **상태**: DESIGN (승인됨 — 구현 진입)
+- **GitHub**: pfplay-platform #209(#31)·#225, web#298(#30·#5), 회귀 연계 #222
+- **관련 설계**: `2026-05-09-presence-grace-window-design.md`(V16 grace), `2026-05-09-crew-grade-host-invariant-design.md`
+- **진실원천(로드맵)**: `bugs/2026-05-14-bug-fix-roadmap.md` Cluster A
+- **불변 제약**: piecemeal 금지 — 본 스펙은 통합 1건. 구현은 invariant별 멀티 PR이나 설계는 단일.
+
+## 1. 문제 — 4개 증상, 한 뿌리
+
+| ID | 증상 | repo |
+|---|---|---|
+| #30 | 입장 직후 의도무관 강제 퇴장 (multi-sub invariant 무력화) | web(+platform 방어) |
+| #31 | 탭/브라우저 닫기 시 서버측 퇴장 미처리 (유령 크루) | platform |
+| #5 | reconnect 시 stale STOMP 구독 부활 → 크로스룸 메시지 하이재킹 | web |
+| #225 | 새로고침/연결끊김 시 DJ 대기열 의도무관 탈락 (grace 우회 레이스) | platform+web |
+
+**공통 뿌리**: 라이프사이클(입퇴장)·presence·구독 격리·DJ큐 상태가 **권위적 서버 상태머신이 아니라 STOMP subscribe 타이밍 + 클라 best-effort unload exit**에 결합되어 있다. 같은 결함의 네 증상이므로 개별 패치는 상호 재파손 — 통합 재설계한다.
+
+근거(코드 확정, 2026-05-17~18 검증):
+- 세션→룸 매핑이 `SubscriptionEventListener`→`RedisSessionCacheAdapter.saveSessionCache`의 **SUBSCRIBE 시점 `getActivePartyroomByUserId` 조회**에 게이트. enter(REST)가 subscribe 전이면 캐시 미기록 → disconnect 시 `markPending` silent no-op → `exited_at` 영영 미갱신 (#31).
+- 클라 `SocketClient.subscribe`가 `onConnectQueue`에 **영구 콜백** 적재, `unsubscribe`는 큐 미정리 → reconnect 시 stale 룸 부활 (#5). `unsubscribe`는 `!connected`시 `subscriptions[]` 미제거 early-return, `PartyroomClient.unsubscribeCurrentRoom`은 `subscribedRoomId=undefined` 무조건 → desync → 가드 영구 throw → `silent` 삼킴 → `router.push('/parties')` → layout unmount → `exit()` (#30 증폭).
+- `app/parties/(room)/[id]/layout.tsx`가 `beforeunload`/`pagehide`/unmount에 `exit()`(일반 axios `DELETE /crews/me`, sendBeacon/keepalive 아님) 등록. DJ 제거는 `exitInternal`→`handleDjQueueOnLeave`→`removeDjFromQueue` 한 경로뿐(grace 비게이트). 새고침=unload 시 클라가 권위 exit를 쏘므로 grace 우회·비결정 레이스 (#225).
+
+## 2. Invariant (회귀테스트로 잠금)
+
+1. **단일 룸 구독**: 한 시점 한 클라는 ≤1개 `/sub/partyrooms/*` 구독. 클라+서버 양쪽 강제.
+2. **라이프사이클 권위 = 서버 grace 상태머신**, 구동 신호는 **WS 연결 생존(STOMP CONNECT/DISCONNECT)** 단 하나.
+3. **즉시 backend exit = 의도적 액션만**: {룸전환(서버 tryEnter auto-exit), penalty/expel(서버), sign-out(명시)}. 그 외(닫기·새고침·네트워크·백그라운드·룸 아닌 인앱이탈) = DISCONNECT→grace.
+4. **room 진실원천 = REST crew**(enter/exit). subscribe-시점 active 조회·세션캐시 추론 폐기.
+5. **DJ큐 라이프사이클은 presence 상태머신에 종속**: grace 내 재연결 시 DJ 자리·순서 보존, grace 만료시에만 탈락.
+
+## 3. 4개 레버 (확정 결정)
+
+- **L1 서버 권위 (user-session 레지스트리)**: STOMP CONNECT `Principal=uid` 기반 sessionId→userId / userId→Set<sessionId>. presence grace = "유저 라이브 세션 0개" 기준. 룸은 DB crew 권위로 resolve. subscribe-타이밍 의존 제거.
+- **L2 클라 unload-exit 제거 (split)**: `beforeunload`/`pagehide` 자동 exit 및 unmount 백엔드-exit 제거. **클라 정리(unsubscribe+store reset+analytics)는 신규 `useTeardownPartyroom`로 unmount 유지**, 백엔드 DELETE만 의도적 액션 게이트.
+- **L3 클라 구독 단일진실원천 (방향 B)**: `subscriptions[]`가 `{destination,callback}` 보유, (re)connect 시 그 배열만 reconcile, unsubscribe는 연결상태 무관 배열에서 제거. `onConnectQueue`는 subscribe 콜백 미보유.
+- **L4 서버 단일룸 가드 + DJ큐 presence 통합**: SUBSCRIBE가 유저 권위 active 룸과 불일치면 서버 거부. DJ 제거는 grace 만료(`forceOffline`→`exitInternal`)에서만(자연 도출, 회귀잠금).
+
+**SE1 결정**: 현재 재생 중 DJ도 균일 grace — 끊겨도 재생 지속, grace 만료시에만 `skipPlayback`. `doStart`에 pending DJ 체크 추가 안 함.
+
+## 4. 컴포넌트 변경
+
+### 4.1 서버 (pfplay-platform)
+
+**C1 User-Session 레지스트리 (신규, Redis 백킹)**
+- 키: `presence:session:{sessionId}` → userId (TTL 안전망), `presence:usersessions:{userId}` → Redis Set<sessionId>.
+- V16 Redis 사용과 일관, 인스턴스 재시작·멀티노드(멀티탭 상이노드) 견딤.
+
+**C2 리스너 재배선**
+- `ConnectionEventListener`(현 passive): `SessionConnectEvent`에서 Principal=uid+sessionId 레지스트리 등록. 유저 pending이면 `clearPending`(**CONNECT 시점 — SE4 fix, SUBSCRIBE 비의존**).
+- `DisconnectionEventListener`: 레지스트리에서 sessionId 제거. 유저의 **마지막** 세션이면 → 유저 active 룸을 `aggregatePort.findActiveRoomByUser`(DB 권위)로 resolve → `markPending`. resolve-before-cache-delete 순서 유지.
+- `SubscriptionEventListener`: presence 트리거 제거. **서버 단일룸 가드** 추가: SUBSCRIBE `/sub/partyrooms/{id}`의 id가 유저 권위 active 룸과 불일치 → 등록 거부(no-op, 로그). presence용 세션캐시 기록 제거.
+- `UnsubscriptionEventListener`: presence 무관(연결 생존 기준). 세션캐시 정리만 잔존(타 용도 있으면 유지).
+
+**C3 REST 재입장 clearPending (SE4 이중방어)**
+- `PartyroomAccessCommandService.tryEnter` 같은-룸 재입장 분기(현 countryCode만 갱신)에 `presenceService.clearPending(partyroomId, userId)` 추가.
+
+**C4 DJ큐 presence 통합 — 회귀잠금 중심 (신규 서버코드 최소)**
+- unload-exit 제거 후 `exitInternal` 호출자 = {tryEnter auto-exit, penalty/expel, forceOffline}. 끊김 경로 DJ 제거는 자동으로 grace-게이트.
+- 잠금: ①`markPending`이 DjData 불변 ②grace내 재연결 DJ 자리·순서 보존 ③grace 만료 DJ 제거 ④현재 DJ 균일 grace(재생 지속, `wasCurrentDj→skipPlayback`은 만료시에만). #222 락 확장.
+
+**C5 SE10 문서/하드닝**
+- `WebSocketConfig` 7.5s 주석 정정. 스펙·코드주석 명기: 유령 진짜 상한 = reconcile cron(60s+버퍼), heartbeat 아님. grace 사이징 현행 유지. cron stale-pending 쓸이 테스트.
+
+**resolve 룸 권위 메서드**: 신규 또는 기존 `getActivePartyroomByUserId`를 presence 경로에서 DB crew(`is_active=true`) 권위 조회로 사용 — subscribe-시점 캐시 의존 완전 제거.
+
+### 4.2 클라 (pfplay-web)
+
+**C6 SocketClient `subscriptions[]` 단일진실원천 (방향 B)**
+- `Subscription` 타입에 `callback` 추가. `subscribe(dest,cb)`: onConnect 래핑 중단, 동기 `subscriptions[]` 기록 + (connected면) 즉시 STOMP subscribe. `handleConnect`: `subscriptions[]` 순회 재구독. `onConnectQueue`에서 subscribe 콜백 제거(heartbeat 등 비-subscribe만 잔존).
+- `unsubscribe(dest)`: 연결상태 무관 `subscriptions[]`에서 제거(+connected면 STOMP unsub). reconnect 재구독 후보서 자연 제외.
+- `handleDisconnect`: 라이브 STOMP만 해제, `subscriptions[]`(desired) 보존. → #5·`!connected` 누수 동시 해소.
+
+**C7 PartyroomClient replace 정책**
+- `subscribe(partyroomId)`: throw 대신 동기 "기존 룸 unsub(있으면) → 새 룸 sub". `subscribedRoomId`/`subscriptions[]` 일관. #30 throw→silent→push 발원 제거.
+
+**C8 exit() 분리**
+- 신규 `useTeardownPartyroom`: `unsubscribeCurrentRoom`+`resetPartyroomStore`+`trackPartyroomExited`만.
+- `layout.tsx`: unmount cleanup = teardown. `beforeunload`/`pagehide` 자동 exit 리스너 제거.
+- 백엔드 exit 경로: 룸전환=서버 `tryEnter` auto-exit(클라 DELETE 불요), penalty/expel=서버, sign-out=명시 유지.
+- `exitedOnBackend`/`markExitedOnBackend`: 이중 DELETE 방지 workaround였으므로 대부분 제거(잔존 필요처만 최소 유지). `MainPartyroomCard` 미호출 부수버그도 이 단순화로 소멸.
+
+**C9 SE3 애널리틱스 (follow-up, 비차단)**
+- 하드 unload 시 `trackPartyroomExited` best-effort. 후속 별건: 서버측 OFFLINE 확정 발행 or sendBeacon. Cluster A 차단 아님 — 별도 이슈 추적.
+
+## 5. 데이터플로우
+
+- **S1 끊김→grace내 재연결**: DISCONNECT→레지스트리 제거→마지막세션→DB resolve→`markPending`(DjData 불변). CONNECT→레지스트리 등록→`clearPending`. ONLINE 복원·DJ 보존·silent.
+- **S2 새로고침(grace내)**: unload(exit 없음)→`markPending`. reload→CONNECT→`clearPending`(CONNECT-시점)→REST tryEnter→`clearPending`(이중)→SUBSCRIBE(가드 통과). S1과 동일·결정적.
+- **S3 grace 만료**: Redis TTL→`PresenceExpirationListener`→`forceOffline`→`exitInternal`(deactivate+handleDjQueueOnLeave[DJ제거,wasCurrentDj면 skip]+EXIT broadcast). backstop=reconcile cron.
+- **S4 룸전환 A→B**: 클라 teardown(A)→nav→`tryEnter(B)`가 A auto-exit(서버 권위)→enter B. 클라 replace.
+- **S5 #30 무력화**: replace(throw無)→증폭경로 발원 제거. 잔여 redirect도 unmount=teardown만(DELETE無). presence=연결생존.
+- **S6 #5 무력화**: subscriptions[] 단일원천, reconnect 현재룸만 reconcile, 서버 가드 이중방어.
+
+## 6. 에러·엣지
+
+- **E1 멀티탭 동일룸**: 비마지막 세션 종료→markPending 안 함(SE5 자기축출 해소).
+- **E2 멀티탭 상이룸**: tryEnter가 prior auto-exit("last enter wins"). stale 탭 SUBSCRIBE는 서버 가드 거부→클라 "미입장" 처리. known behavior 명문화.
+- **E3 멱등/원자토글**: V16 markCrewPending/clearPending 원자토글 보존.
+- **E4 재연결 vs 만료 레이스**: `forceOffline`의 `isPendingExit()` 가드 + reconcile 분산락(V16) 보존.
+- **E5 느린 reload가 grace 경계**: 만료시 탈락 가능 — bounded·오늘 레이스보다 우수, CONNECT-clear가 최조기점. known edge(희귀).
+- **E6 서버 가드 오거부 방지**: DB 권위 active 룸 일치시 통과, 크로스룸 불일치만 거부.
+- **E7 sign-out**: 명시 exit 경로 유지(impl PR 배선 검증).
+- **E8 호스트 끊김**: SE7 — 특수처리 없음(룸 지속, 호스트 슬롯 grace만료시 일반 crew처럼 비움). 기존 설계.
+
+## 7. 테스트 전략
+
+**Platform(통합 Testcontainers + 단위)**:
+- T1 레지스트리: CONNECT 등록 / DISCONNECT 마지막세션→markPending / 비마지막→안함(E1) / CONNECT→clearPending(SE4).
+- T2 REST 같은-룸 재입장→clearPending(SE4 이중).
+- T3 DJ큐 grace 락: markPending DjData 불변 / grace내 자리·순서 보존 / 만료 제거 / 현재DJ 균일grace — #222 락 확장.
+- T4 #31: subscribe-before-enter 순서 무관(DB 권위 resolve) → disconnect시 markPending.
+- T5 서버 단일룸 SUBSCRIBE 가드: 불일치 거부 / 일치 통과.
+- T6 reconcile cron stale-pending 쓸이(SE10 backstop).
+- T7 멱등/race(E3/E4) 보존.
+
+**Web(client.test.ts 등 기존 하니스)**:
+- T8 subscriptions[] 단일원천: subscribe 기록 / reconnect 현재만 / unsubscribe(!connected 포함) 제거 / A→B→reconnect=B만(#5 락).
+- T9 PartyroomClient replace: 기존 존재시 unsub old+sub new, throw無, 일관.
+- T10 exit 분리: unmount=teardown만(DELETE無) / beforeunload·pagehide 리스너 없음 / 룸전환=teardown+서버 auto-exit / sign-out 유지.
+- T11 #30: 구독레이스/redirect → backend exit無·multi-sub無.
+
+**수용(4증상 e2e)**: #30 입장튕김0 / #31 탭닫기→grace·cron 정리 / #5 A→B→offline/online→B만 수신 / #225 새고침 grace내→DJ자리 유지·결정적.
+
+## 8. 구현 분해 (멀티 PR, TDD)
+
+스펙=통합 1건. 구현 PR(repo+invariant별, 각 독립 ship 가능, develop 대상):
+
+1. **PR-1 platform L1**: user-session 레지스트리 + 리스너 재배선(C1·C2) + REST재입장 clearPending(C3) + presence의 subscribe-시점 의존 제거. 회귀: #31, SE4. (#209)
+2. **PR-2 platform L4**: 서버 단일룸 SUBSCRIBE 가드(C2 가드부) + DJ큐 grace 회귀잠금(C4) + SE10 문서/cron 테스트(C5). (#225 서버, #30 백엔드 방어)
+3. **PR-3 web L3**: SocketClient subscriptions[] 단일원천(C6) + PartyroomClient replace(C7). 회귀: #5, #30 클라. (web#298)
+4. **PR-4 web L2**: exit() 분리 `useTeardownPartyroom`(C8) + unload/unmount backend-exit 제거 + `exitedOnBackend` 정리. 회귀: #225a, #30 증폭. (web#298)
+
+순서: PR-1→PR-2(platform 순차, 같은 presence 코드) ‖ PR-3→PR-4(web 순차). platform·web 트랙 병렬 가능. 4개 모두 §2 invariant로 수렴, 각 PR 회귀잠금 동반. 머지=develop(한글 PR), main 진입은 별도 release 게이트.
+
+## 9. 트레이드오프 (수용 확정)
+
+- **bounded ghost(로스터)**: 진짜 이탈도 grace(DJ 30s/listener 10s) + 검출(~15-20s) + cron(≤90s) 동안 잔존. V16가 crew presence에 이미 수용 — DJ큐가 동일 상속(사용자 수용).
+- **bounded absent-DJ playback**: 현재 DJ 끊김시 grace 동안 부재 DJ 트랙이 덱 점유(타 사용자는 계속 청취 가능 — 사용자 수용, SE1).
+- **느린 reload edge(E5)**: 희귀, 오늘의 레이스보다 우수.
+
+## 10. 참조
+
+- 노트: `bugs/2026-05-16-involuntary-exit-multi-subscription.md`(#30), `bugs/2026-05-16-tab-close-no-server-exit.md`(#31), `bugs/2026-05-14-websocket-subscription-resurrection.md`(#5)
+- V16: `docs/superpowers/specs/2026-05-09-presence-grace-window-design.md`
+- 회귀 선행: #222(skip→reorder invariant 잠금, develop 머지)
+- 메모리: single-partyroom-subscription-invariant, project_v16_presence_grace_window, feedback_root_cause_premature_lock

--- a/realtime/src/main/java/com/pfplaybackend/realtime/event/ConnectionEventListener.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/event/ConnectionEventListener.java
@@ -1,5 +1,8 @@
 package com.pfplaybackend.realtime.event;
 
+import com.pfplaybackend.realtime.port.PresencePort;
+import com.pfplaybackend.realtime.port.SessionRegistryPort;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationListener;
@@ -7,14 +10,29 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionConnectEvent;
 
+import java.security.Principal;
+
 @Component
+@RequiredArgsConstructor
 public class ConnectionEventListener implements ApplicationListener<SessionConnectEvent> {
     private static final Logger logger = LoggerFactory.getLogger(ConnectionEventListener.class);
+    private final SessionRegistryPort sessionRegistryPort;
+    private final PresencePort presencePort;
 
     @Override
     public void onApplicationEvent(SessionConnectEvent event) {
         StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
         String sessionId = headerAccessor.getSessionId();
         logger.info("Received a new web socket connection: {}", sessionId);
+
+        Principal principal = headerAccessor.getUser();
+        if (principal == null) {
+            logger.warn("CONNECT without an authenticated principal, skipping session registry: {}", sessionId);
+            return;
+        }
+        // Order matters: register the live session BEFORE presence resolution —
+        // PresencePort resolves the userId by reading back this very mapping.
+        sessionRegistryPort.register(sessionId, principal.getName());
+        presencePort.onSessionConnected(sessionId);
     }
 }

--- a/realtime/src/main/java/com/pfplaybackend/realtime/event/DisconnectionEventListener.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/event/DisconnectionEventListener.java
@@ -1,7 +1,6 @@
 package com.pfplaybackend.realtime.event;
 
 import com.pfplaybackend.realtime.port.PresencePort;
-import com.pfplaybackend.realtime.port.SessionCachePort;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,17 +14,15 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 @RequiredArgsConstructor
 public class DisconnectionEventListener implements ApplicationListener<SessionDisconnectEvent> {
     private static final Logger logger = LoggerFactory.getLogger(DisconnectionEventListener.class);
-    private final SessionCachePort sessionCachePort;
     private final PresencePort presencePort;
 
     @Override
     public void onApplicationEvent(SessionDisconnectEvent event) {
         StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
         String sessionId = headerAccessor.getSessionId();
-        // PRESENCE: enter grace before deleting session cache (adapter still needs it
-        // to look up partyroomId/userId).
+        // PRESENCE: registry 권위로 위임. 세션 캐시 결합 제거 (Task 1.3에서 resolve가
+        // user-session registry + DB authority로 전환됨).
         presencePort.onSessionDisconnected(sessionId);
-        sessionCachePort.deleteSessionCache(sessionId);
         logger.info("Web socket connection closed: {}", sessionId);
 
         CloseStatus closeStatus = event.getCloseStatus();

--- a/realtime/src/main/java/com/pfplaybackend/realtime/event/SubscriptionEventListener.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/event/SubscriptionEventListener.java
@@ -1,5 +1,7 @@
 package com.pfplaybackend.realtime.event;
 
+import com.pfplaybackend.realtime.port.SessionCachePort;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationListener;
@@ -11,8 +13,10 @@ import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 import java.security.Principal;
 
 @Component
+@RequiredArgsConstructor
 public class SubscriptionEventListener implements ApplicationListener<SessionSubscribeEvent> {
     private static final Logger logger = LoggerFactory.getLogger(SubscriptionEventListener.class);
+    private final SessionCachePort sessionCachePort;
 
     @Override
     public void onApplicationEvent(SessionSubscribeEvent event) {
@@ -25,9 +29,12 @@ public class SubscriptionEventListener implements ApplicationListener<SessionSub
             throw new AuthenticationServiceException("Unauthorized Session Requested");
         }
         String userId = principal.getName();
-        // PRESENCE/세션캐시 디커미션 (#209 #31): subscribe-타이밍 의존을 종결한다.
-        // presence는 WS CONNECT/DISCONNECT가 권위(Task 1.4/1.5), 세션캐시 write도 더 이상
-        // SUBSCRIBE에서 수행하지 않는다. 여기서는 인증 가드와 로깅만 남긴다.
+        // 세션캐시 write는 채팅(비-presence) 라이프사이클이다: PartyroomChatCommandService가
+        // getSessionCache로 read하는 sessionId→(partyroom,user,crew) source를 여기서 채운다.
+        // presence 트리거(onSessionConnected)는 디커플링됨 — presence는 WS CONNECT/DISCONNECT가
+        // 권위이며 SUBSCRIBE 타이밍에 의존하지 않는다 (#209 #31, Task 1.4/1.6).
+        sessionCachePort.saveSessionCache(sessionId, userId, destination);
+
         logger.info("Session has subscribed, sessionId : {}, userId : {}, destination : {}", sessionId, userId, destination);
     }
 }

--- a/realtime/src/main/java/com/pfplaybackend/realtime/event/SubscriptionEventListener.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/event/SubscriptionEventListener.java
@@ -31,6 +31,8 @@ public class SubscriptionEventListener implements ApplicationListener<SessionSub
         String userId = principal.getName();
         // 세션캐시 write는 채팅(비-presence) 라이프사이클이다: PartyroomChatCommandService가
         // getSessionCache로 read하는 sessionId→(partyroom,user,crew) source를 여기서 채운다.
+        // 이 write는 24h TTL 백스톱을 함께 건다 — clean path는 UNSUBSCRIBE에서 delete하지만
+        // 비정상 종료 orphan은 그 TTL로 self-heal된다 (RedisSessionCacheAdapter).
         // presence 트리거(onSessionConnected)는 디커플링됨 — presence는 WS CONNECT/DISCONNECT가
         // 권위이며 SUBSCRIBE 타이밍에 의존하지 않는다 (#209 #31, Task 1.4/1.6).
         sessionCachePort.saveSessionCache(sessionId, userId, destination);

--- a/realtime/src/main/java/com/pfplaybackend/realtime/event/SubscriptionEventListener.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/event/SubscriptionEventListener.java
@@ -1,8 +1,5 @@
 package com.pfplaybackend.realtime.event;
 
-import com.pfplaybackend.realtime.port.PresencePort;
-import com.pfplaybackend.realtime.port.SessionCachePort;
-import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationListener;
@@ -14,11 +11,8 @@ import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 import java.security.Principal;
 
 @Component
-@RequiredArgsConstructor
 public class SubscriptionEventListener implements ApplicationListener<SessionSubscribeEvent> {
     private static final Logger logger = LoggerFactory.getLogger(SubscriptionEventListener.class);
-    private final SessionCachePort sessionCachePort;
-    private final PresencePort presencePort;
 
     @Override
     public void onApplicationEvent(SessionSubscribeEvent event) {
@@ -31,11 +25,9 @@ public class SubscriptionEventListener implements ApplicationListener<SessionSub
             throw new AuthenticationServiceException("Unauthorized Session Requested");
         }
         String userId = principal.getName();
-        sessionCachePort.saveSessionCache(sessionId, userId, destination);
-        // PRESENCE: subscribe to a partyroom topic = user is back. Clear any
-        // PENDING_EXIT for their associated room (no-op if not pending).
-        presencePort.onSessionConnected(sessionId);
-
+        // PRESENCE/세션캐시 디커미션 (#209 #31): subscribe-타이밍 의존을 종결한다.
+        // presence는 WS CONNECT/DISCONNECT가 권위(Task 1.4/1.5), 세션캐시 write도 더 이상
+        // SUBSCRIBE에서 수행하지 않는다. 여기서는 인증 가드와 로깅만 남긴다.
         logger.info("Session has subscribed, sessionId : {}, userId : {}, destination : {}", sessionId, userId, destination);
     }
 }

--- a/realtime/src/main/java/com/pfplaybackend/realtime/event/UnsubscriptionEventListener.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/event/UnsubscriptionEventListener.java
@@ -1,5 +1,7 @@
 package com.pfplaybackend.realtime.event;
 
+import com.pfplaybackend.realtime.port.SessionCachePort;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationListener;
@@ -11,8 +13,10 @@ import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
 import java.security.Principal;
 
 @Component
+@RequiredArgsConstructor
 public class UnsubscriptionEventListener implements ApplicationListener<SessionUnsubscribeEvent> {
     private static final Logger logger = LoggerFactory.getLogger(UnsubscriptionEventListener.class);
+    private final SessionCachePort sessionCachePort;
 
     @Override
     public void onApplicationEvent(SessionUnsubscribeEvent event) {
@@ -23,8 +27,10 @@ public class UnsubscriptionEventListener implements ApplicationListener<SessionU
             logger.warn("Unauthorized session requested, UserId is null, Session ID: {}", sessionId);
             throw new AuthenticationServiceException("Unauthorized Session Requested");
         }
-        // 세션캐시 디커미션 (#209 #31): UNSUBSCRIBE에서 deleteSessionCache를 더 이상
-        // 호출하지 않는다. 세션 정리는 WS DISCONNECT가 권위. 인증 가드와 로깅만 남긴다.
+        // 세션캐시 delete는 채팅 세션 캐시의 clean-path 정리다. 비정상 종료(orphan)는
+        // 캐시 TTL로 만료되며 DisconnectionEventListener는 재추가하지 않는다 (#209 #31).
+        sessionCachePort.deleteSessionCache(sessionId);
+
         logger.info("Session has unsubscribed, sessionId : {}", sessionId);
     }
 }

--- a/realtime/src/main/java/com/pfplaybackend/realtime/event/UnsubscriptionEventListener.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/event/UnsubscriptionEventListener.java
@@ -1,7 +1,5 @@
 package com.pfplaybackend.realtime.event;
 
-import com.pfplaybackend.realtime.port.SessionCachePort;
-import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationListener;
@@ -13,10 +11,8 @@ import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
 import java.security.Principal;
 
 @Component
-@RequiredArgsConstructor
 public class UnsubscriptionEventListener implements ApplicationListener<SessionUnsubscribeEvent> {
     private static final Logger logger = LoggerFactory.getLogger(UnsubscriptionEventListener.class);
-    private final SessionCachePort sessionCachePort;
 
     @Override
     public void onApplicationEvent(SessionUnsubscribeEvent event) {
@@ -27,8 +23,8 @@ public class UnsubscriptionEventListener implements ApplicationListener<SessionU
             logger.warn("Unauthorized session requested, UserId is null, Session ID: {}", sessionId);
             throw new AuthenticationServiceException("Unauthorized Session Requested");
         }
-        sessionCachePort.deleteSessionCache(sessionId);
-
+        // 세션캐시 디커미션 (#209 #31): UNSUBSCRIBE에서 deleteSessionCache를 더 이상
+        // 호출하지 않는다. 세션 정리는 WS DISCONNECT가 권위. 인증 가드와 로깅만 남긴다.
         logger.info("Session has unsubscribed, sessionId : {}", sessionId);
     }
 }

--- a/realtime/src/main/java/com/pfplaybackend/realtime/event/UnsubscriptionEventListener.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/event/UnsubscriptionEventListener.java
@@ -27,8 +27,9 @@ public class UnsubscriptionEventListener implements ApplicationListener<SessionU
             logger.warn("Unauthorized session requested, UserId is null, Session ID: {}", sessionId);
             throw new AuthenticationServiceException("Unauthorized Session Requested");
         }
-        // 세션캐시 delete는 채팅 세션 캐시의 clean-path 정리다. 비정상 종료(orphan)는
-        // 캐시 TTL로 만료되며 DisconnectionEventListener는 재추가하지 않는다 (#209 #31).
+        // 세션캐시 delete는 채팅 세션 캐시의 clean-path 정리다. 비정상 종료(1006,
+        // UNSUBSCRIBE 없음) orphan은 RedisSessionCacheAdapter의 24h TTL 백스톱으로
+        // self-heal되며 DisconnectionEventListener는 재추가하지 않는다 (#209 #31).
         sessionCachePort.deleteSessionCache(sessionId);
 
         logger.info("Session has unsubscribed, sessionId : {}", sessionId);

--- a/realtime/src/main/java/com/pfplaybackend/realtime/port/SessionRegistryPort.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/port/SessionRegistryPort.java
@@ -1,0 +1,20 @@
+package com.pfplaybackend.realtime.port;
+
+/**
+ * Bridges a freshly established realtime STOMP session to the live user-session
+ * registry in the app module. The realtime listener knows {@code (sessionId,
+ * userId)} at CONNECT time (Principal); the app implementation translates the
+ * userId String into the domain value and records the mapping so that later
+ * presence resolution can map a bare sessionId back to its user.
+ *
+ * <p>This MUST be called before any presence resolution for the same session —
+ * the resolver reads back the very mapping written here.
+ */
+public interface SessionRegistryPort {
+
+    /**
+     * Registers the live STOMP session for the authenticated user. Invoked once
+     * per CONNECT frame, before {@link PresencePort#onSessionConnected(String)}.
+     */
+    void register(String sessionId, String userId);
+}

--- a/realtime/src/main/java/com/pfplaybackend/realtime/port/SessionRegistryPort.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/port/SessionRegistryPort.java
@@ -9,6 +9,12 @@ package com.pfplaybackend.realtime.port;
  *
  * <p>This MUST be called before any presence resolution for the same session —
  * the resolver reads back the very mapping written here.
+ *
+ * <p>There is intentionally no {@code unregister} on this port: the disconnect
+ * path needs the unregister result (was-this-the-last-session) fused with the
+ * presence decision app-side, so it is handled inside
+ * {@code PresencePortAdapter.onSessionDisconnected} rather than split across the
+ * realtime↔app seam.
  */
 public interface SessionRegistryPort {
 

--- a/realtime/src/test/java/com/pfplaybackend/realtime/event/ConnectionEventListenerTest.java
+++ b/realtime/src/test/java/com/pfplaybackend/realtime/event/ConnectionEventListenerTest.java
@@ -1,0 +1,80 @@
+package com.pfplaybackend.realtime.event;
+
+import com.pfplaybackend.realtime.port.PresencePort;
+import com.pfplaybackend.realtime.port.SessionRegistryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+
+import java.security.Principal;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.mockito.InOrder;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ConnectionEventListener 단위 테스트")
+class ConnectionEventListenerTest {
+
+    @Mock
+    private SessionRegistryPort sessionRegistryPort;
+
+    @Mock
+    private PresencePort presencePort;
+
+    @InjectMocks
+    private ConnectionEventListener listener;
+
+    @Test
+    @DisplayName("Principal 이 있으면 세션을 먼저 등록한 뒤 presence 연결을 트리거한다")
+    void registersBeforeResolvingPresence() {
+        // given
+        String sessionId = "session-connect";
+        String uid = "12345";
+        SessionConnectEvent event = createConnectEvent(sessionId, () -> uid);
+
+        // when
+        listener.onApplicationEvent(event);
+
+        // then
+        InOrder order = inOrder(sessionRegistryPort, presencePort);
+        order.verify(sessionRegistryPort).register(sessionId, uid);
+        order.verify(presencePort).onSessionConnected(sessionId);
+    }
+
+    @Test
+    @DisplayName("Principal 이 없으면 등록도 presence 트리거도 하지 않으며 예외도 던지지 않는다")
+    void noPrincipalIsSilentNoOp() {
+        // given
+        String sessionId = "session-anon";
+        SessionConnectEvent event = createConnectEvent(sessionId, null);
+
+        // when
+        listener.onApplicationEvent(event);
+
+        // then
+        verifyNoInteractions(sessionRegistryPort, presencePort);
+    }
+
+    // --- helper ---
+
+    private SessionConnectEvent createConnectEvent(String sessionId, Principal principal) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+        accessor.setSessionId(sessionId);
+        if (principal != null) {
+            accessor.setUser(principal);
+        }
+
+        Message<byte[]> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+        return new SessionConnectEvent(this, message, principal);
+    }
+}

--- a/realtime/src/test/java/com/pfplaybackend/realtime/event/DisconnectionEventListenerTest.java
+++ b/realtime/src/test/java/com/pfplaybackend/realtime/event/DisconnectionEventListenerTest.java
@@ -1,7 +1,6 @@
 package com.pfplaybackend.realtime.event;
 
 import com.pfplaybackend.realtime.port.PresencePort;
-import com.pfplaybackend.realtime.port.SessionCachePort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,13 +15,11 @@ import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("DisconnectionEventListener 단위 테스트")
 class DisconnectionEventListenerTest {
-
-    @Mock
-    private SessionCachePort sessionCachePort;
 
     @Mock
     private PresencePort presencePort;
@@ -31,8 +28,8 @@ class DisconnectionEventListenerTest {
     private DisconnectionEventListener listener;
 
     @Test
-    @DisplayName("정상 종료(1000) 시 presence를 PENDING으로 표시하고 세션 캐시를 삭제한다")
-    void onApplicationEventNormalCloseDeletesSessionCache() {
+    @DisplayName("정상 종료(1000) 시 presence 종료만 위임하고 세션 캐시는 건드리지 않는다")
+    void onApplicationEventNormalCloseDelegatesPresenceOnly() {
         // given
         String sessionId = "session-normal";
         SessionDisconnectEvent event = createDisconnectEvent(sessionId, CloseStatus.NORMAL);
@@ -40,14 +37,14 @@ class DisconnectionEventListenerTest {
         // when
         listener.onApplicationEvent(event);
 
-        // then
+        // then: presence 종료 위임만 일어나고 세션 캐시 결합은 없다 (registry 권위)
         verify(presencePort).onSessionDisconnected(sessionId);
-        verify(sessionCachePort).deleteSessionCache(sessionId);
+        verifyNoMoreInteractions(presencePort);
     }
 
     @Test
-    @DisplayName("비정상 종료(1006) 시에도 presence와 세션 캐시 정리가 동일하게 일어난다")
-    void onApplicationEventAbnormalCloseDeletesSessionCache() {
+    @DisplayName("비정상 종료(1006) 시에도 presence 종료만 위임한다")
+    void onApplicationEventAbnormalCloseDelegatesPresenceOnly() {
         // given
         String sessionId = "session-abnormal";
         CloseStatus abnormalClose = new CloseStatus(1006, "Abnormal closure");
@@ -58,7 +55,7 @@ class DisconnectionEventListenerTest {
 
         // then
         verify(presencePort).onSessionDisconnected(sessionId);
-        verify(sessionCachePort).deleteSessionCache(sessionId);
+        verifyNoMoreInteractions(presencePort);
     }
 
     // --- helper ---

--- a/realtime/src/test/java/com/pfplaybackend/realtime/event/SubscriptionEventListenerTest.java
+++ b/realtime/src/test/java/com/pfplaybackend/realtime/event/SubscriptionEventListenerTest.java
@@ -1,9 +1,11 @@
 package com.pfplaybackend.realtime.event;
 
+import com.pfplaybackend.realtime.port.SessionCachePort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -14,20 +16,23 @@ import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 
 import java.security.Principal;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("SubscriptionEventListener 단위 테스트")
 class SubscriptionEventListenerTest {
 
+    @Mock
+    private SessionCachePort sessionCachePort;
+
     @InjectMocks
     private SubscriptionEventListener listener;
 
     @Test
-    @DisplayName("유효한 Principal이면 인증을 통과하고 부수효과 없이 정상 처리된다 (presence·세션캐시 디커미션)")
-    void onApplicationEventValidPrincipalPassesAuthWithoutSideEffects() {
+    @DisplayName("유효한 Principal이면 채팅용 세션 캐시를 저장한다 (presence는 디커플링되어 호출 없음)")
+    void onApplicationEventValidPrincipalSavesSessionCache() {
         // given
         String sessionId = "session-abc";
         String userId = "user-123";
@@ -43,8 +48,12 @@ class SubscriptionEventListenerTest {
         Message<byte[]> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
         SessionSubscribeEvent event = new SessionSubscribeEvent(this, message);
 
-        // when & then — SUBSCRIBE는 더 이상 presence/세션캐시를 건드리지 않는다 (CONNECT가 presence 권위)
-        assertThatCode(() -> listener.onApplicationEvent(event)).doesNotThrowAnyException();
+        // when
+        listener.onApplicationEvent(event);
+
+        // then — 채팅이 read하는 세션 캐시를 write한다. presence(onSessionConnected)는
+        // CONNECT/DISCONNECT가 권위이므로 SUBSCRIBE에서 트리거하지 않는다 (#209 #31).
+        verify(sessionCachePort).saveSessionCache(sessionId, userId, destination);
     }
 
     @Test

--- a/realtime/src/test/java/com/pfplaybackend/realtime/event/UnsubscriptionEventListenerTest.java
+++ b/realtime/src/test/java/com/pfplaybackend/realtime/event/UnsubscriptionEventListenerTest.java
@@ -10,7 +10,7 @@ import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.security.authentication.AuthenticationServiceException;
-import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
 
 import java.security.Principal;
 
@@ -19,31 +19,27 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("SubscriptionEventListener 단위 테스트")
-class SubscriptionEventListenerTest {
+@DisplayName("UnsubscriptionEventListener 단위 테스트")
+class UnsubscriptionEventListenerTest {
 
     @InjectMocks
-    private SubscriptionEventListener listener;
+    private UnsubscriptionEventListener listener;
 
     @Test
-    @DisplayName("유효한 Principal이면 인증을 통과하고 부수효과 없이 정상 처리된다 (presence·세션캐시 디커미션)")
-    void onApplicationEventValidPrincipalPassesAuthWithoutSideEffects() {
+    @DisplayName("유효한 Principal이면 세션캐시 삭제 없이 정상 처리된다 (세션캐시 디커미션)")
+    void onApplicationEventValidPrincipalPassesWithoutSessionCacheDelete() {
         // given
         String sessionId = "session-abc";
-        String userId = "user-123";
-        String destination = "/topic/partyroom/1";
 
-        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.UNSUBSCRIBE);
         accessor.setSessionId(sessionId);
-        accessor.setDestination(destination);
         Principal principal = mock(Principal.class);
-        org.mockito.Mockito.when(principal.getName()).thenReturn(userId);
         accessor.setUser(principal);
 
         Message<byte[]> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
-        SessionSubscribeEvent event = new SessionSubscribeEvent(this, message);
+        SessionUnsubscribeEvent event = new SessionUnsubscribeEvent(this, message);
 
-        // when & then — SUBSCRIBE는 더 이상 presence/세션캐시를 건드리지 않는다 (CONNECT가 presence 권위)
+        // when & then — UNSUBSCRIBE는 더 이상 deleteSessionCache를 호출하지 않는다
         assertThatCode(() -> listener.onApplicationEvent(event)).doesNotThrowAnyException();
     }
 
@@ -51,13 +47,12 @@ class SubscriptionEventListenerTest {
     @DisplayName("Principal이 null이면 AuthenticationServiceException을 던진다")
     void onApplicationEventNullPrincipalThrowsException() {
         // given
-        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.UNSUBSCRIBE);
         accessor.setSessionId("session-xyz");
-        accessor.setDestination("/topic/partyroom/1");
         // principal은 설정하지 않음 (null)
 
         Message<byte[]> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
-        SessionSubscribeEvent event = new SessionSubscribeEvent(this, message);
+        SessionUnsubscribeEvent event = new SessionUnsubscribeEvent(this, message);
 
         // when & then
         assertThatThrownBy(() -> listener.onApplicationEvent(event))

--- a/realtime/src/test/java/com/pfplaybackend/realtime/event/UnsubscriptionEventListenerTest.java
+++ b/realtime/src/test/java/com/pfplaybackend/realtime/event/UnsubscriptionEventListenerTest.java
@@ -1,9 +1,11 @@
 package com.pfplaybackend.realtime.event;
 
+import com.pfplaybackend.realtime.port.SessionCachePort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -14,20 +16,23 @@ import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
 
 import java.security.Principal;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("UnsubscriptionEventListener 단위 테스트")
 class UnsubscriptionEventListenerTest {
 
+    @Mock
+    private SessionCachePort sessionCachePort;
+
     @InjectMocks
     private UnsubscriptionEventListener listener;
 
     @Test
-    @DisplayName("유효한 Principal이면 세션캐시 삭제 없이 정상 처리된다 (세션캐시 디커미션)")
-    void onApplicationEventValidPrincipalPassesWithoutSessionCacheDelete() {
+    @DisplayName("유효한 Principal이면 채팅용 세션 캐시를 삭제한다 (clean 경로 정리)")
+    void onApplicationEventValidPrincipalDeletesSessionCache() {
         // given
         String sessionId = "session-abc";
 
@@ -39,8 +44,11 @@ class UnsubscriptionEventListenerTest {
         Message<byte[]> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
         SessionUnsubscribeEvent event = new SessionUnsubscribeEvent(this, message);
 
-        // when & then — UNSUBSCRIBE는 더 이상 deleteSessionCache를 호출하지 않는다
-        assertThatCode(() -> listener.onApplicationEvent(event)).doesNotThrowAnyException();
+        // when
+        listener.onApplicationEvent(event);
+
+        // then — UNSUBSCRIBE는 채팅 세션 캐시의 clean-path 정리를 담당한다 (#209 #31).
+        verify(sessionCachePort).deleteSessionCache(sessionId);
     }
 
     @Test


### PR DESCRIPTION
## 목적

Cluster A PR-1. presence(룸 입퇴장/고스트) 판정을 STOMP **subscribe 타이밍**이 아니라 **서버측 user-session 레지스트리 + DB 권위**로 이관한다.

- **#31**: subscribe-타이밍 근접 의존 제거 — 탭 종료/DISCONNECT 가 subscribe 캐시 게이팅 없이 항상 grace 를 시작
- **SE4 레이스**: DISCONNECT(pending) ↔ 재접속/재입장 사이 레이스를 CONNECT-time + REST 같은-룸 재입장 이중방어로 차단
- **멀티탭 SE5**: 한 탭만 닫혔을 때 self-eviction 방지 — 마지막 세션 종료에서만 grace 시작

## 변경 요약

**L1 — user-session 레지스트리 + 권위 전환**
- `UserSessionRegistry` 신설 + `RedisUserSessionStoreAdapter` (원자 last-session 판정 `SREM`→`SCARD`, ApplicationContext 부팅 복구, missed-DISCONNECT 누수 self-heal TTL 백스톱)
- `PresencePortAdapter` resolve 를 레지스트리 + DB(`PartyroomQueryPort.getActivePartyroomByUserId`) 권위로 전환 — subscribe 캐시 비의존
- `SessionRegistryPort` seam 도입 (realtime↔app 모듈 경계) + `ConnectionEventListener` CONNECT 시 세션 등록 + clearPending
- `DisconnectionEventListener` / `SubscriptionEventListener` / `UnsubscriptionEventListener` 의 **세션캐시 presence 결합 제거** — 단, chat 용 세션캐시 라이프사이클은 유지(비정상 종료 orphan self-heal TTL 백스톱 포함)
- REST 같은-룸 재입장(`PartyroomAccessCommandService.tryEnter`) 시 `clearCrewPending` — SE4 이중방어 (DB-only, cycle-free)

**누적 폴리시 (review sanction, 행위보존)**
- uid 직렬화 대칭(`toString`/`fromString`), `@Service` 스테레오타입 일관, 포트 javadoc, 테스트 tautology/미사용 import 정리, grace-cancel debug 로그, 통합테스트 harden 주석

## 회귀 잠금

- `ClusterAPresenceIntegrationTest` **8** — #31 / SE4 경로 A·B(end-to-end) / 멀티탭 E1 / grace 만료 종착상태, 실제 Redis(registry) + MySQL(crew.pending_exit_at) 끝까지 구동
- 단위 다수 — UserSessionRegistry / PresencePortAdapter / SessionRegistryPortAdapter / PartyroomAccessCommandService / RedisSessionCacheAdapter / 룸 resolve 계약 잠금

## 트레이드오프

- **bounded ghost**: missed-DISCONNECT 시 레지스트리 키가 살아남는 윈도우는 TTL 백스톱(24h)으로 self-heal — V16 presence grace 설계를 상속한 의도된 bounded staleness

## 검증 결과 (XML 증거)

| 스위트 | tests | failures | errors |
|---|---|---|---|
| UserSessionRegistryTest | 6 | 0 | 0 |
| PresencePortAdapterTest | 7 | 0 | 0 |
| SessionRegistryPortAdapterTest | 1 | 0 | 0 |
| PartyroomAccessCommandServiceTest | 16 | 0 | 0 |
| RedisSessionCacheAdapterTest | 6 | 0 | 0 |
| realtime 모듈 전체 (Connection/Disconnection/Subscription/Unsubscription 포함) | 12 | 0 | 0 |
| ClusterAPresenceIntegrationTest (통합) | 8 | 0 | 0 |
| RedisUserSessionStoreAdapterIntegrationTest (통합) | 6 | 0 | 0 |
| PartyroomPresenceServiceTest (회귀 sanity) | 13 | 0 | 0 |

전 PR-1 스위트 GREEN. 회귀 sanity(neighbor) 무영향.

## 후속

- **C9 SE3 analytics**: presence 텔레메트리 갭은 별건으로 분리
- **PresenceService ↔ AccessCommandService 순환 backlog**: 현재 DB-only clearPending 으로 우회 — 구조적 해소는 별 PR
- web#298 / PR-2 후속에서 클라이언트 계약 정렬 follow

Refs #209 #225. web#298 / PR-2 follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)