### PR TITLE
fix(user-activity): DJ_PNT 점수 race-safe atomic UPDATE (E/#6 second face)

### DIFF
--- a/user/src/main/java/com/pfplaybackend/api/user/adapter/out/persistence/ActivityRepository.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/adapter/out/persistence/ActivityRepository.java
@@ -4,6 +4,9 @@ import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.user.domain.entity.data.ActivityData;
 import com.pfplaybackend.api.user.domain.enums.ActivityType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,4 +34,32 @@ public interface ActivityRepository extends JpaRepository<ActivityData, Long> {
      * up explicitly by the caller within the same transaction.
      */
     void deleteAllByUserId(UserId userId);
+
+    /**
+     * Atomically apply a {@code delta} to {@code score} for the given (user, activity_type)
+     * row. Native UPDATE serialised by the DB row lock — defends against the
+     * read-modify-write race that affected DJ_PNT in production (the same race
+     * model as E/#6 / PR #232's {@code PlaybackAggregationRepository.applyAggregationDelta}).
+     *
+     * <p>{@code GREATEST(0, score + :delta)} floor guard (defense-in-depth):
+     * the {@link com.pfplaybackend.api.user.domain.value.Score} VO already clamps to ≥0
+     * on construction, but that runs after a stale read — under heavy contention an
+     * interleaving could still produce a transient negative intermediate. The DB-side
+     * {@code GREATEST} ensures the column never observes a negative value across any
+     * interleaving.
+     *
+     *  - returns 1: row found and updated
+     *  - returns 0: no row for (user, activityType) — caller decides (warn / create / throw)
+     *
+     * <p>{@code @Modifying(clearAutomatically = true)} invalidates the 1st-level cache
+     * so subsequent reads in the same transaction see the persisted value.
+     */
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE user_activity " +
+           "SET score = GREATEST(0, CAST(score AS SIGNED) + :delta) " +
+           "WHERE user_id = :#{#userId.uid} AND activity_type = :#{#activityType.name()}",
+           nativeQuery = true)
+    int applyScoreDelta(@Param("userId") UserId userId,
+                        @Param("activityType") ActivityType activityType,
+                        @Param("delta") int delta);
 }

--- a/user/src/main/java/com/pfplaybackend/api/user/application/service/UserActivityCommandService.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/service/UserActivityCommandService.java
@@ -5,14 +5,15 @@ import com.pfplaybackend.api.user.adapter.out.persistence.ActivityRepository;
 import com.pfplaybackend.api.user.domain.entity.data.ActivityData;
 import com.pfplaybackend.api.user.domain.enums.ActivityType;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserActivityCommandService {
@@ -35,14 +36,31 @@ public class UserActivityCommandService {
     }
 
     /**
-     * Increment the user's DJ-point score by {@code point}. JPA dirty-flush
-     * persists the mutation at transaction end.
+     * Increment the user's DJ-point score by {@code point}. Native atomic UPDATE
+     * with DB row lock — defends against the read-modify-write race that affected
+     * DJ_PNT in production (same race model as E/#6 / PR #232).
+     *
+     * <p>The previous implementation read the entity, called {@link ActivityData#addScore},
+     * and relied on JPA dirty-flush. Two concurrent reactions on the same DJ track
+     * could each read a stale {@code score}, compute {@code +delta}, and one's write
+     * silently overwrites the other — drifting the score downwards over time.
+     *
+     * <p>The atomic native UPDATE in {@link ActivityRepository#applyScoreDelta} performs
+     * {@code SET score = GREATEST(0, score + :delta)} in a single statement, serialised
+     * by the row lock. The {@code GREATEST} floor guard is defense-in-depth on top of
+     * the {@link com.pfplaybackend.api.user.domain.value.Score} VO's own clamp.
+     *
+     * <p>Missing row (DJ_PNT not seeded yet for the user) is logged as WARN and the
+     * delta dropped — the previous code threw {@link java.util.NoSuchElementException}
+     * but the caller in {@code PlaybackReactionPostProcessCommandService} cannot
+     * meaningfully recover; logging is the appropriate boundary behaviour.
      */
     @Transactional
     public void updateDjPointScore(UserId userId, int point) {
-        ActivityData activity = activityRepository.findByUserIdAndActivityType(userId, ActivityType.DJ_PNT)
-                .orElseThrow(() -> new NoSuchElementException(
-                        "DJ_PNT ActivityData not found for userId=" + userId.getUid()));
-        activity.addScore(point);
+        int updated = activityRepository.applyScoreDelta(userId, ActivityType.DJ_PNT, point);
+        if (updated == 0) {
+            log.warn("[updateDjPointScore] no DJ_PNT row for userId={} — delta={} dropped (seed missing?)",
+                    userId.getUid(), point);
+        }
     }
 }

