### PR TITLE
fix(party): 리액션 좋아요/싫어요 카운터 race 차단 + 음수 drift 정합화 (E#6, #231)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PlaybackAggregationRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PlaybackAggregationRepository.java
@@ -14,15 +14,23 @@ public interface PlaybackAggregationRepository extends JpaRepository<PlaybackAgg
      *  - 반환 1: 정상 적용
      *  - 반환 0: row 없음 (호출자 WARN 로그 후 무시)
      * 동시 호출 시 DB row lock으로 직렬화 → lost update 차단.
-     * 음수 가드 없음 — like/dislike는 history 기준 delta라 정상 흐름에선 음수 발생 불가.
-     * 음수 발생 시 WARN 로그가 history vs counter drift 신호.
+     *
+     * <p>E/#6 (#231) 음수 floor 가드(방어선): {@code GREATEST(0, col + :delta)} 로
+     * 어떤 인터리빙/잔존 drift 에서도 카운터가 0 미만으로 떨어지지 않게 한다. 1차 방어는
+     * history PESSIMISTIC_WRITE 락이며 이 가드는 defense-in-depth. {@code GREATEST} 는
+     * JPQL 표준이 아니므로 MySQL native query 로 작성한다.
+     * {@code @Modifying(clearAutomatically=true)} 로 1차 캐시는 비워진다(반환값 계약: affected rows).
      */
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE PlaybackAggregationData a " +
-           "SET a.likeCount = a.likeCount + :deltaLike, " +
-           "    a.dislikeCount = a.dislikeCount + :deltaDislike, " +
-           "    a.grabCount = a.grabCount + :deltaGrab " +
-           "WHERE a.playbackId = :playbackId")
+    @Query(value = "UPDATE playback_aggregation " +
+           "SET like_count = GREATEST(0, like_count + :deltaLike), " +
+           "    dislike_count = GREATEST(0, dislike_count + :deltaDislike), " +
+           "    grab_count = GREATEST(0, grab_count + :deltaGrab) " +
+           // GREATEST 가 native SQL 을 강제 → JPQL 파라미터 바인딩 불가. native query 는
+           // @Embeddable PlaybackId 를 직접 바인딩 못 하므로 SpEL :#{#playbackId.id} 로
+           // 내부 Long 을 unwrap 해 넘긴다 (이 경로에서 playbackId 는 절대 null 아님).
+           "WHERE playback_id = :#{#playbackId.id}",
+           nativeQuery = true)
     int applyAggregationDelta(@Param("playbackId") PlaybackId playbackId,
                               @Param("deltaLike") int deltaLike,
                               @Param("deltaDislike") int deltaDislike,

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PlaybackReactionHistoryRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PlaybackReactionHistoryRepository.java
@@ -4,10 +4,40 @@ package com.pfplaybackend.api.party.adapter.out.persistence;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.party.domain.entity.data.history.PlaybackReactionHistoryData;
 import com.pfplaybackend.api.party.domain.value.PlaybackId;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface PlaybackReactionHistoryRepository extends JpaRepository<PlaybackReactionHistoryData, Long> {
     Optional<PlaybackReactionHistoryData> findByPlaybackIdAndUserId(PlaybackId playbackId, UserId userId);
+
+    /**
+     * E/#6 (#231) 리액션 카운터 race 차단용 비관적 쓰기 락.
+     *
+     * <p>{@code reactToCurrentPlayback} 의 history-read → delta 계산 → aggregation UPDATE
+     * 시퀀스를 같은 (user, playback) 단위로 직렬화한다. 이미 존재하는 history 행에 대해
+     * {@code SELECT ... FOR UPDATE} 행 락을 잡으므로, 두 동시 트랜잭션이 stale 스냅샷에서
+     * 각자 delta 를 계산해 이중 적용하는 drift 가 차단된다.
+     *
+     * <p>락 순서는 history → aggregation 단방향(데드락-세이프). 첫 반응(행 미존재) 경로는
+     * 행 자체가 없어 락 대상이 없으므로 unique 제약 {@code uk_reaction_user_playback} 가
+     * 동시 INSERT 의 패자를 거르고, 호출자가 재시도 시 이제 존재하는 행에 락을 잡는다.
+     *
+     * <p>의도적으로 짧은 락 대기(3s) 를 건다 — MySQL InnoDB 기본 lock-wait(~50s) 동안
+     * 같은 (user, playback) 연타가 Tomcat 워커 + DB 커넥션을 묶어 워커 고갈을 유발하므로,
+     * 워커 굶주림보다 빠른 실패(클라이언트 재시도) 를 택한다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000"))
+    @Query("SELECT h FROM PlaybackReactionHistoryData h " +
+           "WHERE h.playbackId = :playbackId AND h.userId = :userId")
+    Optional<PlaybackReactionHistoryData> findByPlaybackIdAndUserIdForUpdate(
+            @Param("playbackId") PlaybackId playbackId,
+            @Param("userId") UserId userId);
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackReactionCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackReactionCommandService.java
@@ -2,6 +2,7 @@ package com.pfplaybackend.api.party.application.service;
 
 import com.pfplaybackend.api.common.ThreadLocalContext;
 import com.pfplaybackend.api.common.aspect.context.AuthContext;
+import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.enums.AuthorityTier;
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
 import com.pfplaybackend.api.party.adapter.out.persistence.PlaybackReactionHistoryRepository;
@@ -20,11 +21,14 @@ import com.pfplaybackend.api.party.domain.value.CrewId;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import com.pfplaybackend.api.party.domain.value.PlaybackId;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PlaybackReactionCommandService {
@@ -33,7 +37,6 @@ public class PlaybackReactionCommandService {
     private final PlaybackReactionDomainService playbackReactionDomainService;
     private final PartyroomQueryService partyroomQueryService;
     private final PlaybackReactionPostProcessCommandService playbackReactionPostProcessCommandService;
-    private final PlaybackReactionQueryService playbackReactionQueryService;
 
     @Transactional
     public ReactionHistoryDto reactToCurrentPlayback(PartyroomId partyroomId, ReactionType reactionType) {
@@ -60,9 +63,44 @@ public class PlaybackReactionCommandService {
         return info == null ? null : new AddedTrackDto(info.trackId(), info.playlistId());
     }
 
+    /**
+     * E/#6 (#231) race 차단: history 행을 비관적 쓰기 락으로 확보한다.
+     *
+     * <p>행이 이미 존재하면 {@code SELECT ... FOR UPDATE} 가 같은 (user, playback) 의
+     * read→delta→aggregation-UPDATE 시퀀스를 직렬화한다(락 순서 history→aggregation 단방향).
+     *
+     * <p>첫 반응(행 미존재)이면 base 행을 즉시 INSERT+flush 해 물리적으로 존재시키고 그 행에
+     * 락을 잡는다. 동시 첫-INSERT 의 패자는 unique 제약 {@code uk_reaction_user_playback}
+     * 위반({@link DataIntegrityViolationException})을 만나는데, 이를 원천에서 잡아 WARN 로
+     * 관측 가능하게 남기고 {@link ReactionException#REACTION_CONFLICT_RETRY} 로 재던져
+     * 깔끔한 409 로 매핑한다(원시 JDBC/제약 메시지 누출·HTTP 500·무로그 손실 방지). 패자의
+     * delta 는 적용되지 않으므로 카운터는 일관 유지되며, 클라이언트 재시도 시 이제 존재하는
+     * 행에 락을 잡아 정상 처리된다(연타 첫-INSERT 손실은 카운터 무결성 우선 정책상 허용).
+     */
     private PlaybackReactionHistoryData getValidReactionHistoryData(AuthContext authContext, PlaybackId playbackId) {
-        return playbackReactionQueryService.findPrevHistoryData(playbackId, authContext.getUserId())
-                .orElseGet(() -> new PlaybackReactionHistoryData(authContext.getUserId(), playbackId));
+        Optional<PlaybackReactionHistoryData> locked = playbackReactionHistoryRepository
+                .findByPlaybackIdAndUserIdForUpdate(playbackId, authContext.getUserId());
+        if (locked.isPresent()) {
+            return locked.get();
+        }
+        return insertBaseHistoryRow(authContext.getUserId(), playbackId);
+    }
+
+    /**
+     * 첫 반응 base 행을 INSERT+flush. 동시 첫-INSERT 패자는 unique 제약 위반으로
+     * {@link DataIntegrityViolationException} 을 받는데, WARN 로 남기고 409
+     * {@link ReactionException#REACTION_CONFLICT_RETRY} 로 변환한다(클라이언트 재시도 유도).
+     */
+    private PlaybackReactionHistoryData insertBaseHistoryRow(UserId userId, PlaybackId playbackId) {
+        try {
+            return playbackReactionHistoryRepository.saveAndFlush(
+                    new PlaybackReactionHistoryData(userId, playbackId));
+        } catch (DataIntegrityViolationException e) {
+            log.warn("[getValidReactionHistoryData] CONCURRENT_FIRST_INSERT_LOST - " +
+                     "playbackId={}, userId={} - reaction dropped, client should retry",
+                     playbackId, userId);
+            throw ExceptionCreator.create(ReactionException.REACTION_CONFLICT_RETRY);
+        }
     }
 
     private ReactionState getExistingState(PlaybackReactionHistoryData historyData) {

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/exception/ReactionException.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/exception/ReactionException.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 
 @Getter
 public enum ReactionException implements DomainException {
-    INVALID_REACTION("RCT-001", "유효하지 않은 리액션 타입입니다", ErrorType.FORBIDDEN);
+    INVALID_REACTION("RCT-001", "유효하지 않은 리액션 타입입니다", ErrorType.FORBIDDEN),
+    REACTION_CONFLICT_RETRY("RCT-002", "동시 요청 충돌 — 잠시 후 다시 시도해 주세요", ErrorType.CONFLICT);
 
     private final String errorCode;
     private final String message;

--- a/app/src/main/resources/db/migration/V18__fix_negative_reaction_counters.sql
+++ b/app/src/main/resources/db/migration/V18__fix_negative_reaction_counters.sql
@@ -1,0 +1,16 @@
+-- E/#6 (issue #231) 일회성 음수 카운터 보정.
+-- 빠른 연타 race 로 PLAYBACK_AGGREGATION 의 like/dislike/grab 카운터가 음수로 drift 한
+-- 기존 행을 0 으로 floor 한다. 근본 원인(history 미락 + delta staleness)은 같은 PR 에서
+-- PESSIMISTIC_WRITE 락 + native GREATEST(0,...) floor 가드로 차단된다. 본 마이그레이션은
+-- 이미 음수로 떨어진 잔존 데이터만 일회성 보정한다.
+-- 주의: playback_aggregation.updated_at 은 ON UPDATE CURRENT_TIMESTAMP 이므로 보정 대상
+-- 행의 updated_at 이 갱신된다 — 카운터 무결성 회복이 우선이므로 이 side-effect 는 허용한다.
+-- history↔counter 전면 재유도(re-derivation)는 본 PR 범위 밖(별도 검토).
+
+UPDATE playback_aggregation
+SET like_count    = GREATEST(0, like_count),
+    dislike_count = GREATEST(0, dislike_count),
+    grab_count    = GREATEST(0, grab_count)
+WHERE like_count < 0
+   OR dislike_count < 0
+   OR grab_count < 0;

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/PlaybackAggregationAtomicUpdateIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/PlaybackAggregationAtomicUpdateIT.java
@@ -49,4 +49,28 @@ class PlaybackAggregationAtomicUpdateIT extends AbstractIntegrationTest {
         int affected = repository.applyAggregationDelta(new PlaybackId(999_999_999L), 1, 0, 0);
         assertThat(affected).isZero();
     }
+
+    @Test
+    @DisplayName("applyAggregationDelta — E/#6 floor 가드: 0 미만으로 떨어뜨리는 delta 는 0 으로 clamp (음수 금지)")
+    void apply_floorGuardClampsToZero() {
+        PlaybackId pid = new PlaybackId(80003L);
+        repository.saveAndFlush(PlaybackAggregationData.createFor(pid));
+        // 카운터를 (like=2, dislike=1, grab=0) 으로 만든 뒤,
+        repository.applyAggregationDelta(pid, 2, 1, 0);
+
+        // 각 카운터를 0 미만으로 떨어뜨리는 큰 음수 delta 적용
+        int affected = repository.applyAggregationDelta(pid, -5, -3, -4);
+
+        assertThat(affected).isEqualTo(1);
+        PlaybackAggregationData reloaded = repository.findById(pid).orElseThrow();
+        assertThat(reloaded.getLikeCount())
+                .as("like_count 는 GREATEST(0,...) 로 음수 대신 0 으로 floor")
+                .isZero();
+        assertThat(reloaded.getDislikeCount())
+                .as("dislike_count floor")
+                .isZero();
+        assertThat(reloaded.getGrabCount())
+                .as("grab_count floor")
+                .isZero();
+    }
 }

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackReactionCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackReactionCommandServiceTest.java
@@ -1,9 +1,14 @@
 package com.pfplaybackend.api.party.application.service;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.pfplaybackend.api.common.ThreadLocalContext;
 import com.pfplaybackend.api.common.aspect.context.AuthContext;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.enums.AuthorityTier;
+import com.pfplaybackend.api.common.exception.http.ConflictException;
 import com.pfplaybackend.api.common.exception.http.ForbiddenException;
 import com.pfplaybackend.api.party.adapter.out.persistence.PlaybackReactionHistoryRepository;
 import com.pfplaybackend.api.party.application.dto.partyroom.ActivePartyroomDto;
@@ -26,7 +31,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,7 +49,6 @@ class PlaybackReactionCommandServiceTest {
     @Mock PlaybackReactionDomainService playbackReactionDomainService;
     @Mock PartyroomQueryService partyroomQueryService;
     @Mock PlaybackReactionPostProcessCommandService playbackReactionPostProcessCommandService;
-    @Mock PlaybackReactionQueryService playbackReactionQueryService;
 
     @InjectMocks PlaybackReactionCommandService playbackReactionCommandService;
 
@@ -49,16 +56,26 @@ class PlaybackReactionCommandServiceTest {
     private final PartyroomId partyroomId = new PartyroomId(10L);
     private final PlaybackId playbackId = new PlaybackId(100L);
 
+    private Logger logger;
+    private ListAppender<ILoggingEvent> appender;
+
     @BeforeEach
     void setUp() {
         AuthContext authContext = mock(AuthContext.class);
         lenient().when(authContext.getUserId()).thenReturn(userId);
         lenient().when(authContext.getAuthorityTier()).thenReturn(AuthorityTier.FM);
         ThreadLocalContext.setContext(authContext);
+
+        logger = (Logger) LoggerFactory.getLogger(PlaybackReactionCommandService.class);
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        logger.setLevel(Level.WARN);
     }
 
     @AfterEach
     void tearDown() {
+        logger.detachAppender(appender);
         ThreadLocalContext.clearContext();
     }
 
@@ -71,8 +88,9 @@ class PlaybackReactionCommandServiceTest {
         when(partyroomQueryService.getMyActivePartyroom()).thenReturn(Optional.of(activePartyroom));
 
         PlaybackReactionHistoryData historyData = new PlaybackReactionHistoryData(userId, playbackId);
-        when(playbackReactionQueryService.findPrevHistoryData(playbackId, userId))
+        when(playbackReactionHistoryRepository.findByPlaybackIdAndUserIdForUpdate(playbackId, userId))
                 .thenReturn(Optional.empty());
+        when(playbackReactionHistoryRepository.saveAndFlush(any())).thenReturn(historyData);
 
         ReactionState baseState = ReactionState.createBaseState();
         ReactionState targetState = new ReactionState(true, false, false);
@@ -111,8 +129,9 @@ class PlaybackReactionCommandServiceTest {
         when(partyroomQueryService.getMyActivePartyroom()).thenReturn(Optional.of(activePartyroom));
 
         PlaybackReactionHistoryData historyData = new PlaybackReactionHistoryData(userId, playbackId);
-        when(playbackReactionQueryService.findPrevHistoryData(playbackId, userId))
+        when(playbackReactionHistoryRepository.findByPlaybackIdAndUserIdForUpdate(playbackId, userId))
                 .thenReturn(Optional.empty());
+        when(playbackReactionHistoryRepository.saveAndFlush(any())).thenReturn(historyData);
 
         ReactionState baseState = ReactionState.createBaseState();
         ReactionState targetState = new ReactionState(true, false, true);
@@ -154,7 +173,7 @@ class PlaybackReactionCommandServiceTest {
         PlaybackReactionHistoryData historyData = mock(PlaybackReactionHistoryData.class);
         when(historyData.getId()).thenReturn(99L);
         when(historyData.applyReactionState(any())).thenReturn(historyData);
-        when(playbackReactionQueryService.findPrevHistoryData(playbackId, userId))
+        when(playbackReactionHistoryRepository.findByPlaybackIdAndUserIdForUpdate(playbackId, userId))
                 .thenReturn(Optional.of(historyData));
 
         // already-grabbed → GRAB toggle leaves grab false (per ReactionStateResolver: (true,false,true) -GRAB-> (true,false,true);
@@ -209,7 +228,7 @@ class PlaybackReactionCommandServiceTest {
         PlaybackReactionHistoryData historyData = mock(PlaybackReactionHistoryData.class);
         when(historyData.getId()).thenReturn(99L);
         when(historyData.applyReactionState(any())).thenReturn(historyData);
-        when(playbackReactionQueryService.findPrevHistoryData(playbackId, userId))
+        when(playbackReactionHistoryRepository.findByPlaybackIdAndUserIdForUpdate(playbackId, userId))
                 .thenReturn(Optional.of(historyData));
 
         ReactionState existingState = new ReactionState(true, false, false);
@@ -234,5 +253,44 @@ class PlaybackReactionCommandServiceTest {
         // then
         assertThat(result.isLiked()).isFalse();
         verify(playbackReactionDomainService).getReactionStateByHistory(historyData);
+    }
+
+    @Test
+    @DisplayName("동시 첫-INSERT 패자(saveAndFlush unique 위반) — 409 ConflictException 으로 매핑되고 WARN 이 emit 된다")
+    void concurrentFirstInsertLoserMapsToConflictAndWarns() {
+        // given — FOR-UPDATE 가 행을 못 찾는 첫 반응 경로에서 saveAndFlush 가 unique 제약 위반
+        ActivePartyroomDto activePartyroom = new ActivePartyroomDto(
+                partyroomId.getId(), false, 5L, true, playbackId, new CrewId(5L));
+        when(partyroomQueryService.getMyActivePartyroom()).thenReturn(Optional.of(activePartyroom));
+
+        when(playbackReactionHistoryRepository.findByPlaybackIdAndUserIdForUpdate(playbackId, userId))
+                .thenReturn(Optional.empty());
+        when(playbackReactionHistoryRepository.saveAndFlush(any()))
+                .thenThrow(new DataIntegrityViolationException(
+                        "could not execute statement; constraint [uk_reaction_user_playback]"));
+
+        // when & then — 원시 500/SQL 누출이 아니라 도메인 409 ConflictException 으로 변환
+        assertThatThrownBy(() ->
+                playbackReactionCommandService.reactToCurrentPlayback(partyroomId, ReactionType.LIKE))
+                .isInstanceOf(ConflictException.class);
+
+        // delta 적용(save)·후처리는 일어나지 않는다 — 패자 반응은 드롭
+        verify(playbackReactionHistoryRepository, never()).save(any());
+        verify(playbackReactionPostProcessCommandService, never())
+                .postProcess(any(), any(), any(), any(), any());
+
+        // WARN 한 줄이 playbackId/userId + 재시도 안내와 함께 관측 가능하게 emit
+        List<ILoggingEvent> events = appender.list;
+        ILoggingEvent warn = events.stream()
+                .filter(e -> e.getLevel() == Level.WARN)
+                .filter(e -> e.getFormattedMessage().contains("CONCURRENT_FIRST_INSERT_LOST"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "CONCURRENT_FIRST_INSERT_LOST WARN not emitted. Captured: " +
+                                events.stream().map(ILoggingEvent::getFormattedMessage).toList()));
+        assertThat(warn.getFormattedMessage())
+                .contains("playbackId=" + playbackId)
+                .contains("userId=" + userId)
+                .contains("client should retry");
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackReactionCounterRaceIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackReactionCounterRaceIntegrationTest.java
@@ -1,0 +1,252 @@
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.aspect.context.AuthContext;
+import com.pfplaybackend.api.common.domain.value.Duration;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.enums.AuthorityTier;
+import com.pfplaybackend.api.party.adapter.out.persistence.PlaybackAggregationRepository;
+import com.pfplaybackend.api.party.adapter.out.persistence.PlaybackReactionHistoryRepository;
+import com.pfplaybackend.api.party.application.port.out.PlaylistCommandPort;
+import com.pfplaybackend.api.party.application.port.out.UserActivityPort;
+import com.pfplaybackend.api.party.application.port.out.UserProfileQueryPort;
+import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
+import com.pfplaybackend.api.party.domain.entity.data.PlaybackAggregationData;
+import com.pfplaybackend.api.party.domain.entity.data.PlaybackData;
+import com.pfplaybackend.api.party.domain.entity.data.history.PlaybackReactionHistoryData;
+import com.pfplaybackend.api.party.domain.enums.GradeType;
+import com.pfplaybackend.api.party.domain.enums.ReactionType;
+import com.pfplaybackend.api.party.domain.enums.StageType;
+import com.pfplaybackend.api.party.domain.value.CrewId;
+import com.pfplaybackend.api.party.domain.value.LinkDomain;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackId;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * E/#6 (#231) 리액션 카운터 race 회귀 잠금.
+ *
+ * <p>{@link PlaybackReactionCommandService#reactToCurrentPlayback} 는 PLAYBACK_REACTION_HISTORY
+ * 를 락 없이 읽어 (target - existing) delta 를 트랜잭션 밖 스냅샷 기준으로 계산한 뒤 atomic
+ * UPDATE 로 적용한다. 두 동시 트랜잭션이 같은 stale 히스토리 스냅샷을 읽으면 각자 delta 를
+ * 계산해 이중 적용 → PLAYBACK_AGGREGATION 카운터 drift / 음수.
+ *
+ * <p>실제 빈(Testcontainers MySQL+Redis)으로 race 를 끝까지 구동한다. 두 워커 스레드가
+ * {@link TransactionTemplate}(REQUIRES_NEW) 안에서 동시에 {@code reactToCurrentPlayback}
+ * 를 호출하고, {@link CountDownLatch} 로 히스토리 read 직후 진입을 최대한 겹치게 만든다.
+ *
+ * <p>fix 전(현재 코드): 시나리오 (a) like_count 가 2 로 drift, 시나리오 (b) 카운터 음수 가능 →
+ * RED. fix 후(history PESSIMISTIC_WRITE 락 + aggregation 음수 floor 가드): GREEN.
+ */
+class PlaybackReactionCounterRaceIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired private PlaybackReactionCommandService reactionCommandService;
+    @Autowired private PlaybackReactionHistoryRepository historyRepository;
+    @Autowired private PlaybackAggregationRepository aggregationRepository;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    /** reactToCurrentPlayback 와 직교한 주변 게이트만 무력화. */
+    @MockBean private UserProfileQueryPort userProfileQueryPort;
+    @MockBean private PlaylistCommandPort playlistCommandPort;
+    @MockBean private UserActivityPort userActivityPort;
+
+    @BeforeEach
+    void seedOrthogonalGates() {
+        lenient().when(userProfileQueryPort.getUsersProfileSetting(any()))
+                .thenReturn(java.util.Collections.emptyMap());
+        lenient().when(playlistCommandPort.grabTrack(any(), any())).thenReturn(null);
+    }
+
+    @AfterEach
+    void clearAuthContext() {
+        ThreadLocalContext.clearContext();
+    }
+
+    private TransactionTemplate newTx() {
+        TransactionTemplate tt = new TransactionTemplate(transactionManager);
+        tt.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        return tt;
+    }
+
+    /** PARTYROOM + 활성화된 PARTYROOM_PLAYBACK(currentPlaybackId 지정) + DJ_QUEUE + PLAYBACK + AGGREGATION. */
+    private record Fixture(PartyroomId partyroomId, PlaybackId playbackId, long djCrewId) {}
+
+    private Fixture persistActivePlaybackGraph(UserId hostId) {
+        return newTx().execute(status -> {
+            PartyroomData partyroom = PartyroomData.create(
+                    "리액션 race 파티룸", "리액션 카운터 race 잠금용",
+                    LinkDomain.of("reaction-race-" + hostId.getUid()),
+                    PlaybackTimeLimit.ofMinutes(5),
+                    StageType.GENERAL, hostId);
+            entityManager.persist(partyroom);
+            entityManager.flush();
+            PartyroomId partyroomId = new PartyroomId(partyroom.getId());
+
+            // 호스트 crew (DJ) — currentDjCrewId 용
+            CrewData hostCrew = CrewData.create(partyroomId, hostId, GradeType.HOST, null);
+            entityManager.persist(hostCrew);
+            entityManager.flush();
+            long djCrewId = hostCrew.getId();
+
+            // 실제 PLAYBACK 행 — playbackQueryService.getPlaybackById 가 조회
+            PlaybackData playback = PlaybackData.create(
+                    partyroomId, hostId, "race-track", Duration.ofSeconds(180),
+                    "link-race", "thumb-race");
+            entityManager.persist(playback);
+            entityManager.flush();
+            PlaybackId playbackId = new PlaybackId(playback.getId());
+
+            PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+            playbackState.activate(playbackId, new CrewId(djCrewId));
+            entityManager.persist(playbackState);
+            entityManager.persist(DjQueueData.createFor(partyroomId));
+            entityManager.persist(PlaybackAggregationData.createFor(playbackId));
+            entityManager.flush();
+
+            return new Fixture(partyroomId, playbackId, djCrewId);
+        });
+    }
+
+    /** 반응 사용자를 활성 crew 로 등록. */
+    private void persistReactingCrew(PartyroomId partyroomId, UserId userId) {
+        newTx().executeWithoutResult(status -> {
+            entityManager.persist(CrewData.create(partyroomId, userId, GradeType.CLUBBER, null));
+            entityManager.flush();
+        });
+    }
+
+    /** 히스토리 행을 base 상태(모두 false)로 미리 생성 — 시나리오 (a) 는 UPDATE 경로 race 만 격리. */
+    private void persistBaseHistory(PlaybackId playbackId, UserId userId) {
+        newTx().executeWithoutResult(status ->
+                historyRepository.saveAndFlush(new PlaybackReactionHistoryData(userId, playbackId)));
+    }
+
+    private Runnable reactionTask(PartyroomId partyroomId, UserId userId, ReactionType type,
+                                  CountDownLatch start, CountDownLatch done,
+                                  AtomicReference<Throwable> err) {
+        return () -> {
+            try {
+                start.await();
+                ThreadLocalContext.setContext(new AuthContext(userId, AuthorityTier.FM));
+                newTx().executeWithoutResult(status ->
+                        reactionCommandService.reactToCurrentPlayback(partyroomId, type));
+            } catch (Throwable t) {
+                err.compareAndSet(null, t);
+            } finally {
+                ThreadLocalContext.clearContext();
+                done.countDown();
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("(a) 같은 유저 동시 LIKE 2회 — fix 전: like_count drift(2), fix 후: 정확히 1")
+    void concurrentSameUserLikeDoesNotDrift() throws Exception {
+        UserId hostId = new UserId(770001L);
+        UserId reactor = new UserId(770002L);
+        Fixture fx = persistActivePlaybackGraph(hostId);
+        persistReactingCrew(fx.partyroomId(), reactor);
+        persistBaseHistory(fx.playbackId(), reactor);
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(2);
+        AtomicReference<Throwable> err = new AtomicReference<>();
+
+        try {
+            pool.submit(reactionTask(fx.partyroomId(), reactor, ReactionType.LIKE, start, done, err));
+            pool.submit(reactionTask(fx.partyroomId(), reactor, ReactionType.LIKE, start, done, err));
+            start.countDown();
+            assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            pool.shutdown();
+        }
+
+        PlaybackAggregationData agg = newTx().execute(s ->
+                aggregationRepository.findById(fx.playbackId()).orElseThrow());
+
+        assertThat(agg.getLikeCount())
+                .as("동시 LIKE×2 는 멱등이어야 한다 — history 기준 like_count 는 정확히 1 (drift 차단)")
+                .isEqualTo(1);
+        assertThat(agg.getDislikeCount()).isZero();
+        assertThat(agg.getGrabCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("(b) 토글 race (DISLIKE/LIKE/DISLIKE 동시) — 카운터가 절대 음수가 되지 않고 최종 상태가 history 와 일치")
+    void concurrentToggleNeverGoesNegative() throws Exception {
+        UserId hostId = new UserId(770011L);
+        UserId reactor = new UserId(770012L);
+        Fixture fx = persistActivePlaybackGraph(hostId);
+        persistReactingCrew(fx.partyroomId(), reactor);
+        persistBaseHistory(fx.playbackId(), reactor);
+
+        ExecutorService pool = Executors.newFixedThreadPool(3);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(3);
+        AtomicReference<Throwable> err = new AtomicReference<>();
+
+        try {
+            pool.submit(reactionTask(fx.partyroomId(), reactor, ReactionType.DISLIKE, start, done, err));
+            pool.submit(reactionTask(fx.partyroomId(), reactor, ReactionType.LIKE, start, done, err));
+            pool.submit(reactionTask(fx.partyroomId(), reactor, ReactionType.DISLIKE, start, done, err));
+            start.countDown();
+            assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            pool.shutdown();
+        }
+
+        PlaybackAggregationData agg = newTx().execute(s ->
+                aggregationRepository.findById(fx.playbackId()).orElseThrow());
+
+        // 핵심 잠금: 어떤 인터리빙에서도 카운터는 절대 음수가 될 수 없다.
+        assertThat(agg.getLikeCount())
+                .as("토글 race 에서 like_count 음수 금지 (floor 가드)")
+                .isGreaterThanOrEqualTo(0);
+        assertThat(agg.getDislikeCount())
+                .as("토글 race 에서 dislike_count 음수 금지 (floor 가드)")
+                .isGreaterThanOrEqualTo(0);
+        assertThat(agg.getGrabCount())
+                .as("토글 race 에서 grab_count 음수 금지 (floor 가드)")
+                .isGreaterThanOrEqualTo(0);
+
+        // 직렬화(락) 후 최종 history 와 카운터 합계가 일관 — like/dislike 합은 0 또는 1
+        PlaybackReactionHistoryData history =
+                historyRepository.findByPlaybackIdAndUserId(fx.playbackId(), reactor).orElseThrow();
+        int expectedLike = history.isLiked() ? 1 : 0;
+        int expectedDislike = history.isDisliked() ? 1 : 0;
+        assertThat(agg.getLikeCount())
+                .as("최종 like_count 가 최종 history.liked 와 일치 (단일 유저이므로 0 또는 1)")
+                .isEqualTo(expectedLike);
+        assertThat(agg.getDislikeCount())
+                .as("최종 dislike_count 가 최종 history.disliked 와 일치")
+                .isEqualTo(expectedDislike);
+        assertThat(List.of(expectedLike, expectedDislike))
+                .as("단일 유저: like/dislike 동시 true 불가")
+                .containsAnyOf(0);
+    }
+}


### PR DESCRIPTION
## 배경 (#231, E/#6)

좋아요/싫어요를 빠르게 연타(또는 다중 탭/재시도)하면 `PlaybackReactionCommandService.reactToCurrentPlayback` 가 `PLAYBACK_REACTION_HISTORY` 를 **lock 없이** 읽은 stale snapshot 으로 delta(`target - existing`)를 계산한다. atomic UPDATE 의 row lock 은 쓰기만 직렬화할 뿐 **이미 stale 한 delta** 는 보호하지 못해, 두 트랜잭션이 같은 기준으로 각자 delta 를 적용 → counter drift → `like_count`/`dislike_count` 가 음수 진입(floor 가드 부재). unique `uk_reaction_user_playback` 는 동일 row 동시 UPDATE 를 막지 못함.

## 변경 (결정된 3-파트: opt1 락 + opt2 floor + 보정)

1. **PESSIMISTIC_WRITE 락 (race 근본 차단)** — `PlaybackReactionHistoryRepository.findByPlaybackIdAndUserIdForUpdate` `@Lock(PESSIMISTIC_WRITE)` + `@QueryHints` `jakarta.persistence.lock.timeout=3000`(MySQL 기본 ~50s 대기로 인한 worker starvation 방지, fail-fast→클라 재시도). `reactToCurrentPlayback` 의 `@Transactional` 안에서 사용 → `(user,playback)` history read→delta→aggregation update 직렬화. 락 순서 history→aggregation 단방향(deadlock-safe).
2. **첫 반응 + 동시 첫-INSERT 충돌 정합화** — row 부재 시 `insertBaseHistoryRow` `saveAndFlush`. 동시 첫-INSERT 패자는 `uk_reaction_user_playback` 위반으로 tx rollback(**counter 무결성 우선 — delta 미적용**). raw `DataIntegrityViolationException` 을 **좁게** catch → WARN 로그 → `ReactionException.REACTION_CONFLICT_RETRY` 재던짐 → `GlobalExceptionHandler` 가 **409 Conflict**(errorCode `RCT-002`)로 매핑. 기존엔 generic `RuntimeException` 핸들러로 떨어져 **HTTP 500 + 원시 SQL/제약명 누출 + 드롭 무로그**였음 → 정합화.
3. **음수 floor 가드 (방어층)** — `PlaybackAggregationRepository.applyAggregationDelta` native query `GREATEST(0, col+:delta)` (JPQL GREATEST 은 dialect 의존). `@Modifying(clearAutomatically)` + `int` 계약 보존, `@Embeddable PlaybackId` 는 native 라 SpEL `:#{#playbackId.id}` 언랩(사유 주석).
4. **V18 보정 마이그레이션** — `V18__fix_negative_reaction_counters.sql` 기존 음수 row 일회성 `GREATEST(0,...)` floor (`updated_at ON UPDATE` 갱신 동반 — 수용 명시).

## 테스트 (회귀잠금)

- `PlaybackReactionCounterRaceIntegrationTest` (2, real-bean Testcontainers, `TransactionTemplate`+`CountDownLatch` 실제 인터리빙): 동시 LIKE×2 → `like_count==1`(fix 전 2=RED) / 토글 race(DISLIKE↔LIKE) → 음수 미진입 **및** `counter == 최종 history`(floor 마스킹 아닌 직렬화 입증)
- `PlaybackAggregationAtomicUpdateIT` floor 슬라이스: 과대 음수 delta → 3 카운터 0 clamp
- `PlaybackReactionCommandServiceTest`: 동시 첫-INSERT 패자 → `ConflictException`(409) + WARN emit (log-capture, `DjCommandServiceLogCaptureTest` util 미러). 기존 5 테스트 무변경 유지

unit + integration 전 스위트 GREEN. 스펙·코드품질 2단 서브에이전트 리뷰 + fix 재리뷰 통과.

## 범위 밖 (미수정, 의도적)

- history↔counter 전체 재유도 마이그레이션(별도 검토 — 노트 §보정 flagged)
- opt3 atomic-upsert 단일 SQL
- (advisory, non-blocking) `PlaybackId.toString()` 부재로 WARN 이 hashcode 렌더 — 기존 `PlaybackCommandService` 선례와 동일, 본 PR 범위 밖. 추후 코드베이스 차원 정리 후보

## 운영 메모

- 검증: 배포 후 `negative counter detected` WARN(`PlaybackCommandService.updatePlaybackAggregation`) 소멸 추적 (GCP Cloud Logging). 신규 `CONCURRENT_FIRST_INSERT_LOST` WARN 빈도로 첫-INSERT 충돌 가시화.
- prod 미반영 — develop 머지. **#231 은 prod ship 시 close 예정(#211/#212 prod-close 컨벤션, develop 머지로는 OPEN 유지).**