### PR TITLE
fix(test): 프로필 선결조건(PA-7.1) 미반영 통합테스트 4건 픽스처 수정 (#237)

### DIFF
--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/listener/UserActivityLogListenerCrewAccessIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/listener/UserActivityLogListenerCrewAccessIT.java
@@ -11,6 +11,7 @@ import com.pfplaybackend.api.common.enums.AuthorityTier;
 import com.pfplaybackend.api.party.adapter.out.persistence.CrewRepository;
 import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomPlaybackRepository;
 import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomRepository;
+import com.pfplaybackend.api.party.application.port.out.UserProfileQueryPort;
 import com.pfplaybackend.api.party.application.service.PartyroomAccessCommandService;
 import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
 import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
@@ -20,6 +21,7 @@ import com.pfplaybackend.api.party.domain.value.LinkDomain;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
 import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
 import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -27,13 +29,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
+import java.util.Map;
 
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 
 /**
  * G5 end-to-end (2/2): 크루(non-host) 룸 진입 → user_activity_log PARTYROOM_ENTERED row 누적 검증.
@@ -58,6 +65,13 @@ class UserActivityLogListenerCrewAccessIT extends AbstractIntegrationTest {
     @Autowired private UserActivityLogRepository userActivityLogRepository;
     @Autowired private TransactionTemplate transactionTemplate;
 
+    /**
+     * tryEnter → assertHasProfile(PA-7.1) 게이트만 무력화 — listener wiring 검증과 직교.
+     * (실제 ProfileData 행 구성은 fragile — ClusterAPresenceIntegrationTest 와 동일 패턴.)
+     */
+    @MockBean
+    private UserProfileQueryPort userProfileQueryPort;
+
     private static final Long ENTERER_USER_ID = 9981L;
     private static final Long HOST_USER_ID = 9982L;
 
@@ -65,6 +79,16 @@ class UserActivityLogListenerCrewAccessIT extends AbstractIntegrationTest {
 
     @BeforeEach
     void seed() {
+        // 어떤 userId 든 프로필 보유 상태로 — assertHasProfile 통과.
+        lenient().when(userProfileQueryPort.getUsersProfileSetting(any()))
+                .thenAnswer(inv -> {
+                    List<UserId> ids = inv.getArgument(0);
+                    Map<UserId, ProfileSettingDto> result = new java.util.HashMap<>();
+                    for (UserId id : ids) {
+                        result.put(id, mock(ProfileSettingDto.class));
+                    }
+                    return result;
+                });
         // host UA + enterer UA
         userAccountRepository.save(
                 UserAccountData.createForLocalWithMandatoryChange(

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/listener/UserActivityLogListenerPartyroomCreatedIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/listener/UserActivityLogListenerPartyroomCreatedIT.java
@@ -13,8 +13,10 @@ import com.pfplaybackend.api.party.adapter.out.persistence.DjQueueRepository;
 import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomPlaybackRepository;
 import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomRepository;
 import com.pfplaybackend.api.party.application.dto.command.CreatePartyroomCommand;
+import com.pfplaybackend.api.party.application.port.out.UserProfileQueryPort;
 import com.pfplaybackend.api.party.application.service.PartyroomCommandService;
 import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
 import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -22,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.Duration;
@@ -29,6 +32,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 
 /**
  * G4 end-to-end: 호스트 createGeneralPartyRoom 호출 → user_activity_log PARTYROOM_CREATED row 누적 검증.
@@ -55,10 +61,29 @@ class UserActivityLogListenerPartyroomCreatedIT extends AbstractIntegrationTest 
     @Autowired private UserActivityLogRepository userActivityLogRepository;
     @Autowired private TransactionTemplate transactionTemplate;
 
+    /**
+     * createGeneralPartyRoom → enterByHost → assertHasProfile(PA-7.1) 게이트만 무력화 —
+     * listener wiring 검증과 직교. (실제 ProfileData 행 구성은 fragile —
+     * ClusterAPresenceIntegrationTest 와 동일 패턴.)
+     */
+    @MockBean
+    private UserProfileQueryPort userProfileQueryPort;
+
     private static final Long HOST_USER_ID = 8961L;
 
     @BeforeEach
     void seed() {
+        // 어떤 userId 든 프로필 보유 상태로 — assertHasProfile 통과.
+        lenient().when(userProfileQueryPort.getUsersProfileSetting(any()))
+                .thenAnswer(inv -> {
+                    List<UserId> ids = inv.getArgument(0);
+                    Map<UserId, ProfileSettingDto> result = new java.util.HashMap<>();
+                    for (UserId id : ids) {
+                        result.put(id, mock(ProfileSettingDto.class));
+                    }
+                    return result;
+                });
+
         // host user_account — createGeneralPartyRoom의 hostId 기준 audit row 작성을 위해 필요.
         userAccountRepository.save(
                 UserAccountData.createForLocalWithMandatoryChange(

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceRaceIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceRaceIT.java
@@ -6,27 +6,57 @@ import com.pfplaybackend.api.common.ThreadLocalContext;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.enums.AuthorityTier;
 import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomRepository;
+import com.pfplaybackend.api.party.application.port.out.UserProfileQueryPort;
 import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
 import com.pfplaybackend.api.party.domain.enums.StageType;
 import com.pfplaybackend.api.party.domain.value.CountryCode;
 import com.pfplaybackend.api.party.domain.value.LinkDomain;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 
 class PartyroomAccessCommandServiceRaceIT extends AbstractIntegrationTest {
 
     @Autowired private PartyroomAccessCommandService accessCommandService;
     @Autowired private PartyroomRepository partyroomRepository;
+
+    /**
+     * tryEnter → assertHasProfile(PA-7.1) 게이트만 무력화 — race invariant 검증과 직교.
+     * (실제 ProfileData 행 구성은 fragile — ClusterAPresenceIntegrationTest 와 동일 패턴.)
+     */
+    @MockBean
+    private UserProfileQueryPort userProfileQueryPort;
+
+    @BeforeEach
+    void seedProfileGate() {
+        // 어떤 userId 든 프로필 보유 상태로 — assertHasProfile 통과.
+        lenient().when(userProfileQueryPort.getUsersProfileSetting(any()))
+                .thenAnswer(inv -> {
+                    List<UserId> ids = inv.getArgument(0);
+                    Map<UserId, ProfileSettingDto> result = new java.util.HashMap<>();
+                    for (UserId id : ids) {
+                        result.put(id, mock(ProfileSettingDto.class));
+                    }
+                    return result;
+                });
+    }
 
     private long createActiveRoom(long hostUid) {
         PartyroomData p = PartyroomData.create(

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomLifecycleIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomLifecycleIntegrationTest.java
@@ -10,17 +10,23 @@ import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomPlaybackRepo
 import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomRepository;
 import com.pfplaybackend.api.party.application.dto.command.CreatePartyroomCommand;
 import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.application.port.out.UserProfileQueryPort;
 import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
 import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
+import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
@@ -35,6 +41,14 @@ class PartyroomLifecycleIntegrationTest extends AbstractIntegrationTest {
     @Autowired
     private DjQueueRepository djQueueRepository;
 
+    /**
+     * createGeneralPartyRoom → enterByHost → assertHasProfile(PA-7.1) 게이트만 무력화 —
+     * 본 테스트의 aggregate 영속 검증과 직교. (실제 ProfileData 행 구성은 fragile —
+     * ClusterAPresenceIntegrationTest / CreateGeneralPartyRoomInvariantIntegrationTest 와 동일 패턴.)
+     */
+    @MockBean
+    private UserProfileQueryPort userProfileQueryPort;
+
     private UserId hostId;
 
     @BeforeEach
@@ -44,6 +58,17 @@ class PartyroomLifecycleIntegrationTest extends AbstractIntegrationTest {
         lenient().when(authContext.getUserId()).thenReturn(hostId);
         lenient().when(authContext.getAuthorityTier()).thenReturn(AuthorityTier.FM);
         ThreadLocalContext.setContext(authContext);
+
+        // 어떤 userId 든 프로필 보유 상태로 — assertHasProfile 통과.
+        lenient().when(userProfileQueryPort.getUsersProfileSetting(any()))
+                .thenAnswer(inv -> {
+                    List<UserId> ids = inv.getArgument(0);
+                    Map<UserId, ProfileSettingDto> result = new java.util.HashMap<>();
+                    for (UserId id : ids) {
+                        result.put(id, mock(ProfileSettingDto.class));
+                    }
+                    return result;
+                });
     }
 
     @AfterEach


### PR DESCRIPTION
## 배경

`288d4c69`(2026-05-02, PA-7.1)가 `PartyroomAccessCommandService.tryEnter`/`enterByHost` 에 `assertHasProfile()`(`UserProfileQueryPort.getUsersProfileSetting` 결과 맵에 userId 없으면 `PROFILE_REQUIRED` ForbiddenException) 선결조건을 추가. 그 이전 작성된 IT 4건의 픽스처가 프로필 게이트 미반영 → develop red(약 2.5주). E/#3 PR-1(#238) 무관 별건 = **#237**.

## 변경 (테스트 전용)

대상 4: `PartyroomLifecycleIntegrationTest`, `UserActivityLogListenerCrewAccessIT`, `UserActivityLogListenerPartyroomCreatedIT`, `PartyroomAccessCommandServiceRaceIT`.

코드베이스 **canonical 패턴 그대로 재사용**(신규 test-support 인프라 미발명): `@MockBean UserProfileQueryPort` + `lenient().when(getUsersProfileSetting(any())).thenAnswer(요청 userId 들 → ProfileSettingDto mock 맵)` — 이미 GREEN 인 `ClusterAPresenceIntegrationTest`/`CreateGeneralPartyRoomInvariantIntegrationTest` 의 `seedProfileGate` 와 character-identical. 각 파일 기존 라이프사이클(`setUp`/`seed`/신규 `@BeforeEach`)에 맞춰 배치. **프로덕션 코드·단언 변경 0, @Disabled/스킵/마스킹 0.**

## 검증

- 격리 3 + race 별도 + `:app:test` unit: 전부 GREEN (JUnit XML failures=0/errors=0; Hikari shutdown-hook 로그는 통과 후 teardown 잡음). 2단 리뷰(spec+code-quality) 통과.
- 근본은 #237 본문에 git 이력으로 확정 기재(예전 IT가 PA-7.1 invariant 미반영).

## 후속(비차단)

- 동일 ~11줄 스텁이 6 IT 중복 → 추후 공용 헬퍼로 de-dup 가능(별 백로그, 본 PR 범위 밖 — 기존 컨벤션 준수가 우선).
- #237 본문의 "CI 가 :app:integrationTest 를 게이트하는가" 미확정 질문은 별도 확인 대상(본 PR 과 분리).

Closes #237