### PR TITLE
fix(security): 인증 진입점 4경로 토큰검증 생략 — stale 공유쿠키 401 해소 (F#220, #220)

### DIFF
--- a/common/src/main/java/com/pfplaybackend/api/common/config/security/SecurityConfig.java
+++ b/common/src/main/java/com/pfplaybackend/api/common/config/security/SecurityConfig.java
@@ -7,6 +7,8 @@ import com.pfplaybackend.api.common.config.security.csrf.EagerCsrfTokenRequestAt
 import com.pfplaybackend.api.common.config.security.csrf.properties.AdminCsrfProperties;
 import com.pfplaybackend.api.common.config.security.jwt.AdminCookieWriter;
 import com.pfplaybackend.api.common.config.security.jwt.AdminTokenRenewalFilter;
+import com.pfplaybackend.api.common.config.security.jwt.AuthEntryPointSkippingBearerTokenResolver;
+import com.pfplaybackend.api.common.config.security.jwt.AuthEntryPoints;
 import com.pfplaybackend.api.common.config.security.jwt.CookieBearerTokenResolver;
 import com.pfplaybackend.api.common.config.security.jwt.CustomJwtAuthenticationConverter;
 import com.pfplaybackend.api.common.config.security.jwt.JwtService;
@@ -99,9 +101,9 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(request -> request
                         .requestMatchers("/error").permitAll()
-                        .requestMatchers("/api/v1/auth/oauth/callback", "/api/v1/auth/oauth/url", "/api/v1/auth/logout",
-                                "/api/v1/auth/admin/login",
-                                "/api/v1/users/members/sign/**", "/api/v1/users/guests/sign/**", "/api/v1/partyrooms/link/**").permitAll()
+                        // F#220 — 인증 진입점 4경로는 AuthEntryPoints 단일 진실 원천에서 참조 (중복 0).
+                        .requestMatchers(AuthEntryPoints.paths()).permitAll()
+                        .requestMatchers("/api/v1/users/members/sign/**", "/api/v1/users/guests/sign/**", "/api/v1/partyrooms/link/**").permitAll()
                         // V14 시스템 공지 §4.4 — anonymous public status endpoint (10초 cache).
                         .requestMatchers("/api/v1/system/status").permitAll()
                         .requestMatchers("/actuator/health").permitAll()
@@ -116,7 +118,7 @@ public class SecurityConfig {
                         .anyRequest().denyAll()
                 )
                 .oauth2ResourceServer(oauth2 -> oauth2
-                        .bearerTokenResolver(customBearerTokenResolver)
+                        .bearerTokenResolver(authEntryPointSkippingBearerTokenResolver())
                         .jwt(jwt -> jwt
                                 .jwtAuthenticationConverter(jwtAuthenticationConverter)
                         )
@@ -124,6 +126,16 @@ public class SecurityConfig {
                 .addFilterBefore(adminOriginGuardFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(adminTokenRenewalFilter(), BearerTokenAuthenticationFilter.class);
         return http.build();
+    }
+
+    /**
+     * F#220 — 인증 진입점에서 토큰 검증을 생략하는 데코레이터.
+     * 진입점 매칭 시 null 반환, 그 외엔 기존 {@link CookieBearerTokenResolver}에 위임.
+     */
+    @Bean
+    public AuthEntryPointSkippingBearerTokenResolver authEntryPointSkippingBearerTokenResolver() {
+        return new AuthEntryPointSkippingBearerTokenResolver(
+                AuthEntryPoints.requestMatcher(), customBearerTokenResolver);
     }
 
     @Bean

--- a/common/src/main/java/com/pfplaybackend/api/common/config/security/jwt/AuthEntryPointSkippingBearerTokenResolver.java
+++ b/common/src/main/java/com/pfplaybackend/api/common/config/security/jwt/AuthEntryPointSkippingBearerTokenResolver.java
@@ -1,0 +1,32 @@
+package com.pfplaybackend.api.common.config.security.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+/**
+ * F#220 — 인증 진입점({@link AuthEntryPoints})에서는 토큰 검증을 통째로 생략하는
+ * thin {@link BearerTokenResolver} 데코레이터.
+ * <p>
+ * 진입점 매칭 시 {@code null} 반환 → {@code BearerTokenAuthenticationFilter}가
+ * 인증을 시도하지 않음 → 인가 계층의 {@code permitAll}이 정상 적용 →
+ * stale/무효 {@code SharedSessionToken} 쿠키로 인한 진입점 401이 사라진다.
+ * <p>
+ * 그 외 경로는 {@link CookieBearerTokenResolver}(쿠키 이름 picker)에 그대로 위임 —
+ * 일반 인증 경로는 무회귀. 내부 resolver는 open/closed 원칙대로 byte 변경 없음.
+ */
+@RequiredArgsConstructor
+public class AuthEntryPointSkippingBearerTokenResolver implements BearerTokenResolver {
+
+    private final RequestMatcher authEntryPoints;
+    private final BearerTokenResolver delegate;
+
+    @Override
+    public String resolve(HttpServletRequest request) {
+        if (authEntryPoints.matches(request)) {
+            return null;
+        }
+        return delegate.resolve(request);
+    }
+}

--- a/common/src/main/java/com/pfplaybackend/api/common/config/security/jwt/AuthEntryPoints.java
+++ b/common/src/main/java/com/pfplaybackend/api/common/config/security/jwt/AuthEntryPoints.java
@@ -1,0 +1,77 @@
+package com.pfplaybackend.api.common.config.security.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.AntPathMatcher;
+
+/**
+ * F#220 — 인증 진입점 4경로의 <b>유일한 진실 원천</b>.
+ * <p>
+ * 이 4경로는 새 세션을 만들거나 끊는 진입점이라 토큰을 <em>검증하면 안 된다</em>.
+ * {@link #paths()}는 {@code SecurityConfig}의 {@code permitAll} 인가 규칙과
+ * {@link AuthEntryPointSkippingBearerTokenResolver}의 토큰검증 skip 양쪽에서
+ * 동일하게 참조된다 (정의 1회, 사용 2곳, 중복 0).
+ * <p>
+ * {@link #requestMatcher()}가 만드는 matcher는 {@link CookieBearerTokenResolver}와
+ * <b>완전히 동일한 경로 표기</b>(servletPath → 비면 requestURI → {@link AntPathMatcher})를
+ * 사용한다. {@code BearerTokenAuthenticationFilter}가 런타임에 넘기는 요청이
+ * 기존 resolver가 보는 경로와 같은 소스이므로, prod에서 skip이 조용히 안 먹는
+ * 경로-표기 불일치 위험을 원천 차단한다.
+ */
+public final class AuthEntryPoints {
+
+    /**
+     * 인증 진입점 4경로. 여기 한 곳에서만 정의된다.
+     * 변경 범위 = 정확히 이 4개 (이슈 #220 스코프).
+     * <p>
+     * 가변 배열을 public으로 노출하면 {@code AuthEntryPoints.PATHS[0] = "/x"} 같은
+     * 인가 규칙 무력화가 컴파일되는 footgun이므로, 원본은 private으로 봉인하고
+     * {@link #paths()} 방어적 복사 접근자로만 외부에 노출한다.
+     */
+    private static final String[] PATHS_INTERNAL = {
+            "/api/v1/auth/admin/login",
+            "/api/v1/auth/logout",
+            "/api/v1/auth/oauth/callback",
+            "/api/v1/auth/oauth/url",
+    };
+
+    private AuthEntryPoints() {
+    }
+
+    /**
+     * 인증 진입점 4경로의 방어적 복사본. 호출 시점마다 새 배열을 반환하므로
+     * 반환값을 변경해도 {@link #PATHS_INTERNAL} 단일 진실 원천은 불변이다.
+     * 설정 시점(config-time)에 한 번씩만 호출된다.
+     */
+    public static String[] paths() {
+        return PATHS_INTERNAL.clone();
+    }
+
+    /**
+     * {@link CookieBearerTokenResolver#pickCookieName}와 같은 경로 표기 규칙으로
+     * {@link #paths()} 중 하나에 매칭되는지 판단하는 {@link RequestMatcher}.
+     */
+    public static RequestMatcher requestMatcher() {
+        return new AuthEntryPointRequestMatcher();
+    }
+
+    private static final class AuthEntryPointRequestMatcher implements RequestMatcher {
+
+        private final AntPathMatcher matcher = new AntPathMatcher();
+
+        @Override
+        public boolean matches(HttpServletRequest request) {
+            String path = request.getServletPath();
+            if (path == null || path.isEmpty()) {
+                path = request.getRequestURI();
+            }
+            // 핫 경로(요청마다 호출)이므로 clone() 하는 paths() 대신 private 원본을 직접 순회.
+            for (String pattern : PATHS_INTERNAL) {
+                if (matcher.match(pattern, path)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/common/src/test/java/com/pfplaybackend/api/common/config/security/jwt/AuthEntryPointSkippingBearerTokenResolverTest.java
+++ b/common/src/test/java/com/pfplaybackend/api/common/config/security/jwt/AuthEntryPointSkippingBearerTokenResolverTest.java
@@ -1,0 +1,156 @@
+package com.pfplaybackend.api.common.config.security.jwt;
+
+import com.pfplaybackend.api.common.config.security.jwt.properties.JwtProperties;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * F#220 — 인증 진입점 4경로는 토큰을 검증하면 안 된다.
+ * <p>
+ * stale/무효 {@code SharedSessionToken} 쿠키가 {@code .pfplay.xyz}에 남아 있어도
+ * 로그인/로그아웃/oauth 진입점에서 데코레이터가 {@code null}을 반환해
+ * {@code BearerTokenAuthenticationFilter}가 인증을 시도하지 않게 한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class AuthEntryPointSkippingBearerTokenResolverTest {
+
+    @Mock
+    private BearerTokenResolverDelegateStub delegateProbe;
+
+    private CookieBearerTokenResolver realDelegate;
+    private AuthEntryPointSkippingBearerTokenResolver sut;
+
+    @BeforeEach
+    void setup() {
+        JwtProperties props = new JwtProperties();
+        props.getCookie().getAdmin().setName("AdminAccessToken");
+        props.getCookie().getShared().setName("SharedSessionToken");
+        realDelegate = new CookieBearerTokenResolver(props);
+        sut = new AuthEntryPointSkippingBearerTokenResolver(
+                AuthEntryPoints.requestMatcher(), realDelegate);
+    }
+
+    static String[] authEntryPaths() {
+        return new String[]{
+                "/api/v1/auth/admin/login",
+                "/api/v1/auth/logout",
+                "/api/v1/auth/oauth/callback",
+                "/api/v1/auth/oauth/url",
+        };
+    }
+
+    @Test
+    void all_four_entry_paths_with_stale_shared_cookie_resolve_to_null() {
+        for (String path : authEntryPaths()) {
+            MockHttpServletRequest req = new MockHttpServletRequest();
+            req.setServletPath(path);
+            req.setCookies(new Cookie("SharedSessionToken", "stale-or-invalid-jwt"));
+
+            assertThat(sut.resolve(req))
+                    .as("entry path %s must skip token resolution", path)
+                    .isNull();
+        }
+    }
+
+    @Test
+    void entry_path_does_not_consult_delegate() {
+        // Spy decorator built with a probe delegate to assert it is never called.
+        AuthEntryPointSkippingBearerTokenResolver spySut =
+                new AuthEntryPointSkippingBearerTokenResolver(
+                        AuthEntryPoints.requestMatcher(), delegateProbe);
+
+        for (String path : authEntryPaths()) {
+            MockHttpServletRequest req = new MockHttpServletRequest();
+            req.setServletPath(path);
+            req.setCookies(new Cookie("SharedSessionToken", "stale-jwt"));
+
+            assertThat(spySut.resolve(req)).isNull();
+        }
+        verifyNoInteractions(delegateProbe);
+    }
+
+    @Test
+    void entry_path_with_no_cookies_still_null() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setServletPath("/api/v1/auth/admin/login");
+
+        assertThat(sut.resolve(req)).isNull();
+    }
+
+    @Test
+    void entry_path_with_admin_cookie_is_cookie_agnostic_and_skips() {
+        // 진입점 skip은 쿠키 종류와 무관하다 — Shared가 아닌 AdminAccessToken 쿠키가
+        // 붙어 있어도 진입점에서는 토큰을 검증하지 않고 delegate도 호출하지 않는다.
+        AuthEntryPointSkippingBearerTokenResolver spySut =
+                new AuthEntryPointSkippingBearerTokenResolver(
+                        AuthEntryPoints.requestMatcher(), delegateProbe);
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setServletPath("/api/v1/auth/admin/login");
+        req.setCookies(new Cookie("AdminAccessToken", "admin-jwt"));
+
+        assertThat(spySut.resolve(req))
+                .as("entry path must skip regardless of cookie type")
+                .isNull();
+        verifyNoInteractions(delegateProbe);
+    }
+
+    @Test
+    void non_entry_admin_path_delegates_to_inner_resolver() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setServletPath("/api/v1/admin/users");
+        req.setCookies(
+                new Cookie("AdminAccessToken", "admin-jwt"),
+                new Cookie("SharedSessionToken", "shared-jwt")
+        );
+
+        // Inner resolver picks AdminAccessToken for /api/v1/admin/** — delegation intact.
+        assertThat(sut.resolve(req)).isEqualTo("admin-jwt");
+    }
+
+    @Test
+    void non_entry_user_path_delegates_to_inner_resolver() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setServletPath("/api/v1/users/me");
+        req.setCookies(new Cookie("SharedSessionToken", "shared-jwt"));
+
+        assertThat(sut.resolve(req)).isEqualTo("shared-jwt");
+    }
+
+    @Test
+    void non_entry_path_actually_invokes_delegate_once() {
+        when(delegateProbe.resolve(org.mockito.ArgumentMatchers.any()))
+                .thenReturn("delegated-token");
+        AuthEntryPointSkippingBearerTokenResolver spySut =
+                new AuthEntryPointSkippingBearerTokenResolver(
+                        AuthEntryPoints.requestMatcher(), delegateProbe);
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setServletPath("/api/v1/users/me");
+        req.setCookies(new Cookie("SharedSessionToken", "shared-jwt"));
+
+        assertThat(spySut.resolve(req)).isEqualTo("delegated-token");
+        verify(delegateProbe).resolve(req);
+        verify(delegateProbe, never()).resolve(null);
+    }
+
+    /**
+     * Probe interface so Mockito can verify the delegate is (not) consulted.
+     * Implements the same {@link org.springframework.security.oauth2.server.resource.web.BearerTokenResolver}
+     * contract the decorator delegates to.
+     */
+    interface BearerTokenResolverDelegateStub
+            extends org.springframework.security.oauth2.server.resource.web.BearerTokenResolver {
+    }
+}


### PR DESCRIPTION
## 배경 (#220, F/#220)

타환경(staging)/만료 `SharedSessionToken` 쿠키가 공유 도메인 `.pfplay.xyz` 에 잔존한 상태에서 prod 어드민 콘솔 로그인 시, `oauth2ResourceServer` 의 `BearerTokenAuthenticationFilter` 가 **인가 계층보다 앞단**에서 모든 요청에 대해 bearer 토큰을 resolve·검증한다. 인증 진입점(`/auth/admin/login`·`/auth/logout`·`/auth/oauth/callback`·`/auth/oauth/url`)은 `permitAll` 이지만, 헌 쿠키가 환경별 서명/issuer 불일치로 **무조건 검증 실패** → `permitAll` 적용 이전에 **401** → 쿠키 수동 삭제 전까지 어드민 로그인 불가.

## 변경 (사용자 승인 — 우아한 단일출처+데코레이터 설계)

1. **`AuthEntryPoints`** — 4 진입점 경로 **단일 출처**(`PATHS_INTERNAL` private + 방어적 복사 `paths()`). 내부 `RequestMatcher` 는 `CookieBearerTokenResolver` 의 경로표기(`getServletPath()` → empty 시 `getRequestURI()` → `AntPathMatcher`)를 **그대로 미러**. 미러 사유: wrapping 대상 delegate 와 **런타임 경로표기 일치 보장**(불일치 시 prod skip 무발동) — resolver byte-unchanged 위임상 공유추출 불가, Javadoc 명시.
2. **`AuthEntryPointSkippingBearerTokenResolver`** — 얇은 데코레이터. 진입점 매칭 시 `null` 반환(토큰 미해결 → 인증 미시도 → `permitAll` 적용), 그 외 `CookieBearerTokenResolver` 위임. **open/closed — 기존 resolver 무수정**.
3. **`SecurityConfig`** — 그 4경로 `permitAll` 을 `AuthEntryPoints.paths()` 로 교체(경로목록 중복 제거, 인가 동작 byte-동일), `oauth2ResourceServer().bearerTokenResolver(decorator)`. 다른 permitAll/role/filter/csrf 무변경, 순서 보존.

## 범위 밖 (이슈 명시, 미수정)

- `/api/v1/auth/admin/**`(login 외) shared-vs-admin 쿠키 인증 비대칭 → 별 이슈
- SecurityFilterChain 분할 안 함, CSRF post-processor·admin 필터 무변경

## 테스트

- `AuthEntryPointSkippingBearerTokenResolverTest` **7**: 4 진입점 stale 쿠키 → null·delegate 미상담 / 비진입점은 실 `CookieBearerTokenResolver` 로 위임(쿠키 path-aware 선택 검증) / 무쿠키 진입점 → null / 진입점 + AdminAccessToken → null(쿠키-무관 skip)
- `CookieBearerTokenResolverPathAwareTest` **4/4 무수정**(내부 resolver 의 쿠키선택 계약 불변 — `admin_login_path_falls_through_to_shared_cookie_lookup` 포함, 데코레이터가 null 반환하므로 여전히 정합)
- `:common` `:app` 전 unit GREEN, `AdminCsrfIntegrationTest`(실 `@SpringBootTest` 필터체인 부팅) 6/6

스펙·코드품질 2단 서브에이전트 리뷰 + 보강(방어적 복사·쿠키무관 회귀) 재반영 통과.

## 운영 메모

- prod 미반영 — develop 머지. **#220 은 prod ship 시 close 예정(#211/#212/#231 prod-close 컨벤션, develop 머지로는 OPEN 유지).**
- 검증: 배포 후 stale `.pfplay.xyz` 공유쿠키 보유 상태에서 admin 로그인 401 미발생 확인.