### PR TITLE
feat(observability): C/T1-1 critical-path 로그 + RequestId 상관관계 (A1+A6, #210)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/common/adapter/in/web/RequestIdInterceptor.java
+++ b/app/src/main/java/com/pfplaybackend/api/common/adapter/in/web/RequestIdInterceptor.java
@@ -18,6 +18,12 @@ import java.util.UUID;
  * {@link #current()} 는 A1(핫패스 로그에 requestId 부착) 이 소비할 진입점이다.
  * HTTP 컨텍스트가 아니면 null 을 반환하므로 호출자는 반드시 null-safe 해야 한다.
  *
+ * 비동기(async DeferredResult/Callable) dispatch 는 {@code afterConcurrentHandlingStarted}
+ * 경로라 {@link #afterCompletion} 이 즉시 호출되지 않아 컨테이너 스레드에 stale requestId 가
+ * 남을 수 있다. 다만 다음 요청 {@link #preHandle} 이 무조건 덮어쓰므로 누적되지 않고
+ * bounded 이며, {@code current()} 소비자는 off-request 시 best-effort 전제다.
+ * Phase B MDC 전환 시 해소된다.
+ *
  * Spec: 옵저버빌리티 A6 (platform#210, Cluster C / C/T1-1)
  */
 @Component
@@ -33,6 +39,15 @@ public class RequestIdInterceptor implements HandlerInterceptor {
         String requestId = request.getHeader(REQUEST_ID_HEADER);
         if (requestId == null || requestId.isBlank()) {
             requestId = UUID.randomUUID().toString().substring(0, 8);
+        } else {
+            // 신뢰 경계: 클라이언트 제어값. 제어문자 제거(log-forging/헤더 인젝션 방어) + 길이 상한(log 증폭 방어).
+            requestId = requestId.replaceAll("\\p{Cntrl}", "");
+            if (requestId.length() > 64) {
+                requestId = requestId.substring(0, 64);
+            }
+            if (requestId.isBlank()) { // 제거 후 공백만 남으면 생성
+                requestId = UUID.randomUUID().toString().substring(0, 8);
+            }
         }
         request.setAttribute(REQUEST_ID_ATTR, requestId);
         CURRENT.set(requestId);

--- a/app/src/main/java/com/pfplaybackend/api/common/adapter/in/web/RequestIdInterceptor.java
+++ b/app/src/main/java/com/pfplaybackend/api/common/adapter/in/web/RequestIdInterceptor.java
@@ -1,0 +1,53 @@
+package com.pfplaybackend.api.common.adapter.in.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.UUID;
+
+/**
+ * HTTP 요청 상관관계(correlation) 인터셉터.
+ *
+ * 들어오는 {@code X-Request-Id} 헤더가 있으면 그대로 사용하고, 없거나 공백이면
+ * 8자 짧은 id 를 생성한다. 값을 (1) request attribute({@value #REQUEST_ID_ATTR}),
+ * (2) 응답 헤더({@value #REQUEST_ID_HEADER}, 디버깅용 에코), (3) ThreadLocal
+ * ({@link #current()}) 세 곳에 노출한다.
+ *
+ * {@link #current()} 는 A1(핫패스 로그에 requestId 부착) 이 소비할 진입점이다.
+ * HTTP 컨텍스트가 아니면 null 을 반환하므로 호출자는 반드시 null-safe 해야 한다.
+ *
+ * Spec: 옵저버빌리티 A6 (platform#210, Cluster C / C/T1-1)
+ */
+@Component
+public class RequestIdInterceptor implements HandlerInterceptor {
+
+    public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String REQUEST_ID_ATTR = "requestId";
+
+    private static final ThreadLocal<String> CURRENT = new ThreadLocal<>();
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String requestId = request.getHeader(REQUEST_ID_HEADER);
+        if (requestId == null || requestId.isBlank()) {
+            requestId = UUID.randomUUID().toString().substring(0, 8);
+        }
+        request.setAttribute(REQUEST_ID_ATTR, requestId);
+        CURRENT.set(requestId);
+        response.setHeader(REQUEST_ID_HEADER, requestId);
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
+                                Object handler, Exception ex) {
+        CURRENT.remove();
+    }
+
+    /** 현재 스레드의 requestId. 비-HTTP 컨텍스트면 null — 호출자는 null-safe 해야 한다. */
+    public static String current() {
+        return CURRENT.get();
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/common/config/WebMvcConfig.java
+++ b/app/src/main/java/com/pfplaybackend/api/common/config/WebMvcConfig.java
@@ -1,0 +1,26 @@
+package com.pfplaybackend.api.common.config;
+
+import com.pfplaybackend.api.common.adapter.in.web.RequestIdInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Spring MVC 공통 설정.
+ *
+ * 현재는 {@link RequestIdInterceptor}(HTTP 상관관계, 옵저버빌리티 A6) 등록만 담당한다.
+ * 신규 {@link WebMvcConfigurer} 가 코드베이스에 없어 새로 생성. (CORS 는 Spring
+ * Security 체인에서 처리되므로 여기서 건드리지 않는다.)
+ */
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final RequestIdInterceptor requestIdInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(requestIdInterceptor);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/event/DomainEventRedisRelay.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/event/DomainEventRedisRelay.java
@@ -13,12 +13,14 @@ import com.pfplaybackend.api.party.domain.enums.AccessType;
 import com.pfplaybackend.api.party.domain.event.*;
 import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.util.UUID;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class DomainEventRedisRelay {
@@ -44,26 +46,31 @@ public class DomainEventRedisRelay {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     public void on(DjQueueChangedEvent event) {
-        messagePublisher.publish(MessageTopic.DJ_QUEUE_CHANGED.topic(),
-                DjQueueChangeMessage.create(
-                        event.getPartyroomId(),
-                        partyroomQueryService.getDjs(event.getPartyroomId())
-                ));
+        DjQueueChangeMessage message = DjQueueChangeMessage.create(
+                event.getPartyroomId(),
+                partyroomQueryService.getDjs(event.getPartyroomId()));
+        log.info("[relay] DJ_QUEUE_CHANGED - partyroomId={}, messageId={}",
+                event.getPartyroomId().getId(), message.id());
+        messagePublisher.publish(MessageTopic.DJ_QUEUE_CHANGED.topic(), message);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     public void on(PlaybackStartedEvent event) {
-        messagePublisher.publish(MessageTopic.PLAYBACK_STARTED.topic(),
-                new PlaybackStartMessage(event.getPartyroomId(), MessageTopic.PLAYBACK_STARTED,
-                        UUID.randomUUID().toString(), System.currentTimeMillis(),
-                        event.getCrewId().getId(), event.getPlayback()));
+        PlaybackStartMessage message = new PlaybackStartMessage(event.getPartyroomId(), MessageTopic.PLAYBACK_STARTED,
+                UUID.randomUUID().toString(), System.currentTimeMillis(),
+                event.getCrewId().getId(), event.getPlayback());
+        log.info("[relay] PLAYBACK_STARTED - partyroomId={}, messageId={}",
+                event.getPartyroomId().getId(), message.id());
+        messagePublisher.publish(MessageTopic.PLAYBACK_STARTED.topic(), message);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     public void on(PlaybackDeactivatedEvent event) {
-        messagePublisher.publish(MessageTopic.PLAYBACK_DEACTIVATED.topic(),
-                new PartyroomDeactivationMessage(event.getPartyroomId(), MessageTopic.PLAYBACK_DEACTIVATED,
-                        UUID.randomUUID().toString(), System.currentTimeMillis()));
+        PartyroomDeactivationMessage message = new PartyroomDeactivationMessage(event.getPartyroomId(),
+                MessageTopic.PLAYBACK_DEACTIVATED, UUID.randomUUID().toString(), System.currentTimeMillis());
+        log.info("[relay] PLAYBACK_DEACTIVATED - partyroomId={}, messageId={}",
+                event.getPartyroomId().getId(), message.id());
+        messagePublisher.publish(MessageTopic.PLAYBACK_DEACTIVATED.topic(), message);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java
@@ -1,6 +1,7 @@
 package com.pfplaybackend.api.party.application.service;
 
 import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.adapter.in.web.RequestIdInterceptor;
 import com.pfplaybackend.api.common.aspect.context.AuthContext;
 import com.pfplaybackend.api.common.domain.value.PlaylistId;
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
@@ -19,12 +20,14 @@ import com.pfplaybackend.api.party.domain.value.CrewId;
 import com.pfplaybackend.api.party.domain.value.DjId;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DjCommandService {
@@ -39,6 +42,8 @@ public class DjCommandService {
     @Transactional
     public Long enqueueDj(PartyroomId partyroomId, PlaylistId playlistId)  {
         AuthContext authContext = ThreadLocalContext.getAuthContext();
+        log.info("[enqueueDj] ENTER - requestId={}, partyroomId={}, userId={}, playlistId={}",
+                RequestIdInterceptor.current(), partyroomId.getId(), authContext.getUserId().getUid(), playlistId.getId());
         PartyroomData partyroom = partyroomQueryService.getPartyroomById(partyroomId);
         PartyroomPlaybackData playbackState = aggregatePort.findPlaybackState(partyroomId);
         DjQueueData djQueue = aggregatePort.findDjQueueState(partyroomId);
@@ -48,10 +53,19 @@ public class DjCommandService {
         // Find crew
         CrewData crew = partyroomQueryService.getCrewOrThrow(partyroomId, authContext.getUserId());
         CrewId crewId = new CrewId(crew.getId());
+        log.info("[enqueueDj] CREW_FOUND - requestId={}, partyroomId={}, userId={}, crewId={}, isActive={}, grade={}",
+                RequestIdInterceptor.current(), partyroomId.getId(), authContext.getUserId().getUid(),
+                crew.getId(), crew.isActive(), crew.getGradeType());
 
         boolean isAlreadyRegistered = aggregatePort.isDjRegistered(partyroomId, crewId);
+        if (isAlreadyRegistered) {
+            log.info("[enqueueDj] ALREADY_REGISTERED - requestId={}, partyroomId={}, crewId={}",
+                    RequestIdInterceptor.current(), partyroomId.getId(), crew.getId());
+        }
         boolean isEmptyPlaylist = playlistQueryPort.isEmptyPlaylist(playlistId.getId());
         new DjEnqueueSpecification().validate(djQueue, isAlreadyRegistered, isEmptyPlaylist);
+        log.info("[enqueueDj] VALIDATION_PASSED - requestId={}, partyroomId={}, crewId={}",
+                RequestIdInterceptor.current(), partyroomId.getId(), crew.getId());
 
         // Calculate next order number
         List<DjData> queuedDjs = aggregatePort.findDjsOrdered(partyroomId);
@@ -60,6 +74,8 @@ public class DjCommandService {
         // Create and save DJ
         DjData dj = DjData.create(partyroom.getPartyroomId(), playlistId, crewId, nextOrder);
         DjData saved = aggregatePort.saveDj(dj);
+        log.info("[enqueueDj] SAVED - requestId={}, partyroomId={}, crewId={}, djId={}, orderNumber={}",
+                RequestIdInterceptor.current(), partyroomId.getId(), crew.getId(), saved.getId(), nextOrder);
 
         if (isPostActivationProcessingRequired) {
             playbackState.activate(null, null);

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java
@@ -59,7 +59,7 @@ public class DjCommandService {
 
         boolean isAlreadyRegistered = aggregatePort.isDjRegistered(partyroomId, crewId);
         if (isAlreadyRegistered) {
-            log.info("[enqueueDj] ALREADY_REGISTERED - requestId={}, partyroomId={}, crewId={}",
+            log.warn("[enqueueDj] ALREADY_REGISTERED - requestId={}, partyroomId={}, crewId={}",
                     RequestIdInterceptor.current(), partyroomId.getId(), crew.getId());
         }
         boolean isEmptyPlaylist = playlistQueryPort.isEmptyPlaylist(playlistId.getId());

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java
@@ -1,6 +1,7 @@
 package com.pfplaybackend.api.party.application.service;
 
 import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.adapter.in.web.RequestIdInterceptor;
 import com.pfplaybackend.api.common.aspect.context.AuthContext;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
@@ -90,10 +91,12 @@ public class PlaybackCommandService implements PlaybackControlPort {
     private void tryProceed(PartyroomId partyroomId) {
         PartyroomData partyroom = partyroomQueryService.getPartyroomById(partyroomId);
         List<DjData> queuedDjs = aggregatePort.findDjsOrdered(partyroomId);
+        log.info("[tryProceed] partyroomId={}, queueSize={}", partyroomId.getId(), queuedDjs.size());
 
         if(!queuedDjs.isEmpty()) {
             doStart(partyroom, queuedDjs.size());
         }else{
+            log.info("[tryProceed] EMPTY_QUEUE_DEACTIVATE - partyroomId={}", partyroomId.getId());
             deactivateAndNotify(partyroom);
         }
     }
@@ -105,21 +108,36 @@ public class PlaybackCommandService implements PlaybackControlPort {
     }
 
     private void doStart(PartyroomData partyroom, int remainingAttempts) {
+        long partyroomIdValue = partyroom.getPartyroomId().getId();
         List<DjData> rotatedDjs = partyroomAggregateService.rotateDjQueue(partyroom.getPartyroomId());
+        log.info("[doStart] ENTER - requestId={}, partyroomId={}, remainingAttempts={}, queueSize={}",
+                RequestIdInterceptor.current(), partyroomIdValue, remainingAttempts, rotatedDjs.size());
 
         DjData nextDj = rotatedDjs.stream()
                 .min(Comparator.comparingInt(DjData::getOrderNumber)).orElseThrow();
         CrewData djCrew = aggregatePort.findCrewById(nextDj.getCrewId().getId()).orElseThrow();
         PlaybackData nextPlayback = getNextPlaybackInPlaylist(partyroom.getPartyroomId(), nextDj, djCrew.getUserId());
+        long djCrewId = djCrew.getId();
+        String trackName = nextPlayback.getName();
+        long durationSec = nextPlayback.getDuration().toSeconds();
+        int limitMin = partyroom.getPlaybackTimeLimit().getMinutes();
+        log.debug("[doStart] NEXT_TRACK - requestId={}, partyroomId={}, djCrewId={}, trackName={}, durationSec={}, limitMin={}",
+                RequestIdInterceptor.current(), partyroomIdValue, djCrewId, trackName, durationSec, limitMin);
 
         if (partyroom.getPlaybackTimeLimit().exceedsDuration(nextPlayback.getDuration())) {
+            log.warn("[doStart] TRACK_EXCEEDS_LIMIT - requestId={}, partyroomId={}, djCrewId={}, trackName={}, durationSec={}, limitMin={}, remainingAttempts={}",
+                    RequestIdInterceptor.current(), partyroomIdValue, djCrewId, trackName, durationSec, limitMin, remainingAttempts);
             if (remainingAttempts <= 1) {
+                log.warn("[doStart] DEACTIVATE_TRIGGERED - requestId={}, partyroomId={}, reason=ALL_TRACKS_EXCEEDED, lastTrackName={}, lastDurationSec={}, limitMin={}",
+                        RequestIdInterceptor.current(), partyroomIdValue, trackName, durationSec, limitMin);
                 deactivateAndNotify(partyroom);
                 return;
             }
             PartyroomData reloaded = partyroomQueryService.getPartyroomById(partyroom.getPartyroomId());
             List<DjData> remainingDjs = aggregatePort.findDjsOrdered(reloaded.getPartyroomId());
             if (!remainingDjs.isEmpty()) {
+                log.info("[doStart] RETRY_NEXT_DJ - requestId={}, partyroomId={}, remainingAttempts={}",
+                        RequestIdInterceptor.current(), partyroomIdValue, remainingAttempts - 1);
                 doStart(reloaded, remainingAttempts - 1);
             } else {
                 deactivateAndNotify(reloaded);
@@ -177,6 +195,7 @@ public class PlaybackCommandService implements PlaybackControlPort {
 
     private void deactivateAndNotify(PartyroomData partyroom) {
         PartyroomId partyroomId = partyroom.getPartyroomId();
+        log.warn("[deactivateAndNotify] partyroomId={} - publishing DEACTIVATE event + clearing DJ queue", partyroomId.getId());
         eventPublisher.publishEvent(new DjQueueChangedEvent(partyroomId, DjChangeType.DEACTIVATE, null));
         partyroomAggregateService.deactivatePlayback(partyroomId)
                 .forEach(eventPublisher::publishEvent);

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java
@@ -1,7 +1,6 @@
 package com.pfplaybackend.api.party.application.service;
 
 import com.pfplaybackend.api.common.ThreadLocalContext;
-import com.pfplaybackend.api.common.adapter.in.web.RequestIdInterceptor;
 import com.pfplaybackend.api.common.aspect.context.AuthContext;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
@@ -91,7 +90,7 @@ public class PlaybackCommandService implements PlaybackControlPort {
     private void tryProceed(PartyroomId partyroomId) {
         PartyroomData partyroom = partyroomQueryService.getPartyroomById(partyroomId);
         List<DjData> queuedDjs = aggregatePort.findDjsOrdered(partyroomId);
-        log.info("[tryProceed] partyroomId={}, queueSize={}", partyroomId.getId(), queuedDjs.size());
+        log.debug("[tryProceed] partyroomId={}, queueSize={}", partyroomId.getId(), queuedDjs.size());
 
         if(!queuedDjs.isEmpty()) {
             doStart(partyroom, queuedDjs.size());
@@ -110,8 +109,8 @@ public class PlaybackCommandService implements PlaybackControlPort {
     private void doStart(PartyroomData partyroom, int remainingAttempts) {
         long partyroomIdValue = partyroom.getPartyroomId().getId();
         List<DjData> rotatedDjs = partyroomAggregateService.rotateDjQueue(partyroom.getPartyroomId());
-        log.info("[doStart] ENTER - requestId={}, partyroomId={}, remainingAttempts={}, queueSize={}",
-                RequestIdInterceptor.current(), partyroomIdValue, remainingAttempts, rotatedDjs.size());
+        log.debug("[doStart] ENTER - partyroomId={}, remainingAttempts={}, queueSize={}",
+                partyroomIdValue, remainingAttempts, rotatedDjs.size());
 
         DjData nextDj = rotatedDjs.stream()
                 .min(Comparator.comparingInt(DjData::getOrderNumber)).orElseThrow();
@@ -121,23 +120,23 @@ public class PlaybackCommandService implements PlaybackControlPort {
         String trackName = nextPlayback.getName();
         long durationSec = nextPlayback.getDuration().toSeconds();
         int limitMin = partyroom.getPlaybackTimeLimit().getMinutes();
-        log.debug("[doStart] NEXT_TRACK - requestId={}, partyroomId={}, djCrewId={}, trackName={}, durationSec={}, limitMin={}",
-                RequestIdInterceptor.current(), partyroomIdValue, djCrewId, trackName, durationSec, limitMin);
+        log.debug("[doStart] NEXT_TRACK - partyroomId={}, djCrewId={}, trackName={}, durationSec={}, limitMin={}",
+                partyroomIdValue, djCrewId, trackName, durationSec, limitMin);
 
         if (partyroom.getPlaybackTimeLimit().exceedsDuration(nextPlayback.getDuration())) {
-            log.warn("[doStart] TRACK_EXCEEDS_LIMIT - requestId={}, partyroomId={}, djCrewId={}, trackName={}, durationSec={}, limitMin={}, remainingAttempts={}",
-                    RequestIdInterceptor.current(), partyroomIdValue, djCrewId, trackName, durationSec, limitMin, remainingAttempts);
+            log.warn("[doStart] TRACK_EXCEEDS_LIMIT - partyroomId={}, djCrewId={}, trackName={}, durationSec={}, limitMin={}, remainingAttempts={}",
+                    partyroomIdValue, djCrewId, trackName, durationSec, limitMin, remainingAttempts);
             if (remainingAttempts <= 1) {
-                log.warn("[doStart] DEACTIVATE_TRIGGERED - requestId={}, partyroomId={}, reason=ALL_TRACKS_EXCEEDED, lastTrackName={}, lastDurationSec={}, limitMin={}",
-                        RequestIdInterceptor.current(), partyroomIdValue, trackName, durationSec, limitMin);
+                log.warn("[doStart] DEACTIVATE_TRIGGERED - partyroomId={}, reason=ALL_TRACKS_EXCEEDED, lastTrackName={}, lastDurationSec={}, limitMin={}",
+                        partyroomIdValue, trackName, durationSec, limitMin);
                 deactivateAndNotify(partyroom);
                 return;
             }
             PartyroomData reloaded = partyroomQueryService.getPartyroomById(partyroom.getPartyroomId());
             List<DjData> remainingDjs = aggregatePort.findDjsOrdered(reloaded.getPartyroomId());
             if (!remainingDjs.isEmpty()) {
-                log.info("[doStart] RETRY_NEXT_DJ - requestId={}, partyroomId={}, remainingAttempts={}",
-                        RequestIdInterceptor.current(), partyroomIdValue, remainingAttempts - 1);
+                log.debug("[doStart] RETRY_NEXT_DJ - partyroomId={}, remainingAttempts={}",
+                        partyroomIdValue, remainingAttempts - 1);
                 doStart(reloaded, remainingAttempts - 1);
             } else {
                 deactivateAndNotify(reloaded);

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/service/PartyroomAggregateService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/service/PartyroomAggregateService.java
@@ -7,10 +7,12 @@ import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
 import com.pfplaybackend.api.party.domain.value.CrewId;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PartyroomAggregateService {
@@ -64,6 +66,8 @@ public class PartyroomAggregateService {
         playbackState.deactivate();
         aggregatePort.savePlaybackState(playbackState);
         List<DjData> queuedDjs = aggregatePort.findDjsOrdered(partyroomId);
+        log.warn("[deactivatePlayback] partyroomId={} - removing {} DJ(s) from queue",
+                partyroomId.getId(), queuedDjs.size());
         aggregatePort.removeDjs(queuedDjs);
         return playbackState.pollDomainEvents();
     }

--- a/app/src/test/java/com/pfplaybackend/api/common/adapter/in/web/RequestIdInterceptorTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/common/adapter/in/web/RequestIdInterceptorTest.java
@@ -95,6 +95,59 @@ class RequestIdInterceptorTest {
     }
 
     @Test
+    @DisplayName("클라 헤더의 제어문자 제거(log-forging/헤더 인젝션 방어)")
+    void sanitizes_control_chars_in_client_header() {
+        when(request.getHeader(RequestIdInterceptor.REQUEST_ID_HEADER)).thenReturn("a\r\nINJECTED\tx");
+
+        boolean result = interceptor.preHandle(request, response, new Object());
+
+        assertThat(result).isTrue();
+
+        ArgumentCaptor<String> attrCaptor = ArgumentCaptor.forClass(String.class);
+        verify(request).setAttribute(eq(RequestIdInterceptor.REQUEST_ID_ATTR), attrCaptor.capture());
+        String sanitized = attrCaptor.getValue();
+
+        assertThat(sanitized)
+                .isEqualTo("aINJECTEDx")
+                .doesNotContain("\r", "\n", "\t")
+                .doesNotMatch(".*\\p{Cntrl}.*");
+        verify(response).setHeader(RequestIdInterceptor.REQUEST_ID_HEADER, "aINJECTEDx");
+        assertThat(RequestIdInterceptor.current())
+                .isEqualTo("aINJECTEDx")
+                .doesNotMatch(".*\\p{Cntrl}.*");
+    }
+
+    @Test
+    @DisplayName("과도하게 긴 클라 헤더는 64자로 절단(log 증폭 방어)")
+    void caps_overlong_client_header() {
+        String overlong = "x".repeat(200);
+        when(request.getHeader(RequestIdInterceptor.REQUEST_ID_HEADER)).thenReturn(overlong);
+
+        interceptor.preHandle(request, response, new Object());
+
+        ArgumentCaptor<String> attrCaptor = ArgumentCaptor.forClass(String.class);
+        verify(request).setAttribute(eq(RequestIdInterceptor.REQUEST_ID_ATTR), attrCaptor.capture());
+
+        assertThat(attrCaptor.getValue()).hasSize(64);
+        assertThat(RequestIdInterceptor.current()).hasSize(64);
+    }
+
+    @Test
+    @DisplayName("sanitize 후 공백만 남으면 8자 id 생성으로 폴백")
+    void blank_after_sanitize_regenerates() {
+        when(request.getHeader(RequestIdInterceptor.REQUEST_ID_HEADER)).thenReturn("\n\t\r");
+
+        interceptor.preHandle(request, response, new Object());
+
+        ArgumentCaptor<String> attrCaptor = ArgumentCaptor.forClass(String.class);
+        verify(request).setAttribute(eq(RequestIdInterceptor.REQUEST_ID_ATTR), attrCaptor.capture());
+        String generated = attrCaptor.getValue();
+
+        assertThat(generated).isNotBlank().hasSize(8);
+        assertThat(RequestIdInterceptor.current()).isEqualTo(generated);
+    }
+
+    @Test
     @DisplayName("preHandle 호출 없는 스레드에서 current() 는 null")
     void current_is_null_without_preHandle_on_other_thread() throws InterruptedException {
         AtomicReference<String> seen = new AtomicReference<>("sentinel");

--- a/app/src/test/java/com/pfplaybackend/api/common/adapter/in/web/RequestIdInterceptorTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/common/adapter/in/web/RequestIdInterceptorTest.java
@@ -1,0 +1,107 @@
+package com.pfplaybackend.api.common.adapter.in.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RequestIdInterceptorTest {
+
+    @Mock
+    HttpServletRequest request;
+
+    @Mock
+    HttpServletResponse response;
+
+    RequestIdInterceptor interceptor;
+
+    @BeforeEach
+    void setUp() {
+        interceptor = new RequestIdInterceptor();
+        // Defensive: ensure no leaked ThreadLocal from a prior test on this thread.
+        interceptor.afterCompletion(request, response, new Object(), null);
+    }
+
+    @Test
+    @DisplayName("헤더 부재 시 8자 id 생성 + attr/응답헤더/current() 모두 동일")
+    void generates_8char_id_when_header_absent() {
+        when(request.getHeader(RequestIdInterceptor.REQUEST_ID_HEADER)).thenReturn(null);
+
+        boolean result = interceptor.preHandle(request, response, new Object());
+
+        assertThat(result).isTrue();
+
+        ArgumentCaptor<String> attrCaptor = ArgumentCaptor.forClass(String.class);
+        verify(request).setAttribute(eq(RequestIdInterceptor.REQUEST_ID_ATTR), attrCaptor.capture());
+        String generated = attrCaptor.getValue();
+
+        assertThat(generated).isNotNull().hasSize(8);
+        verify(response).setHeader(RequestIdInterceptor.REQUEST_ID_HEADER, generated);
+        assertThat(RequestIdInterceptor.current()).isEqualTo(generated);
+    }
+
+    @Test
+    @DisplayName("X-Request-Id 헤더 존재 시 그 값을 그대로 사용(에코)")
+    void uses_incoming_header_value_when_present() {
+        when(request.getHeader(RequestIdInterceptor.REQUEST_ID_HEADER)).thenReturn("abc123");
+
+        boolean result = interceptor.preHandle(request, response, new Object());
+
+        assertThat(result).isTrue();
+        verify(request).setAttribute(RequestIdInterceptor.REQUEST_ID_ATTR, "abc123");
+        verify(response).setHeader(RequestIdInterceptor.REQUEST_ID_HEADER, "abc123");
+        assertThat(RequestIdInterceptor.current()).isEqualTo("abc123");
+    }
+
+    @Test
+    @DisplayName("공백 헤더는 부재로 간주 → 생성")
+    void blank_header_treated_as_absent() {
+        when(request.getHeader(RequestIdInterceptor.REQUEST_ID_HEADER)).thenReturn("   ");
+
+        interceptor.preHandle(request, response, new Object());
+
+        ArgumentCaptor<String> attrCaptor = ArgumentCaptor.forClass(String.class);
+        verify(request).setAttribute(eq(RequestIdInterceptor.REQUEST_ID_ATTR), attrCaptor.capture());
+        String generated = attrCaptor.getValue();
+
+        assertThat(generated).isNotBlank().hasSize(8);
+        assertThat(generated).isNotEqualTo("   ");
+        assertThat(RequestIdInterceptor.current()).isEqualTo(generated);
+    }
+
+    @Test
+    @DisplayName("afterCompletion 후 current() 는 null (ThreadLocal 정리)")
+    void afterCompletion_clears_threadlocal() {
+        when(request.getHeader(RequestIdInterceptor.REQUEST_ID_HEADER)).thenReturn("xyz789");
+        interceptor.preHandle(request, response, new Object());
+        assertThat(RequestIdInterceptor.current()).isEqualTo("xyz789");
+
+        interceptor.afterCompletion(request, response, new Object(), null);
+
+        assertThat(RequestIdInterceptor.current()).isNull();
+    }
+
+    @Test
+    @DisplayName("preHandle 호출 없는 스레드에서 current() 는 null")
+    void current_is_null_without_preHandle_on_other_thread() throws InterruptedException {
+        AtomicReference<String> seen = new AtomicReference<>("sentinel");
+        Thread other = new Thread(() -> seen.set(RequestIdInterceptor.current()));
+        other.start();
+        other.join();
+
+        assertThat(seen.get()).isNull();
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/common/config/WebMvcConfigTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/common/config/WebMvcConfigTest.java
@@ -1,0 +1,36 @@
+package com.pfplaybackend.api.common.config;
+
+import com.pfplaybackend.api.common.adapter.in.web.RequestIdInterceptor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WebMvcConfigTest {
+
+    @Mock
+    InterceptorRegistry registry;
+
+    @Mock
+    InterceptorRegistration registration;
+
+    @Test
+    @DisplayName("addInterceptors 가 RequestIdInterceptor 를 등록한다")
+    void registers_request_id_interceptor() {
+        RequestIdInterceptor interceptor = new RequestIdInterceptor();
+        WebMvcConfig config = new WebMvcConfig(interceptor);
+
+        when(registry.addInterceptor(interceptor)).thenReturn(registration);
+
+        config.addInterceptors(registry);
+
+        verify(registry).addInterceptor(interceptor);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceLogCaptureTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceLogCaptureTest.java
@@ -1,0 +1,119 @@
+package com.pfplaybackend.api.party.application.service;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.aspect.context.AuthContext;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.enums.AuthorityTier;
+import com.pfplaybackend.api.party.application.port.out.PlaybackControlPort;
+import com.pfplaybackend.api.party.application.port.out.PlaylistQueryPort;
+import com.pfplaybackend.api.party.domain.entity.data.*;
+import com.pfplaybackend.api.party.domain.enums.GradeType;
+import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
+import com.pfplaybackend.api.party.domain.service.PartyroomAggregateService;
+import com.pfplaybackend.api.party.domain.value.CrewId;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * 옵저버빌리티 A1 — 최우선 SLO 시그널 [enqueueDj] CREW_FOUND ... isActive=... 로그 캡처 검증.
+ * isActive=false 누수 시그널이 실제 crew 상태를 반영해 한 줄 emit 되는지 ListAppender 로 확인.
+ */
+@ExtendWith(MockitoExtension.class)
+class DjCommandServiceLogCaptureTest {
+
+    @Mock PartyroomAggregatePort aggregatePort;
+    @Mock PlaybackControlPort playbackControlPort;
+    @Mock PlaylistQueryPort playlistQueryPort;
+    @Mock ApplicationEventPublisher eventPublisher;
+    @Mock PartyroomAggregateService partyroomAggregateService;
+    @Mock PartyroomQueryService partyroomQueryService;
+
+    @InjectMocks DjCommandService djCommandService;
+
+    private final UserId userId = new UserId(1L);
+    private final PartyroomId partyroomId = new PartyroomId(10L);
+    private final PlaylistId playlistId = new PlaylistId(100L);
+
+    private Logger logger;
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void setUp() {
+        AuthContext authContext = mock(AuthContext.class);
+        lenient().when(authContext.getUserId()).thenReturn(userId);
+        lenient().when(authContext.getAuthorityTier()).thenReturn(AuthorityTier.FM);
+        ThreadLocalContext.setContext(authContext);
+
+        logger = (Logger) LoggerFactory.getLogger(DjCommandService.class);
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        logger.setLevel(Level.INFO);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(appender);
+        ThreadLocalContext.clearContext();
+    }
+
+    @Test
+    @DisplayName("enqueueDj — CREW_FOUND 로그가 crew 의 isActive 상태를 반영해 emit 된다")
+    void enqueueDjEmitsCrewFoundLogWithIsActive() {
+        // given
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(partyroomId.getId()).partyroomId(partyroomId).build();
+        PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+        DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+
+        CrewData crew = CrewData.builder()
+                .id(7L).partyroomId(partyroomId).userId(userId)
+                .gradeType(GradeType.CLUBBER).isActive(true).build();
+
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+        when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+        when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+        when(aggregatePort.isDjRegistered(partyroomId, new CrewId(7L))).thenReturn(false);
+        when(playlistQueryPort.isEmptyPlaylist(playlistId.getId())).thenReturn(false);
+        when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(Collections.emptyList());
+        when(aggregatePort.saveDj(any(DjData.class))).thenReturn(mock(DjData.class));
+
+        // when
+        djCommandService.enqueueDj(partyroomId, playlistId);
+
+        // then
+        List<ILoggingEvent> events = appender.list;
+        ILoggingEvent crewFound = events.stream()
+                .filter(e -> e.getFormattedMessage().contains("[enqueueDj] CREW_FOUND"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "CREW_FOUND log not emitted. Captured: " +
+                                events.stream().map(ILoggingEvent::getFormattedMessage).toList()));
+
+        assertThat(crewFound.getFormattedMessage())
+                .contains("crewId=7")
+                .contains("isActive=true");
+    }
+}


### PR DESCRIPTION
## 목적 (#210, Cluster C / C/T1-1)

구조화 로깅/트레이싱 ~0 → prod 버그 사후 확인 불가(이번 디버깅 세션이 로그 부재로 수시간 수동 추적). 모든 Critical fix 의 prod 검증 신호 제공. 의존성/마이그레이션/결정 zero, **행위보존(로깅만)**.

## 변경 (A6 → A1, atomic 4커밋)

- **A6** `RequestIdInterceptor`(`X-Request-Id` 생성/echo, ThreadLocal `current()`, afterCompletion remove) + 신규 `WebMvcConfig` 등록. 클라값 **sanitize**(제어문자 제거+64 길이캡+빈값 재생성 — log-forging/헤더인젝션 방어, A1이 로그 보간하므로 신뢰경계서 차단). async stale 주석.
- **A1** playback/DJ큐 분기 로그 카탈로그: `PlaybackCommandService`(doStart ENTER/NEXT_TRACK/TRACK_EXCEEDS_LIMIT/DEACTIVATE_TRIGGERED/RETRY_NEXT_DJ, tryProceed/EMPTY_QUEUE_DEACTIVATE, deactivateAndNotify), `PartyroomAggregateService.deactivatePlayback`, `DjCommandService.enqueueDj`(ENTER/**CREW_FOUND isActive=SLO**/ALREADY_REGISTERED/VALIDATION_PASSED/SAVED). `DomainEventRedisRelay` 3 핸들러 publish→relay **동일 messageId** 로그(동일 인스턴스 hoist, 행위무변경).
- **레벨 정책 일관화**: WARN=anomaly/요청실패(TRACK_EXCEEDS_LIMIT, DEACTIVATE_*, ALREADY_REGISTERED) / INFO=이산 lifecycle 전이 / DEBUG=per-advance flow-trace(ENTER/tryProceed/NEXT_TRACK/RETRY). timer-driven 경로(Redis listener thread, 非HTTP)의 구조적 `requestId=null` 제거 — `requestId`는 HTTP-entry(enqueueDj)에만, timer 경로는 partyroomId + relay messageId 로 상관.
- **eventLogicalKey 의무화는 미구현(deferred)** — 행위변경이라 A1(로깅) 범위 밖. 별도 결정 필요 시 후속.

## 회귀잠금/검증

- 매 unit(A6/A1) spec+quality 2단계 리뷰 + fix 재리뷰 통과. 행위보존 핵심 안전장치 = 기존 스위트 무회귀.
- `RequestIdInterceptorTest` 8/8(sanitize/echo/blank/afterCompletion/off-thread), `WebMvcConfigTest` 1/1, `DjCommandServiceLogCaptureTest` 1/1(CREW_FOUND isActive SLO, ListAppender).
- 기존: PlaybackCommandServiceTest 10/10·DjCommandServiceTest 5/5·DjCommandServiceDjQueueChangeTest 4/4·PartyroomAggregateServiceTest 6/6, 통합 ClusterAPresenceIntegrationTest 8/8·DjQueueGraceIntegrationTest 4/4 — 전부 green(비캐시 재실행 확인).

## 범위/후속

A1+A6 만(스코프 한정). A2(handleDjQueueOnLeave/admin)·A3(WS unsub/disconnect/SimpMessageSender)·A4(application.yml level)·A5(frontend) 미포함 — #210 후속 또는 별도. acceptance(docker-compose 시나리오 reproduce)는 머지 후 별도 검증. ADR-009(Sentry 거부·GCP sink) 별도.

Refs #210. Cluster A(#226/#227/#301/#302) 머지 후 Tier-1 단독선두로 진행.