### PR TITLE
refactor(partyroom): crewCount → activeCrewCount + Javadoc 명확화

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/administration/adapter/out/persistence/impl/AdminPartyroomQueryRepositoryImpl.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/adapter/out/persistence/impl/AdminPartyroomQueryRepositoryImpl.java
@@ -93,7 +93,7 @@ public class AdminPartyroomQueryRepositoryImpl implements AdminPartyroomQueryRep
                         p.stageType,
                         ua.userId.uid,
                         profile.bio.nickname,
-                        p.crewCount,
+                        p.activeCrewCount,
                         djCountSubquery,
                         pb.isActivated,
                         p.status,
@@ -139,7 +139,7 @@ public class AdminPartyroomQueryRepositoryImpl implements AdminPartyroomQueryRep
                                          JPQLQuery<Long> djCountSubquery) {
         Nickname nickname = t.get(profile.bio.nickname);
         Long djCount = t.get(djCountSubquery);
-        Integer crewCount = t.get(p.crewCount);
+        Integer crewCount = t.get(p.activeCrewCount);
         return new AdminPartyroomListRow(
                 t.get(p.id),
                 t.get(p.title),
@@ -202,7 +202,7 @@ public class AdminPartyroomQueryRepositoryImpl implements AdminPartyroomQueryRep
             ComparableExpressionBase<?> path = switch (order.getProperty()) {
                 case "createdAt"      -> p.createdAt;
                 case "lastActivityAt" -> p.lastActivityAt;
-                case "crewCount"      -> p.crewCount;
+                case "crewCount"      -> p.activeCrewCount;
                 case "title"          -> p.title;
                 case "hostNickname"   -> nicknameExpr;
                 default -> throw new IllegalArgumentException(

--- a/app/src/main/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomQueryService.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomQueryService.java
@@ -166,7 +166,7 @@ public class AdminPartyroomQueryService {
                 hostUserId == null ? null : hostUserId.getUid(),
                 extractNickname(hostMember),
                 hostAccount == null ? null : hostAccount.getEmail(),
-                partyroom.getCrewCount(),
+                partyroom.getActiveCrewCount(),
                 partyroom.getLastActivityAt(),
                 partyroom.getStageType(),
                 playbackLimitMinutes,

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomRepository.java
@@ -30,7 +30,7 @@ public interface PartyroomRepository extends JpaRepository<PartyroomData, Long>,
      */
     @Modifying(clearAutomatically = true)
     @Query("UPDATE PartyroomData p " +
-           "SET p.crewCount = p.crewCount + 1, p.lastActivityAt = :now " +
+           "SET p.activeCrewCount = p.activeCrewCount + 1, p.lastActivityAt = :now " +
            "WHERE p.id = :id " +
            "AND p.status <> com.pfplaybackend.api.party.domain.enums.PartyroomStatus.TERMINATED")
     int incrementCrewCount(@Param("id") Long id, @Param("now") LocalDateTime now);
@@ -40,7 +40,7 @@ public interface PartyroomRepository extends JpaRepository<PartyroomData, Long>,
      */
     @Modifying(clearAutomatically = true)
     @Query("UPDATE PartyroomData p " +
-           "SET p.crewCount = CASE WHEN p.crewCount > 0 THEN p.crewCount - 1 ELSE 0 END, " +
+           "SET p.activeCrewCount = CASE WHEN p.activeCrewCount > 0 THEN p.activeCrewCount - 1 ELSE 0 END, " +
            "    p.lastActivityAt = :now " +
            "WHERE p.id = :id " +
            "AND p.status <> com.pfplaybackend.api.party.domain.enums.PartyroomStatus.TERMINATED")
@@ -64,6 +64,6 @@ public interface PartyroomRepository extends JpaRepository<PartyroomData, Long>,
      * 이미 0인 row를 reset해도 멱등 (UPDATE 자체는 실행, affected row 1).
      */
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE PartyroomData p SET p.crewCount = 0 WHERE p.id = :id")
+    @Query("UPDATE PartyroomData p SET p.activeCrewCount = 0 WHERE p.id = :id")
     int resetCrewCount(@Param("id") Long id);
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/PartyroomData.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/PartyroomData.java
@@ -25,7 +25,7 @@ import java.time.LocalDateTime;
 // Without it, JPA dirty-checking saves (e.g., terminate() from cleanup job)
 // would write back ALL columns including a stale crew_count, silently
 // overwriting concurrent atomic UPDATEs from PartyroomCounterListener.
-// crewCount/lastActivityAt/displayFlag have no setters — they are mutated
+// activeCrewCount/lastActivityAt/displayFlag have no setters — they are mutated
 // exclusively via PartyroomRepository.{increment,decrement,touch}* methods.
 @DynamicInsert
 @DynamicUpdate
@@ -68,9 +68,20 @@ public class PartyroomData extends BaseEntity {
     @Column(name = "status", nullable = false, length = 16)
     private PartyroomStatus status;
 
-    // V6: denormalized counter — atomic UPDATE만 갱신 (PartyroomRepository.incrementCrewCount/decrementCrewCount)
+    /**
+     * 활성(is_active=true) crew row 의 수 — denormalized counter.
+     *
+     * <p>의미상 "방 안에 현재 머무는 인원". V16 grace 정책상 PENDING_EXIT 도 is_active=true 라 카운트에 포함된다
+     * (transient disconnect 중 grace window 안 사용자도 "방 안에 있는 것" 으로 본다).
+     *
+     * <p>누적 입장자 수 아님. 과거 max 아님. atomic UPDATE 만으로 갱신
+     * ({@link com.pfplaybackend.api.party.adapter.out.persistence.PartyroomRepository#incrementCrewCount}
+     * / {@link com.pfplaybackend.api.party.adapter.out.persistence.PartyroomRepository#decrementCrewCount}).
+     *
+     * <p>DB 컬럼은 {@code crew_count} 로 유지 (V6 schema, prod 라이브 — rename 시 expand-and-contract 마이그 필요).
+     */
     @Column(name = "crew_count", nullable = false)
-    private int crewCount;
+    private int activeCrewCount;
 
     // V6: 최근 활동 시각 — atomic UPDATE만 갱신 (PartyroomRepository.touchLastActivity)
     @Column(name = "last_activity_at")
@@ -100,7 +111,7 @@ public class PartyroomData extends BaseEntity {
     @Builder
     public PartyroomData(Long id, PartyroomId partyroomId, UserId hostId, StageType stageType,
                          String title, String introduction, LinkDomain linkDomain, PlaybackTimeLimit playbackTimeLimit,
-                         String noticeContent, PartyroomStatus status, int crewCount,
+                         String noticeContent, PartyroomStatus status, int activeCrewCount,
                          LocalDateTime lastActivityAt, DisplayFlag displayFlag,
                          LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
@@ -113,7 +124,7 @@ public class PartyroomData extends BaseEntity {
         this.playbackTimeLimit = playbackTimeLimit;
         this.noticeContent = noticeContent;
         this.status = status != null ? status : PartyroomStatus.ACTIVE;
-        this.crewCount = crewCount;
+        this.activeCrewCount = activeCrewCount;
         this.lastActivityAt = lastActivityAt;
         this.displayFlag = displayFlag != null ? displayFlag : DisplayFlag.NORMAL;
         this.createdAt = createdAt;
@@ -133,7 +144,7 @@ public class PartyroomData extends BaseEntity {
                 .playbackTimeLimit(timeLimit)
                 .noticeContent("")
                 .status(PartyroomStatus.ACTIVE)
-                .crewCount(0)
+                .activeCrewCount(0)
                 .displayFlag(DisplayFlag.NORMAL)
                 .build();
     }

--- a/app/src/test/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomQueryServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomQueryServiceTest.java
@@ -84,7 +84,7 @@ class AdminPartyroomQueryServiceTest {
         // crew_count is package-private/no-setter; force via reflection so we can assert the
         // list/detail mapping carries it through correctly without standing up a JPA fixture.
         setField(partyroom, "id", 100L);
-        setField(partyroom, "crewCount", 4);
+        setField(partyroom, "activeCrewCount", 4);
         setField(partyroom, "lastActivityAt", LocalDateTime.of(2026, 4, 27, 10, 0));
     }
 

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/in/listener/PartyroomCounterListenerIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/in/listener/PartyroomCounterListenerIT.java
@@ -79,7 +79,7 @@ class PartyroomCounterListenerIT extends AbstractIntegrationTest {
         );
 
         PartyroomData reloaded = partyroomRepository.findById(roomId).orElseThrow();
-        assertThat(reloaded.getCrewCount()).isEqualTo(1);
+        assertThat(reloaded.getActiveCrewCount()).isEqualTo(1);
         assertThat(reloaded.getLastActivityAt()).isNotNull();
     }
 
@@ -101,7 +101,7 @@ class PartyroomCounterListenerIT extends AbstractIntegrationTest {
         );
 
         PartyroomData reloaded = partyroomRepository.findById(roomId).orElseThrow();
-        assertThat(reloaded.getCrewCount()).isZero();
+        assertThat(reloaded.getActiveCrewCount()).isZero();
     }
 
     @Test
@@ -119,7 +119,7 @@ class PartyroomCounterListenerIT extends AbstractIntegrationTest {
 
         PartyroomData reloaded = partyroomRepository.findById(roomId).orElseThrow();
         assertThat(reloaded.getLastActivityAt()).isNotNull();
-        assertThat(reloaded.getCrewCount()).isZero();
+        assertThat(reloaded.getActiveCrewCount()).isZero();
     }
 
     @Test
@@ -157,7 +157,7 @@ class PartyroomCounterListenerIT extends AbstractIntegrationTest {
         );
 
         PartyroomData reloaded = partyroomRepository.findById(roomId).orElseThrow();
-        assertThat(reloaded.getCrewCount()).isZero();
+        assertThat(reloaded.getActiveCrewCount()).isZero();
     }
 
     @Test
@@ -175,7 +175,7 @@ class PartyroomCounterListenerIT extends AbstractIntegrationTest {
         );
 
         PartyroomData reloaded = partyroomRepository.findById(roomId).orElseThrow();
-        assertThat(reloaded.getCrewCount()).isZero();
+        assertThat(reloaded.getActiveCrewCount()).isZero();
     }
 
     @Test
@@ -196,6 +196,6 @@ class PartyroomCounterListenerIT extends AbstractIntegrationTest {
         );
 
         PartyroomData reloaded = partyroomRepository.findById(roomId).orElseThrow();
-        assertThat(reloaded.getCrewCount()).isZero();
+        assertThat(reloaded.getActiveCrewCount()).isZero();
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomCounterConcurrencyIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomCounterConcurrencyIT.java
@@ -94,7 +94,7 @@ class PartyroomCounterConcurrencyIT extends AbstractIntegrationTest {
         assertThat(affectedSum.get()).isEqualTo(THREAD_COUNT);
         PartyroomData reloaded = newTx().execute(status ->
                 partyroomRepository.findById(roomId).orElseThrow());
-        assertThat(reloaded.getCrewCount()).isEqualTo(THREAD_COUNT);
+        assertThat(reloaded.getActiveCrewCount()).isEqualTo(THREAD_COUNT);
     }
 
     @Test
@@ -146,6 +146,6 @@ class PartyroomCounterConcurrencyIT extends AbstractIntegrationTest {
         // pre-50 + concurrent 100 - concurrent 50 = 100
         PartyroomData reloaded = newTx().execute(status ->
                 partyroomRepository.findById(roomId).orElseThrow());
-        assertThat(reloaded.getCrewCount()).isEqualTo(100);
+        assertThat(reloaded.getActiveCrewCount()).isEqualTo(100);
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomRepositoryAtomicUpdateIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomRepositoryAtomicUpdateIT.java
@@ -50,7 +50,7 @@ class PartyroomRepositoryAtomicUpdateIT extends AbstractIntegrationTest {
 
         assertThat(affected).isEqualTo(1);
         PartyroomData reloaded = partyroomRepository.findById(p.getId()).orElseThrow();
-        assertThat(reloaded.getCrewCount()).isEqualTo(1);
+        assertThat(reloaded.getActiveCrewCount()).isEqualTo(1);
         assertThat(reloaded.getLastActivityAt()).isEqualToIgnoringNanos(now);
     }
 
@@ -85,7 +85,7 @@ class PartyroomRepositoryAtomicUpdateIT extends AbstractIntegrationTest {
 
         assertThat(affected).isEqualTo(1);
         PartyroomData reloaded = partyroomRepository.findById(p.getId()).orElseThrow();
-        assertThat(reloaded.getCrewCount()).isEqualTo(1);
+        assertThat(reloaded.getActiveCrewCount()).isEqualTo(1);
         assertThat(reloaded.getLastActivityAt()).isEqualToIgnoringNanos(decrementAt);
     }
 
@@ -100,7 +100,7 @@ class PartyroomRepositoryAtomicUpdateIT extends AbstractIntegrationTest {
         // — what matters is the underflow guard kept the count at 0.
         assertThat(affected).isIn(0, 1);
         PartyroomData reloaded = partyroomRepository.findById(p.getId()).orElseThrow();
-        assertThat(reloaded.getCrewCount()).isZero();
+        assertThat(reloaded.getActiveCrewCount()).isZero();
     }
 
     @Test
@@ -164,7 +164,7 @@ class PartyroomRepositoryAtomicUpdateIT extends AbstractIntegrationTest {
 
         assertThat(affected).isEqualTo(1);
         PartyroomData reloaded = partyroomRepository.findById(p.getId()).orElseThrow();
-        assertThat(reloaded.getCrewCount()).isZero();
+        assertThat(reloaded.getActiveCrewCount()).isZero();
     }
 
     @Test
@@ -178,7 +178,7 @@ class PartyroomRepositoryAtomicUpdateIT extends AbstractIntegrationTest {
         int affected = partyroomRepository.resetCrewCount(p.getId());
 
         assertThat(affected).isEqualTo(1);
-        assertThat(partyroomRepository.findById(p.getId()).orElseThrow().getCrewCount()).isZero();
+        assertThat(partyroomRepository.findById(p.getId()).orElseThrow().getActiveCrewCount()).isZero();
     }
 
     // ── findNonTerminatedHostRoom (status 시맨틱 변경 회귀) ────────────────

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomRepositoryIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomRepositoryIntegrationTest.java
@@ -50,7 +50,7 @@ class PartyroomRepositoryIntegrationTest extends AbstractIntegrationTest {
         assertThat(loaded.isTerminated()).isFalse();
         assertThat(loaded.getPartyroomId()).isNotNull();
         assertThat(loaded.getStatus()).isEqualTo(PartyroomStatus.ACTIVE);
-        assertThat(loaded.getCrewCount()).isZero();
+        assertThat(loaded.getActiveCrewCount()).isZero();
         assertThat(loaded.getDisplayFlag()).isEqualTo(DisplayFlag.NORMAL);
         assertThat(loaded.getLastActivityAt()).isNull();
     }

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceRaceIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceRaceIT.java
@@ -148,7 +148,7 @@ class PartyroomAccessCommandServiceRaceIT extends AbstractIntegrationTest {
 
         // AFTER_COMMIT listener는 REQUIRES_NEW 동기 dispatch라 done.await() 후 모든 UPDATE 완료
         PartyroomData reloaded = partyroomRepository.findById(roomId).orElseThrow();
-        assertThat(reloaded.getCrewCount())
+        assertThat(reloaded.getActiveCrewCount())
                 .as("100 동시 enter → crew_count는 정확히 1 (race B + spurious ENTER 차단 검증)")
                 .isEqualTo(1);
     }

--- a/app/src/test/java/com/pfplaybackend/api/party/domain/entity/data/PartyroomDataTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/domain/entity/data/PartyroomDataTest.java
@@ -41,7 +41,7 @@ class PartyroomDataTest {
             PartyroomData p = newPartyroom();
             assertThat(p.getStatus()).isEqualTo(PartyroomStatus.ACTIVE);
             assertThat(p.getDisplayFlag()).isEqualTo(DisplayFlag.NORMAL);
-            assertThat(p.getCrewCount()).isZero();
+            assertThat(p.getActiveCrewCount()).isZero();
             assertThat(p.getLastActivityAt()).isNull();
             assertThat(p.isActive()).isTrue();
             assertThat(p.isSuspended()).isFalse();


### PR DESCRIPTION
## 요약

stale crew cleanup incident (2026-05-21) 진단 중 \`crew_count\` 컬럼명 모호함이 도드라짐. 누적 / 활성 / peak 등 의미 후보가 다중. **entity field naming 만** rename + Javadoc.

DB 컬럼명·API JSON key 는 그대로 (외부 호환).

## 변경 범위

### Entity / repository (production)
- \`PartyroomData.crewCount\` → \`activeCrewCount\` (field·getter·builder·constructor)
- Javadoc: "활성(is_active=true) crew row 수, V16 grace 정책상 PENDING_EXIT 포함, 누적 아님, atomic UPDATE 만 갱신"
- JPQL \`p.crewCount\` → \`p.activeCrewCount\` (\`PartyroomRepository\` increment/decrement/reset)
- QueryDSL \`p.crewCount\` → \`p.activeCrewCount\` (\`AdminPartyroomQueryRepositoryImpl\`)
- entity getter 호출처 정정 (\`AdminPartyroomQueryService\`)

### Tests (compile-driven sweep)
- \`PartyroomCounterListenerIT\` / \`PartyroomCounterConcurrencyIT\` / \`PartyroomRepositoryAtomicUpdateIT\` / \`PartyroomRepositoryIntegrationTest\` / \`PartyroomAccessCommandServiceRaceIT\` / \`PartyroomDataTest\`: \`.getCrewCount()\` → \`.getActiveCrewCount()\`
- \`AdminPartyroomQueryServiceTest\`: reflection \`setField(partyroom, "crewCount", ...)\` → \`"activeCrewCount"\`

## 유지 사항 (외부 호환)

- **DB 컬럼명 \`crew_count\` 유지** — V6 schema, prod 라이브. \`@Column(name="crew_count")\` 매핑 유지. schema rename 시 expand-and-contract 마이그 필요라 별 PR.
- **DTO/Response field 명 \`crewCount\` 유지** — JSON key, API 외부 계약 보존. frontend (pfplay-web/admin) 무영향.

## 테스트

- \`:app:test\` GREEN (회귀 0)
- \`:app:integrationTest\` GREEN

## 배경

[[reference_stale_crew_cleanup_pattern]] — stale active crew 데이터 cleanup 작업 중 컬럼 의미 모호함이 디버깅 지연 요인이었음. self-documenting field name 으로 의미 잠금.

🤖 Generated with [Claude Code](https://claude.com/claude-code)