### PR TITLE
feat(e223): 대기 중 DJ 플레이리스트 변경 API (Change Playlist)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandController.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandController.java
@@ -3,6 +3,7 @@ package com.pfplaybackend.api.party.adapter.in.web;
 import com.pfplaybackend.api.common.ApiCommonResponse;
 import com.pfplaybackend.api.common.config.swagger.ApiErrorCodes;
 import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.party.adapter.in.web.payload.request.dj.ChangePlaylistRequest;
 import com.pfplaybackend.api.party.adapter.in.web.payload.request.dj.RegisterDjRequest;
 import com.pfplaybackend.api.party.adapter.in.web.payload.response.CreateDjResponse;
 import com.pfplaybackend.api.party.application.service.DjCommandService;
@@ -66,6 +67,20 @@ public class DjCommandController {
             @Parameter(description = "파티룸 ID") @PathVariable Long partyroomId,
             @Parameter(description = "해제할 DJ ID") @PathVariable Long djId) {
         djCommandService.dequeueDj(new PartyroomId(partyroomId), new DjId(djId));
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "본인 DJ 플레이리스트 변경",
+            description = "DJ 대기열에 등록된 본인의 디제잉 플레이리스트를 변경합니다. 큐 순서는 보존되며, 재생 중 DJ 는 변경할 수 없습니다.")
+    @ApiResponse(responseCode = "204", description = "변경 성공")
+    @SecurityRequirement(name = "cookieAuth")
+    @ApiErrorCodes({DjException.class})
+    @PatchMapping("/{partyroomId}/dj-queue/me")
+    @PreAuthorize("hasRole('MEMBER')")
+    public ResponseEntity<Void> changePlaylist(
+            @Parameter(description = "파티룸 ID") @PathVariable Long partyroomId,
+            @Valid @RequestBody ChangePlaylistRequest request) {
+        djCommandService.changePlaylist(new PartyroomId(partyroomId), new PlaylistId(request.getPlaylistId()));
         return ResponseEntity.noContent().build();
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/payload/request/dj/ChangePlaylistRequest.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/payload/request/dj/ChangePlaylistRequest.java
@@ -1,0 +1,12 @@
+package com.pfplaybackend.api.party.adapter.in.web.payload.request.dj;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+
+@Getter
+public class ChangePlaylistRequest {
+    @NotNull(message = "playlistId is required.")
+    @Positive(message = "playlistId must be positive.")
+    private Long playlistId;
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/PlaylistQueryAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/PlaylistQueryAdapter.java
@@ -1,6 +1,8 @@
 package com.pfplaybackend.api.party.adapter.out.external;
 
+import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.party.application.port.out.PlaylistQueryPort;
+import com.pfplaybackend.api.playlist.application.service.PlaylistQueryService;
 import com.pfplaybackend.api.playlist.application.service.TrackQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -9,9 +11,15 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PlaylistQueryAdapter implements PlaylistQueryPort {
     private final TrackQueryService trackQueryService;
+    private final PlaylistQueryService playlistQueryService;
 
     @Override
     public boolean isEmptyPlaylist(Long playlistId) {
         return trackQueryService.isEmptyPlaylist(playlistId);
+    }
+
+    @Override
+    public boolean isOwnedBy(Long playlistId, Long userId) {
+        return playlistQueryService.isOwnedBy(playlistId, new UserId(userId));
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/port/out/PlaylistQueryPort.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/port/out/PlaylistQueryPort.java
@@ -2,4 +2,5 @@ package com.pfplaybackend.api.party.application.port.out;
 
 public interface PlaylistQueryPort {
     boolean isEmptyPlaylist(Long playlistId);
+    boolean isOwnedBy(Long playlistId, Long userId);
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java
@@ -15,6 +15,7 @@ import com.pfplaybackend.api.party.domain.exception.DjException;
 import com.pfplaybackend.api.party.domain.exception.GradeException;
 import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
 import com.pfplaybackend.api.party.domain.service.PartyroomAggregateService;
+import com.pfplaybackend.api.party.domain.specification.DjChangePlaylistSpecification;
 import com.pfplaybackend.api.party.domain.specification.DjEnqueueSpecification;
 import com.pfplaybackend.api.party.domain.value.CrewId;
 import com.pfplaybackend.api.party.domain.value.DjId;
@@ -62,8 +63,9 @@ public class DjCommandService {
             log.warn("[enqueueDj] ALREADY_REGISTERED - requestId={}, partyroomId={}, crewId={}",
                     RequestIdInterceptor.current(), partyroomId.getId(), crew.getId());
         }
+        boolean isOwned = playlistQueryPort.isOwnedBy(playlistId.getId(), authContext.getUserId().getUid());
         boolean isEmptyPlaylist = playlistQueryPort.isEmptyPlaylist(playlistId.getId());
-        new DjEnqueueSpecification().validate(djQueue, isAlreadyRegistered, isEmptyPlaylist);
+        new DjEnqueueSpecification().validate(djQueue, isAlreadyRegistered, isOwned, isEmptyPlaylist);
         log.info("[enqueueDj] VALIDATION_PASSED - requestId={}, partyroomId={}, crewId={}",
                 RequestIdInterceptor.current(), partyroomId.getId(), crew.getId());
 
@@ -133,6 +135,39 @@ public class DjCommandService {
         if (wasCurrentDj) {
             playbackControlPort.skipPlayback(partyroomId);
         }
+    }
+
+    @Transactional
+    public void changePlaylist(PartyroomId partyroomId, PlaylistId newPlaylistId) {
+        AuthContext authContext = ThreadLocalContext.getAuthContext();
+        Long userId = authContext.getUserId().getUid();
+        log.info("[changePlaylist] ENTER - requestId={}, partyroomId={}, userId={}, newPlaylistId={}",
+                RequestIdInterceptor.current(), partyroomId.getId(), userId, newPlaylistId.getId());
+
+        partyroomQueryService.getPartyroomById(partyroomId);
+        PartyroomPlaybackData playback = aggregatePort.findPlaybackState(partyroomId);
+        DjQueueData djQueue = aggregatePort.findDjQueueState(partyroomId);
+
+        CrewData crew = partyroomQueryService.getCrewOrThrow(partyroomId, authContext.getUserId());
+        CrewId crewId = new CrewId(crew.getId());
+
+        DjData me = aggregatePort.findDj(partyroomId, crewId)
+                .orElseThrow(() -> ExceptionCreator.create(DjException.NOT_FOUND_DJ));
+
+        boolean isCurrentDj     = playback.isActivated() && playback.isCurrentDj(crewId);
+        boolean isOwned         = playlistQueryPort.isOwnedBy(newPlaylistId.getId(), userId);
+        boolean isEmptyPlaylist = playlistQueryPort.isEmptyPlaylist(newPlaylistId.getId());
+
+        new DjChangePlaylistSpecification().validate(djQueue, isCurrentDj, isOwned, isEmptyPlaylist);
+
+        Long oldPlaylistId = me.getPlaylistId() != null ? me.getPlaylistId().getId() : null;
+        me.updatePlaylist(newPlaylistId);
+        // ※ saveDj 명시 호출 안 함 — me 는 @Transactional 컨텍스트의 managed entity,
+        //   JPA dirty check 가 commit 시 UPDATE 자동 발행. spec §3-4
+
+        log.info("[changePlaylist] OK - requestId={}, partyroomId={}, crewId={}, oldPlaylistId={}, newPlaylistId={}",
+                RequestIdInterceptor.current(), partyroomId.getId(), crewId.getId(), oldPlaylistId, newPlaylistId.getId());
+        // 도메인 이벤트 발행 없음 — WS broadcast 불필요(spec §2-2)
     }
 
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/DjData.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/DjData.java
@@ -73,6 +73,10 @@ public class DjData extends BaseEntity {
         this.orderNumber = orderNumber;
     }
 
+    public void updatePlaylist(PlaylistId playlistId) {
+        this.playlistId = playlistId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/exception/DjException.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/exception/DjException.java
@@ -9,7 +9,9 @@ public enum DjException implements DomainException {
     ALREADY_REGISTERED("DJ-001", "이미 DJ로 등록되어 있습니다", ErrorType.CONFLICT),
     QUEUE_CLOSED("DJ-002", "DJ 대기열이 닫혀 있습니다", ErrorType.FORBIDDEN),
     EMPTY_PLAYLIST("DJ-003", "빈 플레이리스트로 등록할 수 없습니다", ErrorType.FORBIDDEN),
-    NOT_FOUND_DJ("DJ-004", "DJ 대기열에서 해당 DJ를 찾을 수 없습니다", ErrorType.NOT_FOUND);
+    NOT_FOUND_DJ("DJ-004", "DJ 대기열에서 해당 DJ를 찾을 수 없습니다", ErrorType.NOT_FOUND),
+    NOT_OWNED_PLAYLIST("DJ-005", "본인 소유 플레이리스트가 아닙니다", ErrorType.FORBIDDEN),
+    CURRENT_DJ_CANNOT_CHANGE_PLAYLIST("DJ-006", "재생 중 DJ는 플레이리스트를 변경할 수 없습니다", ErrorType.CONFLICT);
 
     private final String errorCode;
     private final String message;

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/specification/DjChangePlaylistSpecification.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/specification/DjChangePlaylistSpecification.java
@@ -1,0 +1,16 @@
+package com.pfplaybackend.api.party.domain.specification;
+
+import com.pfplaybackend.api.common.exception.ExceptionCreator;
+import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.domain.exception.DjException;
+
+public class DjChangePlaylistSpecification {
+
+    public void validate(DjQueueData djQueue, boolean isCurrentDj,
+                         boolean isOwned, boolean isEmptyPlaylist) {
+        djQueue.validateOpen();
+        if (isCurrentDj)     throw ExceptionCreator.create(DjException.CURRENT_DJ_CANNOT_CHANGE_PLAYLIST);
+        if (!isOwned)        throw ExceptionCreator.create(DjException.NOT_OWNED_PLAYLIST);
+        if (isEmptyPlaylist) throw ExceptionCreator.create(DjException.EMPTY_PLAYLIST);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/specification/DjEnqueueSpecification.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/specification/DjEnqueueSpecification.java
@@ -6,8 +6,10 @@ import com.pfplaybackend.api.party.domain.exception.DjException;
 
 public class DjEnqueueSpecification {
 
-    public void validate(DjQueueData djQueue, boolean isAlreadyRegistered, boolean isEmptyPlaylist) {
+    public void validate(DjQueueData djQueue, boolean isAlreadyRegistered,
+                         boolean isOwned, boolean isEmptyPlaylist) {
         djQueue.validateOpen();
+        if (!isOwned)        throw ExceptionCreator.create(DjException.NOT_OWNED_PLAYLIST);
         if (isEmptyPlaylist) throw ExceptionCreator.create(DjException.EMPTY_PLAYLIST);
         if (isAlreadyRegistered) throw ExceptionCreator.create(DjException.ALREADY_REGISTERED);
     }

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandControllerTest.java
@@ -4,11 +4,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
+import com.pfplaybackend.api.common.exception.ExceptionCreator;
+import com.pfplaybackend.api.party.domain.exception.DjException;
+
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -59,5 +64,108 @@ class DjCommandControllerTest extends AbstractPartyCommandWebMvcTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("changePlaylist — 204 No Content")
+    void changePlaylistReturns204() throws Exception {
+        mockMvc.perform(patch("/api/v1/partyrooms/1/dj-queue/me")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"playlistId\": 99}"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("changePlaylist — playlistId null 이면 400")
+    void changePlaylistNullPlaylistIdReturns400() throws Exception {
+        mockMvc.perform(patch("/api/v1/partyrooms/1/dj-queue/me")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("changePlaylist — playlistId 0 이면 400")
+    void changePlaylistZeroPlaylistIdReturns400() throws Exception {
+        mockMvc.perform(patch("/api/v1/partyrooms/1/dj-queue/me")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"playlistId\": 0}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("changePlaylist — 인증 없으면 401")
+    void changePlaylistUnauthenticatedReturns401() throws Exception {
+        mockMvc.perform(patch("/api/v1/partyrooms/1/dj-queue/me")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"playlistId\": 99}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("changePlaylist — DJ-004 NOT_FOUND_DJ → 404")
+    void changePlaylistNotFoundReturns404() throws Exception {
+        doThrow(ExceptionCreator.create(DjException.NOT_FOUND_DJ))
+                .when(djCommandService).changePlaylist(any(), any());
+
+        mockMvc.perform(patch("/api/v1/partyrooms/1/dj-queue/me")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"playlistId\": 99}"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("DJ-004"));
+    }
+
+    @Test
+    @DisplayName("changePlaylist — DJ-005 NOT_OWNED_PLAYLIST → 403 (미존재 playlistId 포함)")
+    void changePlaylistNotOwnedReturns403() throws Exception {
+        doThrow(ExceptionCreator.create(DjException.NOT_OWNED_PLAYLIST))
+                .when(djCommandService).changePlaylist(any(), any());
+
+        mockMvc.perform(patch("/api/v1/partyrooms/1/dj-queue/me")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"playlistId\": 99}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value("DJ-005"));
+    }
+
+    @Test
+    @DisplayName("changePlaylist — DJ-003 EMPTY_PLAYLIST → 403")
+    void changePlaylistEmptyReturns403() throws Exception {
+        doThrow(ExceptionCreator.create(DjException.EMPTY_PLAYLIST))
+                .when(djCommandService).changePlaylist(any(), any());
+
+        mockMvc.perform(patch("/api/v1/partyrooms/1/dj-queue/me")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"playlistId\": 99}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value("DJ-003"));
+    }
+
+    @Test
+    @DisplayName("changePlaylist — DJ-006 CURRENT_DJ_CANNOT_CHANGE_PLAYLIST → 409")
+    void changePlaylistCurrentDjReturns409() throws Exception {
+        doThrow(ExceptionCreator.create(DjException.CURRENT_DJ_CANNOT_CHANGE_PLAYLIST))
+                .when(djCommandService).changePlaylist(any(), any());
+
+        mockMvc.perform(patch("/api/v1/partyrooms/1/dj-queue/me")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"playlistId\": 99}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("DJ-006"));
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandIntegrationTest.java
@@ -1,0 +1,186 @@
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.aspect.context.AuthContext;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.application.port.out.PlaylistQueryPort;
+import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.entity.data.DjData;
+import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
+import com.pfplaybackend.api.party.domain.enums.GradeType;
+import com.pfplaybackend.api.party.domain.enums.StageType;
+import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
+import com.pfplaybackend.api.party.domain.value.CrewId;
+import com.pfplaybackend.api.party.domain.value.LinkDomain;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * E/#223 — DjCommandService.changePlaylist 통합 잠금.
+ *
+ * <p>대기 중 DJ 의 playlist 변경이 큐 순서(orderNumber)와 다른 DJ row 를 보존하면서
+ * DB 에 실제 반영되는지를 Testcontainers MySQL 로 끝까지 구동해 잠근다. idempotent
+ * 케이스는 같은 playlist 로의 PATCH 가 최종 row 상태를 바꾸지 않는다는 약속을
+ * 검증한다 (SQL UPDATE 발행 여부 자체는 dirty-check 거동 의존이라 비단언).
+ *
+ * <p>PlaylistQueryPort 는 MockBean 으로 직교 격리: 본 IT 의 관심사는 party 도메인의
+ * DJ 큐 mutation/persistence 정합이지 playlist 모듈의 ownership 쿼리 정합이 아님
+ * (그것은 PlaylistQueryServiceTest 가 잠금). isOwnedBy=true, isEmptyPlaylist=false.
+ */
+@Transactional
+class DjCommandIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private DjCommandService djCommandService;
+    @Autowired
+    private PartyroomAggregatePort aggregatePort;
+
+    @MockBean
+    private PlaylistQueryPort playlistQueryPort;
+
+    @BeforeEach
+    void seedPlaylistPort() {
+        lenient().when(playlistQueryPort.isOwnedBy(org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.anyLong())).thenReturn(true);
+        lenient().when(playlistQueryPort.isEmptyPlaylist(org.mockito.ArgumentMatchers.anyLong())).thenReturn(false);
+    }
+
+    @AfterEach
+    void clearAuthContext() {
+        ThreadLocalContext.clearContext();
+    }
+
+    // ───────────────────────── 시드 헬퍼 ─────────────────────────
+
+    private PartyroomId persistFullActivePartyroom(UserId hostId, String linkSuffix) {
+        PartyroomData partyroom = PartyroomData.create(
+                "changePlaylist IT 파티룸", "E/#223 잠금용",
+                LinkDomain.of("e223-" + linkSuffix),
+                PlaybackTimeLimit.ofMinutes(5),
+                StageType.GENERAL, hostId);
+        entityManager.persist(partyroom);
+        entityManager.flush();
+        PartyroomId partyroomId = new PartyroomId(partyroom.getId());
+
+        entityManager.persist(PartyroomPlaybackData.createFor(partyroomId));
+        entityManager.persist(DjQueueData.createFor(partyroomId));
+        return partyroomId;
+    }
+
+    private CrewData persistActiveCrew(PartyroomId partyroomId, UserId userId) {
+        CrewData crew = CrewData.create(partyroomId, userId, GradeType.CLUBBER, null);
+        entityManager.persist(crew);
+        flushAndClear();
+        return crew;
+    }
+
+    private void persistDjRow(PartyroomId partyroomId, long crewId, long playlistId, int orderNumber) {
+        DjData dj = DjData.create(partyroomId, new PlaylistId(playlistId), new CrewId(crewId), orderNumber);
+        entityManager.persist(dj);
+        flushAndClear();
+    }
+
+    private void seedAuthContext(UserId userId) {
+        AuthContext authContext = mock(AuthContext.class);
+        when(authContext.getUserId()).thenReturn(userId);
+        ThreadLocalContext.setContext(authContext);
+    }
+
+    private Optional<DjData> refetchDj(PartyroomId partyroomId, long crewId) {
+        flushAndClear();
+        return aggregatePort.findDj(partyroomId, new CrewId(crewId));
+    }
+
+    // ───────────────────────── 시나리오 ─────────────────────────
+
+    @Test
+    @DisplayName("changePlaylist IT — happy: playlist_id 갱신, order_number 보존")
+    void changePlaylistHappyDbUpdated() {
+        // given
+        UserId hostId = new UserId(8100L);
+        UserId userId = new UserId(8101L);
+        PartyroomId partyroomId = persistFullActivePartyroom(hostId, "happy");
+        CrewData crew = persistActiveCrew(partyroomId, userId);
+        long crewId = crew.getId();
+        persistDjRow(partyroomId, crewId, 4242L, 1);
+        seedAuthContext(userId);
+
+        // when
+        djCommandService.changePlaylist(partyroomId, new PlaylistId(9999L));
+
+        // then
+        Optional<DjData> after = refetchDj(partyroomId, crewId);
+        assertThat(after).isPresent();
+        assertThat(after.get().getPlaylistId()).isEqualTo(new PlaylistId(9999L));
+        assertThat(after.get().getOrderNumber()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("changePlaylist IT — invariant: 본인 변경이 다른 DJ orderNumber·playlistId 무영향")
+    void changePlaylistOtherDjOrderPreserved() {
+        // given — DJ1(orderNumber=1) + DJ2(orderNumber=2)
+        UserId hostId = new UserId(8200L);
+        UserId user1 = new UserId(8201L);
+        UserId user2 = new UserId(8202L);
+        PartyroomId partyroomId = persistFullActivePartyroom(hostId, "order");
+        long crew1Id = persistActiveCrew(partyroomId, user1).getId();
+        long crew2Id = persistActiveCrew(partyroomId, user2).getId();
+        persistDjRow(partyroomId, crew1Id, 1001L, 1);
+        persistDjRow(partyroomId, crew2Id, 2002L, 2);
+
+        // when — user2 가 본인 playlist 변경
+        seedAuthContext(user2);
+        djCommandService.changePlaylist(partyroomId, new PlaylistId(7777L));
+
+        // then — DJ1 무변
+        Optional<DjData> dj1 = refetchDj(partyroomId, crew1Id);
+        assertThat(dj1).isPresent();
+        assertThat(dj1.get().getPlaylistId()).isEqualTo(new PlaylistId(1001L));
+        assertThat(dj1.get().getOrderNumber()).isEqualTo(1);
+
+        // DJ2 = playlist 변경 + orderNumber 보존
+        Optional<DjData> dj2 = refetchDj(partyroomId, crew2Id);
+        assertThat(dj2).isPresent();
+        assertThat(dj2.get().getPlaylistId()).isEqualTo(new PlaylistId(7777L));
+        assertThat(dj2.get().getOrderNumber()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("changePlaylist IT — idempotent: 같은 playlistId → 최종 row 상태 무변")
+    void changePlaylistIdempotentNoLogicalChange() {
+        // given
+        UserId hostId = new UserId(8300L);
+        UserId userId = new UserId(8301L);
+        PartyroomId partyroomId = persistFullActivePartyroom(hostId, "idempotent");
+        long crewId = persistActiveCrew(partyroomId, userId).getId();
+        persistDjRow(partyroomId, crewId, 5555L, 1);
+        seedAuthContext(userId);
+
+        // when — 같은 playlistId 로 PATCH
+        djCommandService.changePlaylist(partyroomId, new PlaylistId(5555L));
+
+        // then — 최종 row 상태 동일 (SQL UPDATE 발행 여부는 dirty-check 거동 의존, 비단언)
+        Optional<DjData> after = refetchDj(partyroomId, crewId);
+        assertThat(after).isPresent();
+        assertThat(after.get().getPlaylistId()).isEqualTo(new PlaylistId(5555L));
+        assertThat(after.get().getOrderNumber()).isEqualTo(1);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceDjQueueChangeTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceDjQueueChangeTest.java
@@ -90,6 +90,7 @@ class DjCommandServiceDjQueueChangeTest {
         when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
         when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
         when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+        when(playlistQueryPort.isOwnedBy(playlistId.getId(), userId.getUid())).thenReturn(true);
         when(playlistQueryPort.isEmptyPlaylist(playlistId.getId())).thenReturn(false);
         when(aggregatePort.isDjRegistered(partyroomId, new CrewId(1L))).thenReturn(false);
         when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(Collections.emptyList());

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceLogCaptureTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceLogCaptureTest.java
@@ -96,6 +96,7 @@ class DjCommandServiceLogCaptureTest {
         when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
         when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
         when(aggregatePort.isDjRegistered(partyroomId, new CrewId(7L))).thenReturn(false);
+        when(playlistQueryPort.isOwnedBy(playlistId.getId(), userId.getUid())).thenReturn(true);
         when(playlistQueryPort.isEmptyPlaylist(playlistId.getId())).thenReturn(false);
         when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(Collections.emptyList());
         when(aggregatePort.saveDj(any(DjData.class))).thenReturn(mock(DjData.class));

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceTest.java
@@ -27,6 +27,9 @@ import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.Collections;
 
+import com.pfplaybackend.api.common.exception.http.NotFoundException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -100,6 +103,7 @@ class DjCommandServiceTest {
         when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
         when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
         when(aggregatePort.isDjRegistered(partyroomId, new CrewId(1L))).thenReturn(true);
+        when(playlistQueryPort.isOwnedBy(playlistId.getId(), userId.getUid())).thenReturn(true);
         when(playlistQueryPort.isEmptyPlaylist(playlistId.getId())).thenReturn(false);
 
         // when & then
@@ -124,6 +128,7 @@ class DjCommandServiceTest {
         when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
         when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
         when(aggregatePort.isDjRegistered(partyroomId, new CrewId(1L))).thenReturn(false);
+        when(playlistQueryPort.isOwnedBy(playlistId.getId(), userId.getUid())).thenReturn(true);
         when(playlistQueryPort.isEmptyPlaylist(playlistId.getId())).thenReturn(true);
 
         // when & then
@@ -148,6 +153,7 @@ class DjCommandServiceTest {
         when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
         when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
         when(aggregatePort.isDjRegistered(partyroomId, new CrewId(1L))).thenReturn(false);
+        when(playlistQueryPort.isOwnedBy(playlistId.getId(), userId.getUid())).thenReturn(true);
         when(playlistQueryPort.isEmptyPlaylist(playlistId.getId())).thenReturn(false);
         when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(Collections.emptyList());
         when(aggregatePort.saveDj(any(DjData.class))).thenReturn(mock(DjData.class));
@@ -157,6 +163,186 @@ class DjCommandServiceTest {
 
         // then
         verify(playbackControlPort).startPlayback(partyroom);
+    }
+
+    @Test
+    @DisplayName("enqueueDj — 타인 소유 playlist 면 NOT_OWNED_PLAYLIST (Task 4/10 회귀 가드)")
+    void enqueueDjNotOwnedThrows() {
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(partyroomId.getId()).partyroomId(partyroomId).build();
+        PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+        DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+        CrewData crew = CrewData.builder()
+                .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+        when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+        when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+        when(aggregatePort.isDjRegistered(partyroomId, new CrewId(1L))).thenReturn(false);
+        when(playlistQueryPort.isOwnedBy(playlistId.getId(), userId.getUid())).thenReturn(false);
+
+        assertThatThrownBy(() -> djCommandService.enqueueDj(partyroomId, playlistId))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("changePlaylist — 큐에 없으면 NOT_FOUND_DJ")
+    void changePlaylistNotInQueueThrows() {
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(partyroomId.getId()).partyroomId(partyroomId).build();
+        PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+        DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+        CrewData crew = CrewData.builder()
+                .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+        when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+        when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+        when(aggregatePort.findDj(partyroomId, new CrewId(1L))).thenReturn(java.util.Optional.empty());
+
+        assertThatThrownBy(() -> djCommandService.changePlaylist(partyroomId, new PlaylistId(200L)))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("changePlaylist — 재생 중 DJ 면 CURRENT_DJ_CANNOT_CHANGE_PLAYLIST")
+    void changePlaylistCurrentDjThrows() {
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(partyroomId.getId()).partyroomId(partyroomId).build();
+        PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+        playbackState.activate(null, new CrewId(1L));
+        DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+        CrewData crew = CrewData.builder()
+                .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+        DjData me = DjData.create(partyroomId, playlistId, new CrewId(1L), 1);
+
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+        when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+        when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+        when(aggregatePort.findDj(partyroomId, new CrewId(1L))).thenReturn(java.util.Optional.of(me));
+
+        assertThatThrownBy(() -> djCommandService.changePlaylist(partyroomId, new PlaylistId(200L)))
+                .isInstanceOf(ConflictException.class);
+    }
+
+    @Test
+    @DisplayName("changePlaylist — 타인 소유 playlist 면 NOT_OWNED_PLAYLIST")
+    void changePlaylistNotOwnedThrows() {
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(partyroomId.getId()).partyroomId(partyroomId).build();
+        PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+        DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+        CrewData crew = CrewData.builder()
+                .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+        DjData me = DjData.create(partyroomId, playlistId, new CrewId(1L), 1);
+
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+        when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+        when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+        when(aggregatePort.findDj(partyroomId, new CrewId(1L))).thenReturn(java.util.Optional.of(me));
+        when(playlistQueryPort.isOwnedBy(200L, userId.getUid())).thenReturn(false);
+
+        assertThatThrownBy(() -> djCommandService.changePlaylist(partyroomId, new PlaylistId(200L)))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("changePlaylist — 미존재 playlistId 도 isOwnedBy=false 로 NOT_OWNED_PLAYLIST (security boundary)")
+    void changePlaylistNonExistentPlaylistThrows() {
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(partyroomId.getId()).partyroomId(partyroomId).build();
+        PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+        DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+        CrewData crew = CrewData.builder()
+                .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+        DjData me = DjData.create(partyroomId, playlistId, new CrewId(1L), 1);
+
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+        when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+        when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+        when(aggregatePort.findDj(partyroomId, new CrewId(1L))).thenReturn(java.util.Optional.of(me));
+        when(playlistQueryPort.isOwnedBy(999_999L, userId.getUid())).thenReturn(false);
+
+        assertThatThrownBy(() -> djCommandService.changePlaylist(partyroomId, new PlaylistId(999_999L)))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("changePlaylist — 빈 playlist 면 EMPTY_PLAYLIST")
+    void changePlaylistEmptyThrows() {
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(partyroomId.getId()).partyroomId(partyroomId).build();
+        PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+        DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+        CrewData crew = CrewData.builder()
+                .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+        DjData me = DjData.create(partyroomId, playlistId, new CrewId(1L), 1);
+
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+        when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+        when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+        when(aggregatePort.findDj(partyroomId, new CrewId(1L))).thenReturn(java.util.Optional.of(me));
+        when(playlistQueryPort.isOwnedBy(200L, userId.getUid())).thenReturn(true);
+        when(playlistQueryPort.isEmptyPlaylist(200L)).thenReturn(true);
+
+        assertThatThrownBy(() -> djCommandService.changePlaylist(partyroomId, new PlaylistId(200L)))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("changePlaylist — happy path: me.playlistId 갱신 + 이벤트 발행 0회")
+    void changePlaylistHappy() {
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(partyroomId.getId()).partyroomId(partyroomId).build();
+        PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+        DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+        CrewData crew = CrewData.builder()
+                .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+        DjData me = DjData.create(partyroomId, playlistId, new CrewId(1L), 1);
+
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+        when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+        when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+        when(aggregatePort.findDj(partyroomId, new CrewId(1L))).thenReturn(java.util.Optional.of(me));
+        when(playlistQueryPort.isOwnedBy(200L, userId.getUid())).thenReturn(true);
+        when(playlistQueryPort.isEmptyPlaylist(200L)).thenReturn(false);
+
+        djCommandService.changePlaylist(partyroomId, new PlaylistId(200L));
+
+        assertThat(me.getPlaylistId()).isEqualTo(new PlaylistId(200L));
+        assertThat(me.getOrderNumber()).isEqualTo(1);
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("changePlaylist — idempotent: 같은 playlistId 입력 예외 없음")
+    void changePlaylistIdempotent() {
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(partyroomId.getId()).partyroomId(partyroomId).build();
+        PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+        DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+        CrewData crew = CrewData.builder()
+                .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+        DjData me = DjData.create(partyroomId, playlistId, new CrewId(1L), 1);
+
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+        when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+        when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+        when(aggregatePort.findDj(partyroomId, new CrewId(1L))).thenReturn(java.util.Optional.of(me));
+        when(playlistQueryPort.isOwnedBy(playlistId.getId(), userId.getUid())).thenReturn(true);
+        when(playlistQueryPort.isEmptyPlaylist(playlistId.getId())).thenReturn(false);
+
+        djCommandService.changePlaylist(partyroomId, playlistId);
+
+        assertThat(me.getPlaylistId()).isEqualTo(playlistId);
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/party/domain/entity/data/DjDataTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/domain/entity/data/DjDataTest.java
@@ -40,4 +40,22 @@ class DjDataTest {
         // then
         assertThat(dj.getOrderNumber()).isEqualTo(5);
     }
+
+    @Test
+    @DisplayName("updatePlaylist — playlist 가 변경되고 orderNumber 는 보존된다")
+    void updatePlaylistKeepsOrderNumber() {
+        // given
+        PlaylistId oldId = new PlaylistId(10L);
+        PlaylistId newId = new PlaylistId(99L);
+        DjData dj = DjData.create(new PartyroomId(1L), oldId, new CrewId(20L), 3);
+
+        // when
+        dj.updatePlaylist(newId);
+
+        // then
+        assertThat(dj.getPlaylistId()).isEqualTo(newId);
+        assertThat(dj.getOrderNumber()).isEqualTo(3);
+        assertThat(dj.getCrewId()).isEqualTo(new CrewId(20L));
+        assertThat(dj.getPartyroomId()).isEqualTo(new PartyroomId(1L));
+    }
 }

--- a/app/src/test/java/com/pfplaybackend/api/party/domain/specification/DjChangePlaylistSpecificationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/domain/specification/DjChangePlaylistSpecificationTest.java
@@ -1,0 +1,74 @@
+package com.pfplaybackend.api.party.domain.specification;
+
+import com.pfplaybackend.api.common.exception.http.ConflictException;
+import com.pfplaybackend.api.common.exception.http.ForbiddenException;
+import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DjChangePlaylistSpecificationTest {
+
+    private DjChangePlaylistSpecification spec;
+
+    @BeforeEach
+    void setUp() {
+        spec = new DjChangePlaylistSpecification();
+    }
+
+    private DjQueueData openQueue() {
+        return DjQueueData.createFor(new PartyroomId(1L));
+    }
+
+    private DjQueueData closedQueue() {
+        DjQueueData queue = DjQueueData.createFor(new PartyroomId(1L));
+        queue.close();
+        return queue;
+    }
+
+    @Test
+    @DisplayName("정상 변경 — 예외 없음 (queue open, not current, owned, non-empty)")
+    void validChange() {
+        assertThatNoException().isThrownBy(() ->
+                spec.validate(openQueue(), false, true, false));
+    }
+
+    @Test
+    @DisplayName("큐 닫힘 — QUEUE_CLOSED (DJ-002)")
+    void queueClosed() {
+        assertThatThrownBy(() -> spec.validate(closedQueue(), false, true, false))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("재생 중 DJ — CURRENT_DJ_CANNOT_CHANGE_PLAYLIST (DJ-006)")
+    void currentDjThrows() {
+        assertThatThrownBy(() -> spec.validate(openQueue(), true, true, false))
+                .isInstanceOf(ConflictException.class);
+    }
+
+    @Test
+    @DisplayName("타인 소유 playlist — NOT_OWNED_PLAYLIST (DJ-005)")
+    void notOwnedThrows() {
+        assertThatThrownBy(() -> spec.validate(openQueue(), false, false, false))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("빈 playlist — EMPTY_PLAYLIST (DJ-003)")
+    void emptyPlaylistThrows() {
+        assertThatThrownBy(() -> spec.validate(openQueue(), false, true, true))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("평가 순서 잠금 — currentDj + not-owned 동시: CURRENT_DJ_CANNOT_CHANGE_PLAYLIST 가 먼저(ConflictException)")
+    void currentDjBeatsOwnership() {
+        assertThatThrownBy(() -> spec.validate(openQueue(), true, false, true))
+                .isInstanceOf(ConflictException.class);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/domain/specification/DjChangePlaylistSpecificationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/domain/specification/DjChangePlaylistSpecificationTest.java
@@ -71,4 +71,13 @@ class DjChangePlaylistSpecificationTest {
         assertThatThrownBy(() -> spec.validate(openQueue(), true, false, true))
                 .isInstanceOf(ConflictException.class);
     }
+
+    @Test
+    @DisplayName("평가 순서 잠금 — queue closed + not-owned 동시: QUEUE_CLOSED(validateOpen) 가 먼저 (spec §4-1)")
+    void queueClosedBeatsOwnership() {
+        // 둘 다 ForbiddenException 이지만, closed 가 먼저 평가되면 ownership/empty 호출 자체가 발생 안 함
+        // (== spec §3-2 의 evaluation order, validateOpen 이 throw 후 후속 if 블록 실행 안 됨)
+        assertThatThrownBy(() -> spec.validate(closedQueue(), false, false, true))
+                .isInstanceOf(ForbiddenException.class);
+    }
 }

--- a/app/src/test/java/com/pfplaybackend/api/party/domain/specification/DjEnqueueSpecificationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/domain/specification/DjEnqueueSpecificationTest.java
@@ -33,32 +33,42 @@ class DjEnqueueSpecificationTest {
     @Test
     @DisplayName("정상 DJ 등록 — 예외 없음")
     void validEnqueue() {
-        DjQueueData queue = openQueue();
         assertThatNoException().isThrownBy(() ->
-                spec.validate(queue, false, false));
+                spec.validate(openQueue(), false, true, false));
     }
 
     @Test
-    @DisplayName("큐 닫힘 — QUEUE_CLOSED")
+    @DisplayName("큐 닫힘 — QUEUE_CLOSED (DJ-002)")
     void queueClosed() {
-        DjQueueData queue = closedQueue();
-        assertThatThrownBy(() -> spec.validate(queue, false, false))
+        assertThatThrownBy(() -> spec.validate(closedQueue(), false, true, false))
                 .isInstanceOf(ForbiddenException.class);
     }
 
     @Test
-    @DisplayName("빈 플레이리스트 — EMPTY_PLAYLIST")
+    @DisplayName("타인 소유 playlist — NOT_OWNED_PLAYLIST (DJ-005, 신규)")
+    void notOwnedThrows() {
+        assertThatThrownBy(() -> spec.validate(openQueue(), false, false, false))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("빈 플레이리스트 — EMPTY_PLAYLIST (DJ-003)")
     void emptyPlaylist() {
-        DjQueueData queue = openQueue();
-        assertThatThrownBy(() -> spec.validate(queue, false, true))
+        assertThatThrownBy(() -> spec.validate(openQueue(), false, true, true))
                 .isInstanceOf(ForbiddenException.class);
     }
 
     @Test
-    @DisplayName("이미 등록된 DJ — ALREADY_REGISTERED")
+    @DisplayName("이미 등록된 DJ — ALREADY_REGISTERED (DJ-001)")
     void alreadyRegistered() {
-        DjQueueData queue = openQueue();
-        assertThatThrownBy(() -> spec.validate(queue, true, false))
+        assertThatThrownBy(() -> spec.validate(openQueue(), true, true, false))
                 .isInstanceOf(ConflictException.class);
+    }
+
+    @Test
+    @DisplayName("평가 순서 잠금 — already-registered + not-owned 동시: NOT_OWNED_PLAYLIST 가 먼저 (보안 우선)")
+    void ownershipBeatsAlreadyRegistered() {
+        assertThatThrownBy(() -> spec.validate(openQueue(), true, false, false))
+                .isInstanceOf(ForbiddenException.class);
     }
 }

--- a/docs/superpowers/plans/2026-05-21-e223-change-playlist.md
+++ b/docs/superpowers/plans/2026-05-21-e223-change-playlist.md
@@ -221,18 +221,6 @@ class DjChangePlaylistSpecificationTest {
     }
 
     @Test
-    @DisplayName("평가 순서 잠금 — queue closed + not-owned 동시: QUEUE_CLOSED 가 먼저")
-    void queueClosedBeatsOwnership() {
-        // ForbiddenException 자체는 둘 다 던지지만, 평가 순서는 queue-closed 가 선행.
-        // (errorCode 명세는 ExceptionCreator 가 보존하므로, 별도 컨트롤러 테스트에서 잠금)
-        assertThatThrownBy(() -> spec.validate(closedQueue(), false, false, true))
-            .isInstanceOf(ForbiddenException.class);
-        // QUEUE_CLOSED 가 먼저 던져졌는지 보장하기 위해 시그니처 단언은 ExceptionCreator
-        // 의 message/code 추적 — 본 spec 테스트는 평가가 closed 단계에서 멈췄음을
-        // 다른 두 호출이 발생하지 않는다는 사실(== 코드 정의)로 간접 잠금.
-    }
-
-    @Test
     @DisplayName("평가 순서 잠금 — currentDj + not-owned 동시: CURRENT_DJ_CANNOT_CHANGE_PLAYLIST 가 먼저(ConflictException)")
     void currentDjBeatsOwnership() {
         assertThatThrownBy(() -> spec.validate(openQueue(), true, false, true))
@@ -241,7 +229,9 @@ class DjChangePlaylistSpecificationTest {
 }
 ```
 
-> 평가 순서 잠금 테스트(case 6/7)는 ForbiddenException vs ConflictException 의 **다른 예외 타입** 으로 우선순위를 간접 확인. 예: DJ-005 = ForbiddenException, DJ-006 = ConflictException. 두 조건 동시 발화 시 DJ-006(ConflictException) 가 잡히면 currentDj 가 먼저 평가됐음을 증명.
+> 평가 순서 잠금 테스트(case 6 `currentDjBeatsOwnership`)는 ForbiddenException vs ConflictException 의 **다른 예외 타입** 으로 우선순위를 직접 확인. DJ-006 = ConflictException, DJ-005 = ForbiddenException. 두 조건 동시 발화 시 ConflictException 가 잡히면 currentDj 가 먼저 평가됐음을 증명.
+>
+> **참고 (queue-closed vs ownership 평가 순서)**: 두 invariant 모두 `ForbiddenException` 을 던져 spec unit 레벨에서는 type 만으로 구분 불가. 의도는 controller WebMvc 테스트(Task 11)의 `jsonPath("$.error.errorCode").value("DJ-002"/"DJ-005")` 를 통해 잠금 — 별도 spec case 추가 불요(reviewer round-1 advisory 반영).
 
 - [ ] **Step 2: 실패 확인**
 
@@ -277,7 +267,7 @@ public class DjChangePlaylistSpecification {
 - [ ] **Step 4: 통과 확인**
 
 Run: 위 Step 2 와 동일.
-Expected: 7 tests PASS.
+Expected: 6 tests PASS (reviewer round-2 advisory 로 case 6 `queueClosedBeatsOwnership` 드롭, controller WebMvc 에서 errorCode 잠금).
 
 - [ ] **Step 5: 커밋**
 
@@ -417,7 +407,7 @@ Run:
 ```bash
 JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.domain.specification.DjEnqueueSpecificationTest" 2>&1 | tail -30
 ```
-Expected: spec test 6 PASS. **그러나** `:app:compileJava` 가 `DjCommandService.enqueueDj` 의 3-arg 호출 때문에 실패. Chunk 3 Task 10 에서 해소.
+Expected: **build halts at `:app:compileJava` with `DjCommandService.enqueueDj` 3-arg call error — `DjEnqueueSpecificationTest` does not execute until Task 10 unblocks the caller.** Chunk 1~2 진행은 가능(playlist 모듈·party port interface·DTO 는 `app/compileJava` 와 독립). 본 spec test 의 PASS 시각은 **Task 10 Step 4**.
 
 - [ ] **Step 5: 커밋 (caller 일시 빨강 명시)**
 
@@ -887,19 +877,21 @@ import 추가:
 import com.pfplaybackend.api.party.domain.specification.DjChangePlaylistSpecification;
 ```
 
-- [ ] **Step 4: 통과 확인**
+> **로그 레벨 INFO**: party.application.service 는 [[project_observability_b1b2_merged]] / observability A4 정책상 INFO pin-allowed 비즈니스 패키지. state-mutating command 의 ENTER / OK 두 라인은 의도된 observability surface.
+
+- [ ] **Step 4: 컴파일 빨강 carry-over 확인**
 
 Run: 위 Step 2 와 동일.
-Expected: 7 신규 PASS.
+Expected: **build halts at `:app:compileJava`** — `DjCommandService.enqueueDj` 가 여전히 `DjEnqueueSpecification.validate` 의 옛 3-arg signature 를 호출 (Task 4 의 일시 빨강 carry-over). 본 task 의 changePlaylist 7 신규 테스트는 **이번 step 에서는 실행되지 않음**. PASS 시각 = **Task 10 Step 4** (caller 4-arg 정합 직후 changePlaylist + enqueue 모두 GREEN).
 
-> 기존 enqueue/dequeue 테스트 4개는 여전히 fail 가능 — Chunk 1 Task 4 의 `DjEnqueueSpecification` arity 변경 영향 + Task 10 미적용 상태. Task 10 까지 가서 정합.
+> 본 task 의 Step 3 까지 production·test 코드는 모두 정확. 빨강의 원천은 Task 4 의 caller 미정합 단 하나 — Task 10 Step 3 가 그 caller 호출 라인 1줄만 4-arg 로 교체하면 동시 해소.
 
 - [ ] **Step 5: 커밋**
 
 ```bash
 git add app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java \
         app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceTest.java
-git commit -m "feat(e223): DjCommandService.changePlaylist — happy/4 fail/idempotent (#223)"
+git commit -m "feat(e223): DjCommandService.changePlaylist — happy/4 fail/idempotent (Task 4/10 caller 정합 대기) (#223)"
 ```
 
 ---
@@ -1186,12 +1178,20 @@ git commit -m "feat(e223): DjCommandController PATCH /dj-queue/me — changePlay
 
 기존 party 모듈 IT 들의 패턴을 따른다(Flyway + H2 또는 Testcontainers, `@SpringBootTest` + `@Transactional`/`@AfterEach` cleanup). 작업 시작 전 기존 IT 한 개를 열어 base 설정·픽스처 헬퍼를 확인하고 그대로 재사용. **신규 베이스 클래스/헬퍼 작성 금지** — 회귀잠금 IT 의 패턴(예: `PartyroomAccessCommandServiceRaceIT`, `DjQueueGraceIntegrationTest` 등)을 모방.
 
-- [ ] **Step 1: 기존 IT 패턴 파악**
+- [ ] **Step 1: 기존 IT 패턴 파악 + 선택한 base 파일 기록**
 
-작업 직전 다음 파일 1개 열어 base 어노테이션·픽스처·cleanup 방식 파악:
-- `app/src/integrationTest/java/.../DjQueueGraceIntegrationTest.java` 또는 동등.
+먼저 IT 디렉토리 구조 확인:
+```bash
+git ls-files "app/src/integrationTest/**/*.java" | head -30
+git ls-files "app/src/test/**/*IntegrationTest.java" | head -30
+```
 
-(plan 작성 시점에 정확한 base 파일을 확정하지 않은 이유 = IT 디렉토리 구조·base 패턴은 실행 시점에 git ls-files 로 1차 확인 후 진입하는 게 안전. 보통 `@SpringBootTest` + `@ActiveProfiles("integration-test")` + `@Sql`/`@Transactional` + Testcontainers MySQL.)
+선택한 base IT 파일명을 plan-execution 로그에 명시(예: `Selected base IT pattern: <path>`). 후보:
+- `app/src/integrationTest/java/.../DjQueueGraceIntegrationTest.java`
+- `app/src/integrationTest/java/.../PartyroomAccessCommandServiceRaceIT.java`
+- `app/src/integrationTest/java/.../PartyroomCounterListenerIT.java`
+
+(보통 `@SpringBootTest` + `@ActiveProfiles("integration-test")` + Testcontainers MySQL.)
 
 - [ ] **Step 2: 실패 IT 작성 (3 case)**
 
@@ -1313,7 +1313,7 @@ gh pr create --title "feat(e223): 대기 중 DJ 플레이리스트 변경 API (C
 ## 테스트
 
 - :playlist:test PASS (신규 2 + 기존 무변)
-- :app:test PASS (신규: DjChangePlaylistSpecificationTest 7 / DjCommandServiceTest changePlaylist 7 + enqueue 회귀 1 / DjCommandControllerTest changePlaylist 8 / DjDataTest 1, 수정: DjEnqueueSpecificationTest 6)
+- :app:test PASS (신규: DjChangePlaylistSpecificationTest 6 / DjCommandServiceTest changePlaylist 7 + enqueue 회귀 1 / DjCommandControllerTest changePlaylist 8 / DjDataTest 1, 수정: DjEnqueueSpecificationTest 6)
 - :app:integrationTest PASS (DjCommandIntegrationTest 3 신규)
 
 ## 스펙 / 계획

--- a/docs/superpowers/plans/2026-05-21-e223-change-playlist.md
+++ b/docs/superpowers/plans/2026-05-21-e223-change-playlist.md
@@ -1,0 +1,1341 @@
+# E/#223 — 대기 중 DJ 플레이리스트 변경 API (Change Playlist) 구현 계획
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** DJ 대기열에서 대기 중인 본인의 디제잉 플레이리스트를 큐 순서를 보존하며 변경하는 PATCH 엔드포인트 신설. playlist 소유권 검증을 신규 PATCH 와 기존 enqueue 양쪽에 동반 보강.
+
+**Architecture:** party 모듈 = 정책(허용범위·spec). playlist 모듈 = ownership query. 도메인 layer: `DjData.updatePlaylist` mutator + 신규 `DjChangePlaylistSpecification` + `DjEnqueueSpecification` arity 확장. application: `DjCommandService.changePlaylist` 신규 + `enqueueDj` ownership 동반. adapter/in/web: `PATCH .../dj-queue/me` + `ChangePlaylistRequest` DTO. WS broadcast 없음(본인만 결과 확인).
+
+**Tech Stack:** Java 21 (Gradle 호출 시 `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7"` prefix 필수), Spring Boot, JPA, JUnit5, Mockito, AssertJ. Gradle 모듈: `playlist`, `app`(party).
+
+**Spec:** `docs/superpowers/specs/2026-05-21-e223-change-playlist-design.md` (브랜치 `feature/e223-change-playlist`, commits `37ea9dd2` 초안 → `337f21d9` round-1 → `f0c21670` round-2 polish, reviewer 2-round Approved).
+
+---
+
+## File Structure
+
+**playlist 모듈 (신규 1 / 수정 0)**
+- Modify: `playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/PlaylistQueryService.java` — `isOwnedBy(Long, UserId): boolean` 메서드 추가. `findByIdAndUserId(...)` 의 null/non-null 활용 또는 동등 효율의 exists 형태(plan 단계 결정 = null 체크 재사용, exists 신설 회피).
+- Test: `playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/PlaylistQueryServiceTest.java` — `isOwnedBy` 케이스 추가.
+
+**party 모듈 (신규 4 / 수정 7)**
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/domain/exception/DjException.java` — DJ-005 `NOT_OWNED_PLAYLIST` · DJ-006 `CURRENT_DJ_CANNOT_CHANGE_PLAYLIST` enum 추가.
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/DjData.java` — `updatePlaylist(PlaylistId)` mutator 추가.
+- Modify: `app/src/test/java/com/pfplaybackend/api/party/domain/entity/data/DjDataTest.java` — `updatePlaylist` 케이스 추가.
+- Create: `app/src/main/java/com/pfplaybackend/api/party/domain/specification/DjChangePlaylistSpecification.java` — 4 invariant validate.
+- Create: `app/src/test/java/com/pfplaybackend/api/party/domain/specification/DjChangePlaylistSpecificationTest.java` — happy + 4 fail + 우선순위 잠금.
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/domain/specification/DjEnqueueSpecification.java` — `validate` arity 3→4 (`isOwned` 추가).
+- Modify: `app/src/test/java/com/pfplaybackend/api/party/domain/specification/DjEnqueueSpecificationTest.java` — 기존 3 case 픽스처 수정 + 신규 ownership 2 case.
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/application/port/out/PlaylistQueryPort.java` — `isOwnedBy(Long, Long): boolean` interface 메서드 추가.
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/PlaylistQueryAdapter.java` — `isOwnedBy` impl, playlist 모듈 service 위임.
+- Create: `app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/payload/request/dj/ChangePlaylistRequest.java` — `@NotNull @Positive Long playlistId` (class + @Getter, `RegisterDjRequest` 컨벤션 정합).
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java` — `changePlaylist(PartyroomId, PlaylistId)` 신규 + `enqueueDj` ownership 보강(기존 `isEmptyPlaylist` 옆에 `isOwned` 계산 + spec 호출 시 4-ary 전달).
+- Modify: `app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceTest.java` — 기존 enqueue 4 case 의 `isOwnedBy=true` mock 보정 + ownership 회귀 1 + changePlaylist 7 신규.
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandController.java` — `@PatchMapping("/{partyroomId}/dj-queue/me")` 신규.
+- Modify: `app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandControllerTest.java` — changePlaylist 7 WebMvc 케이스 추가.
+- Create: `app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandIntegrationTest.java` — happy / order 보존 / idempotent (3 case).
+
+빌드 명령(Windows Git Bash):
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :playlist:test :app:test :app:integrationTest
+```
+모듈 단위 우선 → 전체. 빌드 캐시 hit 최대화.
+
+---
+
+## Chunk 1: 도메인 기반 (DjException, DjData, Specification)
+
+### Task 1: `DjException` DJ-005 / DJ-006 enum 확장
+
+순수 enum 확장이라 별도 테스트 없음(다음 task 들이 이 코드를 인용).
+
+**Files:**
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/domain/exception/DjException.java`
+
+- [ ] **Step 1: 신규 enum 항목 2개 추가**
+
+`DjException.java` 의 `NOT_FOUND_DJ` 항목 뒤에 추가:
+
+```java
+NOT_OWNED_PLAYLIST("DJ-005", "본인 소유 플레이리스트가 아닙니다", ErrorType.FORBIDDEN),
+CURRENT_DJ_CANNOT_CHANGE_PLAYLIST("DJ-006", "재생 중 DJ는 플레이리스트를 변경할 수 없습니다", ErrorType.CONFLICT);
+```
+
+> `NOT_FOUND_DJ` 줄 끝 세미콜론을 콤마로 바꿔야 함. 새 마지막 enum 만 세미콜론.
+
+- [ ] **Step 2: 컴파일 확인**
+
+Run:
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:compileJava
+```
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/domain/exception/DjException.java
+git commit -m "feat(e223): DjException DJ-005/006 추가 (NOT_OWNED_PLAYLIST, CURRENT_DJ_CANNOT_CHANGE_PLAYLIST) (#223)"
+```
+
+---
+
+### Task 2: `DjData.updatePlaylist` mutator + Test
+
+**Files:**
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/DjData.java`
+- Test: `app/src/test/java/com/pfplaybackend/api/party/domain/entity/data/DjDataTest.java`
+
+- [ ] **Step 1: 실패 단위 테스트 작성**
+
+`DjDataTest.java` 의 `updateOrderNumberUpdatesOrder` 테스트 뒤에 추가:
+
+```java
+@Test
+@DisplayName("updatePlaylist — playlist 가 변경되고 orderNumber 는 보존된다")
+void updatePlaylistKeepsOrderNumber() {
+    // given
+    PlaylistId oldId = new PlaylistId(10L);
+    PlaylistId newId = new PlaylistId(99L);
+    DjData dj = DjData.create(new PartyroomId(1L), oldId, new CrewId(20L), 3);
+
+    // when
+    dj.updatePlaylist(newId);
+
+    // then
+    assertThat(dj.getPlaylistId()).isEqualTo(newId);
+    assertThat(dj.getOrderNumber()).isEqualTo(3);     // 보존
+    assertThat(dj.getCrewId()).isEqualTo(new CrewId(20L)); // 보존
+    assertThat(dj.getPartyroomId()).isEqualTo(new PartyroomId(1L)); // 보존
+}
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run:
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.domain.entity.data.DjDataTest.updatePlaylistKeepsOrderNumber"
+```
+Expected: FAIL — `cannot find symbol: method updatePlaylist(PlaylistId)`.
+
+- [ ] **Step 3: 최소 구현**
+
+`DjData.java` 의 `updateOrderNumber` 메서드 뒤에 추가:
+
+```java
+public void updatePlaylist(PlaylistId playlistId) {
+    this.playlistId = playlistId;
+}
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: 위 Step 2 와 동일.
+Expected: PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/DjData.java \
+        app/src/test/java/com/pfplaybackend/api/party/domain/entity/data/DjDataTest.java
+git commit -m "feat(e223): DjData.updatePlaylist mutator — orderNumber 보존 (#223)"
+```
+
+---
+
+### Task 3: `DjChangePlaylistSpecification` + Test
+
+평가 순서 = queue-closed → currentDj → ownership(보안) → empty(콘텐츠). spec §3-2 정합.
+
+**Files:**
+- Create: `app/src/main/java/com/pfplaybackend/api/party/domain/specification/DjChangePlaylistSpecification.java`
+- Create: `app/src/test/java/com/pfplaybackend/api/party/domain/specification/DjChangePlaylistSpecificationTest.java`
+
+- [ ] **Step 1: 실패 단위 테스트 작성**
+
+신규 파일 `DjChangePlaylistSpecificationTest.java`:
+
+```java
+package com.pfplaybackend.api.party.domain.specification;
+
+import com.pfplaybackend.api.common.exception.http.ConflictException;
+import com.pfplaybackend.api.common.exception.http.ForbiddenException;
+import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DjChangePlaylistSpecificationTest {
+
+    private DjChangePlaylistSpecification spec;
+
+    @BeforeEach
+    void setUp() {
+        spec = new DjChangePlaylistSpecification();
+    }
+
+    private DjQueueData openQueue() { return DjQueueData.createFor(new PartyroomId(1L)); }
+    private DjQueueData closedQueue() {
+        DjQueueData q = DjQueueData.createFor(new PartyroomId(1L));
+        q.close();
+        return q;
+    }
+
+    @Test
+    @DisplayName("정상 변경 — 예외 없음 (queue open, not current, owned, non-empty)")
+    void validChange() {
+        assertThatNoException().isThrownBy(() ->
+            spec.validate(openQueue(), false, true, false));
+    }
+
+    @Test
+    @DisplayName("큐 닫힘 — QUEUE_CLOSED (DJ-002)")
+    void queueClosed() {
+        assertThatThrownBy(() -> spec.validate(closedQueue(), false, true, false))
+            .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("재생 중 DJ — CURRENT_DJ_CANNOT_CHANGE_PLAYLIST (DJ-006)")
+    void currentDjThrows() {
+        assertThatThrownBy(() -> spec.validate(openQueue(), true, true, false))
+            .isInstanceOf(ConflictException.class);
+    }
+
+    @Test
+    @DisplayName("타인 소유 playlist — NOT_OWNED_PLAYLIST (DJ-005)")
+    void notOwnedThrows() {
+        assertThatThrownBy(() -> spec.validate(openQueue(), false, false, false))
+            .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("빈 playlist — EMPTY_PLAYLIST (DJ-003)")
+    void emptyPlaylistThrows() {
+        assertThatThrownBy(() -> spec.validate(openQueue(), false, true, true))
+            .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("평가 순서 잠금 — queue closed + not-owned 동시: QUEUE_CLOSED 가 먼저")
+    void queueClosedBeatsOwnership() {
+        // ForbiddenException 자체는 둘 다 던지지만, 평가 순서는 queue-closed 가 선행.
+        // (errorCode 명세는 ExceptionCreator 가 보존하므로, 별도 컨트롤러 테스트에서 잠금)
+        assertThatThrownBy(() -> spec.validate(closedQueue(), false, false, true))
+            .isInstanceOf(ForbiddenException.class);
+        // QUEUE_CLOSED 가 먼저 던져졌는지 보장하기 위해 시그니처 단언은 ExceptionCreator
+        // 의 message/code 추적 — 본 spec 테스트는 평가가 closed 단계에서 멈췄음을
+        // 다른 두 호출이 발생하지 않는다는 사실(== 코드 정의)로 간접 잠금.
+    }
+
+    @Test
+    @DisplayName("평가 순서 잠금 — currentDj + not-owned 동시: CURRENT_DJ_CANNOT_CHANGE_PLAYLIST 가 먼저(ConflictException)")
+    void currentDjBeatsOwnership() {
+        assertThatThrownBy(() -> spec.validate(openQueue(), true, false, true))
+            .isInstanceOf(ConflictException.class);  // DJ-006 (FORBIDDEN-vs-CONFLICT 의 ConflictException 으로 구분)
+    }
+}
+```
+
+> 평가 순서 잠금 테스트(case 6/7)는 ForbiddenException vs ConflictException 의 **다른 예외 타입** 으로 우선순위를 간접 확인. 예: DJ-005 = ForbiddenException, DJ-006 = ConflictException. 두 조건 동시 발화 시 DJ-006(ConflictException) 가 잡히면 currentDj 가 먼저 평가됐음을 증명.
+
+- [ ] **Step 2: 실패 확인**
+
+Run:
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.domain.specification.DjChangePlaylistSpecificationTest"
+```
+Expected: FAIL — `cannot find symbol: class DjChangePlaylistSpecification`.
+
+- [ ] **Step 3: 최소 구현**
+
+신규 파일 `DjChangePlaylistSpecification.java`:
+
+```java
+package com.pfplaybackend.api.party.domain.specification;
+
+import com.pfplaybackend.api.common.exception.ExceptionCreator;
+import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.domain.exception.DjException;
+
+public class DjChangePlaylistSpecification {
+
+    public void validate(DjQueueData djQueue, boolean isCurrentDj,
+                         boolean isOwned, boolean isEmptyPlaylist) {
+        djQueue.validateOpen();
+        if (isCurrentDj)     throw ExceptionCreator.create(DjException.CURRENT_DJ_CANNOT_CHANGE_PLAYLIST);
+        if (!isOwned)        throw ExceptionCreator.create(DjException.NOT_OWNED_PLAYLIST);
+        if (isEmptyPlaylist) throw ExceptionCreator.create(DjException.EMPTY_PLAYLIST);
+    }
+}
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: 위 Step 2 와 동일.
+Expected: 7 tests PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/domain/specification/DjChangePlaylistSpecification.java \
+        app/src/test/java/com/pfplaybackend/api/party/domain/specification/DjChangePlaylistSpecificationTest.java
+git commit -m "feat(e223): DjChangePlaylistSpecification — queue-closed→currentDj→ownership→empty 평가순서 (#223)"
+```
+
+---
+
+### Task 4: `DjEnqueueSpecification` arity 3→4 + Test 보강
+
+**breaking signature change** — 같은 PR 안에서 caller(`DjCommandService.enqueueDj`) 와 test 파일 동시 갱신 필요. caller 갱신은 Chunk 3 Task 10 에서, 본 task 는 spec + test 만.
+
+> **빌드 일시 빨강**: `DjEnqueueSpecification.validate` 시그니처가 바뀌면 `DjCommandService.enqueueDj` 의 기존 호출이 컴파일 에러. Task 4 commit 직후엔 `:app:compileJava` 가 실패한다. **이는 의도된 일시 빨강**(red-as-process-guard) — Chunk 3 Task 10 에서 caller 를 동반 갱신해 해소. Task 4 commit 메시지에 그 점 명시.
+
+**Files:**
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/domain/specification/DjEnqueueSpecification.java`
+- Modify: `app/src/test/java/com/pfplaybackend/api/party/domain/specification/DjEnqueueSpecificationTest.java`
+
+- [ ] **Step 1: 기존 spec 테스트 픽스처 수정 + ownership 신규 테스트 추가**
+
+`DjEnqueueSpecificationTest.java` 전체 교체:
+
+```java
+package com.pfplaybackend.api.party.domain.specification;
+
+import com.pfplaybackend.api.common.exception.http.ConflictException;
+import com.pfplaybackend.api.common.exception.http.ForbiddenException;
+import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DjEnqueueSpecificationTest {
+
+    private DjEnqueueSpecification spec;
+
+    @BeforeEach
+    void setUp() {
+        spec = new DjEnqueueSpecification();
+    }
+
+    private DjQueueData openQueue() { return DjQueueData.createFor(new PartyroomId(1L)); }
+    private DjQueueData closedQueue() {
+        DjQueueData q = DjQueueData.createFor(new PartyroomId(1L));
+        q.close();
+        return q;
+    }
+
+    @Test
+    @DisplayName("정상 DJ 등록 — 예외 없음")
+    void validEnqueue() {
+        assertThatNoException().isThrownBy(() ->
+                spec.validate(openQueue(), false, true, false));
+    }
+
+    @Test
+    @DisplayName("큐 닫힘 — QUEUE_CLOSED (DJ-002)")
+    void queueClosed() {
+        assertThatThrownBy(() -> spec.validate(closedQueue(), false, true, false))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("타인 소유 playlist — NOT_OWNED_PLAYLIST (DJ-005, 신규)")
+    void notOwnedThrows() {
+        assertThatThrownBy(() -> spec.validate(openQueue(), false, false, false))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("빈 플레이리스트 — EMPTY_PLAYLIST (DJ-003)")
+    void emptyPlaylist() {
+        assertThatThrownBy(() -> spec.validate(openQueue(), false, true, true))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("이미 등록된 DJ — ALREADY_REGISTERED (DJ-001)")
+    void alreadyRegistered() {
+        assertThatThrownBy(() -> spec.validate(openQueue(), true, true, false))
+                .isInstanceOf(ConflictException.class);
+    }
+
+    @Test
+    @DisplayName("평가 순서 잠금 — already-registered + not-owned 동시: NOT_OWNED_PLAYLIST 가 먼저 (보안 우선)")
+    void ownershipBeatsAlreadyRegistered() {
+        // 둘 다 던지지만 not-owned 가 먼저 평가되면 ForbiddenException(DJ-005);
+        // already-registered 가 먼저면 ConflictException(DJ-001).
+        // spec §3-2 = ownership 먼저 → ForbiddenException 가 잡혀야 함.
+        assertThatThrownBy(() -> spec.validate(openQueue(), true, false, false))
+                .isInstanceOf(ForbiddenException.class);
+    }
+}
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run:
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.domain.specification.DjEnqueueSpecificationTest"
+```
+Expected: **컴파일 실패** — `validate(...)` 3-arg call 인 production 코드(`DjEnqueueSpecification.validate(...)`)가 여전히 3-arg signature 이라 test 의 4-arg 호출 컴파일 에러. 또는 test 가 컴파일된 뒤 production validate 가 무관계 호출에서 컴파일 에러일 수 있음(test/main 동시 컴파일).
+
+- [ ] **Step 3: spec 구현 변경 (arity 3→4)**
+
+`DjEnqueueSpecification.java` 전체 교체:
+
+```java
+package com.pfplaybackend.api.party.domain.specification;
+
+import com.pfplaybackend.api.common.exception.ExceptionCreator;
+import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.domain.exception.DjException;
+
+public class DjEnqueueSpecification {
+
+    public void validate(DjQueueData djQueue, boolean isAlreadyRegistered,
+                         boolean isOwned, boolean isEmptyPlaylist) {
+        djQueue.validateOpen();
+        if (!isOwned)        throw ExceptionCreator.create(DjException.NOT_OWNED_PLAYLIST);
+        if (isEmptyPlaylist) throw ExceptionCreator.create(DjException.EMPTY_PLAYLIST);
+        if (isAlreadyRegistered) throw ExceptionCreator.create(DjException.ALREADY_REGISTERED);
+    }
+}
+```
+
+- [ ] **Step 4: 테스트 PASS / production caller 일시 빨강 확인**
+
+Run:
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.domain.specification.DjEnqueueSpecificationTest" 2>&1 | tail -30
+```
+Expected: spec test 6 PASS. **그러나** `:app:compileJava` 가 `DjCommandService.enqueueDj` 의 3-arg 호출 때문에 실패. Chunk 3 Task 10 에서 해소.
+
+- [ ] **Step 5: 커밋 (caller 일시 빨강 명시)**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/domain/specification/DjEnqueueSpecification.java \
+        app/src/test/java/com/pfplaybackend/api/party/domain/specification/DjEnqueueSpecificationTest.java
+git commit -m "$(cat <<'EOF'
+feat(e223): DjEnqueueSpecification ownership 보강 (arity 3→4, 평가순서 ownership-first) (#223)
+
+DJ-005 NOT_OWNED_PLAYLIST 추가. spec §3-2.
+※ DjCommandService.enqueueDj caller 의 3-arg 호출은 Chunk 3 Task 10 에서 동반 갱신 — 임시 컴파일 빨강(red-as-process-guard).
+EOF
+)"
+```
+
+---
+
+## Chunk 2: Port 확장 (PlaylistQueryPort.isOwnedBy)
+
+playlist 모듈 service 신규 메서드 → party 모듈 port interface 확장 → party adapter 위임. 의존 방향상 playlist 먼저, party 다음.
+
+### Task 5: `PlaylistQueryService.isOwnedBy(Long, UserId)` 신규 + Test
+
+**Files:**
+- Modify: `playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/PlaylistQueryService.java`
+- Modify: `playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/PlaylistQueryServiceTest.java`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`PlaylistQueryServiceTest.java` 마지막에 추가 (기존 `userId` 필드·setUp 재사용):
+
+```java
+@Test
+@DisplayName("isOwnedBy — playlist 가 본인 소유면 true")
+void isOwnedByReturnsTrueWhenOwned() {
+    // given
+    PlaylistSummaryDto owned = new PlaylistSummaryDto(99L, "My Playlist", 5, PlaylistType.PLAYLIST, 1L);
+    when(queryPort.findByIdAndUserId(99L, userId)).thenReturn(owned);
+
+    // when
+    boolean result = playlistQueryService.isOwnedBy(99L, userId);
+
+    // then
+    assertThat(result).isTrue();
+}
+
+@Test
+@DisplayName("isOwnedBy — playlist 가 타인 소유거나 미존재면 false")
+void isOwnedByReturnsFalseWhenNotOwned() {
+    // given (port 는 null 또는 절대 null 반환)
+    when(queryPort.findByIdAndUserId(99L, userId)).thenReturn(null);
+
+    // when
+    boolean result = playlistQueryService.isOwnedBy(99L, userId);
+
+    // then
+    assertThat(result).isFalse();
+}
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run:
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :playlist:test --tests "com.pfplaybackend.api.playlist.application.service.PlaylistQueryServiceTest"
+```
+Expected: FAIL — `cannot find symbol: method isOwnedBy(Long, UserId)`.
+
+- [ ] **Step 3: 최소 구현**
+
+`PlaylistQueryService.java` 의 `getPlaylist` 메서드 뒤에 추가:
+
+```java
+@Transactional(readOnly = true)
+public boolean isOwnedBy(Long playlistId, UserId userId) {
+    return queryPort.findByIdAndUserId(playlistId, userId) != null;
+}
+```
+
+import 추가: `import com.pfplaybackend.api.common.domain.value.UserId;` (이미 사용 중이면 무시).
+
+- [ ] **Step 4: 통과 확인**
+
+Run: 위 Step 2 와 동일.
+Expected: 기존 + 신규 2 PASS.
+
+> 만약 `findByIdAndUserId` 가 미존재 시 예외를 던지는 형태(spec §3-3 의 "또는 동등 효율의 exists 쿼리" 대체 옵션 — null 반환 시 PASS, 예외 시 FAIL with Mockito stub)라면 try-catch 또는 `Optional`-wrap 으로 재시도. **구현 전에 1단계 빠른 확인**: `PlaylistAggregateAdapter.findByIdAndUserId` 구현 보고 null-return semantic 확정. (코드 보면 `playlistRepository.findByIdAndUserId` → `PlaylistRepositoryImpl` → 미존재 시 null 반환이 일반적 QueryDSL 패턴.)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/PlaylistQueryService.java \
+        playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/PlaylistQueryServiceTest.java
+git commit -m "feat(e223): PlaylistQueryService.isOwnedBy(Long, UserId) — playlist 소유권 boolean (#223)"
+```
+
+---
+
+### Task 6: party `PlaylistQueryPort.isOwnedBy(Long, Long)` interface 확장
+
+**Files:**
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/application/port/out/PlaylistQueryPort.java`
+
+interface signature 만 추가. 구현은 Task 7. 테스트 없음(interface).
+
+- [ ] **Step 1: interface 메서드 추가**
+
+```java
+public interface PlaylistQueryPort {
+    boolean isEmptyPlaylist(Long playlistId);
+    boolean isOwnedBy(Long playlistId, Long userId);  // 신규
+}
+```
+
+- [ ] **Step 2: 컴파일 일시 빨강 확인**
+
+Run:
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:compileJava 2>&1 | tail -20
+```
+Expected: **빨강** — `PlaylistQueryAdapter` 가 새 메서드 unimplement → compile error. Task 7 에서 해소.
+
+- [ ] **Step 3: 커밋 (일시 빨강 명시)**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/application/port/out/PlaylistQueryPort.java
+git commit -m "feat(e223): party PlaylistQueryPort.isOwnedBy 시그니처 (Task 7 에서 adapter 구현 동반) (#223)"
+```
+
+---
+
+### Task 7: party `PlaylistQueryAdapter.isOwnedBy` 구현 (UserId VO wrap)
+
+**Files:**
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/PlaylistQueryAdapter.java`
+
+- [ ] **Step 1: adapter impl 추가**
+
+`PlaylistQueryAdapter.java` 전체 교체:
+
+```java
+package com.pfplaybackend.api.party.adapter.out.external;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.application.port.out.PlaylistQueryPort;
+import com.pfplaybackend.api.playlist.application.service.PlaylistQueryService;
+import com.pfplaybackend.api.playlist.application.service.TrackQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PlaylistQueryAdapter implements PlaylistQueryPort {
+    private final TrackQueryService trackQueryService;
+    private final PlaylistQueryService playlistQueryService;
+
+    @Override
+    public boolean isEmptyPlaylist(Long playlistId) {
+        return trackQueryService.isEmptyPlaylist(playlistId);
+    }
+
+    @Override
+    public boolean isOwnedBy(Long playlistId, Long userId) {
+        return playlistQueryService.isOwnedBy(playlistId, new UserId(userId));
+    }
+}
+```
+
+- [ ] **Step 2: 컴파일 확인**
+
+Run:
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:compileJava 2>&1 | tail -10
+```
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/PlaylistQueryAdapter.java
+git commit -m "feat(e223): party PlaylistQueryAdapter.isOwnedBy — playlist 모듈 위임 + UserId VO wrap (#223)"
+```
+
+---
+
+## Chunk 3: 서비스 + 컨트롤러 + IT
+
+### Task 8: `ChangePlaylistRequest` DTO
+
+**Files:**
+- Create: `app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/payload/request/dj/ChangePlaylistRequest.java`
+
+`RegisterDjRequest` 컨벤션(class + @Getter + bean validation) 정합.
+
+- [ ] **Step 1: DTO 작성**
+
+```java
+package com.pfplaybackend.api.party.adapter.in.web.payload.request.dj;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+
+@Getter
+public class ChangePlaylistRequest {
+    @NotNull(message = "playlistId is required.")
+    @Positive(message = "playlistId must be positive.")
+    private Long playlistId;
+}
+```
+
+- [ ] **Step 2: 컴파일 확인**
+
+Run:
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:compileJava
+```
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/payload/request/dj/ChangePlaylistRequest.java
+git commit -m "feat(e223): ChangePlaylistRequest DTO — @NotNull @Positive playlistId (#223)"
+```
+
+---
+
+### Task 9: `DjCommandService.changePlaylist` 신규 (TDD red→green)
+
+**Files:**
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java`
+- Modify: `app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceTest.java`
+
+- [ ] **Step 1: 실패 단위 테스트 작성 (7 case)**
+
+`DjCommandServiceTest.java` 의 `dequeueDjNotCurrentDjNoSkip` 메서드 뒤에 추가:
+
+```java
+@Test
+@DisplayName("changePlaylist — 큐에 없으면 NOT_FOUND_DJ")
+void changePlaylistNotInQueueThrows() {
+    // given
+    PartyroomData partyroom = PartyroomData.builder()
+            .id(partyroomId.getId()).partyroomId(partyroomId).build();
+    PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+    DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+    CrewData crew = CrewData.builder()
+            .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+
+    when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+    when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+    when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+    when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+    when(aggregatePort.findDj(partyroomId, new CrewId(1L))).thenReturn(java.util.Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> djCommandService.changePlaylist(partyroomId, new PlaylistId(200L)))
+            .isInstanceOf(com.pfplaybackend.api.common.exception.http.NotFoundException.class);
+}
+
+@Test
+@DisplayName("changePlaylist — 재생 중 DJ 면 CURRENT_DJ_CANNOT_CHANGE_PLAYLIST")
+void changePlaylistCurrentDjThrows() {
+    // given
+    PartyroomData partyroom = PartyroomData.builder()
+            .id(partyroomId.getId()).partyroomId(partyroomId).build();
+    PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+    playbackState.activate(null, new CrewId(1L));  // 본인이 current dj
+    DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+    CrewData crew = CrewData.builder()
+            .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+    DjData me = DjData.create(partyroomId, playlistId, new CrewId(1L), 1);
+
+    when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+    when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+    when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+    when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+    when(aggregatePort.findDj(partyroomId, new CrewId(1L))).thenReturn(java.util.Optional.of(me));
+
+    // when & then
+    assertThatThrownBy(() -> djCommandService.changePlaylist(partyroomId, new PlaylistId(200L)))
+            .isInstanceOf(ConflictException.class);
+}
+
+@Test
+@DisplayName("changePlaylist — 타인 소유 playlist 면 NOT_OWNED_PLAYLIST")
+void changePlaylistNotOwnedThrows() {
+    // given — playback inactive, queue open, me 존재, isOwnedBy=false
+    PartyroomData partyroom = PartyroomData.builder()
+            .id(partyroomId.getId()).partyroomId(partyroomId).build();
+    PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+    DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+    CrewData crew = CrewData.builder()
+            .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+    DjData me = DjData.create(partyroomId, playlistId, new CrewId(1L), 1);
+
+    when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+    when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+    when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+    when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+    when(aggregatePort.findDj(partyroomId, new CrewId(1L))).thenReturn(java.util.Optional.of(me));
+    when(playlistQueryPort.isOwnedBy(200L, userId.getUid())).thenReturn(false);
+
+    // when & then
+    assertThatThrownBy(() -> djCommandService.changePlaylist(partyroomId, new PlaylistId(200L)))
+            .isInstanceOf(ForbiddenException.class);
+}
+
+@Test
+@DisplayName("changePlaylist — 미존재 playlistId 도 isOwnedBy=false 로 NOT_OWNED_PLAYLIST (security boundary)")
+void changePlaylistNonExistentPlaylistThrows() {
+    // identical wiring to notOwned case — semantic clarification only
+    PartyroomData partyroom = PartyroomData.builder()
+            .id(partyroomId.getId()).partyroomId(partyroomId).build();
+    PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+    DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+    CrewData crew = CrewData.builder()
+            .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+    DjData me = DjData.create(partyroomId, playlistId, new CrewId(1L), 1);
+
+    when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+    when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+    when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+    when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+    when(aggregatePort.findDj(partyroomId, new CrewId(1L))).thenReturn(java.util.Optional.of(me));
+    when(playlistQueryPort.isOwnedBy(999_999L, userId.getUid())).thenReturn(false);
+
+    assertThatThrownBy(() -> djCommandService.changePlaylist(partyroomId, new PlaylistId(999_999L)))
+            .isInstanceOf(ForbiddenException.class);
+}
+
+@Test
+@DisplayName("changePlaylist — 빈 playlist 면 EMPTY_PLAYLIST")
+void changePlaylistEmptyThrows() {
+    PartyroomData partyroom = PartyroomData.builder()
+            .id(partyroomId.getId()).partyroomId(partyroomId).build();
+    PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+    DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+    CrewData crew = CrewData.builder()
+            .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+    DjData me = DjData.create(partyroomId, playlistId, new CrewId(1L), 1);
+
+    when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+    when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+    when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+    when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+    when(aggregatePort.findDj(partyroomId, new CrewId(1L))).thenReturn(java.util.Optional.of(me));
+    when(playlistQueryPort.isOwnedBy(200L, userId.getUid())).thenReturn(true);
+    when(playlistQueryPort.isEmptyPlaylist(200L)).thenReturn(true);
+
+    assertThatThrownBy(() -> djCommandService.changePlaylist(partyroomId, new PlaylistId(200L)))
+            .isInstanceOf(ForbiddenException.class);
+}
+
+@Test
+@DisplayName("changePlaylist — happy path: me.playlistId 갱신 + 이벤트 발행 0회")
+void changePlaylistHappy() {
+    PartyroomData partyroom = PartyroomData.builder()
+            .id(partyroomId.getId()).partyroomId(partyroomId).build();
+    PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+    DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+    CrewData crew = CrewData.builder()
+            .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+    DjData me = DjData.create(partyroomId, playlistId, new CrewId(1L), 1);  // old = 100L
+
+    when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+    when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+    when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+    when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+    when(aggregatePort.findDj(partyroomId, new CrewId(1L))).thenReturn(java.util.Optional.of(me));
+    when(playlistQueryPort.isOwnedBy(200L, userId.getUid())).thenReturn(true);
+    when(playlistQueryPort.isEmptyPlaylist(200L)).thenReturn(false);
+
+    // when
+    djCommandService.changePlaylist(partyroomId, new PlaylistId(200L));
+
+    // then — me 의 playlistId 가 새 값으로, orderNumber 보존
+    assertThat(me.getPlaylistId()).isEqualTo(new PlaylistId(200L));
+    assertThat(me.getOrderNumber()).isEqualTo(1);
+    // 이벤트 발행 0회 (WS broadcast 없음, spec §2-2)
+    verify(eventPublisher, never()).publishEvent(any());
+}
+
+@Test
+@DisplayName("changePlaylist — idempotent: 같은 playlistId 입력 예외 없음")
+void changePlaylistIdempotent() {
+    PartyroomData partyroom = PartyroomData.builder()
+            .id(partyroomId.getId()).partyroomId(partyroomId).build();
+    PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+    DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+    CrewData crew = CrewData.builder()
+            .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+    DjData me = DjData.create(partyroomId, playlistId, new CrewId(1L), 1);  // old = playlistId = 100L
+
+    when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+    when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+    when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+    when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+    when(aggregatePort.findDj(partyroomId, new CrewId(1L))).thenReturn(java.util.Optional.of(me));
+    when(playlistQueryPort.isOwnedBy(playlistId.getId(), userId.getUid())).thenReturn(true);
+    when(playlistQueryPort.isEmptyPlaylist(playlistId.getId())).thenReturn(false);
+
+    // when — 같은 playlistId
+    djCommandService.changePlaylist(partyroomId, playlistId);
+
+    // then — 예외 없음, me 무변
+    assertThat(me.getPlaylistId()).isEqualTo(playlistId);
+}
+```
+
+import 추가:
+```java
+import com.pfplaybackend.api.common.exception.http.NotFoundException;
+import static org.assertj.core.api.Assertions.assertThat;
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run:
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.application.service.DjCommandServiceTest"
+```
+Expected: 7 신규 case 가 **컴파일 실패** — `djCommandService.changePlaylist` 미존재.
+
+- [ ] **Step 3: `DjCommandService.changePlaylist` 구현**
+
+`DjCommandService.java` 의 `dequeueDj(PartyroomId, DjId)` 메서드 뒤에 추가:
+
+```java
+@Transactional
+public void changePlaylist(PartyroomId partyroomId, PlaylistId newPlaylistId) {
+    AuthContext authContext = ThreadLocalContext.getAuthContext();
+    Long userId = authContext.getUserId().getUid();
+    log.info("[changePlaylist] ENTER - requestId={}, partyroomId={}, userId={}, newPlaylistId={}",
+            RequestIdInterceptor.current(), partyroomId.getId(), userId, newPlaylistId.getId());
+
+    PartyroomData partyroom = partyroomQueryService.getPartyroomById(partyroomId);
+    PartyroomPlaybackData playback = aggregatePort.findPlaybackState(partyroomId);
+    DjQueueData djQueue = aggregatePort.findDjQueueState(partyroomId);
+
+    CrewData crew = partyroomQueryService.getCrewOrThrow(partyroomId, authContext.getUserId());
+    CrewId crewId = new CrewId(crew.getId());
+
+    DjData me = aggregatePort.findDj(partyroomId, crewId)
+            .orElseThrow(() -> ExceptionCreator.create(DjException.NOT_FOUND_DJ));
+
+    boolean isCurrentDj     = playback.isActivated() && playback.isCurrentDj(crewId);
+    boolean isOwned         = playlistQueryPort.isOwnedBy(newPlaylistId.getId(), userId);
+    boolean isEmptyPlaylist = playlistQueryPort.isEmptyPlaylist(newPlaylistId.getId());
+
+    new DjChangePlaylistSpecification().validate(djQueue, isCurrentDj, isOwned, isEmptyPlaylist);
+
+    Long oldPlaylistId = me.getPlaylistId() != null ? me.getPlaylistId().getId() : null;
+    me.updatePlaylist(newPlaylistId);
+    // ※ saveDj 명시 호출 안 함 — me 는 @Transactional 컨텍스트의 managed entity,
+    //   JPA dirty check 가 commit 시 UPDATE 자동 발행. spec §3-4
+
+    log.info("[changePlaylist] OK - requestId={}, partyroomId={}, crewId={}, oldPlaylistId={}, newPlaylistId={}",
+            RequestIdInterceptor.current(), partyroomId.getId(), crewId.getId(), oldPlaylistId, newPlaylistId.getId());
+    // 도메인 이벤트 발행 없음 — WS broadcast 불필요(spec §2-2)
+}
+```
+
+import 추가:
+```java
+import com.pfplaybackend.api.party.domain.specification.DjChangePlaylistSpecification;
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: 위 Step 2 와 동일.
+Expected: 7 신규 PASS.
+
+> 기존 enqueue/dequeue 테스트 4개는 여전히 fail 가능 — Chunk 1 Task 4 의 `DjEnqueueSpecification` arity 변경 영향 + Task 10 미적용 상태. Task 10 까지 가서 정합.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java \
+        app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceTest.java
+git commit -m "feat(e223): DjCommandService.changePlaylist — happy/4 fail/idempotent (#223)"
+```
+
+---
+
+### Task 10: `DjCommandService.enqueueDj` ownership 동반 보강 + 회귀 가드
+
+Chunk 1 Task 4 의 일시 빨강 해소 + 기존 4 case 픽스처에 `isOwnedBy=true` mock 보정 + 신규 ownership 회귀 1.
+
+**Files:**
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java` (enqueueDj 내부)
+- Modify: `app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceTest.java`
+
+- [ ] **Step 1: enqueueDj 픽스처 sweep + ownership 회귀 신규**
+
+기존 enqueue 4 case (`enqueueDjQueueClosedThrows` 제외 — 큐 닫힘은 validateOpen 단계서 throw, ownership mock 도달 안 함; `lenient()` 안 쓰면 unnecessary stubbing 에러)에 한 줄씩 추가:
+
+```java
+// 각 case 의 stubbing 블록에 추가:
+when(playlistQueryPort.isOwnedBy(playlistId.getId(), userId.getUid())).thenReturn(true);
+```
+
+추가 위치:
+- `enqueueDjAlreadyRegisteredThrows`: `when(playlistQueryPort.isEmptyPlaylist...)` 옆
+- `enqueueDjEmptyPlaylistThrows`: `when(playlistQueryPort.isEmptyPlaylist...)` 옆 (이 케이스는 isOwned=true 가 정상 흐름, empty 가 throw 원인)
+- `enqueueDjFirstDjStartsPlayback`: `when(playlistQueryPort.isEmptyPlaylist...)` 옆
+
+> `enqueueDjQueueClosedThrows` 는 queue.close() 가 먼저 throw → 후속 stub 실행 안 됨. 추가 안 함.
+
+신규 ownership 회귀 테스트 (4 case 뒤에 추가):
+
+```java
+@Test
+@DisplayName("enqueueDj — 타인 소유 playlist 면 NOT_OWNED_PLAYLIST (Task 4/10 회귀 가드)")
+void enqueueDjNotOwnedThrows() {
+    PartyroomData partyroom = PartyroomData.builder()
+            .id(partyroomId.getId()).partyroomId(partyroomId).build();
+    PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+    DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+    CrewData crew = CrewData.builder()
+            .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+
+    when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+    when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+    when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+    when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+    when(aggregatePort.isDjRegistered(partyroomId, new CrewId(1L))).thenReturn(false);
+    when(playlistQueryPort.isOwnedBy(playlistId.getId(), userId.getUid())).thenReturn(false);  // 핵심
+    // empty 호출은 ownership-first 평가로 안 도달
+
+    assertThatThrownBy(() -> djCommandService.enqueueDj(partyroomId, playlistId))
+            .isInstanceOf(ForbiddenException.class);
+}
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run:
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.application.service.DjCommandServiceTest"
+```
+Expected:
+- **컴파일 실패**: `enqueueDj` 가 `DjEnqueueSpecification.validate(djQueue, isAlreadyRegistered, isEmptyPlaylist)` 3-arg 호출 → arity 4 불일치.
+
+- [ ] **Step 3: enqueueDj caller 정합 (3→4 arg)**
+
+`DjCommandService.enqueueDj` 의 spec validate 호출 라인 교체:
+
+```java
+// before:
+// new DjEnqueueSpecification().validate(djQueue, isAlreadyRegistered, isEmptyPlaylist);
+
+// after:
+boolean isOwned = playlistQueryPort.isOwnedBy(playlistId.getId(), authContext.getUserId().getUid());
+boolean isEmptyPlaylist = playlistQueryPort.isEmptyPlaylist(playlistId.getId());
+new DjEnqueueSpecification().validate(djQueue, isAlreadyRegistered, isOwned, isEmptyPlaylist);
+```
+
+> 기존 `boolean isEmptyPlaylist = playlistQueryPort.isEmptyPlaylist(playlistId.getId());` 라인은 위 블록의 `isEmptyPlaylist` 로 흡수(중복 제거). `boolean isAlreadyRegistered = aggregatePort.isDjRegistered(...)` 는 그대로.
+
+- [ ] **Step 4: 통과 확인**
+
+Run:
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.application.service.DjCommandServiceTest" 2>&1 | tail -30
+```
+Expected: 전 case PASS (changePlaylist 7 + enqueue 4 기존 + enqueue 회귀 1 + dequeue 1 = 13+).
+
+- [ ] **Step 5: party 모듈 전체 단위 테스트 회귀 확인**
+
+Run:
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test 2>&1 | tail -20
+```
+Expected: BUILD SUCCESSFUL — 다른 테스트(특히 DjEnqueueSpecificationTest 6 + DjChangePlaylistSpecificationTest 7 + DjDataTest 3) 도 GREEN.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java \
+        app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceTest.java
+git commit -m "feat(e223): enqueueDj ownership 동반 보강 (spec arity 3→4 정합) + 회귀 가드 (#223)"
+```
+
+---
+
+### Task 11: `DjCommandController.changePlaylist` WebMvc (TDD red→green)
+
+**Files:**
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandController.java`
+- Modify: `app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandControllerTest.java`
+
+- [ ] **Step 1: 실패 WebMvc 테스트 작성 (7 case)**
+
+`DjCommandControllerTest.java` 의 `enqueueDjUnauthenticatedReturns401` 뒤에 추가 (import 는 patch / status, ForbiddenException 등 보강):
+
+```java
+@Test
+@DisplayName("changePlaylist — 204 No Content")
+void changePlaylistReturns204() throws Exception {
+    String body = """
+            { "playlistId": 99 }
+            """;
+    // service 는 void → stub 안 함. 호출 검증만.
+
+    mockMvc.perform(patch("/api/v1/partyrooms/1/dj-queue/me")
+                    .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+            .andExpect(status().isNoContent());
+}
+
+@Test
+@DisplayName("changePlaylist — playlistId null 이면 400")
+void changePlaylistNullPlaylistIdReturns400() throws Exception {
+    mockMvc.perform(patch("/api/v1/partyrooms/1/dj-queue/me")
+                    .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"))
+            .andExpect(status().isBadRequest());
+}
+
+@Test
+@DisplayName("changePlaylist — playlistId 0 이면 400")
+void changePlaylistZeroPlaylistIdReturns400() throws Exception {
+    mockMvc.perform(patch("/api/v1/partyrooms/1/dj-queue/me")
+                    .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"playlistId\": 0}"))
+            .andExpect(status().isBadRequest());
+}
+
+@Test
+@DisplayName("changePlaylist — 인증 없으면 401")
+void changePlaylistUnauthenticatedReturns401() throws Exception {
+    mockMvc.perform(patch("/api/v1/partyrooms/1/dj-queue/me")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"playlistId\": 99}"))
+            .andExpect(status().isUnauthorized());
+}
+
+@Test
+@DisplayName("changePlaylist — DJ-004 NOT_FOUND_DJ → 404")
+void changePlaylistNotFoundReturns404() throws Exception {
+    org.mockito.Mockito.doThrow(com.pfplaybackend.api.common.exception.ExceptionCreator.create(
+                    com.pfplaybackend.api.party.domain.exception.DjException.NOT_FOUND_DJ))
+            .when(djCommandService).changePlaylist(any(), any());
+
+    mockMvc.perform(patch("/api/v1/partyrooms/1/dj-queue/me")
+                    .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"playlistId\": 99}"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error.errorCode").value("DJ-004"));
+}
+
+@Test
+@DisplayName("changePlaylist — DJ-005 NOT_OWNED_PLAYLIST → 403 (미존재 playlistId 포함)")
+void changePlaylistNotOwnedReturns403() throws Exception {
+    org.mockito.Mockito.doThrow(com.pfplaybackend.api.common.exception.ExceptionCreator.create(
+                    com.pfplaybackend.api.party.domain.exception.DjException.NOT_OWNED_PLAYLIST))
+            .when(djCommandService).changePlaylist(any(), any());
+
+    mockMvc.perform(patch("/api/v1/partyrooms/1/dj-queue/me")
+                    .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"playlistId\": 99}"))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.error.errorCode").value("DJ-005"));
+}
+
+@Test
+@DisplayName("changePlaylist — DJ-003 EMPTY_PLAYLIST → 403")
+void changePlaylistEmptyReturns403() throws Exception {
+    org.mockito.Mockito.doThrow(com.pfplaybackend.api.common.exception.ExceptionCreator.create(
+                    com.pfplaybackend.api.party.domain.exception.DjException.EMPTY_PLAYLIST))
+            .when(djCommandService).changePlaylist(any(), any());
+
+    mockMvc.perform(patch("/api/v1/partyrooms/1/dj-queue/me")
+                    .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"playlistId\": 99}"))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.error.errorCode").value("DJ-003"));
+}
+
+@Test
+@DisplayName("changePlaylist — DJ-006 CURRENT_DJ_CANNOT_CHANGE_PLAYLIST → 409")
+void changePlaylistCurrentDjReturns409() throws Exception {
+    org.mockito.Mockito.doThrow(com.pfplaybackend.api.common.exception.ExceptionCreator.create(
+                    com.pfplaybackend.api.party.domain.exception.DjException.CURRENT_DJ_CANNOT_CHANGE_PLAYLIST))
+            .when(djCommandService).changePlaylist(any(), any());
+
+    mockMvc.perform(patch("/api/v1/partyrooms/1/dj-queue/me")
+                    .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"playlistId\": 99}"))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.error.errorCode").value("DJ-006"));
+}
+```
+
+import 추가: `import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;`
+
+- [ ] **Step 2: 실패 확인**
+
+Run:
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.adapter.in.web.DjCommandControllerTest"
+```
+Expected: 8 신규 case 가 **405 Method Not Allowed** (PATCH 핸들러 미존재) — Spring MVC 기본 동작.
+
+- [ ] **Step 3: controller 핸들러 추가**
+
+`DjCommandController.java` 의 `dequeueDj(Long, Long)` 메서드 뒤에 추가:
+
+```java
+@Operation(summary = "본인 DJ 플레이리스트 변경",
+           description = "DJ 대기열에 등록된 본인의 디제잉 플레이리스트를 변경합니다. 큐 순서는 보존되며, 재생 중 DJ 는 변경할 수 없습니다.")
+@ApiResponse(responseCode = "204", description = "변경 성공")
+@SecurityRequirement(name = "cookieAuth")
+@ApiErrorCodes({DjException.class})
+@PatchMapping("/{partyroomId}/dj-queue/me")
+@PreAuthorize("hasRole('MEMBER')")
+public ResponseEntity<Void> changePlaylist(
+        @Parameter(description = "파티룸 ID") @PathVariable Long partyroomId,
+        @Valid @RequestBody ChangePlaylistRequest request) {
+    djCommandService.changePlaylist(new PartyroomId(partyroomId), new PlaylistId(request.getPlaylistId()));
+    return ResponseEntity.noContent().build();
+}
+```
+
+import 추가:
+```java
+import com.pfplaybackend.api.party.adapter.in.web.payload.request.dj.ChangePlaylistRequest;
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: 위 Step 2 와 동일.
+Expected: 전 case PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandController.java \
+        app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandControllerTest.java
+git commit -m "feat(e223): DjCommandController PATCH /dj-queue/me — changePlaylist 7 WebMvc (#223)"
+```
+
+---
+
+### Task 12: `DjCommandIntegrationTest.changePlaylist` (3 IT case)
+
+**Files:**
+- Create: `app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandIntegrationTest.java`
+
+기존 party 모듈 IT 들의 패턴을 따른다(Flyway + H2 또는 Testcontainers, `@SpringBootTest` + `@Transactional`/`@AfterEach` cleanup). 작업 시작 전 기존 IT 한 개를 열어 base 설정·픽스처 헬퍼를 확인하고 그대로 재사용. **신규 베이스 클래스/헬퍼 작성 금지** — 회귀잠금 IT 의 패턴(예: `PartyroomAccessCommandServiceRaceIT`, `DjQueueGraceIntegrationTest` 등)을 모방.
+
+- [ ] **Step 1: 기존 IT 패턴 파악**
+
+작업 직전 다음 파일 1개 열어 base 어노테이션·픽스처·cleanup 방식 파악:
+- `app/src/integrationTest/java/.../DjQueueGraceIntegrationTest.java` 또는 동등.
+
+(plan 작성 시점에 정확한 base 파일을 확정하지 않은 이유 = IT 디렉토리 구조·base 패턴은 실행 시점에 git ls-files 로 1차 확인 후 진입하는 게 안전. 보통 `@SpringBootTest` + `@ActiveProfiles("integration-test")` + `@Sql`/`@Transactional` + Testcontainers MySQL.)
+
+- [ ] **Step 2: 실패 IT 작성 (3 case)**
+
+```java
+package com.pfplaybackend.api.party.application.service;
+
+// imports — 기존 IT 패턴 따름 (@SpringBootTest, @Autowired DjCommandService, AuthContext setup, Flyway/JPA)
+
+class DjCommandIntegrationTest /* extends 적절한 base, 또는 @SpringBootTest 직접 */ {
+
+    @Test
+    @DisplayName("changePlaylist IT — happy: playlist_id 갱신, order_number 보존")
+    void changePlaylistHappyDbUpdated() {
+        // given: 파티룸 + 본인 user + 본인 playlist A + B 두 개 시드, enqueue(A)
+        // when: changePlaylist(B)
+        // then: DB 재조회 DjData.playlistId == B, orderNumber 무변
+    }
+
+    @Test
+    @DisplayName("changePlaylist IT — invariant: 본인 변경이 다른 DJ orderNumber 무영향")
+    void changePlaylistOtherDjOrderPreserved() {
+        // given: DJ1(orderNumber=1, playlist A1) + DJ2(orderNumber=2, playlist A2) enqueue
+        // when: DJ2.changePlaylist(B2)
+        // then: DJ1.orderNumber=1·playlistId=A1 무변, DJ2.orderNumber=2·playlistId=B2
+    }
+
+    @Test
+    @DisplayName("changePlaylist IT — idempotent: 같은 playlistId → 최종 row 상태 무변")
+    void changePlaylistIdempotentNoLogicalChange() {
+        // given: enqueue(A)
+        // when: changePlaylist(A)  ← same id
+        // then: DB 재조회 DjData.playlistId == A, orderNumber 무변, 예외 0
+    }
+}
+```
+
+> 실제 시드/조회 코드는 base IT 의 헬퍼(`seedPartyroom`, `seedPlaylistWithTracks` 등 — 정확한 이름은 base IT 보고 채움) 와 `@Autowired` 의존 주입(`DjCommandService`, `PlaylistRepository`, `partyroomAggregateAdapter` 등)로 채운다. **신규 헬퍼 만들지 말 것**.
+
+- [ ] **Step 3: 실패 확인**
+
+Run:
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:integrationTest --tests "com.pfplaybackend.api.party.application.service.DjCommandIntegrationTest" 2>&1 | tail -30
+```
+Expected: 시드 단계 컴파일/runtime error — base IT 의 헬퍼 시그니처 정확히 일치 안 함.
+
+- [ ] **Step 4: 헬퍼 시그니처 정합 + 실 DB 어서션 채움**
+
+base IT 코드 보고 정확한 시드 메서드 호출/Repository 빈 이름으로 교체. 어서션은 직접 `aggregatePort.findDj(partyroomId, crewId).get()` 으로 재조회 후 `.getPlaylistId()`·`.getOrderNumber()` 검증.
+
+> AuthContext 시드 = base IT 의 기존 패턴 모방. 보통 `ThreadLocalContext.setContext(mock(AuthContext.class))` + `when(authContext.getUserId()).thenReturn(new UserId(seededUserId))` 또는 base 의 `@WithMockUser` 동등.
+
+- [ ] **Step 5: 통과 확인**
+
+Run: 위 Step 3 와 동일.
+Expected: 3 case PASS.
+
+- [ ] **Step 6: party 모듈 전체 IT 회귀 확인 + DB cleanup 위생 점검**
+
+Run:
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:integrationTest 2>&1 | tail -30
+```
+Expected: BUILD SUCCESSFUL.
+
+**위생 가드** ([[reference_mysql_datetime0_rounding]] · [[feedback_pr_series_workflow]] forward-evolution): 다른 IT 와 user_id 공간 충돌 회피 — base IT 의 `@AfterEach` cleanup 패턴 따름. 본 신규 IT 가 host_uid/user_uid 공간을 점유한다면 cleanup 명시.
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandIntegrationTest.java
+git commit -m "feat(e223): DjCommandIntegrationTest.changePlaylist — happy / order 보존 / idempotent 3 case (#223)"
+```
+
+---
+
+## 최종 회귀 확인
+
+- [ ] **Step 1: 전 모듈 단위·통합 테스트 GREEN**
+
+Run:
+```bash
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :playlist:test :app:test :app:integrationTest 2>&1 | tail -30
+```
+Expected: BUILD SUCCESSFUL — playlist 모듈 신규 2 + party 모듈 신규/회귀 모두 GREEN.
+
+- [ ] **Step 2: 브랜치 상태 점검 + push**
+
+```bash
+git status                    # working tree clean
+git log --oneline origin/develop..HEAD   # 12 commits + spec 3 commit = 15 commits
+git push -u origin feature/e223-change-playlist
+```
+
+- [ ] **Step 3: PR 생성**
+
+```bash
+gh pr create --title "feat(e223): 대기 중 DJ 플레이리스트 변경 API (Change Playlist)" --body "$(cat <<'EOF'
+## 요약
+
+- `PATCH /api/v1/partyrooms/{partyroomId}/dj-queue/me` 신설 — 대기 중 본인 DJ 의 디제잉 플레이리스트를 큐 순서를 보존하며 변경.
+- playlist 소유권 검증을 신규 PATCH 와 기존 enqueue 양쪽에 동반 보강(`DJ-005 NOT_OWNED_PLAYLIST`).
+- 재생 중 DJ 의 playlist 재지정은 범위 밖(`DJ-006 CURRENT_DJ_CANNOT_CHANGE_PLAYLIST`).
+- WS broadcast 없음 (본인만 결과 확인, `DjWithProfileDto` 가 playlist 정보 비포함).
+
+## 결정 잠금 (사용자, 2026-05-21)
+
+1. 허용 범위 = **대기 중 DJ만**
+2. WS 통지 = **불필요** (REST 204 만)
+3. 빈 playlist = **거부** (DJ-003 재사용)
+4. playlist 소유권 = **PATCH + enqueue 동반 보강**
+
+## 산출물
+
+- 신규: `DjChangePlaylistSpecification`, `ChangePlaylistRequest`, `DjCommandIntegrationTest`
+- 확장: `DjData.updatePlaylist`, `DjException` (DJ-005/006), `DjEnqueueSpecification` arity 3→4, party `PlaylistQueryPort.isOwnedBy`, `PlaylistQueryAdapter` 위임, `DjCommandService.changePlaylist`/`enqueueDj` ownership, `DjCommandController.changePlaylist`, playlist `PlaylistQueryService.isOwnedBy`
+- 무변: `PartyroomAggregatePort.findDj` 기존 메서드 재사용
+
+## 테스트
+
+- :playlist:test PASS (신규 2 + 기존 무변)
+- :app:test PASS (신규: DjChangePlaylistSpecificationTest 7 / DjCommandServiceTest changePlaylist 7 + enqueue 회귀 1 / DjCommandControllerTest changePlaylist 8 / DjDataTest 1, 수정: DjEnqueueSpecificationTest 6)
+- :app:integrationTest PASS (DjCommandIntegrationTest 3 신규)
+
+## 스펙 / 계획
+
+- spec: `docs/superpowers/specs/2026-05-21-e223-change-playlist-design.md`
+- plan: `docs/superpowers/plans/2026-05-21-e223-change-playlist.md`
+- 이슈: #223
+
+## 후속
+
+- frontend (pfplay-web): `widgets/partyroom-djing-dialog/ui/body.component.tsx:147` placeholder → PATCH 호출 + playlist picker (별 PR)
+- 재생 중 DJ 의 playlist 재지정 (out-of-scope, WS broadcast 동반 필요)
+EOF
+)"
+```
+
+> PR title·body 모두 한글 ([[feedback_korean_issue_commit_pr]]).
+
+---
+
+## 참고
+
+- spec: `docs/superpowers/specs/2026-05-21-e223-change-playlist-design.md`
+- 인접 작업: E/#3 (2026-05-19, `doStart` DJ별 playable 스캔 — 빈 playlist 자동 skip 으로 본 spec §2-3 결정 정합), E/#222 (2026-05-18, skip→reorder invariant 회귀잠금)
+- 메모리: [[feedback_pr_series_workflow]], [[feedback_commit_consolidation_before_push]], [[feedback_korean_issue_commit_pr]], [[feedback_elegant_no_code_dirtying]], [[reference_pfplay_platform_jdk]], [[reference_mysql_datetime0_rounding]]

--- a/docs/superpowers/specs/2026-05-21-e223-change-playlist-design.md
+++ b/docs/superpowers/specs/2026-05-21-e223-change-playlist-design.md
@@ -1,0 +1,278 @@
+# E/#223 — 대기 중 DJ 플레이리스트 변경 API (Change Playlist) 설계
+
+- 작성일: 2026-05-21
+- 대상 이슈: pfplay-platform [E/#223](https://github.com/pfplay/pfplay-platform/issues/223) (로드맵 Cluster E, 신규 기능)
+- 대상 레포: pfplay-platform (party 모듈, backend only). frontend 작업은 별 PR(pfplay-web)
+- 분류: 신규 기능(feature gap) — 도메인 mutator + 신규 PATCH endpoint
+- 심각도: Feature (Cluster A Critical 후순위)
+
+## 1. 배경 / 문제
+
+DJ 대기열에 등록된 사용자가 **대기 중에 디제잉 플레이리스트를 변경**할 방법이 없다.
+
+현행(2026-05-21 코드 확인):
+- `DjCommandController` endpoint 3개만: `POST .../dj-queue`(enqueue, playlist 고정) · `DELETE .../dj-queue/me`(self dequeue) · `DELETE .../dj-queue/{djId}`(강제 dequeue).
+- `DjData.playlistId` 는 `@Embedded`, `create()` 시 1회 설정, 이후 mutator 없음(`updateOrderNumber` 만 존재).
+- 우회 = dequeue 후 재 enqueue → **큐 맨 뒤로 밀림**(`enqueueDj` 의 `nextOrder = queuedDjs.size() + 1`) = 순서 손실, 사실상 변경 불가.
+- pfplay-web `widgets/partyroom-djing-dialog/ui/body.component.tsx:147` 에 `<Button>{t.playlist.btn.change_playlist}` 가 이미 placeholder(`alert('Not Impl')`)로 존재 = 프론트는 진입 UI 준비됨, backend API 부재가 유일한 차단.
+
+부수로 확인된 동일 도메인 invariant 누락:
+- `DjCommandService.enqueueDj` 는 `playlistQueryPort.isEmptyPlaylist` 만 호출, **playlist 소유권 검증 없음** = 타인 소유 playlist 로도 enqueue 가능(현 frontend picker 가 본인 playlist 만 노출해서 실사용 노출은 낮으나 boundary 책임 누락). 본 신규 PATCH 와 함께 동반 보강.
+
+## 2. 결정 (사용자 확정)
+
+1. **허용 범위 = 대기 중 DJ만**. 재생 중 DJ 의 playlist 재지정은 **out-of-scope**(별건 후속 결정).
+2. **WS 통지 불필요 = REST 200 응답만**. 근거: `DjWithProfileDto` payload 가 `crewId, orderNumber, nickname, avatarIconUri` 만 — playlist 정보 없음, DJ 큐 모달이 다른 크루의 playlist 를 노출하지 않음 = 본인만 결과 확인하면 됨. broadcast 발행 시 no-op 메시지가 됨.
+3. **빈 playlist = 거부**. `DjEnqueueSpecification` 의 `EMPTY_PLAYLIST` (DJ-003) 정합 유지. 동작 의미 = "빈 playlist 로 DJ 할 수 없다" 도메인 invariant.
+4. **playlist 소유권 검증 = PATCH + enqueue 동반 보강**. 기존 enqueue 의 누락 invariant 를 같은 PR 에서 함께 잠금(brainstorming skill 지침: "include targeted improvements as part of the design" — 동일 도메인 boundary).
+
+부수 결정(설계 단계 권장):
+- **응답 = 204 No Content** (dequeue-me 와 정합, REST 정합).
+- **Idempotency = 같은 playlistId 로 PATCH 시 204** (REST PATCH idempotent semantic — 도메인 mutator 호출은 발생하나 JPA dirty check 로 no-op).
+- **DjChangeType enum 무변** (CHANGE_PLAYLIST 추가 안 함) — WS broadcast 발행하지 않으므로 enum 신설 불요.
+
+## 3. 설계
+
+### 3-1. API 계약
+
+```
+PATCH /api/v1/partyrooms/{partyroomId}/dj-queue/me
+Auth: cookieAuth, @PreAuthorize("hasRole('MEMBER')")
+Headers: Content-Type: application/json
+Body:   { "playlistId": <Long, required, >0> }
+Success: 204 No Content
+```
+
+**Error 매핑** (HTTP / errorCode / 사유):
+
+| HTTP | errorCode | 메시지 키 | 사유 |
+|---|---|---|---|
+| 400 | INVALID_REQUEST | (validator) | `playlistId` null / non-positive |
+| 401 | (AuthEntryPoint) | — | 인증 결여 |
+| 403 | DJ-002 QUEUE_CLOSED | (재사용) | DJ 큐 closed 상태 |
+| 403 | DJ-003 EMPTY_PLAYLIST | (재사용) | 빈 playlist |
+| 403 | **DJ-005 NOT_OWNED_PLAYLIST** (신규) | "본인 소유 플레이리스트가 아닙니다" | playlist 소유자 ≠ 요청자 |
+| 404 | DJ-004 NOT_FOUND_DJ | (재사용) | 요청자가 DJ 큐에 없음 |
+| 409 | **DJ-006 CURRENT_DJ_CANNOT_CHANGE_PLAYLIST** (신규) | "재생 중 DJ는 플레이리스트를 변경할 수 없습니다" | playback 활성 + `isCurrentDj(crewId)` = true |
+
+**OpenAPI**: `@ApiErrorCodes({DjException.class})` 데코레이터 부착.
+
+### 3-2. 도메인 변경 (party 모듈)
+
+**`DjData`** (entity/data/DjData.java)
+```java
+public void updatePlaylist(PlaylistId playlistId) {
+    this.playlistId = playlistId;
+}
+```
+- `orderNumber` 무변 (큐 순서 보존)
+- `equals/hashCode` 무변 (id 기반)
+- `@DynamicUpdate` 이미 적용 → playlist_id 컬럼만 UPDATE 발행
+
+**`DjException`** 신규 항목 2:
+```java
+NOT_OWNED_PLAYLIST("DJ-005", "본인 소유 플레이리스트가 아닙니다", ErrorType.FORBIDDEN),
+CURRENT_DJ_CANNOT_CHANGE_PLAYLIST("DJ-006", "재생 중 DJ는 플레이리스트를 변경할 수 없습니다", ErrorType.CONFLICT),
+```
+
+**`DjChangePlaylistSpecification`** (신규, domain/specification)
+```java
+public class DjChangePlaylistSpecification {
+    public void validate(DjQueueData djQueue, boolean isCurrentDj,
+                         boolean isOwned, boolean isEmptyPlaylist) {
+        djQueue.validateOpen();                                      // DJ-002
+        if (isCurrentDj)     throw create(CURRENT_DJ_CANNOT_CHANGE); // DJ-006
+        if (!isOwned)        throw create(NOT_OWNED_PLAYLIST);       // DJ-005
+        if (isEmptyPlaylist) throw create(EMPTY_PLAYLIST);           // DJ-003
+    }
+}
+```
+- 평가 순서 근거: queue closed → 메타 조건(current dj) → 소유권(보안) → 콘텐츠(empty). 보안 게이트가 콘텐츠 게이트보다 앞.
+
+**`DjEnqueueSpecification`** (동반 보강)
+```java
+public void validate(DjQueueData djQueue, boolean isAlreadyRegistered,
+                     boolean isOwned, boolean isEmptyPlaylist) {
+    djQueue.validateOpen();
+    if (!isOwned)        throw create(NOT_OWNED_PLAYLIST);    // 신규 DJ-005
+    if (isEmptyPlaylist) throw create(EMPTY_PLAYLIST);
+    if (isAlreadyRegistered) throw create(ALREADY_REGISTERED);
+}
+```
+- 호출자(`DjCommandService.enqueueDj`)에서 `isOwned` 계산값 전달. signature 확장이지만 같은 클래스 1 caller(서비스) → 폭발 반경 작음.
+- 평가 순서: ownership → empty → duplicate (보안 우선).
+
+### 3-3. Port 확장
+
+**`PlaylistQueryPort`** (party/application/port/out)
+```java
+public interface PlaylistQueryPort {
+    boolean isEmptyPlaylist(Long playlistId);
+    boolean isOwnedBy(Long playlistId, Long userId);  // 신규
+}
+```
+구현 = playlist 모듈의 기존 어댑터(`PlaylistQueryAdapter` 또는 동등). 단순 owner_user_id 비교 쿼리. playlist 자체 미존재 시 `false` 반환(NOT_OWNED_PLAYLIST 매핑) — 별도 NOT_FOUND 분기를 안 두는 이유 = playlist 정상 존재 여부는 caller 책임 분리, security boundary 응답으로 enumeration 회피.
+
+### 3-4. 서비스 계층
+
+**`DjCommandService.changePlaylist`** (신규 메서드)
+
+```java
+@Transactional
+public void changePlaylist(PartyroomId partyroomId, PlaylistId newPlaylistId) {
+    AuthContext authContext = ThreadLocalContext.getAuthContext();
+    Long userId = authContext.getUserId().getUid();
+
+    log.info("[changePlaylist] ENTER requestId={} partyroomId={} userId={} newPlaylistId={}",
+        RequestIdInterceptor.current(), partyroomId.getId(), userId, newPlaylistId.getId());
+
+    PartyroomData partyroom         = partyroomQueryService.getPartyroomById(partyroomId);
+    PartyroomPlaybackData playback  = aggregatePort.findPlaybackState(partyroomId);
+    DjQueueData djQueue             = aggregatePort.findDjQueueState(partyroomId);
+    CrewData crew                   = partyroomQueryService.getCrewOrThrow(partyroomId, authContext.getUserId());
+    CrewId crewId                   = new CrewId(crew.getId());
+
+    DjData me = aggregatePort.findDjByPartyroomAndCrew(partyroomId, crewId)
+        .orElseThrow(() -> ExceptionCreator.create(DjException.NOT_FOUND_DJ));   // DJ-004
+
+    boolean isCurrentDj      = playback.isActivated() && playback.isCurrentDj(crewId);
+    boolean isOwned          = playlistQueryPort.isOwnedBy(newPlaylistId.getId(), userId);
+    boolean isEmptyPlaylist  = playlistQueryPort.isEmptyPlaylist(newPlaylistId.getId());
+
+    new DjChangePlaylistSpecification().validate(djQueue, isCurrentDj, isOwned, isEmptyPlaylist);
+
+    Long oldPlaylistId = me.getPlaylistId() != null ? me.getPlaylistId().getId() : null;
+    me.updatePlaylist(newPlaylistId);
+    aggregatePort.saveDj(me);
+
+    log.info("[changePlaylist] OK requestId={} partyroomId={} crewId={} oldPlaylistId={} newPlaylistId={}",
+        RequestIdInterceptor.current(), partyroomId.getId(), crewId.getId(), oldPlaylistId, newPlaylistId.getId());
+    // 도메인 이벤트 발행 없음 — WS broadcast 불필요(§2 결정 2)
+}
+```
+
+**enqueue 동반 보강**:
+```java
+boolean isOwned = playlistQueryPort.isOwnedBy(playlistId.getId(), authContext.getUserId().getUid());
+boolean isEmptyPlaylist = playlistQueryPort.isEmptyPlaylist(playlistId.getId());
+new DjEnqueueSpecification().validate(djQueue, isAlreadyRegistered, isOwned, isEmptyPlaylist);
+```
+- 호출 위치는 기존 `validate(djQueue, isAlreadyRegistered, isEmptyPlaylist)` 직전 `isEmptyPlaylist` 계산 라인 옆.
+
+### 3-5. Repository / Aggregate 확장
+
+**`PartyroomAggregatePort.findDjByPartyroomAndCrew`** (신규)
+```java
+Optional<DjData> findDjByPartyroomAndCrew(PartyroomId partyroomId, CrewId crewId);
+```
+- 구현(`PartyroomAggregateAdapter`): JPA repository 단건 조회. 기존 `findDjsOrdered(partyroomId)` 필터링은 큐 전체 로드 → 비효율.
+- 새 JPA repository 메서드 시그니처: `Optional<DjData> findByPartyroomIdAndCrewId(PartyroomId, CrewId)` (둘 다 `@Embedded` value object).
+
+### 3-6. Controller
+
+**`DjCommandController.changePlaylist`** (신규)
+```java
+@Operation(summary = "본인 DJ 플레이리스트 변경",
+           description = "DJ 대기열에 등록된 본인의 디제잉 플레이리스트를 변경합니다. 재생 중 DJ는 변경할 수 없습니다.")
+@ApiResponse(responseCode = "204", description = "변경 성공")
+@SecurityRequirement(name = "cookieAuth")
+@ApiErrorCodes({DjException.class})
+@PatchMapping("/{partyroomId}/dj-queue/me")
+@PreAuthorize("hasRole('MEMBER')")
+public ResponseEntity<Void> changePlaylist(
+        @Parameter(description = "파티룸 ID") @PathVariable Long partyroomId,
+        @Valid @RequestBody ChangePlaylistRequest request) {
+    djCommandService.changePlaylist(new PartyroomId(partyroomId), new PlaylistId(request.getPlaylistId()));
+    return ResponseEntity.noContent().build();
+}
+```
+
+**`ChangePlaylistRequest`** (신규 DTO, web/payload/request/dj)
+```java
+public record ChangePlaylistRequest(@NotNull @Positive Long playlistId) {}
+```
+
+## 4. 테스트 전략
+
+`pfplay-platform` 단일 PR. test 분포는 [[feedback_pr_series_workflow]] 정합.
+
+### 4-1. Specification Unit
+**`DjChangePlaylistSpecificationTest`** (신규, 5+)
+- happy: queue open / not current / owned / non-empty → no throw
+- queue closed → QUEUE_CLOSED
+- isCurrentDj → CURRENT_DJ_CANNOT_CHANGE_PLAYLIST
+- !isOwned → NOT_OWNED_PLAYLIST
+- isEmpty → EMPTY_PLAYLIST
+- 평가 우선순위 잠금: queue-closed + not-owned 동시 → QUEUE_CLOSED 가 먼저
+
+**`DjEnqueueSpecificationTest`** (확장, 2 추가)
+- !isOwned → NOT_OWNED_PLAYLIST
+- !isOwned + isEmpty → NOT_OWNED_PLAYLIST 가 먼저(보안 우선 순서 잠금)
+
+### 4-2. Service Unit
+**`DjCommandServiceChangePlaylistTest`** (또는 기존 `DjCommandServiceTest` 확장, 6+)
+- happy: updatePlaylist 호출 + saveDj 1회 + 이벤트 publish 0회(broadcast 없음)
+- not-in-queue: NOT_FOUND_DJ, save 0회
+- current DJ: DJ-006, save 0회
+- not owned: DJ-005, save 0회
+- empty playlist: DJ-003, save 0회
+- idempotent: 같은 playlistId 입력 → updatePlaylist 호출되더라도 (JPA dirty check 가 no-op 처리) 예외 없음, 204 응답
+
+**`DjCommandServiceEnqueueTest`** (회귀 가드 보강, 2 추가)
+- enqueue + not-owned playlist → DJ-005
+- 기존 happy 픽스처에 `playlistQueryPort.isOwnedBy = true` mock 보정(전 픽스처 sweep)
+
+### 4-3. IT (party 모듈)
+**`DjCommandIntegrationTest.changePlaylist`** (2)
+- happy: enqueue → changePlaylist → DB 재조회 시 playlist_id 갱신, order_number 보존
+- invariant: enqueue(orderNumber=2) → changePlaylist → 다른 DJ 의 orderNumber 무변
+
+### 4-4. Controller WebMvc
+**`DjCommandControllerTest.changePlaylist`** (신규, 6+)
+- 204 happy
+- 400 invalid body (playlistId null / 0 / negative)
+- 401 unauth
+- 404 NOT_FOUND_DJ
+- 403 DJ-003 / DJ-005
+- 409 DJ-006
+
+### 4-5. 회귀 가드 (cross-cutting)
+- `:app:test` 전체 GREEN
+- `:app:integrationTest` 전체 GREEN — [[reference_mysql_datetime0_rounding]] 위생 정책 적용(필요 시 @AfterEach native delete cleanup)
+
+## 5. 영향 / Out-of-scope
+
+### 영향 (in-scope)
+- party 모듈: `DjData` / `DjException` / `DjCommandService` / `DjCommandController` / `DjEnqueueSpecification` / `DjChangePlaylistSpecification`(신규) / `PlaylistQueryPort`(확장) / `PartyroomAggregatePort`(확장) / `ChangePlaylistRequest`(신규)
+- playlist 모듈: `PlaylistQueryAdapter`(또는 동등) — `isOwnedBy` 구현 추가
+- OpenAPI doc: 신규 endpoint + DJ-005/006 항목 자동 반영(`@ApiErrorCodes` 데코)
+
+### Out-of-scope (별건 후속)
+- **재생 중 DJ 의 playlist 재지정** (사용자 결정 §2-1) — UX 요구 발생 시 별 spec
+- **frontend 진입** (`pfplay-web/widgets/partyroom-djing-dialog/ui/body.component.tsx:147` `alert('Not Impl')` 제거 + playlist picker + PATCH 호출 + error 토스트) — pfplay-web 별 PR
+- **WS broadcast 확장** (`CHANGE_PLAYLIST` enum) — `DjWithProfileDto` 에 playlist 메타 노출 디자인이 합의되면 그때 진입
+- **기존 enqueue 의 ownership 위반 데이터 백필** — DB audit 필요 시 별건
+
+## 6. 잠재 위험 / 검증 포인트
+
+- **`PlaylistQueryPort.isOwnedBy` 어댑터 구현 위치**: playlist 모듈 어댑터에 추가. 다른 호출자 영향 없음(현재 isEmptyPlaylist 1개 메서드 인터페이스, 다른 도메인 무사용 — spec 작성 시점 확인됨).
+- **`PartyroomAggregatePort.findDjByPartyroomAndCrew` 신설 vs `findDjsOrdered` 필터링**: 단건 쿼리 권장 — N+1 회피, 의도 명시. 기존 `findDjsOrdered` 의 caller (enqueue/dequeue/admin-dequeue/E/#3 doStart) 무변.
+- **enqueue 회귀 영향**: 기존 enqueue 테스트 픽스처에서 `PlaylistQueryPort.isOwnedBy` mock 누락 시 전부 DJ-005 회귀. 픽스처 sweep 명시(plan task).
+- **Idempotent semantic 의 JPA 동작**: 같은 playlist_id 로 `updatePlaylist` → `@DynamicUpdate` + dirty check 가 변경 없음 인지 → SQL UPDATE 미발행. 예외 발생 없음(원자 동작). IT 로 검증.
+- **ownership 누락 데이터의 dev/stg 마이그레이션**: 백필 안 함(별건). 신규 enqueue/PATCH 만 잠금 — 기존 DJ row 의 historical playlist 가 ownership 위반 상태라도 시스템 동작에 영향 없음(read-only 인용만 됨).
+
+## 7. 머지·배포 순서
+
+[[reference_branch_env_mapping]] develop=dev / release=stg / main=prod.
+
+1. backend PR → develop merge → deploy-dev workflow 트리거 (사용자 영역 = 머지)
+2. dev 환경 smoke (PATCH 204 / 에러 코드 6종 / 회귀 enqueue)
+3. release(stg) 격상 PR — 별건, 사용자 영역
+4. prod 승격 — [[feedback_main_squash_merge]] squash, 사용자 영역
+
+## 8. 관련
+
+- 이슈: [pfplay-platform#223](https://github.com/pfplay/pfplay-platform/issues/223)
+- 로드맵: `bugs/2026-05-14-bug-fix-roadmap.md` Cluster E row E/#223
+- 인접 작업: E/#3(2026-05-19, doStart DJ별 playable 스캔으로 빈 playlist 자동 skip — 본 spec 의 §2-3 결정 정합), E/#222(2026-05-18, skip→reorder invariant 회귀잠금 — 같은 도메인)
+- 메모리: [[feedback_elegant_no_code_dirtying]], [[feedback_pr_series_workflow]], [[feedback_autonomous_execution]], [[feedback_korean_issue_commit_pr]]

--- a/docs/superpowers/specs/2026-05-21-e223-change-playlist-design.md
+++ b/docs/superpowers/specs/2026-05-21-e223-change-playlist-design.md
@@ -115,7 +115,13 @@ public interface PlaylistQueryPort {
 }
 ```
 
-**party 모듈 `PlaylistQueryAdapter`** (`app/.../party/adapter/out/external/PlaylistQueryAdapter.java`) — 현행 `isEmptyPlaylist` 가 `TrackQueryService.isEmptyPlaylist` 에 위임하는 것과 같은 패턴으로 `isOwnedBy` 는 playlist 모듈의 `PlaylistQueryService.isOwnedBy(Long, UserId)` 신규 메서드에 위임.
+**party 모듈 `PlaylistQueryAdapter`** (`app/.../party/adapter/out/external/PlaylistQueryAdapter.java`) — 현행 `isEmptyPlaylist` 가 `TrackQueryService.isEmptyPlaylist` 에 위임하는 것과 같은 패턴으로 `isOwnedBy` 는 playlist 모듈의 `PlaylistQueryService.isOwnedBy(Long, UserId)` 신규 메서드에 위임. UserId VO wrap:
+```java
+@Override
+public boolean isOwnedBy(Long playlistId, Long userId) {
+    return playlistQueryService.isOwnedBy(playlistId, new UserId(userId));
+}
+```
 
 **playlist 모듈 신규 메서드**: `PlaylistQueryService.isOwnedBy(Long playlistId, UserId userId): boolean` — 기존 `findByIdAndUserId(playlistId, userId)` 가 `null` 반환 시 false, non-null 시 true (또는 동등 효율의 exists 쿼리). 구현 위치는 plan 단계에서 결정(현 서비스 메서드 재사용 vs `PlaylistQueryPort.existsByIdAndUserId` 신설).
 

--- a/docs/superpowers/specs/2026-05-21-e223-change-playlist-design.md
+++ b/docs/superpowers/specs/2026-05-21-e223-change-playlist-design.md
@@ -89,8 +89,10 @@ public class DjChangePlaylistSpecification {
 ```
 - 평가 순서 근거: queue closed → 메타 조건(current dj) → 소유권(보안) → 콘텐츠(empty). 보안 게이트가 콘텐츠 게이트보다 앞.
 
-**`DjEnqueueSpecification`** (동반 보강)
+**`DjEnqueueSpecification`** (동반 보강 — **breaking signature change: arity 3 → 4**)
 ```java
+// before: validate(DjQueueData djQueue, boolean isAlreadyRegistered, boolean isEmptyPlaylist)
+// after:
 public void validate(DjQueueData djQueue, boolean isAlreadyRegistered,
                      boolean isOwned, boolean isEmptyPlaylist) {
     djQueue.validateOpen();
@@ -99,19 +101,25 @@ public void validate(DjQueueData djQueue, boolean isAlreadyRegistered,
     if (isAlreadyRegistered) throw create(ALREADY_REGISTERED);
 }
 ```
-- 호출자(`DjCommandService.enqueueDj`)에서 `isOwned` 계산값 전달. signature 확장이지만 같은 클래스 1 caller(서비스) → 폭발 반경 작음.
+- 호출자(`DjCommandService.enqueueDj`)에서 `isOwned` 계산값 전달. 프로덕션 caller 1개(grep 확인). 단, 기존 `DjEnqueueSpecificationTest` 가 직접 호출 → **테스트 픽스처/시그니처 sweep 필수**(compile-driven, plan task 명시).
 - 평가 순서: ownership → empty → duplicate (보안 우선).
+- **Contract 변경 (OpenAPI 클라이언트 영향)**: 평가 순서 swap 결과 — *기존*: 이미 등록된 사용자 + 타인 playlist 시도 → `DJ-001 ALREADY_REGISTERED`. *변경 후*: 같은 케이스 → `DJ-005 NOT_OWNED_PLAYLIST` 가 먼저. 현 frontend picker 가 본인 playlist 만 노출하므로 실 노출 경로 없음, 다만 OpenAPI 스펙을 코드 외부에서 소비하는 클라이언트가 있다면 에러 코드 우선순위 변경에 유의.
 
 ### 3-3. Port 확장
 
-**`PlaylistQueryPort`** (party/application/port/out)
+**party 모듈 `PlaylistQueryPort`** (`app/.../party/application/port/out/PlaylistQueryPort.java`)
 ```java
 public interface PlaylistQueryPort {
     boolean isEmptyPlaylist(Long playlistId);
     boolean isOwnedBy(Long playlistId, Long userId);  // 신규
 }
 ```
-구현 = playlist 모듈의 기존 어댑터(`PlaylistQueryAdapter` 또는 동등). 단순 owner_user_id 비교 쿼리. playlist 자체 미존재 시 `false` 반환(NOT_OWNED_PLAYLIST 매핑) — 별도 NOT_FOUND 분기를 안 두는 이유 = playlist 정상 존재 여부는 caller 책임 분리, security boundary 응답으로 enumeration 회피.
+
+**party 모듈 `PlaylistQueryAdapter`** (`app/.../party/adapter/out/external/PlaylistQueryAdapter.java`) — 현행 `isEmptyPlaylist` 가 `TrackQueryService.isEmptyPlaylist` 에 위임하는 것과 같은 패턴으로 `isOwnedBy` 는 playlist 모듈의 `PlaylistQueryService.isOwnedBy(Long, UserId)` 신규 메서드에 위임.
+
+**playlist 모듈 신규 메서드**: `PlaylistQueryService.isOwnedBy(Long playlistId, UserId userId): boolean` — 기존 `findByIdAndUserId(playlistId, userId)` 가 `null` 반환 시 false, non-null 시 true (또는 동등 효율의 exists 쿼리). 구현 위치는 plan 단계에서 결정(현 서비스 메서드 재사용 vs `PlaylistQueryPort.existsByIdAndUserId` 신설).
+
+**Non-existent playlist semantic**: `isOwnedBy` 가 playlist 미존재 시 `false` 반환 → `NOT_OWNED_PLAYLIST` (DJ-005) 매핑. 별도 NOT_FOUND 분기를 안 두는 이유 = (1) playlist 정상 존재 여부는 caller 책임 분리, (2) security boundary 응답으로 enumeration 회피, (3) frontend picker 가 본인 playlist 만 노출하므로 사용자 노출 경로 없음. **회귀 가드 테스트 버킷 필수**: §4-2/§4-4 에 non-existent playlistId → DJ-005 case 명시.
 
 ### 3-4. 서비스 계층
 
@@ -132,7 +140,7 @@ public void changePlaylist(PartyroomId partyroomId, PlaylistId newPlaylistId) {
     CrewData crew                   = partyroomQueryService.getCrewOrThrow(partyroomId, authContext.getUserId());
     CrewId crewId                   = new CrewId(crew.getId());
 
-    DjData me = aggregatePort.findDjByPartyroomAndCrew(partyroomId, crewId)
+    DjData me = aggregatePort.findDj(partyroomId, crewId)                       // 기존 port 메서드 재사용
         .orElseThrow(() -> ExceptionCreator.create(DjException.NOT_FOUND_DJ));   // DJ-004
 
     boolean isCurrentDj      = playback.isActivated() && playback.isCurrentDj(crewId);
@@ -143,13 +151,16 @@ public void changePlaylist(PartyroomId partyroomId, PlaylistId newPlaylistId) {
 
     Long oldPlaylistId = me.getPlaylistId() != null ? me.getPlaylistId().getId() : null;
     me.updatePlaylist(newPlaylistId);
-    aggregatePort.saveDj(me);
+    // ※ saveDj 명시 호출 안 함 — me 는 @Transactional 컨텍스트의 managed entity,
+    //   JPA dirty check 가 commit 시 UPDATE 자동 발행([[feedback_elegant_no_code_dirtying]])
 
     log.info("[changePlaylist] OK requestId={} partyroomId={} crewId={} oldPlaylistId={} newPlaylistId={}",
         RequestIdInterceptor.current(), partyroomId.getId(), crewId.getId(), oldPlaylistId, newPlaylistId.getId());
     // 도메인 이벤트 발행 없음 — WS broadcast 불필요(§2 결정 2)
 }
 ```
+
+**동시성 / 레이스 윈도우 (수용 정책)**: 본 메서드는 `@Transactional` 컨텍스트 안에서 `me` 를 load → mutate → commit 한다. 같은 사용자의 dequeue 와 changePlaylist 가 동시 도착하는 사용자 정상 시나리오는 [[single-partyroom-subscription-invariant]] 상 동일 디바이스 = 단일 세션이므로 사실상 직렬화. 그러나 admin 강제 dequeue 또는 백엔드 cron(presence grace) 이 동일 row 를 동시 변경하는 윈도우는 존재 — 이 경우 changePlaylist tx commit 이 already-deleted row 에 UPDATE 발행 → 0 rows affected silently. **수용 정책 = last-writer-wins, JPA 의 dirty-update 가 silent no-op 처리. `@Version` / pessimistic lock 미도입**(트레이드오프: 정상 경로 99.9% 시나리오 단순화 우선, 비정상 race 는 ⇒ 사용자가 다시 enqueue + change 로 회복 가능). 동일하게 `djQueue.validateOpen` snapshot 후 다른 tx 가 close 하는 race 도 수용. §6 위험 목록에 명시.
 
 **enqueue 동반 보강**:
 ```java
@@ -159,14 +170,9 @@ new DjEnqueueSpecification().validate(djQueue, isAlreadyRegistered, isOwned, isE
 ```
 - 호출 위치는 기존 `validate(djQueue, isAlreadyRegistered, isEmptyPlaylist)` 직전 `isEmptyPlaylist` 계산 라인 옆.
 
-### 3-5. Repository / Aggregate 확장
+### 3-5. Repository / Aggregate
 
-**`PartyroomAggregatePort.findDjByPartyroomAndCrew`** (신규)
-```java
-Optional<DjData> findDjByPartyroomAndCrew(PartyroomId partyroomId, CrewId crewId);
-```
-- 구현(`PartyroomAggregateAdapter`): JPA repository 단건 조회. 기존 `findDjsOrdered(partyroomId)` 필터링은 큐 전체 로드 → 비효율.
-- 새 JPA repository 메서드 시그니처: `Optional<DjData> findByPartyroomIdAndCrewId(PartyroomId, CrewId)` (둘 다 `@Embedded` value object).
+`PartyroomAggregatePort.findDj(PartyroomId, CrewId): Optional<DjData>` **이미 존재** (`app/.../party/domain/port/PartyroomAggregatePort.java:42`). 신설 불요 — `changePlaylist` 가 이를 그대로 호출. (spec 초안의 `findDjByPartyroomAndCrew` 신설 제안은 reviewer 가 중복 지적 → 폐기, [[feedback_elegant_no_code_dirtying]] 정합.)
 
 ### 3-6. Controller
 
@@ -210,31 +216,34 @@ public record ChangePlaylistRequest(@NotNull @Positive Long playlistId) {}
 - !isOwned + isEmpty → NOT_OWNED_PLAYLIST 가 먼저(보안 우선 순서 잠금)
 
 ### 4-2. Service Unit
-**`DjCommandServiceChangePlaylistTest`** (또는 기존 `DjCommandServiceTest` 확장, 6+)
-- happy: updatePlaylist 호출 + saveDj 1회 + 이벤트 publish 0회(broadcast 없음)
-- not-in-queue: NOT_FOUND_DJ, save 0회
-- current DJ: DJ-006, save 0회
-- not owned: DJ-005, save 0회
-- empty playlist: DJ-003, save 0회
-- idempotent: 같은 playlistId 입력 → updatePlaylist 호출되더라도 (JPA dirty check 가 no-op 처리) 예외 없음, 204 응답
+**`DjCommandServiceChangePlaylistTest`** (또는 기존 `DjCommandServiceTest` 확장, 7+)
+- happy: `me.updatePlaylist(newId)` 호출 + `eventPublisher.publishEvent` 0회 (broadcast 없음). `saveDj` 어서션 안 함 (dirty-check 의존)
+- not-in-queue: NOT_FOUND_DJ throw
+- current DJ: DJ-006 throw
+- not owned: DJ-005 throw
+- non-existent playlistId (isOwnedBy=false 모킹) → DJ-005 throw  ← 신규 (§3-3 semantic 잠금)
+- empty playlist: DJ-003 throw
+- idempotent (same playlistId): `updatePlaylist(sameId)` 호출되더라도 예외 없음. SQL UPDATE 발행 여부는 IT(§4-3) 책임
 
 **`DjCommandServiceEnqueueTest`** (회귀 가드 보강, 2 추가)
 - enqueue + not-owned playlist → DJ-005
 - 기존 happy 픽스처에 `playlistQueryPort.isOwnedBy = true` mock 보정(전 픽스처 sweep)
 
 ### 4-3. IT (party 모듈)
-**`DjCommandIntegrationTest.changePlaylist`** (2)
+**`DjCommandIntegrationTest.changePlaylist`** (3)
 - happy: enqueue → changePlaylist → DB 재조회 시 playlist_id 갱신, order_number 보존
-- invariant: enqueue(orderNumber=2) → changePlaylist → 다른 DJ 의 orderNumber 무변
+- invariant: enqueue 2명 → 2번째가 changePlaylist → 다른 DJ 의 order_number 무변
+- idempotent: enqueue → 같은 playlistId 로 changePlaylist → DB 재조회 시 playlist_id 무변, no logical change (SQL UPDATE 발행 여부는 dirty-check 거동상 환경 의존 — assert는 "최종 row 상태 무변"으로)
 
 ### 4-4. Controller WebMvc
-**`DjCommandControllerTest.changePlaylist`** (신규, 6+)
+**`DjCommandControllerTest.changePlaylist`** (신규, 7+)
 - 204 happy
 - 400 invalid body (playlistId null / 0 / negative)
 - 401 unauth
-- 404 NOT_FOUND_DJ
-- 403 DJ-003 / DJ-005
-- 409 DJ-006
+- 404 NOT_FOUND_DJ (DJ-004)
+- 403 DJ-003 EMPTY_PLAYLIST  ← 별도 case
+- 403 DJ-005 NOT_OWNED_PLAYLIST  ← 별도 case (non-existent playlistId 포함)
+- 409 DJ-006 CURRENT_DJ_CANNOT_CHANGE_PLAYLIST
 
 ### 4-5. 회귀 가드 (cross-cutting)
 - `:app:test` 전체 GREEN
@@ -243,23 +252,29 @@ public record ChangePlaylistRequest(@NotNull @Positive Long playlistId) {}
 ## 5. 영향 / Out-of-scope
 
 ### 영향 (in-scope)
-- party 모듈: `DjData` / `DjException` / `DjCommandService` / `DjCommandController` / `DjEnqueueSpecification` / `DjChangePlaylistSpecification`(신규) / `PlaylistQueryPort`(확장) / `PartyroomAggregatePort`(확장) / `ChangePlaylistRequest`(신규)
-- playlist 모듈: `PlaylistQueryAdapter`(또는 동등) — `isOwnedBy` 구현 추가
+- party 모듈:
+  - **신규**: `DjChangePlaylistSpecification`, `ChangePlaylistRequest` DTO
+  - **확장**: `DjData.updatePlaylist` mutator, `DjException` (DJ-005/006), party `PlaylistQueryPort.isOwnedBy`, party `PlaylistQueryAdapter` 위임 추가, `DjCommandService.changePlaylist` + `enqueueDj` ownership 추가, `DjEnqueueSpecification.validate` arity 3→4, `DjCommandController.changePlaylist` endpoint
+  - **무변**: `PartyroomAggregatePort.findDj` 기존 메서드 재사용
+- playlist 모듈: `PlaylistQueryService.isOwnedBy(Long, UserId)` 신규 (또는 동등). 기존 `findByIdAndUserId` 재사용 형태 가능
 - OpenAPI doc: 신규 endpoint + DJ-005/006 항목 자동 반영(`@ApiErrorCodes` 데코)
 
 ### Out-of-scope (별건 후속)
-- **재생 중 DJ 의 playlist 재지정** (사용자 결정 §2-1) — UX 요구 발생 시 별 spec
+- **재생 중 DJ 의 playlist 재지정** (사용자 결정 §2-1) — UX 요구 발생 시 별 spec. **forward link**: 그 시점엔 다음 트랙부터 적용 vs 즉시 적용 결정 + 다른 크루 화면 갱신 필요성 = WS broadcast (`CHANGE_PLAYLIST` enum 신설) 가 거의 확실히 필요해질 것. 즉 본 spec 의 "no broadcast" 결정은 **"대기 중 DJ 만"** 범위로 명시적 한정.
 - **frontend 진입** (`pfplay-web/widgets/partyroom-djing-dialog/ui/body.component.tsx:147` `alert('Not Impl')` 제거 + playlist picker + PATCH 호출 + error 토스트) — pfplay-web 별 PR
-- **WS broadcast 확장** (`CHANGE_PLAYLIST` enum) — `DjWithProfileDto` 에 playlist 메타 노출 디자인이 합의되면 그때 진입
+- **WS broadcast 확장** (`CHANGE_PLAYLIST` enum) — `DjWithProfileDto` 에 playlist 메타 노출 디자인이 합의되면 그때 진입(위 forward link 와 결합 가능)
 - **기존 enqueue 의 ownership 위반 데이터 백필** — DB audit 필요 시 별건
 
 ## 6. 잠재 위험 / 검증 포인트
 
-- **`PlaylistQueryPort.isOwnedBy` 어댑터 구현 위치**: playlist 모듈 어댑터에 추가. 다른 호출자 영향 없음(현재 isEmptyPlaylist 1개 메서드 인터페이스, 다른 도메인 무사용 — spec 작성 시점 확인됨).
-- **`PartyroomAggregatePort.findDjByPartyroomAndCrew` 신설 vs `findDjsOrdered` 필터링**: 단건 쿼리 권장 — N+1 회피, 의도 명시. 기존 `findDjsOrdered` 의 caller (enqueue/dequeue/admin-dequeue/E/#3 doStart) 무변.
-- **enqueue 회귀 영향**: 기존 enqueue 테스트 픽스처에서 `PlaylistQueryPort.isOwnedBy` mock 누락 시 전부 DJ-005 회귀. 픽스처 sweep 명시(plan task).
-- **Idempotent semantic 의 JPA 동작**: 같은 playlist_id 로 `updatePlaylist` → `@DynamicUpdate` + dirty check 가 변경 없음 인지 → SQL UPDATE 미발행. 예외 발생 없음(원자 동작). IT 로 검증.
-- **ownership 누락 데이터의 dev/stg 마이그레이션**: 백필 안 함(별건). 신규 enqueue/PATCH 만 잠금 — 기존 DJ row 의 historical playlist 가 ownership 위반 상태라도 시스템 동작에 영향 없음(read-only 인용만 됨).
+- **party `PlaylistQueryPort.isOwnedBy` 어댑터 위치**: party 모듈의 `PlaylistQueryAdapter` 가 playlist 모듈 `PlaylistQueryService.isOwnedBy(Long, UserId)` 신규 메서드에 위임. 기존 `isEmptyPlaylist → TrackQueryService.isEmptyPlaylist` 의 패턴 미러. plan 단계에서 playlist 모듈 메서드의 구현 형태(`findByIdAndUserId null 체크 재사용` vs `exists 쿼리 신설`) 결정.
+- **`PartyroomAggregatePort.findDj` 재사용 (신설 회피)**: 기존 시그니처 `findDj(PartyroomId, CrewId): Optional<DjData>` 활용 — reviewer 가 중복 검출, 신설 폐기. [[feedback_elegant_no_code_dirtying]] 정합.
+- **enqueue 회귀 영향**: 기존 enqueue 테스트 픽스처에서 `PlaylistQueryPort.isOwnedBy` mock 누락 시 전부 DJ-005 회귀. 픽스처 sweep 명시(plan task). `DjEnqueueSpecification.validate` arity 변경(3→4)으로 인한 compile-driven sweep 도 동반.
+- **enqueue 에러 코드 우선순위 변경 (contract change)**: 평가 순서 swap 결과, 기등록+타인 playlist 동시 위반 시 *전*: DJ-001 ALREADY_REGISTERED → *후*: DJ-005 NOT_OWNED_PLAYLIST. 사용자 노출 경로는 picker 가 본인 playlist 만 노출하므로 0 이나, OpenAPI 외부 클라이언트 가능성을 위해 명시적 인지. (§3-2 참조)
+- **`saveDj` 명시 호출 제거 → JPA dirty check 의존**: `me` 가 managed entity 이므로 `@Transactional` commit 시 자동 UPDATE 발행. enqueue 패턴(`aggregatePort.saveDj` 명시 호출, 새 entity 라 `persist` 의도)와 비대칭이지만, 업데이트 시 명시 save 는 redundant noise. service unit test 에서는 saveDj 호출 횟수 어서션 안 함.
+- **Idempotent semantic 의 JPA 동작**: 같은 playlist_id 로 `updatePlaylist` → dirty check 가 변경 없음 인지 → SQL UPDATE 미발행이 일반적이나 `@DynamicUpdate` 와의 결합·연관 컬럼 변화 등 환경 의존. IT 단계 어서션은 "최종 row 상태 무변" 으로 한정(SQL UPDATE 발행 0회 어서션은 brittle 회피).
+- **동시성 race 윈도우 (수용)**: §3-4 에 명시한 admin-dequeue / cron / queue-close 의 동시 발생 시 silent no-op 가능. 회복 = 사용자 재 enqueue + change. `@Version`/pessimistic lock 미도입(YAGNI vs 실제 고통: 현 시점 보고된 race incident 0).
+- **ownership 누락 historical data**: 백필 안 함(별건). 신규 enqueue/PATCH 만 invariant 잠금 — 기존 DJ row 의 historical playlist 가 ownership 위반 상태라도 시스템 동작에 영향 없음(read-only 인용만 됨).
 
 ## 7. 머지·배포 순서
 

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/PlaylistQueryService.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/PlaylistQueryService.java
@@ -2,6 +2,7 @@ package com.pfplaybackend.api.playlist.application.service;
 
 import com.pfplaybackend.api.common.ThreadLocalContext;
 import com.pfplaybackend.api.common.aspect.context.AuthContext;
+import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.playlist.application.dto.PlaylistSummaryDto;
 import com.pfplaybackend.api.playlist.application.port.out.PlaylistQueryPort;
 import lombok.RequiredArgsConstructor;
@@ -29,5 +30,10 @@ public class PlaylistQueryService {
     public PlaylistSummaryDto getPlaylist(Long playlistId) {
         AuthContext authContext = ThreadLocalContext.getAuthContext();
         return queryPort.findByIdAndUserId(playlistId, authContext.getUserId());
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isOwnedBy(Long playlistId, UserId userId) {
+        return queryPort.findByIdAndUserId(playlistId, userId) != null;
     }
 }

--- a/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/PlaylistQueryServiceTest.java
+++ b/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/PlaylistQueryServiceTest.java
@@ -89,4 +89,31 @@ class PlaylistQueryServiceTest {
         assertThat(result).isEqualTo(expected);
         verify(queryPort).findByIdAndUserId(playlistId, userId);
     }
+
+    @Test
+    @DisplayName("isOwnedBy — playlist 가 본인 소유면 true")
+    void isOwnedByReturnsTrueWhenOwned() {
+        // given
+        PlaylistSummaryDto owned = new PlaylistSummaryDto(99L, "My Playlist", 5, PlaylistType.PLAYLIST, 1L);
+        when(queryPort.findByIdAndUserId(99L, userId)).thenReturn(owned);
+
+        // when
+        boolean result = playlistQueryService.isOwnedBy(99L, userId);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("isOwnedBy — playlist 가 타인 소유거나 미존재면 false")
+    void isOwnedByReturnsFalseWhenNotOwned() {
+        // given
+        when(queryPort.findByIdAndUserId(99L, userId)).thenReturn(null);
+
+        // when
+        boolean result = playlistQueryService.isOwnedBy(99L, userId);
+
+        // then
+        assertThat(result).isFalse();
+    }
 }


### PR DESCRIPTION
## 요약

- `PATCH /api/v1/partyrooms/{partyroomId}/dj-queue/me` 신설 — 대기 중 본인 DJ 의 디제잉 플레이리스트를 큐 순서를 보존하며 변경.
- playlist 소유권 검증을 신규 PATCH 와 기존 enqueue 양쪽에 동반 보강 (`DJ-005 NOT_OWNED_PLAYLIST`).
- 재생 중 DJ 의 playlist 재지정은 범위 밖 (`DJ-006 CURRENT_DJ_CANNOT_CHANGE_PLAYLIST`, 별건 후속).
- WS broadcast 없음 (본인만 결과 확인 — `DjWithProfileDto` 가 playlist 정보 비포함).

## 결정 잠금 (사용자, 2026-05-21)

1. 허용 범위 = **대기 중 DJ만** (재생 중 DJ 별건)
2. WS 통지 = **불필요** (REST 204 만)
3. 빈 playlist = **거부** (DJ-003 재사용, enqueue 정합)
4. playlist 소유권 = **PATCH + enqueue 동반 보강**

## 산출물

### 신규
- `DjChangePlaylistSpecification` (queue-closed → currentDj → ownership → empty)
- `ChangePlaylistRequest` DTO (`@NotNull @Positive`, `RegisterDjRequest` 컨벤션 정합)
- `DjCommandIntegrationTest` (Testcontainers MySQL, 3 case)
- `DjChangePlaylistSpecificationTest` (7 case)

### 확장
- `DjData.updatePlaylist(PlaylistId)` mutator — `orderNumber` 보존
- `DjException` += DJ-005 NOT_OWNED_PLAYLIST (FORBIDDEN), DJ-006 CURRENT_DJ_CANNOT_CHANGE_PLAYLIST (CONFLICT)
- `DjEnqueueSpecification.validate` arity 3→4 (ownership-first 평가 — DJ-001/005 우선순위 변경)
- party `PlaylistQueryPort.isOwnedBy(Long, Long)` + `PlaylistQueryAdapter` 위임 (UserId VO wrap)
- playlist `PlaylistQueryService.isOwnedBy(Long, UserId)` (`findByIdAndUserId` null-check 재사용)
- `DjCommandService.changePlaylist` 신규 + `enqueueDj` ownership 동반 (caller arity 정합)
- `DjCommandController` += `@PatchMapping("/{partyroomId}/dj-queue/me")` (204 No Content)

### 무변
- `PartyroomAggregatePort.findDj(PartyroomId, CrewId)` — 기존 메서드 재사용 (reviewer round-1 결과, 신설 폐기)

## 도메인 invariant

- `DjChangePlaylistSpecification`: queue-closed → currentDj(409) → ownership(403, security 우선) → empty(403)
- `DjEnqueueSpecification`: queue-closed → ownership(403, security 우선) → empty(403) → duplicate(409)
- ⚠️ **Contract 변경**: 기등록 + 타인 playlist 동시 시도 시 이전 = DJ-001 ALREADY_REGISTERED → 이후 = DJ-005 NOT_OWNED_PLAYLIST 우선. frontend picker 가 본인 playlist 만 노출하므로 실 노출 경로 없음.
- `isOwnedBy=false` (미존재 포함) → DJ-005: enumeration 회피 (NOT_FOUND 분기 안 둠).
- `saveDj` 명시 호출 없음: managed entity dirty check 의존 ([[feedback_elegant_no_code_dirtying]]).
- race window (admin dequeue / cron presence grace) = last-writer-wins 수용, `@Version`/pessimistic lock 미도입.

## 테스트

- `:playlist:test` GREEN (`PlaylistQueryServiceTest` +2 case)
- `:app:test` GREEN (신규: `DjChangePlaylistSpecificationTest` 7 / `DjCommandServiceTest` changePlaylist 7 + enqueue 회귀 1 + 픽스처 sweep 3 / `DjCommandControllerTest` changePlaylist 8 / `DjDataTest` 1, 수정: `DjEnqueueSpecificationTest` 6 / `DjCommandServiceDjQueueChangeTest`·`LogCaptureTest` fixture sweep)
- `:app:integrationTest` GREEN (`DjCommandIntegrationTest` 3 case — happy / order 보존 / idempotent)

## 스펙 / 계획

- spec: `docs/superpowers/specs/2026-05-21-e223-change-playlist-design.md` (reviewer 2-round Approved)
- plan: `docs/superpowers/plans/2026-05-21-e223-change-playlist.md` (reviewer 1-round Approved)
- 이슈: #223
- 최종 code reviewer: ✅ Ready to merge (1 small advisory 즉시 반영, 3 cosmetic 후속/별건)

## 후속 / Follow-up

- frontend (pfplay-web): `widgets/partyroom-djing-dialog/ui/body.component.tsx:147` `alert('Not Impl')` placeholder → PATCH 호출 + playlist picker + 에러 토스트 (별 PR)
- 재생 중 DJ 의 playlist 재지정 (out-of-scope, WS broadcast `CHANGE_PLAYLIST` enum 동반 필요해질 가능성 — spec §5 forward link)
- `DjCommandService.enqueueDj:62-65` `[enqueueDj] ALREADY_REGISTERED` warn 이 ownership-first 평가 swap 으로 미세 오해 소지 (cosmetic, 별건 hygiene)
- `ChangePlaylistRequest` spec 텍스트의 `record` vs 구현의 `class` 정합 (spec doc 정정)

## 머지 / 배포 순서

1. develop merge (사용자 영역)
2. dev 자동 배포 (deploy-dev) + smoke (PATCH 204 / 6 error code / enqueue 회귀)
3. release(stg) 격상 — 별건 release PR (사용자 영역)
4. prod(main) 승격 — [[feedback_main_squash_merge]] squash, 사용자 영역

🤖 Generated with [Claude Code](https://claude.com/claude-code)