### PR TITLE
[Obs] Phase A 나머지 A2~A4 — access/admin 로그 + WS·messageId 체인 + 로깅 정책

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/GroupBroadcastTopicListener.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/GroupBroadcastTopicListener.java
@@ -21,6 +21,8 @@ public class GroupBroadcastTopicListener<T extends GroupBroadcastMessage> implem
     public void onMessage(Message message, byte[] pattern) {
         try {
             T msg = objectMapper.readValue(new String(message.getBody()), messageType);
+            log.info("[listener.onMessage] topic={}, type={}, partyroomId={}, messageId={}",
+                    new String(pattern), messageType.getSimpleName(), msg.partyroomId().getId(), msg.id());
             messageSender.sendToGroup(msg.partyroomId().getId(), msg);
         } catch (JsonProcessingException e) {
             log.error("Failed to deserialize {} message: {}", messageType.getSimpleName(), new String(message.getBody()), e);

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java
@@ -124,6 +124,9 @@ public class DjCommandService {
                 .orElseThrow(() -> ExceptionCreator.create(DjException.NOT_FOUND_DJ));
 
         boolean wasCurrentDj = playbackState.isActivated() && playbackState.isCurrentDj(targetDj.getCrewId());
+        log.info("[dequeueDj-admin] requestId={}, partyroomId={}, adjusterUserId={}, targetDjId={}, targetCrewId={}, wasCurrentDj={}",
+                RequestIdInterceptor.current(), partyroomId.getId(), authContext.getUserId().getUid(),
+                djId.getId(), targetDj.getCrewId().getId(), wasCurrentDj);
         partyroomAggregateService.removeDjFromQueue(partyroomId, targetDj.getCrewId());
 
         eventPublisher.publishEvent(new DjQueueChangedEvent(partyroom.getPartyroomId(), DjChangeType.DEQUEUE_ADMIN, targetDj.getCrewId()));

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
@@ -369,6 +369,8 @@ public class PartyroomAccessCommandService {
         PartyroomPlaybackData playbackState = aggregatePort.findPlaybackState(partyroom.getPartyroomId());
         boolean wasCurrentDj = playbackState.isActivated() && wasInDjQueue
                 && playbackState.isCurrentDj(crewId);
+        log.info("[handleDjQueueOnLeave] partyroomId={}, crewId={}, wasInDjQueue={}, wasCurrentDj={}",
+                partyroom.getPartyroomId().getId(), crewId.getId(), wasInDjQueue, wasCurrentDj);
 
         partyroomAggregateService.removeDjFromQueue(partyroom.getPartyroomId(), crewId);
 

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -80,6 +80,12 @@ logging:
   level:
     org.springframework.security: DEBUG
     org.springframework.web.reactive.function.client: DEBUG
+    # 비즈니스 critical-path 명시 INFO 고정 — Spring Boot 기본 변경에 영향받지 않게.
+    # profile별 logging.level 은 key 단위 merge 라 prod/staging 에도 상속된다.
+    com.pfplaybackend.api.party: INFO
+    com.pfplaybackend.api.administration: INFO
+    com.pfplaybackend.api.playlist: INFO
+    com.pfplaybackend.realtime: INFO
 
 service-api:
   pytube:
@@ -279,6 +285,7 @@ logging:
   level:
     org.springframework.security: INFO
     org.springframework.web.reactive.function.client: INFO
+    p6spy: WARN   # SQL 로그 누출 차단 (개발 편의는 local/dev 기본 INFO 유지)
 
 app:
   jwt:
@@ -339,6 +346,7 @@ logging:
   level:
     org.springframework.security: WARN
     org.springframework.web.reactive.function.client: WARN
+    p6spy: WARN   # prod SQL 로그 누출 차단
 
 app:
   jwt:

--- a/realtime/src/main/java/com/pfplaybackend/realtime/event/DisconnectionEventListener.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/event/DisconnectionEventListener.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
+import java.security.Principal;
+
 @Component
 @RequiredArgsConstructor
 public class DisconnectionEventListener implements ApplicationListener<SessionDisconnectEvent> {
@@ -20,10 +22,12 @@ public class DisconnectionEventListener implements ApplicationListener<SessionDi
     public void onApplicationEvent(SessionDisconnectEvent event) {
         StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
         String sessionId = headerAccessor.getSessionId();
+        Principal principal = headerAccessor.getUser();
+        String userId = principal != null ? principal.getName() : null;
         // PRESENCE: registry 권위로 위임. 세션 캐시 결합 제거 (Task 1.3에서 resolve가
         // user-session registry + DB authority로 전환됨).
         presencePort.onSessionDisconnected(sessionId);
-        logger.info("Web socket connection closed: {}", sessionId);
+        logger.info("Web socket connection closed: sessionId={}, userId={}", sessionId, userId);
 
         CloseStatus closeStatus = event.getCloseStatus();
         Integer closeStatusCode = closeStatus.getCode();

--- a/realtime/src/main/java/com/pfplaybackend/realtime/event/UnsubscriptionEventListener.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/event/UnsubscriptionEventListener.java
@@ -32,6 +32,6 @@ public class UnsubscriptionEventListener implements ApplicationListener<SessionU
         // self-heal되며 DisconnectionEventListener는 재추가하지 않는다 (#209 #31).
         sessionCachePort.deleteSessionCache(sessionId);
 
-        logger.info("Session has unsubscribed, sessionId : {}", sessionId);
+        logger.info("Session has unsubscribed, sessionId : {}, userId : {}", sessionId, principal.getName());
     }
 }


### PR DESCRIPTION
## 요약

Observability Phase A 의 나머지 backend 분(A2~A4). A1+A6 은 #210(PR #229) 으로 머지됨. 의존성/마이그레이션 zero, **행위 보존**(로그·설정만). 로드맵 C/T2-4. Closes #235 (prod ship 시 close 컨벤션 — develop 단계선 OPEN 유지).

## 변경

### A2 — access/admin 경로 로그
- `PartyroomAccessCommandService.handleDjQueueOnLeave`: `partyroomId/crewId/wasInDjQueue/wasCurrentDj` (DJ 큐 정리 발동 사후 확인)
- `DjCommandService.dequeueDj(admin)`: `requestId/partyroomId/adjusterUserId/targetDjId/targetCrewId/wasCurrentDj` (A1 requestId 컨벤션 일관)
- admin terminate 경로는 기존 `[AdminPartyroom.terminate]` 로그가 이미 crew 비활성 수를 커버 → 중복 로그 미추가

### A3 — realtime WS + 다운스트림 messageId
- `UnsubscriptionEventListener`/`DisconnectionEventListener` 로그에 `userId` 추가
- `GroupBroadcastTopicListener.onMessage` 에 `[listener.onMessage] topic/type/partyroomId/messageId` — A1 의 relay 로그와 동일 messageId 로 Redis hop 이후 chain 추적
- **모듈 경계 준수(계획 대비 의도적 조정)**: 계획 초안의 `RedisMessagePublisher`(common)·`SimpMessageSender`(realtime) 에 `instanceof GroupBroadcastMessage`(app) 추가는 잘못된 의존 방향(common/realtime → app)이라 **제외**. relay(step2, A1 완료)↔listener(step5) 로그 쌍으로 Redis hop latency·도달은 충분히 추적 가능

### A4 — `application.yml` 로깅 레벨 정책
- 비즈니스 패키지(`com.pfplaybackend.api.party/.administration/.playlist`, `com.pfplaybackend.realtime`) 명시 `INFO` — common 에 단일 배치(profile별 `logging.level` 은 key 단위 merge 라 prod/staging 상속)
- `p6spy` staging/prod `WARN` — 의도치 않은 SQL 로그 누출 차단. dev/local 은 개발 편의(기본 INFO) 유지

## 비범위(Phase B deferred)
- `eventLogicalKey` 의무화 (#210 review 에서 deferred)
- clock-skew/`estimatedServerTs` 등 분석 layer 보강
- frontend A5 (pfplay-web 별 PR)

## 검증
- 전 모듈 테스트 GREEN (JDK21, `./gradlew test` BUILD SUCCESSFUL) — 행위 보존
- 수동 acceptance: 로컬 docker-compose 에서 입/퇴장·admin dequeue·broadcast 시 해당 로그 라인 발생 확인 (운영자 절차)

🤖 Generated with [Claude Code](https://claude.com/claude-code)