### PR TITLE
feat(E/#3) PR-1: 길이초과 트랙 단위 스킵 + deactivate 조건 정정 (platform 핵심)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/PlaylistCommandAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/PlaylistCommandAdapter.java
@@ -11,6 +11,8 @@ import com.pfplaybackend.api.playlist.application.service.TrackCommandService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class PlaylistCommandAdapter implements PlaylistCommandPort {
@@ -25,7 +27,12 @@ public class PlaylistCommandAdapter implements PlaylistCommandPort {
     }
 
     @Override
-    public PlaybackTrackDto getFirstTrack(PlaylistId playlistId) {
-        return trackCommandService.getFirstTrack(playlistId.getId());
+    public List<PlaybackTrackDto> peekOrderedTracks(PlaylistId playlistId) {
+        return trackCommandService.peekOrderedTracks(playlistId.getId());
+    }
+
+    @Override
+    public void rotatePlayed(PlaylistId playlistId, int playedOrderNumber, long totalCount) {
+        trackCommandService.rotatePlayed(playlistId.getId(), playedOrderNumber, totalCount);
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/port/out/PlaylistCommandPort.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/port/out/PlaylistCommandPort.java
@@ -6,5 +6,6 @@ import com.pfplaybackend.api.playlist.application.dto.PlaybackTrackDto;
 
 public interface PlaylistCommandPort {
     AddedTrackInfo grabTrack(UserId userId, String linkId);
-    PlaybackTrackDto getFirstTrack(PlaylistId playlistId);
+    java.util.List<PlaybackTrackDto> peekOrderedTracks(PlaylistId playlistId);
+    void rotatePlayed(PlaylistId playlistId, int playedOrderNumber, long totalCount);
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java
@@ -93,7 +93,7 @@ public class PlaybackCommandService implements PlaybackControlPort {
         log.debug("[tryProceed] partyroomId={}, queueSize={}", partyroomId.getId(), queuedDjs.size());
 
         if(!queuedDjs.isEmpty()) {
-            doStart(partyroom, queuedDjs.size());
+            doStart(partyroom);
         }else{
             log.info("[tryProceed] EMPTY_QUEUE_DEACTIVATE - partyroomId={}", partyroomId.getId());
             deactivateAndNotify(partyroom);
@@ -102,68 +102,63 @@ public class PlaybackCommandService implements PlaybackControlPort {
 
     @Override
     public void startPlayback(PartyroomData partyroom) {
-        List<DjData> queuedDjs = aggregatePort.findDjsOrdered(partyroom.getPartyroomId());
-        doStart(partyroom, queuedDjs.size());
+        doStart(partyroom);
     }
 
-    private void doStart(PartyroomData partyroom, int remainingAttempts) {
+    private void doStart(PartyroomData partyroom) {
         long partyroomIdValue = partyroom.getPartyroomId().getId();
         List<DjData> rotatedDjs = partyroomAggregateService.rotateDjQueue(partyroom.getPartyroomId());
-        log.debug("[doStart] ENTER - partyroomId={}, remainingAttempts={}, queueSize={}",
-                partyroomIdValue, remainingAttempts, rotatedDjs.size());
-
-        DjData nextDj = rotatedDjs.stream()
-                .min(Comparator.comparingInt(DjData::getOrderNumber)).orElseThrow();
-        CrewData djCrew = aggregatePort.findCrewById(nextDj.getCrewId().getId()).orElseThrow();
-        PlaybackData nextPlayback = getNextPlaybackInPlaylist(partyroom.getPartyroomId(), nextDj, djCrew.getUserId());
-        long djCrewId = djCrew.getId();
-        String trackName = nextPlayback.getName();
-        long durationSec = nextPlayback.getDuration().toSeconds();
         int limitMin = partyroom.getPlaybackTimeLimit().getMinutes();
-        log.debug("[doStart] NEXT_TRACK - partyroomId={}, djCrewId={}, trackName={}, durationSec={}, limitMin={}",
-                partyroomIdValue, djCrewId, trackName, durationSec, limitMin);
+        log.debug("[doStart] ENTER - partyroomId={}, queueSize={}, limitMin={}",
+                partyroomIdValue, rotatedDjs.size(), limitMin);
 
-        if (partyroom.getPlaybackTimeLimit().exceedsDuration(nextPlayback.getDuration())) {
-            log.warn("[doStart] TRACK_EXCEEDS_LIMIT - partyroomId={}, djCrewId={}, trackName={}, durationSec={}, limitMin={}, remainingAttempts={}",
-                    partyroomIdValue, djCrewId, trackName, durationSec, limitMin, remainingAttempts);
-            if (remainingAttempts <= 1) {
-                log.warn("[doStart] DEACTIVATE_TRIGGERED - partyroomId={}, reason=ALL_TRACKS_EXCEEDED, lastTrackName={}, lastDurationSec={}, limitMin={}",
-                        partyroomIdValue, trackName, durationSec, limitMin);
-                deactivateAndNotify(partyroom);
-                return;
+        List<DjData> orderedDjs = rotatedDjs.stream()
+                .sorted(Comparator.comparingInt(DjData::getOrderNumber))
+                .toList();
+
+        for (DjData dj : orderedDjs) {
+            CrewData djCrew = aggregatePort.findCrewById(dj.getCrewId().getId()).orElseThrow();
+            long djCrewId = djCrew.getId();
+            List<PlaybackTrackDto> peeked = playlistCommandPort.peekOrderedTracks(dj.getPlaylistId());
+
+            PlaybackTrackDto chosen = peeked.stream()
+                    .filter(t -> !partyroom.getPlaybackTimeLimit().exceedsDuration(t.duration()))
+                    .findFirst()
+                    .orElse(null);
+
+            if (chosen == null) {
+                log.warn("[doStart] DJ_NO_PLAYABLE_TRACK - partyroomId={}, djCrewId={}, peekedCount={}, limitMin={} - skipping to next DJ",
+                        partyroomIdValue, djCrewId, peeked.size(), limitMin);
+                continue;
             }
-            PartyroomData reloaded = partyroomQueryService.getPartyroomById(partyroom.getPartyroomId());
-            List<DjData> remainingDjs = aggregatePort.findDjsOrdered(reloaded.getPartyroomId());
-            if (!remainingDjs.isEmpty()) {
-                log.debug("[doStart] RETRY_NEXT_DJ - partyroomId={}, remainingAttempts={}",
-                        partyroomIdValue, remainingAttempts - 1);
-                doStart(reloaded, remainingAttempts - 1);
-            } else {
-                deactivateAndNotify(reloaded);
-            }
+
+            log.debug("[doStart] PLAYABLE_TRACK - partyroomId={}, djCrewId={}, trackName={}, durationSec={}, orderNumber={}, limitMin={}",
+                    partyroomIdValue, djCrewId, chosen.name(), chosen.duration().toSeconds(), chosen.orderNumber(), limitMin);
+
+            PlaybackData nextPlayback = PlaybackData.create(partyroom.getPartyroomId(), djCrew.getUserId(),
+                    chosen.name(), chosen.duration(), chosen.linkId(), chosen.thumbnailImage(), clock.instant());
+            playlistCommandPort.rotatePlayed(dj.getPlaylistId(), chosen.orderNumber(), peeked.size());
+
+            PlaybackData playbackData = playbackRepository.save(nextPlayback);
+            playbackAggregationRepository.save(PlaybackAggregationData.createFor(new PlaybackId(playbackData.getId())));
+            // Update playback state in PARTYROOM_PLAYBACK
+            PartyroomPlaybackData playbackState = aggregatePort.findPlaybackState(partyroom.getPartyroomId());
+            playbackState.updatePlayback(new PlaybackId(playbackData.getId()), new CrewId(djCrew.getId()));
+            aggregatePort.savePlaybackState(playbackState);
+            // Schedule Task to wait for playback time
+            scheduleTask(nextPlayback);
+            // Propagation Websocket Event
+            PlaybackSnapshot snapshot = new PlaybackSnapshot(
+                    playbackData.getId(), playbackData.getLinkId(), playbackData.getName(),
+                    playbackData.getDuration().toDisplayString(), playbackData.getThumbnailImage(), playbackData.getEndTime());
+            eventPublisher.publishEvent(new PlaybackStartedEvent(partyroom.getPartyroomId(), new CrewId(djCrew.getId()), snapshot));
+            eventPublisher.publishEvent(new DjQueueChangedEvent(partyroom.getPartyroomId(), DjChangeType.ROTATE, new CrewId(djCrew.getId())));
             return;
         }
 
-        PlaybackData playbackData = playbackRepository.save(nextPlayback);
-        playbackAggregationRepository.save(PlaybackAggregationData.createFor(new PlaybackId(playbackData.getId())));
-        // Update playback state in PARTYROOM_PLAYBACK
-        PartyroomPlaybackData playbackState = aggregatePort.findPlaybackState(partyroom.getPartyroomId());
-        playbackState.updatePlayback(new PlaybackId(playbackData.getId()), new CrewId(djCrew.getId()));
-        aggregatePort.savePlaybackState(playbackState);
-        // Schedule Task to wait for playback time
-        scheduleTask(nextPlayback);
-        // Propagation Websocket Event
-        PlaybackSnapshot snapshot = new PlaybackSnapshot(
-                playbackData.getId(), playbackData.getLinkId(), playbackData.getName(),
-                playbackData.getDuration().toDisplayString(), playbackData.getThumbnailImage(), playbackData.getEndTime());
-        eventPublisher.publishEvent(new PlaybackStartedEvent(partyroom.getPartyroomId(), new CrewId(djCrew.getId()), snapshot));
-        eventPublisher.publishEvent(new DjQueueChangedEvent(partyroom.getPartyroomId(), DjChangeType.ROTATE, new CrewId(djCrew.getId())));
-    }
-
-    PlaybackData getNextPlaybackInPlaylist(PartyroomId partyroomId, DjData dj, UserId djUserId) {
-        PlaybackTrackDto trackDto = playlistCommandPort.getFirstTrack(dj.getPlaylistId());
-        return PlaybackData.create(partyroomId, djUserId,
-                trackDto.name(), trackDto.duration(), trackDto.linkId(), trackDto.thumbnailImage(), clock.instant());
+        log.warn("[doStart] DEACTIVATE_TRIGGERED - partyroomId={}, reason=ALL_DJS_NO_PLAYABLE_TRACK, queueSize={}, limitMin={}",
+                partyroomIdValue, orderedDjs.size(), limitMin);
+        deactivateAndNotify(partyroom);
     }
 
     @Transactional

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java
@@ -135,30 +135,34 @@ public class PlaybackCommandService implements PlaybackControlPort {
             log.debug("[doStart] PLAYABLE_TRACK - partyroomId={}, djCrewId={}, trackName={}, durationSec={}, orderNumber={}, limitMin={}",
                     partyroomIdValue, djCrewId, chosen.name(), chosen.duration().toSeconds(), chosen.orderNumber(), limitMin);
 
-            PlaybackData nextPlayback = PlaybackData.create(partyroom.getPartyroomId(), djCrew.getUserId(),
-                    chosen.name(), chosen.duration(), chosen.linkId(), chosen.thumbnailImage(), clock.instant());
-            playlistCommandPort.rotatePlayed(dj.getPlaylistId(), chosen.orderNumber(), peeked.size());
-
-            PlaybackData playbackData = playbackRepository.save(nextPlayback);
-            playbackAggregationRepository.save(PlaybackAggregationData.createFor(new PlaybackId(playbackData.getId())));
-            // Update playback state in PARTYROOM_PLAYBACK
-            PartyroomPlaybackData playbackState = aggregatePort.findPlaybackState(partyroom.getPartyroomId());
-            playbackState.updatePlayback(new PlaybackId(playbackData.getId()), new CrewId(djCrew.getId()));
-            aggregatePort.savePlaybackState(playbackState);
-            // Schedule Task to wait for playback time
-            scheduleTask(nextPlayback);
-            // Propagation Websocket Event
-            PlaybackSnapshot snapshot = new PlaybackSnapshot(
-                    playbackData.getId(), playbackData.getLinkId(), playbackData.getName(),
-                    playbackData.getDuration().toDisplayString(), playbackData.getThumbnailImage(), playbackData.getEndTime());
-            eventPublisher.publishEvent(new PlaybackStartedEvent(partyroom.getPartyroomId(), new CrewId(djCrew.getId()), snapshot));
-            eventPublisher.publishEvent(new DjQueueChangedEvent(partyroom.getPartyroomId(), DjChangeType.ROTATE, new CrewId(djCrew.getId())));
+            startPlaybackFor(partyroom, dj, djCrew, chosen, peeked.size());
             return;
         }
 
         log.warn("[doStart] DEACTIVATE_TRIGGERED - partyroomId={}, reason=ALL_DJS_NO_PLAYABLE_TRACK, queueSize={}, limitMin={}",
                 partyroomIdValue, orderedDjs.size(), limitMin);
         deactivateAndNotify(partyroom);
+    }
+
+    private void startPlaybackFor(PartyroomData partyroom, DjData dj, CrewData djCrew, PlaybackTrackDto chosen, long total) {
+        PlaybackData nextPlayback = PlaybackData.create(partyroom.getPartyroomId(), djCrew.getUserId(),
+                chosen.name(), chosen.duration(), chosen.linkId(), chosen.thumbnailImage(), clock.instant());
+        playlistCommandPort.rotatePlayed(dj.getPlaylistId(), chosen.orderNumber(), total);
+
+        PlaybackData playbackData = playbackRepository.save(nextPlayback);
+        playbackAggregationRepository.save(PlaybackAggregationData.createFor(new PlaybackId(playbackData.getId())));
+        // Update playback state in PARTYROOM_PLAYBACK
+        PartyroomPlaybackData playbackState = aggregatePort.findPlaybackState(partyroom.getPartyroomId());
+        playbackState.updatePlayback(new PlaybackId(playbackData.getId()), new CrewId(djCrew.getId()));
+        aggregatePort.savePlaybackState(playbackState);
+        // Schedule Task to wait for playback time
+        scheduleTask(nextPlayback);
+        // Propagation Websocket Event
+        PlaybackSnapshot snapshot = new PlaybackSnapshot(
+                playbackData.getId(), playbackData.getLinkId(), playbackData.getName(),
+                playbackData.getDuration().toDisplayString(), playbackData.getThumbnailImage(), playbackData.getEndTime());
+        eventPublisher.publishEvent(new PlaybackStartedEvent(partyroom.getPartyroomId(), new CrewId(djCrew.getId()), snapshot));
+        eventPublisher.publishEvent(new DjQueueChangedEvent(partyroom.getPartyroomId(), DjChangeType.ROTATE, new CrewId(djCrew.getId())));
     }
 
     @Transactional

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackCommandServiceTest.java
@@ -15,6 +15,7 @@ import com.pfplaybackend.api.party.application.port.out.PlaylistCommandPort;
 import com.pfplaybackend.api.party.application.port.out.UserActivityPort;
 import com.pfplaybackend.api.party.domain.entity.data.*;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
+import com.pfplaybackend.api.party.domain.event.PlaybackStartedEvent;
 import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
 import com.pfplaybackend.api.party.domain.service.PartyroomAggregateService;
 import com.pfplaybackend.api.party.domain.value.CrewId;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -184,7 +186,7 @@ class PlaybackCommandServiceTest {
         when(aggregatePort.findCrewById(1L)).thenReturn(Optional.of(djCrew));
 
         PlaybackTrackDto trackDto = new PlaybackTrackDto("linkId", "Song", "thumb.jpg", Duration.fromString("3:30"), 1);
-        when(playlistCommandPort.getFirstTrack(playlistId)).thenReturn(trackDto);
+        when(playlistCommandPort.peekOrderedTracks(playlistId)).thenReturn(List.of(trackDto));
 
         PlaybackData savedPlayback = mock(PlaybackData.class);
         lenient().when(savedPlayback.getId()).thenReturn(1L);
@@ -208,9 +210,9 @@ class PlaybackCommandServiceTest {
 
     // ── #222 회귀 잠금: skip(자의/타의) 시 DJ큐 회전 + 본인 플레이리스트 회전이 함께 wiring 되는지 ──
     // DJ큐 산술(#1→맨뒤)은 PartyroomAggregateServiceTest.rotatesCorrectly,
-    // 트랙 회전 SQL(orderNumber=1→total)은 TrackRepositoryReorderIntegrationTest 가 별도로 잠금.
-    // 여기서는 "skip 경로가 rotateDjQueue + getFirstTrack(현재 DJ 플레이리스트) 양쪽을 호출한다"는
-    // 수렴 지점의 invariant 를 잠근다.
+    // 트랙 회전 SQL(played→맨뒤)은 TrackRepositoryReorderIntegrationTest 가 별도로 잠금.
+    // 여기서는 "skip 경로가 rotateDjQueue + peekOrderedTracks/rotatePlayed(현재 DJ 플레이리스트)
+    // 양쪽을 호출한다"는 수렴 지점의 invariant 를 잠근다.
 
     private DjData stubDoStartWithQueuedDj(PlaybackTimeLimit timeLimit, Duration trackDuration) {
         PartyroomData partyroom = PartyroomData.builder()
@@ -231,12 +233,12 @@ class PlaybackCommandServiceTest {
         when(aggregatePort.findCrewById(1L)).thenReturn(Optional.of(djCrew));
 
         PlaybackTrackDto trackDto = new PlaybackTrackDto("linkId", "Song", "thumb.jpg", trackDuration, 1);
-        when(playlistCommandPort.getFirstTrack(playlistId)).thenReturn(trackDto);
+        when(playlistCommandPort.peekOrderedTracks(playlistId)).thenReturn(List.of(trackDto));
         return djData;
     }
 
     @Test
-    @DisplayName("#222 skipPlayback — 큐에 DJ가 있으면 DJ큐 회전과 현재 DJ 플레이리스트 회전(getFirstTrack)이 함께 호출된다")
+    @DisplayName("#222 skipPlayback — 큐에 DJ가 있으면 DJ큐 회전과 현재 DJ 플레이리스트 회전(rotatePlayed)이 함께 호출된다")
     void skipPlaybackWithQueuedDjRotatesQueueAndPlaylist() {
         // given — 트랙 길이가 제한 이내(재생됨)
         DjData dj = stubDoStartWithQueuedDj(PlaybackTimeLimit.ofMinutes(10), Duration.fromString("3:30"));
@@ -251,13 +253,15 @@ class PlaybackCommandServiceTest {
         playbackCommandService.skipPlayback(partyroomId);
 
         // then — 스케줄 취소 + DJ큐 밀림 + 트랙 회전 양쪽 wiring
+        // position-1 트랙(orderNumber=1, size=1)이 제한 이내라 그대로 선택 → rotatePlayed(pl,1,1)
         verify(expirationTaskPort).cancelExpiration(String.valueOf(partyroomId.getId()));
         verify(partyroomAggregateService).rotateDjQueue(partyroomId);
-        verify(playlistCommandPort).getFirstTrack(dj.getPlaylistId());
+        verify(playlistCommandPort).peekOrderedTracks(dj.getPlaylistId());
+        verify(playlistCommandPort).rotatePlayed(dj.getPlaylistId(), 1, 1L);
     }
 
     @Test
-    @DisplayName("#222 skipByManager — MODERATOR 타의 skip 도 DJ큐 회전 + 플레이리스트 회전을 함께 호출한다")
+    @DisplayName("#222 skipByManager — MODERATOR 타의 skip 도 DJ큐 회전 + 플레이리스트 회전(rotatePlayed)을 함께 호출한다")
     void skipByManagerWithQueuedDjRotatesQueueAndPlaylist() {
         // given — MODERATOR 권한 컨텍스트
         ActivePartyroomDto activeDto = new ActivePartyroomDto(partyroomId.getId(), false, 1L, true, new PlaybackId(1L), new CrewId(1L));
@@ -279,25 +283,149 @@ class PlaybackCommandServiceTest {
         // then
         verify(expirationTaskPort).cancelExpiration(String.valueOf(partyroomId.getId()));
         verify(partyroomAggregateService).rotateDjQueue(partyroomId);
-        verify(playlistCommandPort).getFirstTrack(dj.getPlaylistId());
+        verify(playlistCommandPort).peekOrderedTracks(dj.getPlaylistId());
+        verify(playlistCommandPort).rotatePlayed(dj.getPlaylistId(), 1, 1L);
     }
 
+    // ── E/#3 트랙단위 스킵 동작 잠금 ──
+
     @Test
-    @DisplayName("#222 time-limit edge — 트랙이 제한을 초과하면 재생되지 않아도 getFirstTrack(플레이리스트 회전)은 이미 호출된다 (의도된 동작)")
-    void timeLimitExceededStillRotatesPlaylistBeforeCheck() {
-        // given — 단일 DJ, 트랙 길이(3:30=210s)가 제한(1분=60s)을 초과 → 재생 안 됨
-        // doStart 는 getFirstTrack(플레이리스트 회전) 호출 '후' time-limit 검사 → 회전은 이미 발생.
-        // remainingAttempts(=큐 size=1) <= 1 이므로 deactivate. 첫 DJ silent deactivate 패턴과 정렬된 의도 동작.
-        DjData dj = stubDoStartWithQueuedDj(PlaybackTimeLimit.ofMinutes(1), Duration.fromString("3:30"));
+    @DisplayName("E/#3 singleDj_allOverLimit — 단일 DJ의 트랙이 모두 제한 초과면 deactivate, rotatePlayed 미호출")
+    void singleDj_allOverLimit_deactivates() {
+        // given — 단일 DJ, peek 트랙이 전부 제한(1분=60s) 초과
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(partyroomId.getId()).partyroomId(partyroomId)
+                .playbackTimeLimit(PlaybackTimeLimit.ofMinutes(1))
+                .build();
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+
+        PlaylistId playlistId = new PlaylistId(100L);
+        DjData dj = DjData.builder()
+                .id(1L).partyroomId(partyroomId).crewId(new CrewId(1L))
+                .playlistId(playlistId).orderNumber(1).build();
+        when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(List.of(dj));
+        when(partyroomAggregateService.rotateDjQueue(partyroomId)).thenReturn(List.of(dj));
+
+        CrewData djCrew = CrewData.builder()
+                .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+        when(aggregatePort.findCrewById(1L)).thenReturn(Optional.of(djCrew));
+
+        List<PlaybackTrackDto> overLimit = List.of(
+                new PlaybackTrackDto("l1", "T1", "t1.jpg", Duration.fromString("3:30"), 1),
+                new PlaybackTrackDto("l2", "T2", "t2.jpg", Duration.fromString("4:00"), 2));
+        when(playlistCommandPort.peekOrderedTracks(playlistId)).thenReturn(overLimit);
 
         // when — 자의 skip
         playbackCommandService.skipPlayback(partyroomId);
 
-        // then — 트랙은 재생 안 됨(save 미호출)이나 플레이리스트 회전은 이미 발생, 큐도 회전, 이후 deactivate
-        verify(playlistCommandPort).getFirstTrack(dj.getPlaylistId());
-        verify(partyroomAggregateService).rotateDjQueue(partyroomId);
-        verify(playbackRepository, never()).save(any(PlaybackData.class));
+        // then — deactivate, save/rotatePlayed 미호출(peek 부수효과 없음)
         verify(partyroomAggregateService).deactivatePlayback(partyroomId);
+        verify(playbackRepository, never()).save(any(PlaybackData.class));
+        verify(playlistCommandPort, never()).rotatePlayed(any(PlaylistId.class), anyInt(), anyLong());
+    }
+
+    @Test
+    @DisplayName("E/#3 singleDj_skipsOverLimit — 제한 초과 트랙은 건너뛰고 첫 재생가능 트랙을 재생한다")
+    void singleDj_skipsOverLimit_playsFirstPlayable() {
+        // given — 단일 DJ, peek=[t1 초과, t2 이내] (제한 5분=300s)
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(partyroomId.getId()).partyroomId(partyroomId)
+                .playbackTimeLimit(PlaybackTimeLimit.ofMinutes(5))
+                .build();
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+
+        PlaylistId playlistId = new PlaylistId(100L);
+        DjData dj = DjData.builder()
+                .id(1L).partyroomId(partyroomId).crewId(new CrewId(1L))
+                .playlistId(playlistId).orderNumber(1).build();
+        when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(List.of(dj));
+        when(partyroomAggregateService.rotateDjQueue(partyroomId)).thenReturn(List.of(dj));
+
+        CrewData djCrew = CrewData.builder()
+                .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+        when(aggregatePort.findCrewById(1L)).thenReturn(Optional.of(djCrew));
+
+        PlaybackTrackDto overLimit = new PlaybackTrackDto("over", "Over", "o.jpg", Duration.fromString("6:00"), 1);
+        PlaybackTrackDto playable = new PlaybackTrackDto("ok", "Playable", "p.jpg", Duration.fromString("3:00"), 2);
+        when(playlistCommandPort.peekOrderedTracks(playlistId)).thenReturn(List.of(overLimit, playable));
+
+        PlaybackData savedPlayback = mock(PlaybackData.class);
+        lenient().when(savedPlayback.getId()).thenReturn(1L);
+        lenient().when(savedPlayback.getLinkId()).thenReturn("ok");
+        lenient().when(savedPlayback.getName()).thenReturn("Playable");
+        lenient().when(savedPlayback.getDuration()).thenReturn(Duration.ofSeconds(180));
+        lenient().when(savedPlayback.getThumbnailImage()).thenReturn("p.jpg");
+        lenient().when(savedPlayback.getEndTime()).thenReturn(9999L);
+        ArgumentCaptor<PlaybackData> playbackCaptor = ArgumentCaptor.forClass(PlaybackData.class);
+        when(playbackRepository.save(playbackCaptor.capture())).thenReturn(savedPlayback);
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(PartyroomPlaybackData.createFor(partyroomId));
+
+        // when — 자의 skip
+        playbackCommandService.skipPlayback(partyroomId);
+
+        // then — t2(orderNumber=2) 재생 + rotatePlayed(pl,2,2), deactivate 미호출
+        PlaybackData saved = playbackCaptor.getValue();
+        assertThat(saved.getLinkId()).isEqualTo("ok");
+        assertThat(saved.getName()).isEqualTo("Playable");
+        verify(playlistCommandPort).rotatePlayed(playlistId, 2, 2L);
+        verify(eventPublisher).publishEvent(any(PlaybackStartedEvent.class));
+        verify(partyroomAggregateService, never()).deactivatePlayback(any(PartyroomId.class));
+    }
+
+    @Test
+    @DisplayName("E/#3 multiDj_firstDjAllOverLimit — 첫 DJ가 전부 초과면 다음 DJ로 넘어가 재생(rotateDjQueue 1회)")
+    void multiDj_firstDjAllOverLimit_playsNextDj() {
+        // given — 큐 [dj1(전부 초과), dj2(재생가능)], 제한 5분=300s
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(partyroomId.getId()).partyroomId(partyroomId)
+                .playbackTimeLimit(PlaybackTimeLimit.ofMinutes(5))
+                .build();
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+
+        PlaylistId pl1 = new PlaylistId(101L);
+        PlaylistId pl2 = new PlaylistId(102L);
+        DjData dj1 = DjData.builder()
+                .id(1L).partyroomId(partyroomId).crewId(new CrewId(1L))
+                .playlistId(pl1).orderNumber(1).build();
+        DjData dj2 = DjData.builder()
+                .id(2L).partyroomId(partyroomId).crewId(new CrewId(2L))
+                .playlistId(pl2).orderNumber(2).build();
+        when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(List.of(dj1, dj2));
+        when(partyroomAggregateService.rotateDjQueue(partyroomId)).thenReturn(List.of(dj1, dj2));
+
+        CrewData djCrew1 = CrewData.builder()
+                .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+        CrewData djCrew2 = CrewData.builder()
+                .id(2L).partyroomId(partyroomId).userId(new UserId(2L)).gradeType(GradeType.CLUBBER).build();
+        when(aggregatePort.findCrewById(1L)).thenReturn(Optional.of(djCrew1));
+        when(aggregatePort.findCrewById(2L)).thenReturn(Optional.of(djCrew2));
+
+        when(playlistCommandPort.peekOrderedTracks(pl1)).thenReturn(List.of(
+                new PlaybackTrackDto("o1", "Over1", "o1.jpg", Duration.fromString("6:00"), 1)));
+        when(playlistCommandPort.peekOrderedTracks(pl2)).thenReturn(List.of(
+                new PlaybackTrackDto("ok2", "Playable2", "p2.jpg", Duration.fromString("3:00"), 1)));
+
+        PlaybackData savedPlayback = mock(PlaybackData.class);
+        lenient().when(savedPlayback.getId()).thenReturn(1L);
+        lenient().when(savedPlayback.getLinkId()).thenReturn("ok2");
+        lenient().when(savedPlayback.getName()).thenReturn("Playable2");
+        lenient().when(savedPlayback.getDuration()).thenReturn(Duration.ofSeconds(180));
+        lenient().when(savedPlayback.getThumbnailImage()).thenReturn("p2.jpg");
+        lenient().when(savedPlayback.getEndTime()).thenReturn(9999L);
+        ArgumentCaptor<PlaybackData> playbackCaptor = ArgumentCaptor.forClass(PlaybackData.class);
+        when(playbackRepository.save(playbackCaptor.capture())).thenReturn(savedPlayback);
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(PartyroomPlaybackData.createFor(partyroomId));
+
+        // when — 자의 skip
+        playbackCommandService.skipPlayback(partyroomId);
+
+        // then — dj2 트랙 재생 + rotateDjQueue 정확히 1회(이중 회전 없음), deactivate 미호출
+        PlaybackData saved = playbackCaptor.getValue();
+        assertThat(saved.getLinkId()).isEqualTo("ok2");
+        verify(playlistCommandPort).rotatePlayed(pl2, 1, 1L);
+        verify(playlistCommandPort, never()).rotatePlayed(eq(pl1), anyInt(), anyLong());
+        verify(partyroomAggregateService, times(1)).rotateDjQueue(partyroomId);
+        verify(partyroomAggregateService, never()).deactivatePlayback(any(PartyroomId.class));
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepositoryReorderIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepositoryReorderIntegrationTest.java
@@ -123,4 +123,64 @@ class TrackRepositoryReorderIntegrationTest extends AbstractIntegrationTest {
                 trackRepository.findById(c.getId()).orElseThrow().getOrderNumber());
         assertThat(orders).containsExactly(2, 3, 1);
     }
+
+    // ===== rotatePlayedOrder (E/#3: over-limit skip — k번째 재생 트랙을 최하단으로) =====
+
+    @Test
+    @DisplayName("rotatePlayedOrder(k>1) — k번 트랙은 최하단, k 이전은 불변, k 이후는 -1 (갭 없음)")
+    void rotatePlayedOrder_k_gt_1() {
+        // given — 플레이리스트 5트랙 [1,2,3,4,5]
+        long playlistId = 9500L;
+        TrackData t1 = saveTrack(playlistId, 1, "r-link-1");
+        TrackData t2 = saveTrack(playlistId, 2, "r-link-2");
+        TrackData t3 = saveTrack(playlistId, 3, "r-link-3");
+        TrackData t4 = saveTrack(playlistId, 4, "r-link-4");
+        TrackData t5 = saveTrack(playlistId, 5, "r-link-5");
+        flushAndClear();
+
+        // when — k=3 재생 트랙 최하단 이동 (total=5)
+        trackRepository.rotatePlayedOrder(playlistId, 3, 5L);
+        flushAndClear();
+
+        // then — 갭/중복 없음: 결과 orderNumber 집합 = [1,2,3,4,5]
+        List<Integer> allOrders = List.of(
+                trackRepository.findById(t1.getId()).orElseThrow().getOrderNumber(),
+                trackRepository.findById(t2.getId()).orElseThrow().getOrderNumber(),
+                trackRepository.findById(t3.getId()).orElseThrow().getOrderNumber(),
+                trackRepository.findById(t4.getId()).orElseThrow().getOrderNumber(),
+                trackRepository.findById(t5.getId()).orElseThrow().getOrderNumber());
+        assertThat(allOrders).containsExactlyInAnyOrder(1, 2, 3, 4, 5);
+
+        // then — 개별 이동 검증
+        // k < 3: 불변
+        assertThat(trackRepository.findById(t1.getId()).orElseThrow().getOrderNumber()).isEqualTo(1);
+        assertThat(trackRepository.findById(t2.getId()).orElseThrow().getOrderNumber()).isEqualTo(2);
+        // k = 3: 최하단(5)으로
+        assertThat(trackRepository.findById(t3.getId()).orElseThrow().getOrderNumber()).isEqualTo(5);
+        // k > 3: 한 칸씩 앞으로
+        assertThat(trackRepository.findById(t4.getId()).orElseThrow().getOrderNumber()).isEqualTo(3);
+        assertThat(trackRepository.findById(t5.getId()).orElseThrow().getOrderNumber()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("rotatePlayedOrder(k=1) — reorderTracks(pid, total)과 산술적으로 동일")
+    void rotatePlayedOrder_k_eq_1_equivalent_to_legacy_reorder() {
+        // given — 플레이리스트 4트랙 [1,2,3,4]
+        long playlistId = 9600L;
+        TrackData t1 = saveTrack(playlistId, 1, "s-link-1");
+        TrackData t2 = saveTrack(playlistId, 2, "s-link-2");
+        TrackData t3 = saveTrack(playlistId, 3, "s-link-3");
+        TrackData t4 = saveTrack(playlistId, 4, "s-link-4");
+        flushAndClear();
+
+        // when — k=1 (reorderTracks 와 동등)
+        trackRepository.rotatePlayedOrder(playlistId, 1, 4L);
+        flushAndClear();
+
+        // then — old-1→4, old-2→1, old-3→2, old-4→3 (legacy reorderTracks 결과와 동일)
+        assertThat(trackRepository.findById(t1.getId()).orElseThrow().getOrderNumber()).isEqualTo(4);
+        assertThat(trackRepository.findById(t2.getId()).orElseThrow().getOrderNumber()).isEqualTo(1);
+        assertThat(trackRepository.findById(t3.getId()).orElseThrow().getOrderNumber()).isEqualTo(2);
+        assertThat(trackRepository.findById(t4.getId()).orElseThrow().getOrderNumber()).isEqualTo(3);
+    }
 }

--- a/app/src/test/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepositoryReorderIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepositoryReorderIntegrationTest.java
@@ -15,12 +15,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * #222 회귀 잠금 — skip(자의/타의/time-limit) 시 "재생된 트랙이 본인 플레이리스트 최하단으로" invariant 의
- * 산술 핵심인 {@link TrackRepository#reorderTracks} 의 SQL 동작을 잠근다.
+ * 산술 핵심인 {@link TrackRepository#rotatePlayedOrder} 의 SQL 동작을 잠근다.
  *
- * <p>이 동작은 명시적 "skip→재정렬" 로직이 아니라 재생 시작(getFirstTrack)의 부수효과라
- * 회귀 테스트로 묶지 않으면 재생/큐 로직 리팩터 시 조용히 깨질 수 있다.
- * DJ 큐 회전 산술은 PartyroomAggregateServiceTest.rotatesCorrectly,
- * getFirstTrack wiring 은 TrackCommandServiceTest.getFirstTrackReturnsFirstTrackAndRotates 가 별도로 잠금.
+ * <p>E/#3 에서 legacy {@code reorderTracks} 는 단일 CASE {@code rotatePlayedOrder} 로 일반화되어 제거됐다.
+ * k=1 케이스가 legacy reorderTracks(pid, total) 와 산술적으로 동일함은
+ * {@link #rotatePlayedOrder_k_eq_1_equivalent_to_legacy_reorder} 가 명시적으로 잠근다.
+ * DJ 큐 회전 산술은 PartyroomAggregateServiceTest.rotatesCorrectly 가 별도로 잠금.
  */
 @Transactional
 class TrackRepositoryReorderIntegrationTest extends AbstractIntegrationTest {
@@ -37,91 +37,6 @@ class TrackRepositoryReorderIntegrationTest extends AbstractIntegrationTest {
                 .duration(Duration.fromString("3:30"))
                 .thumbnailImage("thumb.jpg")
                 .build());
-    }
-
-    @Test
-    @DisplayName("reorderTracks — orderNumber=1 트랙은 맨 뒤(total)로, 나머지는 한 칸씩 앞으로 이동한다")
-    void rotatesFirstTrackToBottom() {
-        // given — 한 플레이리스트의 트랙 순서 [1,2,3,4]
-        long playlistId = 9001L;
-        TrackData t1 = saveTrack(playlistId, 1, "link-1");
-        TrackData t2 = saveTrack(playlistId, 2, "link-2");
-        TrackData t3 = saveTrack(playlistId, 3, "link-3");
-        TrackData t4 = saveTrack(playlistId, 4, "link-4");
-        flushAndClear();
-
-        // when — 재생 시작 시점에 호출되는 회전 (total=4)
-        trackRepository.reorderTracks(playlistId, 4L);
-        flushAndClear();
-
-        // then — 재생된 #1 트랙이 최하단으로, 나머지는 -1
-        assertThat(trackRepository.findById(t1.getId()).orElseThrow().getOrderNumber()).isEqualTo(4);
-        assertThat(trackRepository.findById(t2.getId()).orElseThrow().getOrderNumber()).isEqualTo(1);
-        assertThat(trackRepository.findById(t3.getId()).orElseThrow().getOrderNumber()).isEqualTo(2);
-        assertThat(trackRepository.findById(t4.getId()).orElseThrow().getOrderNumber()).isEqualTo(3);
-    }
-
-    @Test
-    @DisplayName("reorderTracks — 다른 플레이리스트의 트랙 순서는 영향받지 않는다 (playlist_id 격리)")
-    void doesNotAffectOtherPlaylists() {
-        // given
-        long target = 9100L;
-        long other = 9200L;
-        TrackData targetFirst = saveTrack(target, 1, "t-link-1");
-        TrackData targetSecond = saveTrack(target, 2, "t-link-2");
-        TrackData otherFirst = saveTrack(other, 1, "o-link-1");
-        TrackData otherSecond = saveTrack(other, 2, "o-link-2");
-        flushAndClear();
-
-        // when
-        trackRepository.reorderTracks(target, 2L);
-        flushAndClear();
-
-        // then — target 만 회전, other 는 불변
-        assertThat(trackRepository.findById(targetFirst.getId()).orElseThrow().getOrderNumber()).isEqualTo(2);
-        assertThat(trackRepository.findById(targetSecond.getId()).orElseThrow().getOrderNumber()).isEqualTo(1);
-        assertThat(trackRepository.findById(otherFirst.getId()).orElseThrow().getOrderNumber()).isEqualTo(1);
-        assertThat(trackRepository.findById(otherSecond.getId()).orElseThrow().getOrderNumber()).isEqualTo(2);
-    }
-
-    @Test
-    @DisplayName("reorderTracks — 단일 트랙(total=1)이면 orderNumber=1 그대로 (skip 후 같은 트랙 재생, 의도된 동작)")
-    void singleTrackStaysAtOne() {
-        // given
-        long playlistId = 9300L;
-        TrackData only = saveTrack(playlistId, 1, "only-link");
-        flushAndClear();
-
-        // when
-        trackRepository.reorderTracks(playlistId, 1L);
-        flushAndClear();
-
-        // then — CASE WHEN orderNumber=1 THEN 1: 그대로. 트랙이 하나면 skip 해도 같은 트랙
-        assertThat(trackRepository.findById(only.getId()).orElseThrow().getOrderNumber()).isEqualTo(1);
-    }
-
-    @Test
-    @DisplayName("reorderTracks — 회전을 두 번 적용하면 #1·#2가 차례로 최하단으로 (skip 누적 시 순서 보존)")
-    void repeatedRotationPreservesCyclicOrder() {
-        // given — [1,2,3]
-        long playlistId = 9400L;
-        TrackData a = saveTrack(playlistId, 1, "a");
-        TrackData b = saveTrack(playlistId, 2, "b");
-        TrackData c = saveTrack(playlistId, 3, "c");
-        flushAndClear();
-
-        // when — 연속 skip 2회
-        trackRepository.reorderTracks(playlistId, 3L); // a:1->3, b:2->1, c:3->2
-        flushAndClear();
-        trackRepository.reorderTracks(playlistId, 3L); // b:1->3, c:2->1, a:3->2
-        flushAndClear();
-
-        // then — 순환 순서 보존 (b가 최하단, c가 다음 재생 대상)
-        List<Integer> orders = List.of(
-                trackRepository.findById(a.getId()).orElseThrow().getOrderNumber(),
-                trackRepository.findById(b.getId()).orElseThrow().getOrderNumber(),
-                trackRepository.findById(c.getId()).orElseThrow().getOrderNumber());
-        assertThat(orders).containsExactly(2, 3, 1);
     }
 
     // ===== rotatePlayedOrder (E/#3: over-limit skip — k번째 재생 트랙을 최하단으로) =====

--- a/docs/superpowers/plans/2026-05-19-e3-pr1-track-skip-deactivate.md
+++ b/docs/superpowers/plans/2026-05-19-e3-pr1-track-skip-deactivate.md
@@ -31,7 +31,17 @@
 
 ### Task 1: `rotatePlayed` 영속 계층 (TrackRepository + port + adapter)
 
-`rotatePlayed(playlistId, k)` 알고리즘: total=count → `shiftUpOrderByDelete(playlistId, k)`(orderNumber>k → -1) → 재생트랙(orderNumber=k, >k 아니라 미변경)을 orderNumber=total 로. orderNumber<k(over-limit 제자리) 불변. 갭/충돌 없음. k=1 이면 기존 `reorderTracks`(`1→total, rest -1`)와 산술 동일(#222 position-1 보존).
+`rotatePlayed(playlistId, k, total)` 알고리즘 = **단일 set-based CASE** (기존
+`reorderTracks` 가 이미 CASE 인 패턴의 일반화 — 코드베이스 정합·증명가능).
+~~두 문장 조합(shiftUpOrderByDelete+append)~~ 은 **부정확**: shift 가 old-(k+1)
+을 orderNumber=k 로 옮겨 `WHERE orderNumber=k` 가 재생행+old-(k+1) 둘 다
+매칭(중복/갭). 단일 CASE 는 pre-state 기준 atomic 평가라 충돌 없음:
+`WHEN orderNumber=k THEN total / WHEN orderNumber>k THEN -1 / ELSE 불변`.
+- k=1: `WHEN 1 THEN total / >1 THEN -1 / else(공집합)` = 기존
+  `reorderTracks`(`WHEN 1 THEN total ELSE -1`)와 **산술 동일** (#222
+  position-1 보존, 증명: 시작 `[1,2,3,4]` → 둘 다 `{4,1,2,3}`).
+- k=3,total=5 `[1,2,3✱,4,5]` → `{1,2,5,3,4}` = 정렬 시 1..5 갭없음, 재생행
+  tail, over-limit(<k) 제자리, >k −1. ✓
 
 **Files:**
 - Modify: `playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepository.java`
@@ -43,49 +53,46 @@
 
 ```java
 @Test
-@DisplayName("rotatePlayed: k>1 — 재생트랙만 tail, k 이전(over-limit 제자리) 불변, k 이후 -1")
-void rotatePlayed_k_gt_1_moves_played_to_tail_keeps_before_intact() {
-    // given: playlist P 에 트랙 5개 orderNumber 1..5 (헬퍼는 기존 테스트 방식 재사용)
-    Long pid = seedPlaylistWithTracks(5); // 기존 헬퍼 없으면 기존 seed 패턴대로 5개 삽입
-    // when: orderNumber=3 인 트랙을 재생했다고 가정
-    trackRepository.shiftUpOrderByDelete(pid, 3);   // 4->3, 5->4
-    trackRepository.appendOrderToTail(pid, 3, 5);   // 옛 orderNumber=3 → 5
-
-    // then: [1,2 불변], [옛4->3, 옛5->4], [옛3->5]
-    List<TrackData> ordered = trackRepository.findByPlaylistId... // 기존 조회 방식
-        .stream().sorted(comparingInt(t -> t.getOrderNumber())).toList();
-    assertThat(ordered).extracting(TrackData::getOrderNumber).containsExactly(1,2,3,4,5);
-    // 옛 orderNumber=1,2 트랙 식별자가 여전히 1,2 위치 (linkId 등으로 검증)
-    // 옛 orderNumber=3 트랙이 이제 orderNumber=5
+@DisplayName("rotatePlayedOrder: k>1 — 재생행 tail, <k(over-limit) 제자리, >k -1, 갭없음")
+void rotatePlayedOrder_k_gt_1() {
+    Long pid = seedPlaylistWithTracks(5); // 기존 파일의 seed 패턴 그대로(신규 헬퍼 금지)
+    // 옛 orderNumber 1..5 트랙의 linkId 를 사전 캡처(검증용)
+    trackRepository.rotatePlayedOrder(pid, 3, 5L);
+    List<TrackData> ordered = /* 기존 조회 방식 */ .stream()
+        .sorted(comparingInt(TrackData::getOrderNumber)).toList();
+    assertThat(ordered).extracting(TrackData::getOrderNumber).containsExactly(1,2,3,4,5); // 갭/중복 없음
+    // 옛1→1, 옛2→2 (불변), 옛4→3, 옛5→4, 옛3→5(tail) — linkId 로 매핑 검증
 }
 
 @Test
-@DisplayName("rotatePlayed: k=1 — 기존 reorderTracks(1→total, rest -1) 와 산술 동일 (#222 position-1 보존)")
-void rotatePlayed_k_eq_1_equivalent_to_legacy_reorder() {
+@DisplayName("rotatePlayedOrder: k=1 — 기존 reorderTracks 와 산술 동일 (#222 position-1 보존)")
+void rotatePlayedOrder_k_eq_1_equivalent_to_legacy_reorder() {
     Long pid = seedPlaylistWithTracks(4);
-    trackRepository.shiftUpOrderByDelete(pid, 1);  // 2->1,3->2,4->3
-    trackRepository.appendOrderToTail(pid, 1, 4);   // 옛1 -> 4
-    // == 기존 reorderTracks(pid,4) 결과와 동일: 옛[1,2,3,4] -> [4,1,2,3] 의 orderNumber 매핑
-    var ordered = ...; assertThat(...).containsExactly(1,2,3,4);
-    // 옛 orderNumber=1 트랙이 4, 옛2->1, 옛3->2, 옛4->3 (linkId 검증)
+    trackRepository.rotatePlayedOrder(pid, 1, 4L);
+    var ordered = /* 조회 */; assertThat(ordered).extracting(TrackData::getOrderNumber).containsExactly(1,2,3,4);
+    // 옛1→4, 옛2→1, 옛3→2, 옛4→3 (== reorderTracks(pid,4) 결과, linkId 검증)
 }
 ```
 
-> 구현자: 기존 `TrackRepositoryReorderIntegrationTest` 의 seed/조회 헬퍼·어노테이션을 그대로 사용. 위 의사코드의 `seedPlaylistWithTracks`/조회는 그 파일의 기존 패턴으로 치환(신규 헬퍼 만들지 말 것 — 기존 것 재사용).
+> 구현자: 기존 `TrackRepositoryReorderIntegrationTest` 의 seed/조회 헬퍼·어노테이션을 그대로 사용. `seedPlaylistWithTracks`/조회는 그 파일 기존 패턴으로 치환(신규 헬퍼 만들지 말 것). 옛 orderNumber↔linkId 매핑을 잡아 "어느 트랙이 어디로" 까지 검증(orderNumber 집합만이 아니라).
 
 - [ ] **Step 2: 실패 확인**
 
 Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.playlist.adapter.out.persistence.TrackRepositoryReorderIntegrationTest"`
-Expected: FAIL — `appendOrderToTail` 메서드 없음(컴파일 에러).
+Expected: FAIL — `rotatePlayedOrder` 메서드 없음(컴파일 에러).
 
-- [ ] **Step 3: 구현** — `TrackRepository.java` 에 추가 (기존 `shiftUpOrderByDelete` 바로 아래, 동일 스타일):
+- [ ] **Step 3: 구현** — `TrackRepository.java` 에 추가 (기존 `reorderTracks`
+바로 아래, 동일 CASE 스타일 — `reorderTracks` 의 일반화):
 
 ```java
 @Modifying
-@Query("UPDATE TrackData pm SET pm.orderNumber = :totalElements " +
-        "WHERE pm.playlistId.id = :playlistId AND pm.orderNumber = :playedOrderNumber")
-void appendOrderToTail(@Param("playlistId") Long playlistId,
-                       @Param("playedOrderNumber") Integer playedOrderNumber,
+@Query("UPDATE TrackData pm SET pm.orderNumber = CASE " +
+        "WHEN pm.orderNumber = :playedOrderNumber THEN :totalElements " +
+        "WHEN pm.orderNumber > :playedOrderNumber THEN pm.orderNumber - 1 " +
+        "ELSE pm.orderNumber END " +
+        "WHERE pm.playlistId.id = :playlistId")
+void rotatePlayedOrder(@Param("playlistId") Long playlistId,
+                       @Param("playedOrderNumber") int playedOrderNumber,
                        @Param("totalElements") long totalElements);
 ```
 
@@ -95,17 +102,21 @@ void appendOrderToTail(@Param("playlistId") Long playlistId,
 void rotatePlayed(Long playlistId, int playedOrderNumber, long totalCount);
 ```
 
-`PlaylistAggregateAdapter.java` 에 구현 추가 (기존 `rotateTrackOrder` 구현 인근, 동일 위임 스타일):
+`PlaylistAggregateAdapter.java` 에 구현 추가 (기존 `rotateTrackOrder` 구현이
+repository/aggregatePort 어디로 위임하는지 **그 패턴 그대로** 따라):
 
 ```java
 @Override
 public void rotatePlayed(Long playlistId, int playedOrderNumber, long totalCount) {
-    trackRepository.shiftUpOrderByDelete(playlistId, playedOrderNumber);
-    trackRepository.appendOrderToTail(playlistId, playedOrderNumber, totalCount);
+    trackRepository.rotatePlayedOrder(playlistId, playedOrderNumber, totalCount);
 }
 ```
 
-> `shiftUpOrderByDelete` 의 파라미터 타입은 `Integer deleteOrderNumber`. `playedOrderNumber:int` 자동 박싱 OK. `trackRepository` 가 adapter에 주입돼 있는지 확인(기존 `rotateTrackOrder` 가 `aggregatePort`/repository 어디로 위임하는지 따라 일관되게 — adapter가 repository 직접 호출하면 위처럼, 아니면 기존 패턴 준수).
+> 단일 set-based UPDATE 라 pre-state 기준 atomic — old-(k+1) 충돌 없음.
+> `reorderTracks`(`WHEN orderNumber=1 THEN total ELSE orderNumber-1`)의
+> 파라미터화 일반화이며 k=1 시 산술 동일(기존 #222 회귀 그대로 통과).
+> 기존 `reorderTracks`·`shiftUpOrderByDelete` 는 **건드리지 않음**(다른 caller
+> 영향 0; 미사용 정리는 Task 5).
 
 - [ ] **Step 4: 통과 확인**
 
@@ -116,7 +127,7 @@ Expected: PASS (신규 2 + 기존 회귀 그린).
 
 ```bash
 git add playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepository.java playlist/src/main/java/com/pfplaybackend/api/playlist/domain/port/PlaylistAggregatePort.java playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/PlaylistAggregateAdapter.java app/src/test/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepositoryReorderIntegrationTest.java
-git commit -m "feat(E/#3): rotatePlayed 영속 — shiftUpOrderByDelete+appendOrderToTail (k>1 일반화, k=1 #222 보존)"
+git commit -m "feat(E/#3): rotatePlayedOrder 단일 CASE — reorderTracks 일반화 (k>1 갭없음·k=1 #222 산술동일)"
 ```
 
 ---
@@ -258,7 +269,21 @@ void multiDj_firstAllOverLimit_playsNextDj() {
 }
 ```
 
-기존 테스트 갱신: `getFirstTrack` mock → `peekOrderedTracks`/`rotatePlayed` mock 으로 와이어링 교체. **#222 관련(skip→재생 트랙 최하단·DJ큐 밀림) 어서션은 동작 보존**: position-1(over-limit 선행 없음) 케이스에서 재생트랙이 tail 로 가고 DJ큐 회전 동일 → 어서션 의미 유지(메서드명만 rotatePlayed 로). 정당 deactivate 케이스 보존.
+기존 테스트 갱신 (테스트별 처리 명시):
+- `skipPlaybackWithQueuedDjRotatesQueueAndPlaylist`, `skipByManager...` 류
+  (#222 정상 skip→재생트랙 최하단·DJ큐 밀림): **동작 보존**. position-1
+  (over-limit 선행 없음)에서 재생트랙이 tail·DJ큐 회전 동일 → 어서션 의미
+  유지, `getFirstTrack` mock → `peekOrderedTracks`(해당 DJ 트랙 리스트 반환)
+  + `rotatePlayed` verify 로 와이어링만 교체.
+- `timeLimitExceededStillRotatesPlaylistBeforeCheck`: 이 테스트의 *의도*
+  ("체크 전 회전이 이미 일어난다"는 부작용)는 본 설계가 **의도적으로 제거**.
+  relabel 금지 → **삭제하고 신규 테스트로 대체**: "DJ1 + 전 트랙 over-limit →
+  deactivate, `rotatePlayed` 미호출"(peek 부작용0 검증 포함). = Step1 의
+  `singleDj_allOverLimit_deactivates` 가 이를 대체.
+- 정당 deactivate(전 DJ 무재생) 케이스 어서션 보존.
+- `stubDoStartWithQueuedDj` 헬퍼가 `playlistCommandPort.getFirstTrack` 을
+  stub 하므로, 헬퍼를 `peekOrderedTracks` stub 으로 갱신(헬퍼 1곳 수정이 다
+  테스트에 전파 — 신규 헬퍼 만들지 말 것).
 
 - [ ] **Step 2: 실패 확인**
 

--- a/docs/superpowers/plans/2026-05-19-e3-pr1-track-skip-deactivate.md
+++ b/docs/superpowers/plans/2026-05-19-e3-pr1-track-skip-deactivate.md
@@ -14,9 +14,9 @@
 
 ## File Structure
 
-- `playlist/.../adapter/out/persistence/TrackRepository.java` — Modify: `appendOrderToTail` 쿼리 추가 (rotatePlayed 용; 기존 `reorderTracks`·`shiftUpOrderByDelete` 보존).
-- `playlist/.../domain/port/PlaylistAggregatePort.java` — Modify: `appendOrderToTail` 선언 추가.
-- `playlist/.../adapter/out/persistence/PlaylistAggregateAdapter.java` — Modify: `appendOrderToTail` 구현.
+- `playlist/.../adapter/out/persistence/TrackRepository.java` — Modify: `rotatePlayedOrder` 단일 CASE 쿼리 추가 (rotatePlayed 용; 기존 `reorderTracks`·`shiftUpOrderByDelete` 보존·무변경).
+- `playlist/.../domain/port/PlaylistAggregatePort.java` — Modify: `rotatePlayed` 선언 추가.
+- `playlist/.../adapter/out/persistence/PlaylistAggregateAdapter.java` — Modify: `rotatePlayed` 구현(→ `rotatePlayedOrder` 위임).
 - `playlist/.../application/service/TrackCommandService.java` — Modify: `peekOrderedTracks(Long)`·`rotatePlayed(Long, int)` 신설. `getFirstTrack` 는 그대로 두되 사용 안 함(다른 caller 없음 → PR 말미 제거 여부 §Task6).
 - `app/.../party/application/port/out/PlaylistCommandPort.java` — Modify: `peekOrderedTracks(PlaylistId)`·`rotatePlayed(PlaylistId, int)` 선언, `getFirstTrack` 제거.
 - `app/.../party/adapter/out/external/PlaylistCommandAdapter.java` — Modify: 신규 2메서드 위임, `getFirstTrack` 제거.

--- a/docs/superpowers/plans/2026-05-19-e3-pr1-track-skip-deactivate.md
+++ b/docs/superpowers/plans/2026-05-19-e3-pr1-track-skip-deactivate.md
@@ -1,0 +1,357 @@
+# E/#3 PR-1 — 트랙단위 스킵 + deactivate 조건 정정 (platform 핵심) 구현 계획
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** active DJ 차례 트랙이 파티룸 `playbackTimeLimit` 초과 시, 그 트랙만 스킵하고 같은/다음 DJ의 한도 이내 첫 트랙을 재생하며, **큐의 모든 DJ가 재생가능 트랙이 없을 때만** deactivate 한다 (over-limit 트랙은 제자리 보존).
+
+**Architecture:** playlist 모듈 = 순서 메커니즘만(`peekOrderedTracks` 부작용0 + `rotatePlayed` 재생트랙만 tail·나머지 상대순서 보존). party 모듈 = 정책(limit 판정·회전된 DJ 리스트 내부 스캔·deactivate 결정). `getFirstTrack`(rotate-then-take)은 유일 caller(`getNextPlaybackInPlaylist`)만 가지므로 안전히 대체.
+
+**Tech Stack:** Java 21 (빌드 시 `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7"` prefix 필수), Spring Boot, JPA, JUnit5. Gradle 모듈: `playlist`, `app`(party).
+
+**Spec:** `docs/superpowers/specs/2026-05-19-e3-track-skip-deactivate-cascade-design.md` (§3-1 / §5)
+
+---
+
+## File Structure
+
+- `playlist/.../adapter/out/persistence/TrackRepository.java` — Modify: `appendOrderToTail` 쿼리 추가 (rotatePlayed 용; 기존 `reorderTracks`·`shiftUpOrderByDelete` 보존).
+- `playlist/.../domain/port/PlaylistAggregatePort.java` — Modify: `appendOrderToTail` 선언 추가.
+- `playlist/.../adapter/out/persistence/PlaylistAggregateAdapter.java` — Modify: `appendOrderToTail` 구현.
+- `playlist/.../application/service/TrackCommandService.java` — Modify: `peekOrderedTracks(Long)`·`rotatePlayed(Long, int)` 신설. `getFirstTrack` 는 그대로 두되 사용 안 함(다른 caller 없음 → PR 말미 제거 여부 §Task6).
+- `app/.../party/application/port/out/PlaylistCommandPort.java` — Modify: `peekOrderedTracks(PlaylistId)`·`rotatePlayed(PlaylistId, int)` 선언, `getFirstTrack` 제거.
+- `app/.../party/adapter/out/external/PlaylistCommandAdapter.java` — Modify: 신규 2메서드 위임, `getFirstTrack` 제거.
+- `app/.../party/application/service/PlaybackCommandService.java` — Modify: `doStart` 재설계(peek+limit스캔+rotatePlayed), `getNextPlaybackInPlaylist` 시그니처/구현 변경.
+- Tests: `playlist/.../service/TrackCommandServiceTest.java`, `app/.../persistence/TrackRepositoryReorderIntegrationTest.java`, `app/.../service/PlaybackCommandServiceTest.java` (#222 포함) — 갱신/신설.
+
+빌드: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :playlist:test :app:test --tests <FQN>` (Windows: Git Bash 경유). 모듈 단위 우선, 마지막 전체.
+
+---
+
+## Chunk 1: PR-1 — peek/rotatePlayed 분리 + 트랙스킵 + deactivate 조건
+
+### Task 1: `rotatePlayed` 영속 계층 (TrackRepository + port + adapter)
+
+`rotatePlayed(playlistId, k)` 알고리즘: total=count → `shiftUpOrderByDelete(playlistId, k)`(orderNumber>k → -1) → 재생트랙(orderNumber=k, >k 아니라 미변경)을 orderNumber=total 로. orderNumber<k(over-limit 제자리) 불변. 갭/충돌 없음. k=1 이면 기존 `reorderTracks`(`1→total, rest -1`)와 산술 동일(#222 position-1 보존).
+
+**Files:**
+- Modify: `playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepository.java`
+- Modify: `playlist/src/main/java/com/pfplaybackend/api/playlist/domain/port/PlaylistAggregatePort.java`
+- Modify: `playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/PlaylistAggregateAdapter.java`
+- Test: `app/src/test/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepositoryReorderIntegrationTest.java`
+
+- [ ] **Step 1: 실패 통합테스트 작성** — `TrackRepositoryReorderIntegrationTest.java` 에 추가 (기존 클래스 패턴/픽스처 재사용; @DataJpaTest 등 기존 설정 따름):
+
+```java
+@Test
+@DisplayName("rotatePlayed: k>1 — 재생트랙만 tail, k 이전(over-limit 제자리) 불변, k 이후 -1")
+void rotatePlayed_k_gt_1_moves_played_to_tail_keeps_before_intact() {
+    // given: playlist P 에 트랙 5개 orderNumber 1..5 (헬퍼는 기존 테스트 방식 재사용)
+    Long pid = seedPlaylistWithTracks(5); // 기존 헬퍼 없으면 기존 seed 패턴대로 5개 삽입
+    // when: orderNumber=3 인 트랙을 재생했다고 가정
+    trackRepository.shiftUpOrderByDelete(pid, 3);   // 4->3, 5->4
+    trackRepository.appendOrderToTail(pid, 3, 5);   // 옛 orderNumber=3 → 5
+
+    // then: [1,2 불변], [옛4->3, 옛5->4], [옛3->5]
+    List<TrackData> ordered = trackRepository.findByPlaylistId... // 기존 조회 방식
+        .stream().sorted(comparingInt(t -> t.getOrderNumber())).toList();
+    assertThat(ordered).extracting(TrackData::getOrderNumber).containsExactly(1,2,3,4,5);
+    // 옛 orderNumber=1,2 트랙 식별자가 여전히 1,2 위치 (linkId 등으로 검증)
+    // 옛 orderNumber=3 트랙이 이제 orderNumber=5
+}
+
+@Test
+@DisplayName("rotatePlayed: k=1 — 기존 reorderTracks(1→total, rest -1) 와 산술 동일 (#222 position-1 보존)")
+void rotatePlayed_k_eq_1_equivalent_to_legacy_reorder() {
+    Long pid = seedPlaylistWithTracks(4);
+    trackRepository.shiftUpOrderByDelete(pid, 1);  // 2->1,3->2,4->3
+    trackRepository.appendOrderToTail(pid, 1, 4);   // 옛1 -> 4
+    // == 기존 reorderTracks(pid,4) 결과와 동일: 옛[1,2,3,4] -> [4,1,2,3] 의 orderNumber 매핑
+    var ordered = ...; assertThat(...).containsExactly(1,2,3,4);
+    // 옛 orderNumber=1 트랙이 4, 옛2->1, 옛3->2, 옛4->3 (linkId 검증)
+}
+```
+
+> 구현자: 기존 `TrackRepositoryReorderIntegrationTest` 의 seed/조회 헬퍼·어노테이션을 그대로 사용. 위 의사코드의 `seedPlaylistWithTracks`/조회는 그 파일의 기존 패턴으로 치환(신규 헬퍼 만들지 말 것 — 기존 것 재사용).
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.playlist.adapter.out.persistence.TrackRepositoryReorderIntegrationTest"`
+Expected: FAIL — `appendOrderToTail` 메서드 없음(컴파일 에러).
+
+- [ ] **Step 3: 구현** — `TrackRepository.java` 에 추가 (기존 `shiftUpOrderByDelete` 바로 아래, 동일 스타일):
+
+```java
+@Modifying
+@Query("UPDATE TrackData pm SET pm.orderNumber = :totalElements " +
+        "WHERE pm.playlistId.id = :playlistId AND pm.orderNumber = :playedOrderNumber")
+void appendOrderToTail(@Param("playlistId") Long playlistId,
+                       @Param("playedOrderNumber") Integer playedOrderNumber,
+                       @Param("totalElements") long totalElements);
+```
+
+`PlaylistAggregatePort.java` 에 선언 추가 (기존 `rotateTrackOrder` 인근):
+
+```java
+void rotatePlayed(Long playlistId, int playedOrderNumber, long totalCount);
+```
+
+`PlaylistAggregateAdapter.java` 에 구현 추가 (기존 `rotateTrackOrder` 구현 인근, 동일 위임 스타일):
+
+```java
+@Override
+public void rotatePlayed(Long playlistId, int playedOrderNumber, long totalCount) {
+    trackRepository.shiftUpOrderByDelete(playlistId, playedOrderNumber);
+    trackRepository.appendOrderToTail(playlistId, playedOrderNumber, totalCount);
+}
+```
+
+> `shiftUpOrderByDelete` 의 파라미터 타입은 `Integer deleteOrderNumber`. `playedOrderNumber:int` 자동 박싱 OK. `trackRepository` 가 adapter에 주입돼 있는지 확인(기존 `rotateTrackOrder` 가 `aggregatePort`/repository 어디로 위임하는지 따라 일관되게 — adapter가 repository 직접 호출하면 위처럼, 아니면 기존 패턴 준수).
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.playlist.adapter.out.persistence.TrackRepositoryReorderIntegrationTest"`
+Expected: PASS (신규 2 + 기존 회귀 그린).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepository.java playlist/src/main/java/com/pfplaybackend/api/playlist/domain/port/PlaylistAggregatePort.java playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/PlaylistAggregateAdapter.java app/src/test/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepositoryReorderIntegrationTest.java
+git commit -m "feat(E/#3): rotatePlayed 영속 — shiftUpOrderByDelete+appendOrderToTail (k>1 일반화, k=1 #222 보존)"
+```
+
+---
+
+### Task 2: `peekOrderedTracks` + `rotatePlayed` (TrackCommandService)
+
+**Files:**
+- Modify: `playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackCommandService.java`
+- Test: `playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/TrackCommandServiceTest.java`
+
+- [ ] **Step 1: 실패 단위테스트 작성** — `TrackCommandServiceTest.java` 에 추가(기존 mock 셋업 재사용):
+
+```java
+@Test
+@DisplayName("peekOrderedTracks: 회전 없이 orderNumber ASC 전 트랙 반환 (부작용 0)")
+void peekOrderedTracks_returns_ordered_without_rotation() {
+    // given queryPort.getTracksWithPagination(...) stub: 15개 한도 커버 (PageRequest size>=15)
+    // when
+    List<PlaybackTrackDto> r = trackCommandService.peekOrderedTracks(1L);
+    // then: orderNumber ASC, rotateTrackOrder/rotatePlayed 미호출 (verify never)
+    verify(aggregatePort, never()).rotateTrackOrder(anyLong(), anyLong());
+    verify(aggregatePort, never()).rotatePlayed(anyLong(), anyInt(), anyLong());
+    assertThat(r).extracting(PlaybackTrackDto::orderNumber).isSorted();
+}
+
+@Test
+@DisplayName("rotatePlayed: aggregatePort.rotatePlayed(playlistId, k, total) 위임")
+void rotatePlayed_delegates() {
+    trackCommandService.rotatePlayed(1L, 3, 5L);
+    verify(aggregatePort).rotatePlayed(1L, 3, 5L);
+}
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :playlist:test --tests "com.pfplaybackend.api.playlist.application.service.TrackCommandServiceTest"`
+Expected: FAIL — `peekOrderedTracks`/`rotatePlayed` 미정의.
+
+- [ ] **Step 3: 구현** — `TrackCommandService.java`:
+
+```java
+@Transactional(readOnly = true)
+public List<PlaybackTrackDto> peekOrderedTracks(Long playlistId) {
+    Pageable pageable = PageRequest.of(0, 15, Sort.by(Sort.Direction.ASC, "orderNumber"));
+    Page<PlaylistTrackDto> page = queryPort.getTracksWithPagination(new PlaylistId(playlistId), pageable);
+    return page.getContent().stream()
+            .map(dto -> new PlaybackTrackDto(dto.linkId(), dto.name(),
+                    dto.thumbnailImage(), dto.duration(), dto.orderNumber()))
+            .toList();
+}
+
+@Transactional
+public void rotatePlayed(Long playlistId, int playedOrderNumber, long totalCount) {
+    aggregatePort.rotatePlayed(playlistId, playedOrderNumber, totalCount);
+}
+```
+
+> size 15 = 플레이리스트 트랙 상한(`addTrackInPlaylist` `musicCount() >= 15` 가드와 정합 — 전 트랙 peek 보장). `PlaylistTrackDto` 필드는 기존 `getFirstTrack` 매핑과 동일.
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :playlist:test --tests "com.pfplaybackend.api.playlist.application.service.TrackCommandServiceTest"`
+Expected: PASS (신규 + 기존 `getFirstTrack` 테스트 그린 — getFirstTrack 미변경).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackCommandService.java playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/TrackCommandServiceTest.java
+git commit -m "feat(E/#3): TrackCommandService peekOrderedTracks(부작용0)+rotatePlayed"
+```
+
+---
+
+### Task 3: 포트/어댑터 교체 (PlaylistCommandPort / Adapter)
+
+**Files:**
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/application/port/out/PlaylistCommandPort.java`
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/PlaylistCommandAdapter.java`
+
+- [ ] **Step 1: 포트 인터페이스 변경** — `PlaylistCommandPort.java`: `getFirstTrack` 제거, 추가:
+
+```java
+java.util.List<PlaybackTrackDto> peekOrderedTracks(PlaylistId playlistId);
+void rotatePlayed(PlaylistId playlistId, int playedOrderNumber, long totalCount);
+```
+
+- [ ] **Step 2: 어댑터 구현** — `PlaylistCommandAdapter.java`: `getFirstTrack` 위임 제거, 추가:
+
+```java
+@Override
+public List<PlaybackTrackDto> peekOrderedTracks(PlaylistId playlistId) {
+    return trackCommandService.peekOrderedTracks(playlistId.getId());
+}
+
+@Override
+public void rotatePlayed(PlaylistId playlistId, int playedOrderNumber, long totalCount) {
+    trackCommandService.rotatePlayed(playlistId.getId(), playedOrderNumber, totalCount);
+}
+```
+
+- [ ] **Step 3: 컴파일 확인 (의도된 PlaybackCommandService 깨짐)**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:compileJava 2>&1 | head`
+Expected: FAIL — `PlaybackCommandService.getNextPlaybackInPlaylist` 가 `playlistCommandPort.getFirstTrack` 호출(제거됨). 이는 Task 4에서 해소(의도된 red).
+
+- [ ] **Step 4: 커밋(WIP 경계 — Task3+4 한 커밋으로 합칠 것이므로 여기선 커밋 보류, Task4 Step5에서 함께)**
+
+게이트만: 포트/어댑터 변경이 의도대로 PlaybackCommandService 만 깨뜨림 확인.
+
+---
+
+### Task 4: `doStart` 재설계 — 트랙스킵 + DJ 내부 스캔 + deactivate 조건 정정
+
+핵심. 현재 `doStart`(PlaybackCommandService.java ~L109-160): `rotateDjQueue` 1회 → min-order DJ → `getNextPlaybackInPlaylist`(getFirstTrack, 회전부작용) → exceeds 면 `remainingAttempts<=1?deactivate:재귀(rotateDjQueue 또 호출)`.
+
+신설계: `rotateDjQueue` **사이클당 1회 유지**. 회전된 DJ 리스트를 orderNumber ASC 로 **내부 순회**(재귀 재진입 금지). 각 DJ: `peekOrderedTracks(dj.playlistId)` → limit 이내 첫 트랙 선택. 찾으면 그 트랙 재생 + `rotatePlayed(playlistId, 그트랙.orderNumber, total)` + 기존 publish/schedule. 그 DJ 전 트랙 over-limit → 다음 DJ. **모든 DJ 스캔 후 재생가능 0 → `deactivateAndNotify`**(기존 경로 그대로).
+
+**Files:**
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java`
+- Test: `app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackCommandServiceTest.java`
+
+- [ ] **Step 1: 실패/회귀 테스트 작성** — `PlaybackCommandServiceTest.java`. 기존 #222·deactivate 테스트의 mock 셋업 패턴 재사용. 신규 + 기존 갱신:
+
+```java
+@Test @DisplayName("E/#3: DJ1 + [over-limit, playable] → playable 재생, deactivate 안 됨, over-limit 제자리")
+void singleDj_skipsOverLimit_playsPlayable() {
+  // given: queuedDjs=[dj1]; peekOrderedTracks(dj1.pl)=[t1(over limit), t2(<=limit)]
+  // when tryProceed/startPlayback
+  // then: playbackRepository.save( t2 ), rotatePlayed(pl, t2.orderNumber, total) 호출,
+  //       deactivateAndNotify 미호출, PlaybackStartedEvent(t2) publish
+}
+@Test @DisplayName("E/#3: DJ1 + 전트랙 over-limit → deactivate (정당, 큐 removeDjs)")
+void singleDj_allOverLimit_deactivates() {
+  // peek=[t1,t2 모두 over limit] → deactivateAndNotify 호출(DjQueueChangedEvent DEACTIVATE)
+}
+@Test @DisplayName("E/#3: 다DJ — 앞 DJ 전트랙 over-limit → 다음 DJ 재생, rotateDjQueue 1회만")
+void multiDj_firstAllOverLimit_playsNextDj() {
+  // queued=[dj1(all over), dj2(playable)] → dj2 트랙 재생, partyroomAggregateService.rotateDjQueue 1회 verify
+}
+```
+
+기존 테스트 갱신: `getFirstTrack` mock → `peekOrderedTracks`/`rotatePlayed` mock 으로 와이어링 교체. **#222 관련(skip→재생 트랙 최하단·DJ큐 밀림) 어서션은 동작 보존**: position-1(over-limit 선행 없음) 케이스에서 재생트랙이 tail 로 가고 DJ큐 회전 동일 → 어서션 의미 유지(메서드명만 rotatePlayed 로). 정당 deactivate 케이스 보존.
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.application.service.PlaybackCommandServiceTest"`
+Expected: FAIL — 신규 테스트(메서드 미구현) + 컴파일(getFirstTrack 제거).
+
+- [ ] **Step 3: 구현** — `PlaybackCommandService.java`:
+
+`getNextPlaybackInPlaylist` 제거(또는 시그니처 변경). `doStart` 를 아래 구조로 재작성(기존 publish/schedule/PlaybackData.create·PlaybackStartedEvent·DjQueueChangedEvent(ROTATE)·scheduleTask·playbackState 갱신 블록은 **그대로 재사용**, 선택 로직만 교체):
+
+```java
+private void doStart(PartyroomData partyroom, int remainingAttempts) {
+    long pid = partyroom.getPartyroomId().getId();
+    List<DjData> rotatedDjs = partyroomAggregateService.rotateDjQueue(partyroom.getPartyroomId()); // 사이클당 1회
+    List<DjData> ordered = rotatedDjs.stream()
+            .sorted(Comparator.comparingInt(DjData::getOrderNumber)).toList();
+
+    for (DjData dj : ordered) {
+        CrewData djCrew = aggregatePort.findCrewById(dj.getCrewId().getId()).orElseThrow();
+        List<PlaybackTrackDto> tracks = playlistCommandPort.peekOrderedTracks(dj.getPlaylistId());
+        PlaybackTrackDto chosen = tracks.stream()
+                .filter(t -> !partyroom.getPlaybackTimeLimit().exceedsDuration(t.duration()))
+                .findFirst().orElse(null);
+        if (chosen == null) {
+            log.warn("[doStart] DJ_ALL_TRACKS_EXCEED - partyroomId={}, djCrewId={}", pid, djCrew.getId());
+            continue; // 다음 DJ
+        }
+        // 재생 확정: 기존 PlaybackData.create + save + playbackState.updatePlayback
+        PlaybackData nextPlayback = PlaybackData.create(partyroom.getPartyroomId(), djCrew.getUserId(),
+                chosen.name(), chosen.duration(), chosen.linkId(), chosen.thumbnailImage(), clock.instant());
+        playlistCommandPort.rotatePlayed(dj.getPlaylistId(), chosen.orderNumber(), tracks.size());
+        PlaybackData playbackData = playbackRepository.save(nextPlayback);
+        playbackAggregationRepository.save(PlaybackAggregationData.createFor(new PlaybackId(playbackData.getId())));
+        PartyroomPlaybackData st = aggregatePort.findPlaybackState(partyroom.getPartyroomId());
+        st.updatePlayback(new PlaybackId(playbackData.getId()), new CrewId(djCrew.getId()));
+        aggregatePort.savePlaybackState(st);
+        scheduleTask(nextPlayback);
+        PlaybackSnapshot snap = new PlaybackSnapshot(playbackData.getId(), playbackData.getLinkId(),
+                playbackData.getName(), playbackData.getDuration().toDisplayString(),
+                playbackData.getThumbnailImage(), playbackData.getEndTime());
+        eventPublisher.publishEvent(new PlaybackStartedEvent(partyroom.getPartyroomId(), new CrewId(djCrew.getId()), snap));
+        eventPublisher.publishEvent(new DjQueueChangedEvent(partyroom.getPartyroomId(), DjChangeType.ROTATE, new CrewId(djCrew.getId())));
+        return;
+    }
+    log.warn("[doStart] DEACTIVATE_TRIGGERED - partyroomId={}, reason=ALL_DJS_NO_PLAYABLE_TRACK", pid);
+    deactivateAndNotify(partyroom);
+}
+```
+
+> `remainingAttempts` 파라미터: 호출지(`tryProceed`/`startPlayback`) 시그니처 호환 위해 유지하되 내부 스캔이 큐 전체를 1회 순회하므로 미사용(또는 호출지에서 제거 — 더 깔끔하면 `doStart(PartyroomData)` 로 단순화하고 `tryProceed`/`startPlayback` 도 인자 제거. 구현자 판단; 단 다른 caller 없음 확인 후). 무한루프 불가(for 1회·재귀 없음). `getNextPlaybackInPlaylist` 제거로 그 메서드 참조 전부 정리. import: `java.util.List`, `Comparator` 등.
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.application.service.PlaybackCommandServiceTest"`
+Expected: PASS (신규 3 + 갱신된 #222/deactivate 회귀 그린).
+
+- [ ] **Step 5: 커밋 (Task3+4 합본)**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/application/port/out/PlaylistCommandPort.java app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/PlaylistCommandAdapter.java app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackCommandServiceTest.java
+git commit -m "feat(E/#3): doStart 트랙단위 스킵 + 회전된 DJ 내부 스캔 + 전-DJ-무재생 시에만 deactivate (rotateDjQueue 사이클당 1회)"
+```
+
+---
+
+### Task 5: 전 모듈 회귀 + 행위보존 검증
+
+- [ ] **Step 1: 영향 모듈 전체 테스트**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :playlist:test :app:test`
+Expected: 전 그린. 특히 #222(skip→reorder)·기존 정당 deactivate·DJ큐 회전 회귀 그린(position-1 동작 보존).
+
+- [ ] **Step 2: 잔존 `getFirstTrack` 정리 판단**
+
+`getFirstTrack`(TrackCommandService)·`reorderTracks`(미사용 시) 의 다른 프로덕션 caller 0 확인되면(grep) **제거**(YAGNI·죽은코드). 테스트만 참조면 테스트도 정리. caller 있으면 보존. 결정·근거 커밋 메시지에 명시.
+
+```bash
+# grep 확인 후
+git add -A && git commit -m "refactor(E/#3): 미사용 getFirstTrack/reorderTracks 정리 (peek/rotatePlayed 대체, caller 0 확인)"
+```
+(caller 존재 시 이 Task는 no-op·스킵.)
+
+- [ ] **Step 3: 최종 게이트**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :playlist:test :app:test`
+Expected: 전 그린. `git log --oneline origin/develop..HEAD` 로 논리커밋 확인(push 전 통합은 PR 생성 단계서).
+
+---
+
+## 완료 정의 (DoD)
+
+- DJ1+혼재 → playable 재생·over-limit 제자리·deactivate 안 됨 / DJ1+전트랙 over-limit → deactivate(큐 removeDjs) / 다DJ 앞-전트랙-over → 다음 DJ, `rotateDjQueue` 사이클당 1회.
+- `peekOrderedTracks` 부작용 0, `rotatePlayed` k>1 일반화·k=1 #222 산술 동일(보존).
+- 신규 단위/통합 + 기존 #222·deactivate·회전 회귀 전 그린(`:playlist:test :app:test`).
+- 무한루프/DJ큐 이중회전 불가(for 1회·재귀 제거).
+- 범위 = PR-1(동작)만. PR-2(changeType payload)·PR-3(web UX)·PR-4(배지)는 별 계획/PR. DEACTIVATE 시 발행되는 `DjQueueChangedEvent(DEACTIVATE,null)` payload 변경은 PR-1 범위 밖(기존 그대로).

--- a/docs/superpowers/specs/2026-05-19-e3-track-skip-deactivate-cascade-design.md
+++ b/docs/superpowers/specs/2026-05-19-e3-track-skip-deactivate-cascade-design.md
@@ -1,0 +1,162 @@
+# E/#3 — DJ 1명 + 길이 초과 트랙 → 파티룸 deactivate·DJ큐 전원 퇴출 근본 수정 설계
+
+- 작성일: 2026-05-19
+- 대상 이슈: pfplay-platform E/#3 (로드맵 Cluster E). 노트: `bugs/2026-05-14-playback-time-limit-deactivate-cascade.md`
+- 대상 레포: pfplay-platform(party 모듈, 핵심) + pfplay-web(UX 신호·배지)
+- 분류: 재생 라이프사이클 동작 결함 + UX 신호 경로 단절 (cross-cutting, cross-repo)
+- 심각도: High
+
+## 1. 배경 / 문제
+
+DJ 큐에 등록된 사용자가 그 파티룸의 active DJ 전부일 때, 회전 차례에 파티룸
+`playbackTimeLimit` 초과 트랙을 만나면 그 트랙이 패스되지 않고 **파티룸 전체가
+deactivate 되며 DJ 큐의 모든 DJ 가 일괄 삭제**된다(`removeDjs`). 사용자는
+"추가한 곡이 안 나오고 큐에서 영문 없이 빠짐" 으로 체감.
+
+근본(노트 코드 트레이스, 2026-05-19 현행 코드 재확인):
+1. `TrackCommandService.getFirstTrack` 이 패스 여부 무관 **항상 회전**
+   (`rotateTrackOrder` 호출 후 `[0]` 반환).
+2. `PlaybackCommandService.doStart`: `getNextPlaybackInPlaylist` 결과가
+   `exceedsDuration` 이면 `remainingAttempts <= 1` → `deactivateAndNotify`.
+   `remainingAttempts` 는 `queuedDjs.size()` 로 초기화 → **DJ 수 ≤ 1 이면 즉시
+   deactivate**.
+3. `PartyroomAggregateService.deactivatePlayback` 이 `findDjsOrdered` →
+   `removeDjs(queuedDjs)` 로 **큐 전원 삭제**.
+
+부수: over-limit 트랙은 자기 차례마다 회전으로 맨 뒤로 밀려 영구 미재생.
+UX 갭: `DjQueueChangeMessage` 에 변경 사유(`DjChangeType`)가 없어
+(`DomainEventRedisRelay` 가 type 을 떼고 djs 리스트만 전송) 프론트는 "왜
+빠졌는지" 알 수 없고, 자가검출은 analytics `track` 만 하며 모달/토스트 0.
+
+(현행 확인: observability A2~A4 머지가 `[doStart] DEACTIVATE_TRIGGERED
+reason=ALL_TRACKS_EXCEEDED` 등 로그만 추가, 구조·`DjQueueChangeMessage`
+무 changeType·`DjChangeType` 6값 enum 모두 노트와 일치.)
+
+## 2. 결정 (사용자 확정)
+
+- **핵심 정책 = 트랙 단위 스킵**: over-limit 트랙은 재생 안 하고 같은 DJ
+  플레이리스트에서 한도 이내 첫 트랙을 재생. DJ 전 트랙이 over-limit 이면 그
+  DJ 는 이번 사이클 패스(다음 DJ). **어느 DJ 도 재생가능 트랙이 없을 때만**
+  deactivate.
+- **스킵 트랙 처리 = 제자리 유지**: peek → 판정 → *재생한 트랙만* 회전.
+  over-limit 트랙은 순서 보존, 선택만 안 됨(노트가 경고한 "N회 회전 → 순서
+  손실" 회피).
+- **UX 신호 = 번들** (이번 스코프): backend `changeType` payload + frontend
+  changeType별 모달.
+- **옵션 D(프론트 사전 가드) 제외**: 플레이리스트는 DJ 중에도 동적 편집되니
+  add/switch 사전검사 모델 부적합 — 백엔드 skip 이 옳은 레이어.
+- **잔여(over-limit 곡 silent 미재생) = 반응형 배지**: 사전검사 아닌, 방 현재
+  limit 기준 플레이리스트 UI 반응형 표시.
+- **DEACTIVATE 모달 = 리치(b)**: 거부 트랙명·duration·limit 포함.
+
+## 3. 설계
+
+### 3-1. 백엔드 동작 재설계 (pfplay-platform, party 모듈) — 핵심 (PR-1)
+
+- **TrackCommandService**: `getFirstTrack`(rotate-then-take)의 회전 부작용을
+  분리.
+  - `peekOrderedTracks(playlistId)` — 회전 없이 orderNumber ASC 트랙 조회(부작용
+    0, 비-`@Transactional` 또는 read-only).
+  - `rotatePlayed(playlistId, playedTrack)` — *실제 재생된* 트랙만 tail 로,
+    나머지(스킵된 over-limit 포함) 상대순서 보존. 기존 `rotateTrackOrder`
+    (`orderNumber=1→total, rest -1`)는 position-1 가정이라, "선택된 트랙을
+    tail 로, 그 외 상대순서 유지" 형태로 재정의(스킵된 over-limit 트랙은
+    제자리).
+- **PlaybackCommandService.doStart**: rotation order 로 DJ 순회. 각 DJ 의
+  `peekOrderedTracks` 에서 **limit 이내 첫 트랙** 선택:
+  - 찾음 → 그 트랙 재생 + `rotatePlayed`.
+  - 그 DJ 전 트랙 over-limit → 그 DJ 이번 사이클 **패스**(큐 잔류, 다음 DJ).
+  - **deactivate 조건 정정**: `remainingAttempts` 의미를 "DJ 수" → "이번 해소
+    패스에서 아직 시도 안 한 DJ". **큐의 모든 DJ 가 재생가능 트랙 0 일 때만**
+    `deactivateAndNotify`(기존 `deactivatePlayback`→`removeDjs` 경로 그대로 =
+    정당 케이스). 1 해소 패스 내 각 DJ 최대 1회 시도 → 무한루프 가드.
+- 불변식: "DJ 1명 + 전 트랙 over-limit → deactivate"(정당) 보존 / "DJ 1명 +
+  재생가능 트랙 있음 → 그 트랙들 재생"(버그 해소) / over-limit 트랙 순서 보존.
+- 범위밖: DJ 전 트랙 over-limit 인 DJ 의 큐 자동 제거(파괴적, 미채택 — 큐 잔류
+  패스). #222 skip→reorder 동작 불변(회귀 잠금).
+
+### 3-2. UX 신호 백엔드 (pfplay-platform) — (PR-2)
+
+- `DjQueueChangeMessage` 에 `changeType: DjChangeType` 필드 **추가(additive)**.
+  `create` 시그니처 확장(changeType 인자). 호출지(도메인 이벤트→메시지 변환)
+  가 `DjQueueChangedEvent` 의 changeType 을 전달.
+- `DomainEventRedisRelay.on(DjQueueChangedEvent)` 가 현재 type 을 떼는 것을
+  **passthrough**(이벤트 changeType 보존). djs 리스트 late-binding(AFTER_COMMIT
+  query, [[reference_first_dj_silent_deactivate]]) 동작 무변경.
+- **리치(b)**: DEACTIVATE 케이스에 한해 거부 트랙 식별(name·durationSec) +
+  partyroom limit(min) 을 메시지에 포함(전용 필드 또는 DEACTIVATE 전용
+  서브페이로드). 다른 changeType 은 미포함(YAGNI).
+- *Cluster A 겹침*: 동일 dj-queue-changed 메시지를 Cluster A 프론트 구독이
+  소비 → **순수 additive·기존 `.djs`/`.partyroomId` 처리 무변경 =
+  backward-compat**. 구 프론트(신규 필드 미인지) 무영향.
+
+### 3-3. UX 신호 프론트 (pfplay-web) — (PR-3, PR-2 의존)
+
+- `use-dj-queue-changed-callback.hook.ts` self-removed 검출 분기에
+  `changeType` 별 처리:
+  - `DEACTIVATE` → 모달/토스트: "재생 시간 제한(<limit>분)을 초과하는 곡
+    '<trackName>'(<duration>) 으로 재생이 중단되었습니다" (리치 payload 사용).
+  - `DEQUEUE_ADMIN` → "관리자에 의해 DJ 대기열에서 제외되었습니다".
+  - `DEQUEUE_EXIT` → silent.
+  - 기존 analytics `track('DJ Deregistered', reason)` 의 하드코딩
+    `reason:'admin'` → 실제 changeType 매핑.
+- `use-playback-deactivated-callback.hook.ts` 는 state-reset 유지(모달은
+  changeType=DEACTIVATE 단일 출처 — 더블모달 회피).
+- 미지 changeType / 신규필드 부재 → 무동작(silent) = 양방향 안전.
+
+### 3-4. 반응형 배지 (pfplay-web) — (PR-4, 독립)
+
+- 플레이리스트 트랙 UI: `track.duration > 현재방.playbackTimeLimit` 트랙에
+  "이 방에선 재생 안 됨" 배지/디밍. 방 limit 기준 반응형, **비차단**(추가
+  허용). 방 `playbackTimeLimit` 을 플레이리스트 UI 컨텍스트에 노출.
+
+## 4. 에러 / 엣지
+
+- DJ 전 트랙 over-limit → 큐 잔류·매 사이클 패스(파괴 X). 그 DJ 유일 → 전-DJ
+  -무재생 → deactivate(정당, 기존 경로·전원 removeDjs 유지).
+- 빈 플레이리스트 DJ: 기존 동작 보존(별도 회귀 아님, 테스트로 확인).
+- peek 부작용 0(트랜잭션/회전 없음). 무한루프: 1 해소 패스 내 각 DJ 1회.
+- changeType 구·신 혼재: 프론트 미지값=무동작, 신규필드 부재=기존 경로 — 안전.
+- 리치 payload: 거부 트랙이 식별 불가한 극단(플레이리스트 동시삭제 등) →
+  trackName/duration null 허용, 모달은 일반 문구로 폴백.
+
+## 5. 테스트 (TDD)
+
+- 백엔드(PR-1):
+  - DJ1 + 재생가능·over-limit 혼재 → 재생가능만 재생, over-limit 제자리,
+    deactivate 안 됨.
+  - DJ1 + 전 트랙 over-limit → deactivate(+ 큐 removeDjs).
+  - 다DJ, 앞 DJ 전트랙 over-limit → 다음 DJ 재생.
+  - peek 부작용 0 / `rotatePlayed` 가 재생트랙만 tail·나머지 순서 보존.
+  - 회귀: 기존 정상 회전·#222 skip→reorder 불변·기존 deactivate 정당 케이스.
+- 백엔드(PR-2): `DjQueueChangeMessage` changeType 직렬화 + relay passthrough +
+  DEACTIVATE 리치 payload 채워짐 / 다른 type 미포함.
+- 프론트(PR-3): changeType별 모달 분기(DEACTIVATE 리치 문구/ADMIN/EXIT
+  silent) + reason 라벨 매핑 단위.
+- 프론트(PR-4): 배지 렌더(over/under limit, 방 limit 변경 반응) 단위.
+- 행위보존 회귀 + 전 모듈 그린(JDK 21 빌드 [[reference_pfplay_platform_jdk]]).
+
+## 6. 스코프 / PR 시리즈 + 조율
+
+- **PR-1 (platform)**: §3-1 동작 재설계. 핵심·독립. 머지 게이트=사용자.
+- **PR-2 (platform)**: §3-2 changeType payload + relay passthrough + 리치.
+  Additive·backward-compat. PR-1 후행 권장(같은 party 모듈 충돌 최소화).
+- **PR-3 (web)**: §3-3 changeType별 모달 + reason 매핑. **PR-2 의존**(payload).
+- **PR-4 (web)**: §3-4 반응형 배지. 독립.
+- Cluster A 조율: PR-2/3 가 dj-queue-changed 메시지·소비자 접점 — additive
+  확인, 기존 djs-list·구독·single-partyroom invariant
+  ([[feedback_single_partyroom_subscription_invariant]]) 무변경.
+- 진행: 각 PR brainstorm 불요(본 spec 이 설계) → plan → TDD → 2단 리뷰 → 전 CI
+  → 머지. 한글 커밋/PR/이슈([[feedback_korean_issue_commit_pr]]), push 전 논리
+  단위 커밋 통합([[feedback_commit_consolidation_before_push]]). dev/stg 머지
+  후 prod 는 별도 release 게이트(사용자). 로드맵 LIVE·메모리 갱신.
+
+## 7. 관련 메모리
+
+- [[reference_first_dj_silent_deactivate]] — 첫 DJ silent deactivate(의도)·
+  payload late-binding. 본 수정이 "프론트 UX 책임" 미구현 갭을 실제 구현.
+- [[feedback_root_cause_premature_lock]] · [[feedback_pr_series_workflow]] ·
+  [[feedback_commit_consolidation_before_push]] · [[feedback_korean_issue_commit_pr]]
+- [[feedback_single_partyroom_subscription_invariant]] — Cluster A 조율 접점
+- [[reference_pfplay_platform_jdk]] — JDK 21 빌드 환경
+- [[reference_branch_env_mapping]] — platform main=prod/release=stg/develop=dev

--- a/docs/superpowers/specs/2026-05-19-e3-track-skip-deactivate-cascade-design.md
+++ b/docs/superpowers/specs/2026-05-19-e3-track-skip-deactivate-cascade-design.md
@@ -32,6 +32,15 @@ UX 갭: `DjQueueChangeMessage` 에 변경 사유(`DjChangeType`)가 없어
 reason=ALL_TRACKS_EXCEEDED` 등 로그만 추가, 구조·`DjQueueChangeMessage`
 무 changeType·`DjChangeType` 6값 enum 모두 노트와 일치.)
 
+> **개정 (2026-05-19, plan 리뷰 반영)**: §3-1 의 `rotatePlayed` 구현을
+> "`shiftUpOrderByDelete` + tail-append 두 문장 조합" 으로 권했으나 이는
+> **부정확**(shift 가 old-(k+1)→k 충돌 → append 가 2행 매칭, k=1 도 legacy
+> 불일치). 정정: **단일 set-based CASE `rotatePlayedOrder`**
+> (`WHEN orderNumber=k THEN total / WHEN >k THEN -1 / ELSE 불변`) — 기존
+> `reorderTracks` CASE 의 파라미터화 일반화(코드베이스 정합·k=1 시 legacy 와
+> 산술 동일·갭없음 증명). 본 §3-1 의 seam 문구는 이 정정으로 대체. 상세는
+> plan `2026-05-19-e3-pr1-*` Task 1 참조.
+
 ## 2. 결정 (사용자 확정)
 
 - **핵심 정책 = 트랙 단위 스킵**: over-limit 트랙은 재생 안 하고 같은 DJ

--- a/docs/superpowers/specs/2026-05-19-e3-track-skip-deactivate-cascade-design.md
+++ b/docs/superpowers/specs/2026-05-19-e3-track-skip-deactivate-cascade-design.md
@@ -54,26 +54,61 @@ reason=ALL_TRACKS_EXCEEDED` 등 로그만 추가, 구조·`DjQueueChangeMessage`
 ### 3-1. 백엔드 동작 재설계 (pfplay-platform, party 모듈) — 핵심 (PR-1)
 
 - **TrackCommandService**: `getFirstTrack`(rotate-then-take)의 회전 부작용을
-  분리.
+  분리. (유일 프로덕션 caller = `PlaybackCommandService.getNextPlaybackInPlaylist`
+  → `PlaylistCommandAdapter.getFirstTrack` → `TrackCommandService.getFirstTrack`;
+  다른 프로덕션 caller 없음 — split 가능.)
   - `peekOrderedTracks(playlistId)` — 회전 없이 orderNumber ASC 트랙 조회(부작용
-    0, 비-`@Transactional` 또는 read-only).
+    0, read-only).
   - `rotatePlayed(playlistId, playedTrack)` — *실제 재생된* 트랙만 tail 로,
-    나머지(스킵된 over-limit 포함) 상대순서 보존. 기존 `rotateTrackOrder`
-    (`orderNumber=1→total, rest -1`)는 position-1 가정이라, "선택된 트랙을
-    tail 로, 그 외 상대순서 유지" 형태로 재정의(스킵된 over-limit 트랙은
-    제자리).
+    나머지(스킵된 over-limit 포함) 상대순서 보존.
+
+  **`rotatePlayed` 알고리즘 (명시 — 기존 seam 재사용)**: 기존 `rotateTrackOrder`
+  SQL(`TrackRepository.java:23-28`, `WHEN orderNumber=1 THEN total ELSE -1`)은
+  played 트랙이 항상 position 1 이라는 가정이라, skip 으로 played 트랙이
+  position k>1 일 수 있는 본 설계엔 부적합. 신규 bespoke CASE SQL 대신
+  **기존 `shiftUpOrderByDelete` + tail append(`musicCount+1`) 패턴**
+  (`addTrackInPlaylist`/`moveTrackToPlaylist` 가 쓰는 검증된 seam)을 일반화:
+  played 트랙 orderNumber=k 일 때 → `orderNumber > k` 인 트랙 전부 `-1` 시프트
+  + played 트랙을 `orderNumber = total`(tail) 로. `orderNumber < k`(스킵된
+  over-limit 포함) 트랙은 **불변**(제자리). 갭/충돌 없음.
+  - 예: `[1:ol, 2:ol, 3:playable→played, 4, 5]` → `[1:ol, 2:ol, 4, 5, 3]`
+    (4→3, 5→4, 3→5; 1·2 불변). 다음 peek 첫 playable = 옛 4. over-limit
+    1·2 는 front 에 영구 "speed bump"(skip-in-place, 의도된 동작).
+  - **#222 불변식 정확한 스코프**: played 트랙이 position 1 인 *정상 흐름*
+    (over-limit 선행 트랙 없음)에서는 이 일반화가 옛 `orderNumber=1→total,
+    rest -1` 와 **산술적으로 정확히 동일** → #222(skip→트랙 최하단) 잠긴 동작
+    behaviorally identical 보존. 새 산술은 **over-limit 선행 트랙이 있을
+    때만** 옛 SQL 과 달라짐(= #222 도메인 밖, 본 기능의 신규 동작). 즉
+    "#222 불변" 은 *position-1 케이스 한정*이며, k>1 reorder 산술은 PR-1
+    in-scope 신규 설계(blanket invariance 주장 아님).
+  - **수정/신설 테스트 (TDD red 명확화)**: position-1 보존 어서션
+    (`TrackCommandServiceTest` getFirstTrack rotate ~L434,
+    `TrackRepositoryReorderIntegrationTest`, `PlaybackCommandServiceTest`
+    #222 ~L239/260/286)은 **행위보존**(position-1 경로 동일하므로 통과 유지
+    — 단 getFirstTrack→peek/rotatePlayed 분리로 *호출 와이어링* 갱신 필요).
+    k>1 skip reorder + 트랙스킵 + deactivate-조건은 **신규 테스트**.
 - **PlaybackCommandService.doStart**: rotation order 로 DJ 순회. 각 DJ 의
   `peekOrderedTracks` 에서 **limit 이내 첫 트랙** 선택:
   - 찾음 → 그 트랙 재생 + `rotatePlayed`.
   - 그 DJ 전 트랙 over-limit → 그 DJ 이번 사이클 **패스**(큐 잔류, 다음 DJ).
-  - **deactivate 조건 정정**: `remainingAttempts` 의미를 "DJ 수" → "이번 해소
-    패스에서 아직 시도 안 한 DJ". **큐의 모든 DJ 가 재생가능 트랙 0 일 때만**
+  - **deactivate 조건 정정 + 재귀/회전 정합**: 현재 `doStart` 는 진입마다
+    `rotateDjQueue(...)` 를 **무조건 1회** 호출(line ~111) 후
+    `remainingAttempts<=1` 면 deactivate, 아니면 `doStart(reloaded,
+    remainingAttempts-1)` 재귀(재진입마다 또 rotateDjQueue). 본 설계는
+    **DJ 큐 회전을 사이클당 1회로 유지**하고, "재생가능 DJ 탐색"을
+    *재귀 재진입(매번 rotateDjQueue)* 이 아니라 **이미 회전된 DJ 리스트
+    위의 내부 순회**로 구현: 회전된 큐를 orderNumber 순으로 스캔하며 첫
+    "재생가능 트랙 보유 DJ" 를 찾고, 그 DJ 의 첫 limit-이내 트랙 재생 +
+    `rotatePlayed`. **스캔이 큐 전체를 돌아도 재생가능 트랙이 0 일 때만**
     `deactivateAndNotify`(기존 `deactivatePlayback`→`removeDjs` 경로 그대로 =
-    정당 케이스). 1 해소 패스 내 각 DJ 최대 1회 시도 → 무한루프 가드.
+    정당 케이스). 각 DJ 1 스캔당 최대 1회 평가 → 무한루프·DJ큐 이중회전
+    가드. (`remainingAttempts`(=`queuedDjs.size()`) 카운터는 이 내부 스캔
+    상한으로 의미 재정의.)
 - 불변식: "DJ 1명 + 전 트랙 over-limit → deactivate"(정당) 보존 / "DJ 1명 +
-  재생가능 트랙 있음 → 그 트랙들 재생"(버그 해소) / over-limit 트랙 순서 보존.
+  재생가능 트랙 있음 → 그 트랙들 재생"(버그 해소) / over-limit 트랙 순서 보존 /
+  #222 position-1 정상흐름 behaviorally identical.
 - 범위밖: DJ 전 트랙 over-limit 인 DJ 의 큐 자동 제거(파괴적, 미채택 — 큐 잔류
-  패스). #222 skip→reorder 동작 불변(회귀 잠금).
+  패스). per-user `tryEnter` race 등 무관 영역.
 
 ### 3-2. UX 신호 백엔드 (pfplay-platform) — (PR-2)
 
@@ -119,6 +154,15 @@ reason=ALL_TRACKS_EXCEEDED` 등 로그만 추가, 구조·`DjQueueChangeMessage`
 - changeType 구·신 혼재: 프론트 미지값=무동작, 신규필드 부재=기존 경로 — 안전.
 - 리치 payload: 거부 트랙이 식별 불가한 극단(플레이리스트 동시삭제 등) →
   trackName/duration null 허용, 모달은 일반 문구로 폴백.
+- **롤링 배포 직렬화 윈도우 (명시 스코프)**: `DjQueueChangeMessage` 는
+  `Serializable` record. 필드 추가는 *신규 메시지 생산*·*소비자 필드 독해*
+  관점에선 backward-compat 이나, **롤링 배포 윈도우 중 Redis pub/sub 에 떠
+  있던 구 포맷 메시지를 신 인스턴스가 deserialize**(또는 역) 할 때 record
+  암묵 `serialVersionUID` 변경으로 실패 가능. Redis pub/sub 는 fire-and-forget
+  ·저블래스트라 **해당 메시지 1건 transient drop 으로 허용**(다음
+  dj-queue-changed 가 late-binding 전체 djs 재브로드캐스트로 self-heal).
+  스탠스 = 명시적 수용(별도 `serialVersionUID` 핀은 필드 변경 cross-compat
+  를 보장하지 못하므로 무의미 — 수용이 정직한 결정). 배포 윈도우 외 정상.
 
 ## 5. 테스트 (TDD)
 

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/PlaylistAggregateAdapter.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/PlaylistAggregateAdapter.java
@@ -96,11 +96,6 @@ public class PlaylistAggregateAdapter implements PlaylistAggregatePort, Playlist
     // ===== Track Reordering =====
 
     @Override
-    public void rotateTrackOrder(Long playlistId, long totalCount) {
-        trackRepository.reorderTracks(playlistId, totalCount);
-    }
-
-    @Override
     public void rotatePlayed(Long playlistId, int playedOrderNumber, long totalCount) {
         trackRepository.rotatePlayedOrder(playlistId, playedOrderNumber, totalCount);
     }

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/PlaylistAggregateAdapter.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/PlaylistAggregateAdapter.java
@@ -101,6 +101,11 @@ public class PlaylistAggregateAdapter implements PlaylistAggregatePort, Playlist
     }
 
     @Override
+    public void rotatePlayed(Long playlistId, int playedOrderNumber, long totalCount) {
+        trackRepository.rotatePlayedOrder(playlistId, playedOrderNumber, totalCount);
+    }
+
+    @Override
     public void shiftUpTrackOrderByDelete(Long playlistId, Integer deleteOrderNumber) {
         trackRepository.shiftUpOrderByDelete(playlistId, deleteOrderNumber);
     }

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepository.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepository.java
@@ -28,6 +28,16 @@ public interface TrackRepository extends JpaRepository<TrackData, Long>, TrackRe
     void reorderTracks(@Param("playlistId") Long playlistId, @Param("totalElements") long totalElements);
 
     @Modifying
+    @Query("UPDATE TrackData pm SET pm.orderNumber = CASE " +
+            "WHEN pm.orderNumber = :playedOrderNumber THEN :totalElements " +
+            "WHEN pm.orderNumber > :playedOrderNumber THEN pm.orderNumber - 1 " +
+            "ELSE pm.orderNumber END " +
+            "WHERE pm.playlistId.id = :playlistId")
+    void rotatePlayedOrder(@Param("playlistId") Long playlistId,
+                           @Param("playedOrderNumber") int playedOrderNumber,
+                           @Param("totalElements") long totalElements);
+
+    @Modifying
     @Query("UPDATE TrackData pm " +
             "SET pm.orderNumber =  pm.orderNumber - 1" +
             "WHERE pm.playlistId.id = :playlistId " +

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepository.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepository.java
@@ -22,13 +22,6 @@ public interface TrackRepository extends JpaRepository<TrackData, Long>, TrackRe
 
     @Modifying
     @Query("UPDATE TrackData pm SET pm.orderNumber = CASE " +
-            "WHEN pm.orderNumber = 1 THEN :totalElements " +
-            "ELSE pm.orderNumber - 1 END " +
-            "WHERE pm.playlistId.id = :playlistId")
-    void reorderTracks(@Param("playlistId") Long playlistId, @Param("totalElements") long totalElements);
-
-    @Modifying
-    @Query("UPDATE TrackData pm SET pm.orderNumber = CASE " +
             "WHEN pm.orderNumber = :playedOrderNumber THEN :totalElements " +
             "WHEN pm.orderNumber > :playedOrderNumber THEN pm.orderNumber - 1 " +
             "ELSE pm.orderNumber END " +

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackCommandService.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackCommandService.java
@@ -37,6 +37,8 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class TrackCommandService {
 
+    private static final int MAX_PLAYLIST_TRACK_COUNT = 15;
+
     private final PlaylistAggregatePort aggregatePort;
     private final PlaylistQueryPort queryPort;
     private final PlaylistQueryService playlistQueryService;
@@ -53,7 +55,7 @@ public class TrackCommandService {
         if (optional.isPresent()) throw ExceptionCreator.create(TrackException.DUPLICATE_TRACK_IN_PLAYLIST);
         // 최대 보유 한계치 초과 검사
         PlaylistSummaryDto playlistSummary = playlistQueryService.getPlaylist(playlistId);
-        if (playlistSummary.musicCount() >= 15) throw ExceptionCreator.create(TrackException.EXCEEDED_TRACK_LIMIT);
+        if (playlistSummary.musicCount() >= MAX_PLAYLIST_TRACK_COUNT) throw ExceptionCreator.create(TrackException.EXCEEDED_TRACK_LIMIT);
 
         long nextMusicOrderNumber = playlistSummary.musicCount() == 0 ? 1 : playlistSummary.musicCount() + 1;
 
@@ -122,7 +124,7 @@ public class TrackCommandService {
         if (duplicate.isPresent()) throw ExceptionCreator.create(TrackException.DUPLICATE_TRACK_IN_PLAYLIST);
         // 타겟 트랙 개수 15개 제한 검사
         PlaylistSummaryDto targetSummary = playlistQueryService.getPlaylist(command.targetPlaylistId());
-        if (targetSummary.musicCount() >= 15) throw ExceptionCreator.create(TrackException.EXCEEDED_TRACK_LIMIT);
+        if (targetSummary.musicCount() >= MAX_PLAYLIST_TRACK_COUNT) throw ExceptionCreator.create(TrackException.EXCEEDED_TRACK_LIMIT);
         // 소스 orderNumber 재정렬
         aggregatePort.shiftUpTrackOrderByDelete(sourcePlaylistId, trackData.getOrderNumber());
         // 트랙을 타겟 플레이리스트로 이동
@@ -169,7 +171,7 @@ public class TrackCommandService {
 
     @Transactional(readOnly = true)
     public List<PlaybackTrackDto> peekOrderedTracks(Long playlistId) {
-        Pageable pageable = PageRequest.of(0, 15, Sort.by(Sort.Direction.ASC, "orderNumber"));
+        Pageable pageable = PageRequest.of(0, MAX_PLAYLIST_TRACK_COUNT, Sort.by(Sort.Direction.ASC, "orderNumber"));
         Page<PlaylistTrackDto> page = queryPort.getTracksWithPagination(new PlaylistId(playlistId), pageable);
         return page.getContent().stream()
                 .map(dto -> new PlaybackTrackDto(dto.linkId(), dto.name(),

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackCommandService.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackCommandService.java
@@ -150,25 +150,6 @@ public class TrackCommandService {
         eventPublisher.publishEvent(new TrackRemovedEvent(new PlaylistId(playlistId), trackId, trackData.getLinkId(), trackData.getName()));
     }
 
-    @Transactional
-    public PlaybackTrackDto getFirstTrack(Long playlistId) {
-        Pageable pageable = PageRequest.of(0, 5, Sort.by(Sort.Direction.ASC, "orderNumber"));
-        Page<PlaylistTrackDto> page = queryPort.getTracksWithPagination(new PlaylistId(playlistId), pageable);
-        rotateTrackOrder(playlistId, page.getTotalElements());
-        PlaylistTrackDto dto = page.getContent().get(0);
-        return new PlaybackTrackDto(
-                dto.linkId(),
-                dto.name(),
-                dto.thumbnailImage(),
-                dto.duration(),
-                dto.orderNumber()
-        );
-    }
-
-    public void rotateTrackOrder(Long playlistId, long totalCount) {
-        aggregatePort.rotateTrackOrder(playlistId, totalCount);
-    }
-
     @Transactional(readOnly = true)
     public List<PlaybackTrackDto> peekOrderedTracks(Long playlistId) {
         Pageable pageable = PageRequest.of(0, MAX_PLAYLIST_TRACK_COUNT, Sort.by(Sort.Direction.ASC, "orderNumber"));

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackCommandService.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackCommandService.java
@@ -29,6 +29,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -164,5 +165,20 @@ public class TrackCommandService {
 
     public void rotateTrackOrder(Long playlistId, long totalCount) {
         aggregatePort.rotateTrackOrder(playlistId, totalCount);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PlaybackTrackDto> peekOrderedTracks(Long playlistId) {
+        Pageable pageable = PageRequest.of(0, 15, Sort.by(Sort.Direction.ASC, "orderNumber"));
+        Page<PlaylistTrackDto> page = queryPort.getTracksWithPagination(new PlaylistId(playlistId), pageable);
+        return page.getContent().stream()
+                .map(dto -> new PlaybackTrackDto(dto.linkId(), dto.name(),
+                        dto.thumbnailImage(), dto.duration(), dto.orderNumber()))
+                .toList();
+    }
+
+    @Transactional
+    public void rotatePlayed(Long playlistId, int playedOrderNumber, long totalCount) {
+        aggregatePort.rotatePlayed(playlistId, playedOrderNumber, totalCount);
     }
 }

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/port/PlaylistAggregatePort.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/port/PlaylistAggregatePort.java
@@ -30,6 +30,7 @@ public interface PlaylistAggregatePort {
 
     // ===== Track Reordering (batch operations) =====
     void rotateTrackOrder(Long playlistId, long totalCount);
+    void rotatePlayed(Long playlistId, int playedOrderNumber, long totalCount);
     void shiftUpTrackOrderByDelete(Long playlistId, Integer deleteOrderNumber);
     void shiftUpTrackOrderByDnD(Long playlistId, Integer prevOrderNumber, Integer nextOrderNumber);
     void shiftDownTrackOrderByDnD(Long playlistId, Integer prevOrderNumber, Integer nextOrderNumber);

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/port/PlaylistAggregatePort.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/port/PlaylistAggregatePort.java
@@ -29,7 +29,6 @@ public interface PlaylistAggregatePort {
     boolean hasTracksByPlaylist(PlaylistId playlistId);
 
     // ===== Track Reordering (batch operations) =====
-    void rotateTrackOrder(Long playlistId, long totalCount);
     void rotatePlayed(Long playlistId, int playedOrderNumber, long totalCount);
     void shiftUpTrackOrderByDelete(Long playlistId, Integer deleteOrderNumber);
     void shiftUpTrackOrderByDnD(Long playlistId, Integer prevOrderNumber, Integer nextOrderNumber);

--- a/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/TrackCommandServiceTest.java
+++ b/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/TrackCommandServiceTest.java
@@ -558,4 +558,49 @@ class TrackCommandServiceTest {
         assertThatThrownBy(() -> trackCommandService.deleteTrackInPlaylist(playlistId, trackId))
                 .isInstanceOf(NotFoundException.class);
     }
+
+    // ========== peekOrderedTracks ==========
+
+    @Test
+    @DisplayName("peekOrderedTracks — 순서 오름차순으로 반환하며 회전 없음")
+    void peekOrderedTracks_returns_ordered_without_rotation() {
+        // given
+        Long playlistId = 1L;
+        PlaylistTrackDto trackDto1 = new PlaylistTrackDto(10L, LINK_ID, "Song A", 1, Duration.fromString("3:30"), THUMBNAIL);
+        PlaylistTrackDto trackDto2 = new PlaylistTrackDto(11L, "linkId2", "Song B", 2, Duration.fromString("4:00"), THUMBNAIL);
+
+        @SuppressWarnings("unchecked")
+        Page<PlaylistTrackDto> page = mock(Page.class);
+        when(page.getContent()).thenReturn(List.of(trackDto1, trackDto2));
+
+        when(queryPort.getTracksWithPagination(eq(new PlaylistId(playlistId)), any(Pageable.class)))
+                .thenReturn(page);
+
+        // when
+        List<PlaybackTrackDto> result = trackCommandService.peekOrderedTracks(playlistId);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).orderNumber()).isEqualTo(1);
+        assertThat(result.get(0).linkId()).isEqualTo(LINK_ID);
+        assertThat(result.get(0).name()).isEqualTo("Song A");
+        assertThat(result.get(0).thumbnailImage()).isEqualTo(THUMBNAIL);
+        assertThat(result.get(0).duration()).isEqualTo(Duration.fromString("3:30"));
+        assertThat(result.get(1).orderNumber()).isEqualTo(2);
+
+        verify(aggregatePort, never()).rotateTrackOrder(anyLong(), anyLong());
+        verify(aggregatePort, never()).rotatePlayed(anyLong(), anyInt(), anyLong());
+    }
+
+    // ========== rotatePlayed ==========
+
+    @Test
+    @DisplayName("rotatePlayed — aggregatePort.rotatePlayed에 위임한다")
+    void rotatePlayed_delegates() {
+        // when
+        trackCommandService.rotatePlayed(1L, 3, 5L);
+
+        // then
+        verify(aggregatePort).rotatePlayed(1L, 3, 5L);
+    }
 }

--- a/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/TrackCommandServiceTest.java
+++ b/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/TrackCommandServiceTest.java
@@ -427,35 +427,6 @@ class TrackCommandServiceTest {
                 .isInstanceOf(BadRequestException.class);
     }
 
-    // ========== getFirstTrack ==========
-
-    @Test
-    @DisplayName("getFirstTrack — 첫 번째 트랙을 PlaybackTrackDto로 반환하고 순서를 회전시킨다")
-    void getFirstTrackReturnsFirstTrackAndRotates() {
-        // given
-        Long playlistId = 1L;
-        PlaylistTrackDto trackDto = new PlaylistTrackDto(10L, LINK_ID, "Song A", 1, Duration.fromString("3:30"), THUMBNAIL);
-
-        @SuppressWarnings("unchecked")
-        Page<PlaylistTrackDto> page = mock(Page.class);
-        when(page.getContent()).thenReturn(List.of(trackDto));
-        when(page.getTotalElements()).thenReturn(3L);
-
-        when(queryPort.getTracksWithPagination(eq(new PlaylistId(playlistId)), any(Pageable.class)))
-                .thenReturn(page);
-
-        // when
-        PlaybackTrackDto result = trackCommandService.getFirstTrack(playlistId);
-
-        // then
-        assertThat(result.linkId()).isEqualTo(LINK_ID);
-        assertThat(result.name()).isEqualTo("Song A");
-        assertThat(result.thumbnailImage()).isEqualTo(THUMBNAIL);
-        assertThat(result.duration()).isEqualTo(Duration.fromString("3:30"));
-        assertThat(result.orderNumber()).isEqualTo(1);
-        verify(aggregatePort).rotateTrackOrder(playlistId, 3L);
-    }
-
     // ========== 추가 예외 케이스 ==========
 
     @Test
@@ -588,7 +559,6 @@ class TrackCommandServiceTest {
         assertThat(result.get(0).duration()).isEqualTo(Duration.fromString("3:30"));
         assertThat(result.get(1).orderNumber()).isEqualTo(2);
 
-        verify(aggregatePort, never()).rotateTrackOrder(anyLong(), anyLong());
         verify(aggregatePort, never()).rotatePlayed(anyLong(), anyInt(), anyLong());
     }
 


### PR DESCRIPTION
## 배경 (E/#3)

DJ 큐의 사용자들이 그 파티룸 active DJ 전부일 때, 회전 차례에 파티룸 `playbackTimeLimit` 초과 트랙을 만나면 그 트랙이 패스되지 않고 **파티룸 전체 deactivate + DJ 큐 전원 removeDjs** 됐다(remainingAttempts=DJ수≤1 즉시 deactivate). 사용자 체감 = "추가한 곡이 안 나오고 큐에서 영문없이 빠짐". 노트: `bugs/2026-05-14-playback-time-limit-deactivate-cascade.md`.

본 PR = **E/#3 4-PR 시리즈의 PR-1 (platform 핵심 동작)**. 독립 출하 가능. PR-2(changeType payload)·PR-3(web UX 모달)·PR-4(반응형 배지)는 후속(별 PR, 동일 spec).

## 변경 (결정: 트랙 단위 스킵 / 제자리 유지 — 사용자 확정)

- **`rotatePlayedOrder`** (TrackRepository, 단일 set-based CASE — 기존 `reorderTracks` CASE 의 파라미터화 일반화): 재생 트랙만 tail, `<k`(over-limit) 제자리, `>k` −1. k=1 시 legacy `reorderTracks` 와 **산술 동일**(통합테스트로 잠금) → #222 position-1 정상흐름 behaviorally identical.
- **`peekOrderedTracks`** (부작용 0, `@Transactional(readOnly)`, size=`MAX_PLAYLIST_TRACK_COUNT`=15=플레이리스트 상한) + **`rotatePlayed`** 위임. 포트/어댑터 `getFirstTrack`(rotate-then-take) → peek/rotatePlayed 교체.
- **`doStart` 재설계**: `rotateDjQueue` **사이클당 1회** → 회전된 DJ 를 orderNumber 순 내부 스캔. 각 DJ peek 에서 **limit 이내 첫 트랙** 재생(+`rotatePlayed`); DJ 전 트랙 over-limit → 그 DJ 패스(큐 잔류, 다음 DJ); **큐의 모든 DJ 가 재생가능 트랙 0 일 때만** `deactivateAndNotify`(기존 경로 그대로). 재귀 제거(무한루프·DJ큐 이중회전 불가). 커밋 블록은 `startPlaybackFor` 헬퍼로 추출(행위 불변). 죽은코드(getFirstTrack/rotateTrackOrder/reorderTracks/getNextPlaybackInPlaylist) 정리.
- **불변식**: "DJ 1명 + 전 트랙 over-limit → deactivate"(정당) 보존 / "DJ 1명 + 재생가능 트랙 있음 → 재생"(버그 해소) / over-limit 제자리.

## 범위 경계

`deactivateAndNotify`/`PartyroomAggregateService.deactivatePlayback`/`DjQueueChangeMessage`/`DjChangeType` **무변경**(changeType payload·web·배지 = PR-2/3/4). spec/plan: `docs/superpowers/{specs,plans}/2026-05-19-e3-*`. brainstorm→spec(리뷰 2회)→plan(리뷰 2회, rotatePlayed 2문장 조합 산술버그 포착·CASE 로 정정)→subagent-driven TDD(태스크별 spec+code-quality 2단 리뷰)→최종 종합리뷰 ✅.

## 검증

- **unit GREEN**: `:playlist:test` **71/71** · `:app:test` **898/898** (forced rerun). `PlaybackCommandServiceTest` 12(트랙스킵/다DJ/전트랙초과 신규 + #222 보존), `TrackCommandServiceTest`, `TrackRepositoryReorderIntegrationTest` **2/2**(k>1 갭없음·k=1≡legacy).
- **`:app:integrationTest` 4건 실패 = 본 PR 무관·사전존재 develop 테스트 부채** → 별도 추적 **#237**. 근본 = `288d4c69`(PA-7.1, 2026-05-02) 가 추가한 프로필 선결조건을 그 이전 작성된 IT 픽스처가 미반영(프로필 등록 누락 → `ForbiddenException`). clean `origin/develop`(E/#3 코드 0)에서 동일 시그니처 재현으로 PR-1 회귀 아님 입증. Hikari 에러는 teardown 하류 잡음(원인 아님)으로 확정.
- prod(main/release) 승격은 별도 release 게이트(사용자 영역). dev/stg 머지 후 PR-2 진행.

Refs E/#3 (로드맵 Cluster E). 별건: #237 (PA-7.1 IT 부채).