### PR TITLE
feat(E/#3) PR-2: dj-queue-changed changeType + DEACTIVATE limit payload (platform)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/message/DjQueueChangeMessage.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/message/DjQueueChangeMessage.java
@@ -2,6 +2,7 @@ package com.pfplaybackend.api.party.adapter.in.listener.message;
 
 import com.pfplaybackend.api.common.domain.enums.MessageTopic;
 import com.pfplaybackend.api.party.application.dto.dj.DjWithProfileDto;
+import com.pfplaybackend.api.party.domain.enums.DjChangeType;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 
 import java.io.Serializable;
@@ -13,11 +14,15 @@ public record DjQueueChangeMessage(
         MessageTopic eventType,
         String id,
         long timestamp,
-        List<DjWithProfileDto> djs
+        List<DjWithProfileDto> djs,
+        DjChangeType changeType,
+        Integer playbackTimeLimitMinutes
 ) implements Serializable, GroupBroadcastMessage {
 
-    public static DjQueueChangeMessage create(PartyroomId partyroomId, List<DjWithProfileDto> djs) {
+    public static DjQueueChangeMessage create(PartyroomId partyroomId, List<DjWithProfileDto> djs,
+                                              DjChangeType changeType, Integer playbackTimeLimitMinutes) {
         return new DjQueueChangeMessage(partyroomId, MessageTopic.DJ_QUEUE_CHANGED,
-                UUID.randomUUID().toString(), System.currentTimeMillis(), djs);
+                UUID.randomUUID().toString(), System.currentTimeMillis(), djs,
+                changeType, playbackTimeLimitMinutes);
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/message/DjQueueChangeMessage.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/message/DjQueueChangeMessage.java
@@ -16,6 +16,7 @@ public record DjQueueChangeMessage(
         long timestamp,
         List<DjWithProfileDto> djs,
         DjChangeType changeType,
+        // DEACTIVATE 한정 limit-only(분), 그 외 null
         Integer playbackTimeLimitMinutes
 ) implements Serializable, GroupBroadcastMessage {
 

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/event/DomainEventRedisRelay.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/event/DomainEventRedisRelay.java
@@ -48,7 +48,9 @@ public class DomainEventRedisRelay {
     public void on(DjQueueChangedEvent event) {
         DjQueueChangeMessage message = DjQueueChangeMessage.create(
                 event.getPartyroomId(),
-                partyroomQueryService.getDjs(event.getPartyroomId()));
+                partyroomQueryService.getDjs(event.getPartyroomId()),
+                event.getChangeType(),
+                event.getPlaybackTimeLimitMinutes());
         log.info("[relay] DJ_QUEUE_CHANGED - partyroomId={}, messageId={}",
                 event.getPartyroomId().getId(), message.id());
         messagePublisher.publish(MessageTopic.DJ_QUEUE_CHANGED.topic(), message);

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java
@@ -194,7 +194,8 @@ public class PlaybackCommandService implements PlaybackControlPort {
     private void deactivateAndNotify(PartyroomData partyroom) {
         PartyroomId partyroomId = partyroom.getPartyroomId();
         log.warn("[deactivateAndNotify] partyroomId={} - publishing DEACTIVATE event + clearing DJ queue", partyroomId.getId());
-        eventPublisher.publishEvent(new DjQueueChangedEvent(partyroomId, DjChangeType.DEACTIVATE, null));
+        eventPublisher.publishEvent(new DjQueueChangedEvent(partyroomId, DjChangeType.DEACTIVATE, null,
+                partyroom.getPlaybackTimeLimit().getMinutes()));
         partyroomAggregateService.deactivatePlayback(partyroomId)
                 .forEach(eventPublisher::publishEvent);
     }

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/event/DjQueueChangedEvent.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/event/DjQueueChangedEvent.java
@@ -11,11 +11,18 @@ public class DjQueueChangedEvent extends DomainEvent {
     private final PartyroomId partyroomId;
     private final DjChangeType changeType;
     private final CrewId affectedCrewId;
+    private final Integer playbackTimeLimitMinutes; // DEACTIVATE 한정 limit-only, 그 외 null
 
     public DjQueueChangedEvent(PartyroomId partyroomId, DjChangeType changeType, CrewId affectedCrewId) {
+        this(partyroomId, changeType, affectedCrewId, null);
+    }
+
+    public DjQueueChangedEvent(PartyroomId partyroomId, DjChangeType changeType, CrewId affectedCrewId,
+                               Integer playbackTimeLimitMinutes) {
         this.partyroomId = partyroomId;
         this.changeType = changeType;
         this.affectedCrewId = affectedCrewId;
+        this.playbackTimeLimitMinutes = playbackTimeLimitMinutes;
     }
 
     @Override

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/in/listener/message/DjQueueChangeMessageTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/in/listener/message/DjQueueChangeMessageTest.java
@@ -1,0 +1,45 @@
+package com.pfplaybackend.api.party.adapter.in.listener.message;
+
+import com.pfplaybackend.api.common.domain.enums.MessageTopic;
+import com.pfplaybackend.api.party.application.dto.dj.DjWithProfileDto;
+import com.pfplaybackend.api.party.domain.enums.DjChangeType;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DjQueueChangeMessageTest {
+
+    private final PartyroomId partyroomId = new PartyroomId(1L);
+    private final List<DjWithProfileDto> djs = List.of(new DjWithProfileDto(10L, 1, "DJ1", "icon1"));
+
+    @Test
+    @DisplayName("create — DEACTIVATE + limit 분이 changeType/playbackTimeLimitMinutes 로 보존된다")
+    void createWithDeactivateAndLimitCarriesChangeTypeAndLimit() {
+        // when
+        DjQueueChangeMessage message =
+                DjQueueChangeMessage.create(partyroomId, djs, DjChangeType.DEACTIVATE, 5);
+
+        // then
+        assertThat(message.changeType()).isEqualTo(DjChangeType.DEACTIVATE);
+        assertThat(message.playbackTimeLimitMinutes()).isEqualTo(5);
+        assertThat(message.eventType()).isEqualTo(MessageTopic.DJ_QUEUE_CHANGED);
+        assertThat(message.djs()).isEqualTo(djs);
+        assertThat(message.id()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("create — DEACTIVATE 외 changeType 은 playbackTimeLimitMinutes 가 null 로 유지된다")
+    void createWithNonDeactivateKeepsLimitNull() {
+        // when
+        DjQueueChangeMessage message =
+                DjQueueChangeMessage.create(partyroomId, djs, DjChangeType.ROTATE, null);
+
+        // then
+        assertThat(message.changeType()).isEqualTo(DjChangeType.ROTATE);
+        assertThat(message.playbackTimeLimitMinutes()).isNull();
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/out/event/DomainEventRedisRelayTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/out/event/DomainEventRedisRelayTest.java
@@ -4,6 +4,7 @@ import com.pfplaybackend.api.common.config.redis.RedisMessagePublisher;
 import com.pfplaybackend.api.common.domain.enums.AvatarCompositionType;
 import com.pfplaybackend.api.common.domain.enums.MessageTopic;
 import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.adapter.in.listener.message.DjQueueChangeMessage;
 import com.pfplaybackend.api.party.adapter.out.persistence.CrewRepository;
 import com.pfplaybackend.api.party.application.dto.dj.DjWithProfileDto;
 import com.pfplaybackend.api.party.application.port.out.UserProfileQueryPort;
@@ -22,6 +23,7 @@ import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -29,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -98,6 +101,44 @@ class DomainEventRedisRelayTest {
 
         // then
         verify(messagePublisher).publish(eq(MessageTopic.DJ_QUEUE_CHANGED.topic()), any());
+    }
+
+    @Test
+    @DisplayName("on(DjQueueChangedEvent) — DEACTIVATE 이벤트의 changeType/limit 분이 메시지로 전달된다")
+    void onDjQueueChangedEventDeactivatePassesChangeTypeAndLimit() {
+        // given
+        DjQueueChangedEvent event = new DjQueueChangedEvent(partyroomId, DjChangeType.DEACTIVATE, null, 5);
+        List<DjWithProfileDto> djs = List.of(new DjWithProfileDto(crewId.getId(), 1, "DJ1", "icon1"));
+        when(partyroomQueryService.getDjs(partyroomId)).thenReturn(djs);
+
+        // when
+        domainEventRedisRelay.on(event);
+
+        // then
+        ArgumentCaptor<DjQueueChangeMessage> captor = ArgumentCaptor.forClass(DjQueueChangeMessage.class);
+        verify(messagePublisher).publish(eq(MessageTopic.DJ_QUEUE_CHANGED.topic()), captor.capture());
+        DjQueueChangeMessage published = captor.getValue();
+        assertThat(published.changeType()).isEqualTo(DjChangeType.DEACTIVATE);
+        assertThat(published.playbackTimeLimitMinutes()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("on(DjQueueChangedEvent) — DEACTIVATE 외 changeType 은 limit 분이 null 로 전달된다")
+    void onDjQueueChangedEventNonDeactivatePassesNullLimit() {
+        // given
+        DjQueueChangedEvent event = new DjQueueChangedEvent(partyroomId, DjChangeType.ROTATE, crewId);
+        List<DjWithProfileDto> djs = List.of(new DjWithProfileDto(crewId.getId(), 1, "DJ1", "icon1"));
+        when(partyroomQueryService.getDjs(partyroomId)).thenReturn(djs);
+
+        // when
+        domainEventRedisRelay.on(event);
+
+        // then
+        ArgumentCaptor<DjQueueChangeMessage> captor = ArgumentCaptor.forClass(DjQueueChangeMessage.class);
+        verify(messagePublisher).publish(eq(MessageTopic.DJ_QUEUE_CHANGED.topic()), captor.capture());
+        DjQueueChangeMessage published = captor.getValue();
+        assertThat(published.changeType()).isEqualTo(DjChangeType.ROTATE);
+        assertThat(published.playbackTimeLimitMinutes()).isNull();
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackCommandServiceTest.java
@@ -14,7 +14,9 @@ import com.pfplaybackend.api.party.application.port.out.ExpirationTaskPort;
 import com.pfplaybackend.api.party.application.port.out.PlaylistCommandPort;
 import com.pfplaybackend.api.party.application.port.out.UserActivityPort;
 import com.pfplaybackend.api.party.domain.entity.data.*;
+import com.pfplaybackend.api.party.domain.enums.DjChangeType;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
+import com.pfplaybackend.api.party.domain.event.DjQueueChangedEvent;
 import com.pfplaybackend.api.party.domain.event.PlaybackStartedEvent;
 import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
 import com.pfplaybackend.api.party.domain.service.PartyroomAggregateService;
@@ -84,7 +86,8 @@ class PlaybackCommandServiceTest {
     @DisplayName("complete — 완료 시 DJ 점수가 1 증가한다")
     void completeUpdatesDjScore() {
         // given — tryProceed에서 DJ가 없으면 deactivate
-        PartyroomData partyroom = PartyroomData.builder().id(partyroomId.getId()).partyroomId(partyroomId).build();
+        PartyroomData partyroom = PartyroomData.builder().id(partyroomId.getId()).partyroomId(partyroomId)
+                .playbackTimeLimit(PlaybackTimeLimit.ofMinutes(10)).build();
         when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
         when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(List.of());
 
@@ -99,7 +102,8 @@ class PlaybackCommandServiceTest {
     @DisplayName("complete — 대기열에 DJ가 없으면 재생이 비활성화된다")
     void completeNoDjsDeactivates() {
         // given
-        PartyroomData partyroom = PartyroomData.builder().id(partyroomId.getId()).partyroomId(partyroomId).build();
+        PartyroomData partyroom = PartyroomData.builder().id(partyroomId.getId()).partyroomId(partyroomId)
+                .playbackTimeLimit(PlaybackTimeLimit.ofMinutes(10)).build();
         when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
         when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(List.of());
 
@@ -117,7 +121,8 @@ class PlaybackCommandServiceTest {
         ActivePartyroomDto activeDto = new ActivePartyroomDto(partyroomId.getId(), false, 1L, true, new PlaybackId(1L), new CrewId(1L));
         CrewData adjuster = CrewData.builder()
                 .id(1L).userId(userId).gradeType(GradeType.MODERATOR).build();
-        PartyroomData partyroom = PartyroomData.builder().id(partyroomId.getId()).partyroomId(partyroomId).build();
+        PartyroomData partyroom = PartyroomData.builder().id(partyroomId.getId()).partyroomId(partyroomId)
+                .playbackTimeLimit(PlaybackTimeLimit.ofMinutes(10)).build();
 
         when(partyroomQueryService.getMyActivePartyroom(userId)).thenReturn(Optional.of(activeDto));
         when(partyroomQueryService.getCrewOrThrow(new PartyroomId(activeDto.id()), userId)).thenReturn(adjuster);
@@ -152,7 +157,8 @@ class PlaybackCommandServiceTest {
     @DisplayName("skipPlayback — 스케줄 태스크를 취소하고 tryProceed를 실행한다")
     void skipPlaybackCancelsTaskAndProceeds() {
         // given
-        PartyroomData partyroom = PartyroomData.builder().id(partyroomId.getId()).partyroomId(partyroomId).build();
+        PartyroomData partyroom = PartyroomData.builder().id(partyroomId.getId()).partyroomId(partyroomId)
+                .playbackTimeLimit(PlaybackTimeLimit.ofMinutes(10)).build();
         when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
         when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(List.of());
 
@@ -322,6 +328,18 @@ class PlaybackCommandServiceTest {
         verify(partyroomAggregateService).deactivatePlayback(partyroomId);
         verify(playbackRepository, never()).save(any(PlaybackData.class));
         verify(playlistCommandPort, never()).rotatePlayed(any(PlaylistId.class), anyInt(), anyLong());
+
+        // and — DEACTIVATE 이벤트에 changeType + 룸 limit 분(1)이 실린다
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(eventPublisher, atLeastOnce()).publishEvent(eventCaptor.capture());
+        DjQueueChangedEvent deactivateEvent = eventCaptor.getAllValues().stream()
+                .filter(DjQueueChangedEvent.class::isInstance)
+                .map(DjQueueChangedEvent.class::cast)
+                .filter(e -> e.getChangeType() == DjChangeType.DEACTIVATE)
+                .findFirst()
+                .orElseThrow();
+        assertThat(deactivateEvent.getChangeType()).isEqualTo(DjChangeType.DEACTIVATE);
+        assertThat(deactivateEvent.getPlaybackTimeLimitMinutes()).isEqualTo(1);
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/party/domain/event/DjQueueChangedEventTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/domain/event/DjQueueChangedEventTest.java
@@ -1,0 +1,29 @@
+package com.pfplaybackend.api.party.domain.event;
+
+import com.pfplaybackend.api.party.domain.enums.DjChangeType;
+import com.pfplaybackend.api.party.domain.value.CrewId;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DjQueueChangedEventTest {
+
+    @Test
+    @DisplayName("3-arg ctor → playbackTimeLimitMinutes null (기존 5 publish 사이트 호환)")
+    void threeArg_limitNull() {
+        var e = new DjQueueChangedEvent(new PartyroomId(1L), DjChangeType.ROTATE, new CrewId(2L));
+        assertThat(e.getChangeType()).isEqualTo(DjChangeType.ROTATE);
+        assertThat(e.getAffectedCrewId()).isNotNull();
+        assertThat(e.getPlaybackTimeLimitMinutes()).isNull();
+    }
+
+    @Test
+    @DisplayName("4-arg ctor → DEACTIVATE + limit 보존")
+    void fourArg_limitSet() {
+        var e = new DjQueueChangedEvent(new PartyroomId(1L), DjChangeType.DEACTIVATE, null, 5);
+        assertThat(e.getChangeType()).isEqualTo(DjChangeType.DEACTIVATE);
+        assertThat(e.getPlaybackTimeLimitMinutes()).isEqualTo(5);
+    }
+}

--- a/docs/superpowers/plans/2026-05-19-e3-pr2-changetype-payload.md
+++ b/docs/superpowers/plans/2026-05-19-e3-pr2-changetype-payload.md
@@ -1,0 +1,170 @@
+# E/#3 PR-2 — DjQueueChangeMessage changeType payload + relay passthrough + DEACTIVATE limit (platform) 구현 계획
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`).
+
+**Goal:** dj-queue-changed 메시지에 `changeType`(DjChangeType)를 additive 로 실어 보내고(현재 relay 가 type 을 떼고 djs 만 전송), DEACTIVATE 케이스엔 `playbackTimeLimitMinutes`(limit-only) 동봉 — 프론트(PR-3)가 "왜 빠졌나/왜 중단됐나"를 changeType 별로 안내할 수 있게.
+
+**Architecture:** `DjQueueChangedEvent` 는 이미 `changeType` 보유. limit 은 event 의 nullable 4번째 필드로 추가(3-arg ctor 가 null 위임 → 기존 5개 publish 사이트 무변경, DEACTIVATE 1곳만 4-arg). `DjQueueChangeMessage` record 에 `changeType`+`playbackTimeLimitMinutes` 컴포넌트 additive 추가, factory 시그니처 확장(유일 caller=relay). `DomainEventRedisRelay.on` 가 type drop → passthrough.
+
+**Tech Stack:** Java 21 (빌드 `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7"`), Spring, Lombok, JUnit5. 모듈 `:app`. unit=`:app:test`.
+
+**Spec:** `docs/superpowers/specs/2026-05-19-e3-track-skip-deactivate-cascade-design.md` §3-2 (+ 2026-05-19 limit-only 개정 노트).
+
+**Scope 경계:** PR-2 = platform payload+relay 만. web(PR-3)·배지(PR-4) 무관. PR-1 동작은 무변경(deactivate 발화 조건/스킵 로직 그대로). additive·backward-compat: Cluster A 프론트 구독은 `.partyroomId`/`.djs` 만 읽음 → 신규 컴포넌트 무영향. 롤링배포 직렬화 윈도우 = transient drop 수용(spec §4, 변경 없음).
+
+---
+
+## File Structure
+
+- Modify `app/.../party/domain/event/DjQueueChangedEvent.java` — nullable `Integer playbackTimeLimitMinutes` + 4-arg ctor, 3-arg→4-arg(null) 위임.
+- Modify `app/.../party/application/service/PlaybackCommandService.java` — `deactivateAndNotify` 의 DEACTIVATE publish 만 4-arg(limit) 로.
+- Modify `app/.../party/adapter/in/listener/message/DjQueueChangeMessage.java` — record 에 `DjChangeType changeType` + `Integer playbackTimeLimitMinutes` 컴포넌트, `create` 시그니처 확장.
+- Modify `app/.../party/adapter/out/event/DomainEventRedisRelay.java` — `on(DjQueueChangedEvent)` passthrough.
+- Tests: `DjQueueChangedEventTest`(없으면 신설), `DjQueueChangeMessageTest`/relay 테스트(기존 패턴), `PlaybackCommandServiceTest`(DEACTIVATE publish 가 limit 동반 검증).
+
+---
+
+## Chunk 1: changeType payload + relay passthrough
+
+### Task 1: `DjQueueChangedEvent` 에 nullable limit 추가 (additive, 단독 컴파일)
+
+현재:
+```java
+@Getter
+public class DjQueueChangedEvent extends DomainEvent {
+    private final PartyroomId partyroomId;
+    private final DjChangeType changeType;
+    private final CrewId affectedCrewId;
+    public DjQueueChangedEvent(PartyroomId partyroomId, DjChangeType changeType, CrewId affectedCrewId) { ... }
+    @Override public String getAggregateId() { ... }
+}
+```
+
+**Files:** Modify `app/src/main/java/com/pfplaybackend/api/party/domain/event/DjQueueChangedEvent.java`; Test `app/src/test/java/com/pfplaybackend/api/party/domain/event/DjQueueChangedEventTest.java`(기존 없으면 신설, 같은 패키지 테스트 컨벤션 따름).
+
+- [ ] **Step 1: 실패 단위테스트** — `DjQueueChangedEventTest`:
+```java
+@Test @DisplayName("3-arg ctor → playbackTimeLimitMinutes null (기존 사이트 호환)")
+void threeArg_limitNull() {
+    var e = new DjQueueChangedEvent(new PartyroomId(1L), DjChangeType.ROTATE, new CrewId(2L));
+    assertThat(e.getChangeType()).isEqualTo(DjChangeType.ROTATE);
+    assertThat(e.getPlaybackTimeLimitMinutes()).isNull();
+}
+@Test @DisplayName("4-arg ctor → DEACTIVATE + limit 보존")
+void fourArg_limitSet() {
+    var e = new DjQueueChangedEvent(new PartyroomId(1L), DjChangeType.DEACTIVATE, null, 5);
+    assertThat(e.getChangeType()).isEqualTo(DjChangeType.DEACTIVATE);
+    assertThat(e.getPlaybackTimeLimitMinutes()).isEqualTo(5);
+}
+```
+(`PartyroomId`/`CrewId` 생성은 그 테스트 트리의 기존 방식 따름.)
+
+- [ ] **Step 2: 실패 확인** — `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.domain.event.DjQueueChangedEventTest"` → FAIL (`getPlaybackTimeLimitMinutes`/4-arg 없음).
+
+- [ ] **Step 3: 구현** — 필드+ctor 추가(3-arg 는 4-arg 로 null 위임):
+```java
+    private final PartyroomId partyroomId;
+    private final DjChangeType changeType;
+    private final CrewId affectedCrewId;
+    private final Integer playbackTimeLimitMinutes; // DEACTIVATE 한정 limit-only, 그 외 null
+
+    public DjQueueChangedEvent(PartyroomId partyroomId, DjChangeType changeType, CrewId affectedCrewId) {
+        this(partyroomId, changeType, affectedCrewId, null);
+    }
+
+    public DjQueueChangedEvent(PartyroomId partyroomId, DjChangeType changeType, CrewId affectedCrewId,
+                               Integer playbackTimeLimitMinutes) {
+        this.partyroomId = partyroomId;
+        this.changeType = changeType;
+        this.affectedCrewId = affectedCrewId;
+        this.playbackTimeLimitMinutes = playbackTimeLimitMinutes;
+    }
+```
+(`@Getter` 가 `getPlaybackTimeLimitMinutes()` 자동 생성. `getAggregateId()` 무변경. 기존 6 publish 사이트는 3-arg 라 무변경.)
+
+- [ ] **Step 4: 통과 확인** — 위 gradle 명령 → PASS. `JAVA_HOME=... ./gradlew :app:compileJava` → 0 (기존 호출 사이트 호환).
+
+- [ ] **Step 5: 커밋**
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/domain/event/DjQueueChangedEvent.java app/src/test/java/com/pfplaybackend/api/party/domain/event/DjQueueChangedEventTest.java
+git commit -m "feat(E/#3): DjQueueChangedEvent nullable playbackTimeLimitMinutes (DEACTIVATE limit-only, 3-arg 호환)"
+```
+
+---
+
+### Task 2: message 컴포넌트 + relay passthrough + DEACTIVATE limit 주입 (합본 커밋)
+
+상호 의존(factory 시그니처 변경이 relay 깨뜨림 → 함께). 
+
+**Files (modify):**
+- `app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/message/DjQueueChangeMessage.java`
+- `app/src/main/java/com/pfplaybackend/api/party/adapter/out/event/DomainEventRedisRelay.java`
+- `app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java`
+- Test: `app/src/test/java/.../PlaybackCommandServiceTest.java` (DEACTIVATE publish), + relay/message 단위테스트(기존 있으면 확장, 없으면 신설)
+
+- [ ] **Step 1: 실패/회귀 테스트**
+  - `DjQueueChangeMessage` 단위: `create(pid, djs, DjChangeType.DEACTIVATE, 5)` → `.changeType()==DEACTIVATE`, `.playbackTimeLimitMinutes()==5`, `eventType==DJ_QUEUE_CHANGED`, djs 보존; `create(pid, djs, DjChangeType.ROTATE, null)` → changeType ROTATE, limit null.
+  - relay passthrough: `DomainEventRedisRelay` 테스트가 있으면(예: messageId/relay 테스트, C/T1-1 산출) 거기에 — `on(new DjQueueChangedEvent(pid, DEACTIVATE, null, 5))` → publish 된 `DjQueueChangeMessage.changeType()==DEACTIVATE && playbackTimeLimitMinutes()==5`; `on(... ROTATE ...)` → ROTATE·limit null. 없으면 relay 단위테스트 신설(messagePublisher mock 캡처, partyroomQueryService.getDjs stub — 기존 relay 테스트 패턴 따름).
+  - `PlaybackCommandServiceTest`: 기존 `singleDj_allOverLimit_deactivates`(및 deactivate 검증 테스트)에서, 발행된 `DjQueueChangedEvent` 를 ArgumentCaptor 로 잡아 `changeType==DEACTIVATE && playbackTimeLimitMinutes == 그 파티룸 limit(min)` 추가 단언. (해당 테스트가 partyroom limit 을 어떻게 셋업하는지 그 파일 픽스처 따름 — 신규 픽스처 금지.)
+
+- [ ] **Step 2: 실패 확인** — `JAVA_HOME=... ./gradlew :app:test --tests "*DjQueueChangeMessage*" --tests "*DomainEventRedisRelay*" --tests "com.pfplaybackend.api.party.application.service.PlaybackCommandServiceTest"` → FAIL(시그니처/필드 부재·단언 미충족).
+
+- [ ] **Step 3: 구현**
+  `DjQueueChangeMessage.java` (record 컴포넌트 2개 additive + factory 시그니처 확장; 유일 caller=relay 라 오버로드 대신 시그니처 변경):
+  ```java
+  import com.pfplaybackend.api.party.domain.enums.DjChangeType;
+  ...
+  public record DjQueueChangeMessage(
+          PartyroomId partyroomId,
+          MessageTopic eventType,
+          String id,
+          long timestamp,
+          List<DjWithProfileDto> djs,
+          DjChangeType changeType,
+          Integer playbackTimeLimitMinutes
+  ) implements Serializable, GroupBroadcastMessage {
+      public static DjQueueChangeMessage create(PartyroomId partyroomId, List<DjWithProfileDto> djs,
+                                                DjChangeType changeType, Integer playbackTimeLimitMinutes) {
+          return new DjQueueChangeMessage(partyroomId, MessageTopic.DJ_QUEUE_CHANGED,
+                  UUID.randomUUID().toString(), System.currentTimeMillis(), djs,
+                  changeType, playbackTimeLimitMinutes);
+      }
+  }
+  ```
+  `DomainEventRedisRelay.java` `on(DjQueueChangedEvent)` — passthrough:
+  ```java
+  DjQueueChangeMessage message = DjQueueChangeMessage.create(
+          event.getPartyroomId(),
+          partyroomQueryService.getDjs(event.getPartyroomId()),
+          event.getChangeType(),
+          event.getPlaybackTimeLimitMinutes());
+  ```
+  `PlaybackCommandService.java` `deactivateAndNotify(PartyroomData partyroom)` — DEACTIVATE publish 만 4-arg(limit):
+  ```java
+  eventPublisher.publishEvent(new DjQueueChangedEvent(partyroomId, DjChangeType.DEACTIVATE, null,
+          partyroom.getPlaybackTimeLimit().getMinutes()));
+  ```
+  (다른 5개 publish 사이트·doStart 로직·deactivatePlayback 무변경.)
+
+- [ ] **Step 4: 통과 확인** — Step 2 명령 → PASS.
+
+- [ ] **Step 5: 커밋 (Task2 합본)**
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/message/DjQueueChangeMessage.java app/src/main/java/com/pfplaybackend/api/party/adapter/out/event/DomainEventRedisRelay.java app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackCommandServiceTest.java <relay/message 테스트 파일>
+git commit -m "feat(E/#3): DjQueueChangeMessage changeType+limit additive + relay passthrough + DEACTIVATE limit 주입"
+```
+
+---
+
+### Task 3: 전 모듈 회귀 + scope 확인
+
+- [ ] **Step 1:** `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test :playlist:test` → 전 GREEN(특히 PlaybackCommandServiceTest 12+ / 기존 relay·djqueue 회귀; PR-1 동작 무변경 확인). `:app:integrationTest` 는 #237 fix 머지됨 — E/#3 IT(`TrackRepositoryReorderIntegrationTest`) green 확인(전체 integrationTest 의 잔여 known-pre-existing 부채는 #237 에서 처리됨; 신규 red 없는지 확인).
+- [ ] **Step 2:** `git diff origin/develop..HEAD --stat` — 변경 = Task1·2 의 4 main + 테스트만. `deactivatePlayback`/`PartyroomAggregateService`/doStart 스킵로직/web/DjChangeType enum/5개 비-DEACTIVATE publish 사이트 무변경 확인. `git log --oneline origin/develop..HEAD`.
+
+---
+
+## 완료 정의 (DoD)
+
+- `DjQueueChangedEvent` 3-arg 호환·4-arg limit 보존. `DjQueueChangeMessage` changeType+playbackTimeLimitMinutes additive·factory 확장. relay 가 changeType·limit passthrough(type drop 제거). `deactivateAndNotify` DEACTIVATE event 가 partyroom limit(min) 동반, 다른 changeType 은 limit null.
+- 신규/회귀 단위테스트 GREEN, `:app:test`/`:playlist:test` 무회귀. PR-1 동작·scope 경계 보존(payload/relay 만).
+- 범위밖: web 모달/배지(PR-3/4). PR-3 가 이 changeType+limit 을 소비.

--- a/docs/superpowers/specs/2026-05-19-e3-track-skip-deactivate-cascade-design.md
+++ b/docs/superpowers/specs/2026-05-19-e3-track-skip-deactivate-cascade-design.md
@@ -41,6 +41,15 @@ reason=ALL_TRACKS_EXCEEDED` 등 로그만 추가, 구조·`DjQueueChangeMessage`
 > 산술 동일·갭없음 증명). 본 §3-1 의 seam 문구는 이 정정으로 대체. 상세는
 > plan `2026-05-19-e3-pr1-*` Task 1 참조.
 
+> **개정 (2026-05-19, PR-1 머지 후 PR-2 착수)**: PR-1 재설계로 `deactivateAndNotify`
+> 발화 조건 = "회전된 큐의 **모든 DJ가 재생가능 트랙 0**" → 단일 "거부 트랙"이
+> 존재하지 않음(여러 DJ/트랙/빈 플레이리스트 혼재 가능). 따라서 §3-2 리치(b)의
+> "거부 트랙명·durationSec" 는 **드롭**, **DEACTIVATE payload = `playbackTimeLimit`
+> (분) limit-only** 로 확정(사용자 결정). §3-3 프론트 DEACTIVATE 모달 문구도
+> 트랙명 없이 "재생 시간 제한(N분)을 초과하는 곡으로 재생이 중단되었습니다" 로
+> 조정(PR-3). 나머지 changeType(ADMIN/EXIT) 처리·additive·backward-compat·
+> 직렬화 윈도우(§4)는 불변.
+
 ## 2. 결정 (사용자 확정)
 
 - **핵심 정책 = 트랙 단위 스킵**: over-limit 트랙은 재생 안 하고 같은 DJ


### PR DESCRIPTION
## 배경 (E/#3 PR-2/4)

PR-1(#238, develop 머지)으로 트랙단위 스킵·deactivate 조건은 해소. 그러나 큐에서 빠지는 이유(`DjChangeType`)가 `DomainEventRedisRelay` 에서 떨어져 프론트가 "왜 빠졌나" 알 수 없음(노트 UX 갭). PR-2 = **platform payload 배선만**: changeType + DEACTIVATE 한정 limit 을 메시지에 실음. 프론트 모달은 PR-3(web), 배지는 PR-4.

## 변경 (additive, backward-compat)

- `DjQueueChangedEvent`: nullable `Integer playbackTimeLimitMinutes` (4-arg ctor; 3-arg → null 위임 → 비-DEACTIVATE 5개 publish 사이트 무변경).
- `DjQueueChangeMessage`(record): `DjChangeType changeType` + `Integer playbackTimeLimitMinutes` 컴포넌트 additive(djs 뒤), factory 확장. Cluster A 프론트 구독은 `partyroomId`/`djs` 만 읽음 → 무영향.
- `DomainEventRedisRelay.on`: type drop 제거 → `changeType`·limit **passthrough**.
- `PlaybackCommandService.deactivateAndNotify`: DEACTIVATE publish 만 4-arg(`partyroom.getPlaybackTimeLimit().getMinutes()`). doStart 스킵로직·deactivatePlayback·PR-1 동작·DjChangeType enum **무변경**.
- **limit-only 결정**(spec 2026-05-19 개정): PR-1 재설계로 deactivate=전-DJ-무재생이라 단일 "거부 트랙" 부재 → 트랙명/duration 드롭, limit(분)만. PR-3 모달은 트랙명 없이 "재생 시간 제한(N분) 초과로 중단".

## 검증

- 전 unit GREEN: `:app:test` 904/904 · `:playlist:test` 71/71 (rerun). 신규/확장 단위: `DjQueueChangedEventTest`(3-arg null·4-arg limit), `DjQueueChangeMessageTest`(DEACTIVATE+limit / 비-DEACTIVATE null), `DomainEventRedisRelayTest`(ArgumentCaptor passthrough capture), `PlaybackCommandServiceTest`(DEACTIVATE event limit 단언) — PR-1 #222/skip/multiDj 12/12 보존.
- bare-fixture 4건에 `.playbackTimeLimit(ofMinutes(10))` 보완(NPE 회피) — 마스킹 아님 검증: PR-1 `doStart:111` 이 이미 동일 dereference 의존 + `PartyroomData.create` 가 limit 항상 set(생성 불변)이라 충실 보완.
- plan/spec 리뷰 + 태스크별 2단 리뷰 + 최종 종합 ✅. brainstorm 불요(spec 확정). additive·롤링배포 직렬화 윈도우=spec §4(불변).
- 후속: PR-3(web) 가 이 changeType+limit 소비. `unlimited()`→limit 0 케이스는 PR-3 모달 copy 에서 graceful 처리(별 메모).

Refs E/#3 (Cluster E). 시리즈: PR-1 #238(merged) → **PR-2(본 PR)** → PR-3(web UX) → PR-4(web 배지).