--- a/user/src/test/java/com/pfplaybackend/api/user/application/service/UserActivityCommandServiceTest.java
+++ b/user/src/test/java/com/pfplaybackend/api/user/application/service/UserActivityCommandServiceTest.java
@@ -13,11 +13,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -50,31 +48,43 @@ class UserActivityCommandServiceTest {
     }
 
     @Test
-    @DisplayName("updateDjPointScore — DJ_PNT 활동 데이터의 점수를 증가시킨다")
-    void updateDjPointScoreIncrementsScore() {
+    @DisplayName("updateDjPointScore — atomic UPDATE 로 DJ_PNT delta 적용 (race-safe)")
+    void updateDjPointScoreAtomicDelta() {
         // given
         UserId userId = new UserId(1L);
-        ActivityData djActivity = ActivityData.create(userId, ActivityType.DJ_PNT, 10);
-        when(activityRepository.findByUserIdAndActivityType(userId, ActivityType.DJ_PNT))
-                .thenReturn(Optional.of(djActivity));
+        when(activityRepository.applyScoreDelta(userId, ActivityType.DJ_PNT, 5)).thenReturn(1);
 
-        // when
-        userActivityCommandService.updateDjPointScore(userId, 5);
+        // when & then — applyScoreDelta 단일 호출로 끝 (read-modify-write 패턴 제거)
+        assertThatNoException().isThrownBy(() ->
+                userActivityCommandService.updateDjPointScore(userId, 5));
 
-        // then — JPA dirty-flush handles persistence; verify in-memory mutation
-        assertThat(djActivity.getScore().getValue()).isEqualTo(15);
+        verify(activityRepository).applyScoreDelta(userId, ActivityType.DJ_PNT, 5);
     }
 
     @Test
-    @DisplayName("updateDjPointScore — DJ_PNT 데이터가 없으면 NoSuchElementException 발생")
-    void updateDjPointScoreThrowsWhenMissing() {
+    @DisplayName("updateDjPointScore — DJ_PNT 행 없으면 silent no-op (이전 NoSuchElementException → WARN 로그 + drop)")
+    void updateDjPointScoreSilentNoopWhenMissing() {
         // given
         UserId userId = new UserId(1L);
-        when(activityRepository.findByUserIdAndActivityType(userId, ActivityType.DJ_PNT))
-                .thenReturn(Optional.empty());
+        when(activityRepository.applyScoreDelta(userId, ActivityType.DJ_PNT, 5)).thenReturn(0);
 
-        // when & then
-        assertThatThrownBy(() -> userActivityCommandService.updateDjPointScore(userId, 5))
-                .isInstanceOf(NoSuchElementException.class);
+        // when & then — exception 없음, 호출자 (PlaybackReactionPostProcessCommandService) 의
+        // 흐름이 시드 누락 케이스에 의해 깨지지 않게 boundary 동작.
+        assertThatNoException().isThrownBy(() ->
+                userActivityCommandService.updateDjPointScore(userId, 5));
+    }
+
+    @Test
+    @DisplayName("updateDjPointScore — 음수 delta 도 atomic UPDATE 로 전달 (DB 측 GREATEST 가 floor 가드)")
+    void updateDjPointScoreNegativeDeltaPropagates() {
+        // given — 청취자가 reaction 토글로 -delta 적용하는 케이스
+        UserId userId = new UserId(1L);
+        when(activityRepository.applyScoreDelta(userId, ActivityType.DJ_PNT, -3)).thenReturn(1);
+
+        // when
+        userActivityCommandService.updateDjPointScore(userId, -3);
+
+        // then — 음수 floor 는 DB-side GREATEST(0, ...) 책임. 서비스는 delta 만 전달.
+        verify(activityRepository).applyScoreDelta(userId, ActivityType.DJ_PNT, -3);
     }
 }


### PR DESCRIPTION
## 요약

E/#6 race 의 **두 번째 face** 차단. PR #232 가 \`playback_aggregation\` 에 PESSIMISTIC_WRITE 락 + native UPDATE 로 race 차단했지만 같은 호출 사이트 (\`PlaybackReactionPostProcessCommandService.postProcess\`) 의 \`user_activity.score\` (DJ_PNT) 측 read-modify-write 갭은 잔존. 운영 점수 drift 누적 → 2026-05-21 backfill (cleanup SQL) 로 회복했으나 **코드측 원인은 그대로**. 본 PR 이 PR #232 패턴 미러로 갭을 닫음.

## 변경

### \`ActivityRepository.applyScoreDelta\` (신규 atomic UPDATE)
\`\`\`sql
UPDATE user_activity
SET score = GREATEST(0, CAST(score AS SIGNED) + :delta)
WHERE user_id = :userId AND activity_type = :activityType
\`\`\`

- \`@Modifying(clearAutomatically = true)\`, native SQL
- \`GREATEST(0, ...)\` floor — E/#6 의 \`PlaybackAggregationRepository.applyAggregationDelta\` 정합. defense-in-depth (\`Score\` VO 의 \`Math.max(0, value)\` clamp 위에)
- \`CAST(score AS SIGNED)\` — score 컬럼이 \`INTEGER UNSIGNED\` 라 음수 delta 시 underflow wrap 회피
- SpEL \`:#{#userId.uid}\` / \`:#{#activityType.name()}\` — native query 가 @Embeddable VO·enum 바인딩 못 하므로 unwrap (\`PlaybackAggregationRepository:32\` 동일 패턴)

### \`UserActivityCommandService.updateDjPointScore\` (단순화)
- find + addScore 두 단계 read-modify-write → atomic 1-step
- 시드 누락 (DJ_PNT row 없음) 케이스: \`NoSuchElementException\` 던지던 거 → WARN 로그 + drop (caller \`PlaybackReactionPostProcessCommandService\` 는 의미있는 recovery 불가, boundary 정합)

### 테스트 (4 case)
- \`createUserActivities\` 회귀
- atomic delta 적용 happy
- missing row → silent no-op (이전 exception → WARN)
- 음수 delta propagation (DB-side GREATEST 가드 검증)

## 영향 / 무변

- **DB 스키마 변경 0** (\`score INTEGER UNSIGNED\` 그대로)
- \`user_activity\` 외부 계약·기존 호출자 무수정
- \`@Embeddable PlaybackId\` 우회 패턴 (SpEL) 은 \`PlaybackAggregationRepository\` 와 동일

## 회귀

- \`:user:test\` GREEN
- \`:app:test\` GREEN
- \`:app:integrationTest\` GREEN (\`PlaybackReactionCounterRaceIntegrationTest\` 포함 — reaction 호출 path 전체 stress 시 user_activity 측 atomic UPDATE 도 부수 검증)

## 후속 효과

- backfill 빈도 ↓ (race 자체 차단), 운영 비용 ↓
- 음수 wraparound / 0 floor truncate 같은 unsigned underflow 사고도 부수 차단

## 관련

- E/#6 (#231) PR #232 \`e3cd67e5\` — first face (\`playback_aggregation\`) 차단 PR. 본 PR 은 second face 차단
- 2026-05-21 backfill — \`UPDATE user_activity ... SET score = derived WHERE score < derived\` (단방향 하한선 보정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)