### PR TITLE
feat(user): 게스트 기본 아바타를 유령 바디(ava_body_basic_003)로 전환

### DIFF
--- a/app/src/main/resources/db/migration/V20__change_guest_default_avatar_body_to_ghost.sql
+++ b/app/src/main/resources/db/migration/V20__change_guest_default_avatar_body_to_ghost.sql
@@ -1,0 +1,49 @@
+-- =====================================================
+-- V20: Guest default avatar body → 유령 바디 (ava_body_basic_003)
+--
+-- Why:
+--   게스트의 기본 아바타 바디를 ava_body_basic_001 → ava_body_basic_003
+--   (combinable=0, "유령 바디") 으로 일괄 전환. 향후 신규 게스트는
+--   is_default_setting 플래그가 가리키는 row 를 자동으로 받으므로,
+--   본 마이그레이션에서 플래그를 이동시키면 코드 변경 없이도 신규 게스트는
+--   유령 바디를 받는다. 동시 적용되는 코드 변경(combinable-aware
+--   createProfileDataForGuest) 은 SINGLE_BODY 모드로 face 합성을
+--   끊는다.
+--
+-- 기존 게스트 row 정합성:
+--   ava_body_basic_003 은 is_combinable=0 (face 합성 불가) 이므로,
+--   이미 001 디폴트로 박혀있던 게스트는 avatar_composition_type 도
+--   BODY_WITH_FACE → SINGLE_BODY 로 함께 전환되어야 한다. 그렇지
+--   않으면 "유령 바디에 face overlay" 라는 도메인 모순이 발생한다.
+--   SINGLE_BODY 규약(UserAvatarCommandService.setUserAvatar 참고):
+--     avatar_face_uri = '' (empty)
+--     avatar_icon_uri = body 페어 아이콘
+--     combine_position_x/y = body 의 시드값 (003 은 0,0)
+--     face_source_type 은 untouched (INTERNAL_IMAGE 유지)
+--
+-- 식별 조건:
+--   guest.profile_id (FK) 로 user_profile.id 와 INNER JOIN 후,
+--   현재 avatar_body_uri 가 001 시드 URL 인 게스트만 대상.
+--   사용자가 명시적으로 다른 바디로 바꿔놓은 게스트는 건드리지 않는다.
+-- =====================================================
+
+-- 1. avatar_body_resource: is_default_setting 플래그를 001 → 003 으로 이동
+UPDATE avatar_body_resource
+   SET is_default_setting = 0
+ WHERE name = 'ava_body_basic_001';
+
+UPDATE avatar_body_resource
+   SET is_default_setting = 1
+ WHERE name = 'ava_body_basic_003';
+
+-- 2. 기존 게스트 user_profile 일괄 업데이트
+--    avatar_body_uri 가 001 시드 URL 이고 guest 테이블에 연결된 row 만 대상.
+UPDATE user_profile up
+  JOIN guest g ON g.profile_id = up.id
+   SET up.avatar_body_uri          = 'https://firebasestorage.googleapis.com/v0/b/pfplay-firebase.appspot.com/o/ava_basic%2Fava_basic_003.png?alt=media',
+       up.avatar_face_uri          = '',
+       up.avatar_icon_uri          = 'https://firebasestorage.googleapis.com/v0/b/pfplay-firebase.appspot.com/o/ava_icon%2Fava_icon_body_basic_003.png?alt=media',
+       up.avatar_composition_type  = 'SINGLE_BODY',
+       up.combine_positionx        = 0,
+       up.combine_positiony        = 0
+ WHERE up.avatar_body_uri = 'https://firebasestorage.googleapis.com/v0/b/pfplay-firebase.appspot.com/o/ava_basic%2Fava_basic_001.png?alt=media';

--- a/user/src/main/java/com/pfplaybackend/api/user/application/service/UserAvatarQueryService.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/service/UserAvatarQueryService.java
@@ -51,6 +51,11 @@ public class UserAvatarQueryService {
         return new AvatarIconUri(avatarIconDto.resourceUri());
     }
 
+    public AvatarIconUri getDefaultAvatarBodyPairIconUri() {
+        AvatarIconDto avatarIconDto = avatarResourceQueryService.findPairAvatarIconByBodyUri(this.getDefaultAvatarBodyUri());
+        return new AvatarIconUri(avatarIconDto.resourceUri());
+    }
+
     public List<AvatarFaceDto> findMyAvatarFaces() {
         return avatarResourceQueryService.findAllAvatarFaces();
     }

--- a/user/src/main/java/com/pfplaybackend/api/user/application/service/UserProfileCommandService.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/service/UserProfileCommandService.java
@@ -1,6 +1,7 @@
 package com.pfplaybackend.api.user.application.service;
 
 import com.pfplaybackend.api.avatar.application.dto.AvatarBodyDto;
+import com.pfplaybackend.api.avatar.domain.value.AvatarFaceUri;
 import com.pfplaybackend.api.common.domain.enums.AvatarCompositionType;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.user.adapter.out.persistence.UserProfileRepository;
@@ -21,18 +22,7 @@ public class UserProfileCommandService {
     private final UserProfileRepository userProfileRepository;
 
     public ProfileData createProfileDataForGuest(UserId userId) {
-        AvatarBodyDto avatarBodyResource = userAvatarQueryService.getDefaultAvatarBody();
-        return ProfileData.builder()
-                .userId(userId)
-                .nickname(new Nickname(generateUniqueGuestNickname()))
-                .avatarCompositionType(AvatarCompositionType.BODY_WITH_FACE)
-                .faceSourceType(FaceSourceType.INTERNAL_IMAGE)
-                .avatarBodyUri(userAvatarQueryService.getDefaultAvatarBodyUri())
-                .avatarFaceUri(userAvatarQueryService.getDefaultAvatarFaceUri())
-                .avatarIconUri(userAvatarQueryService.getDefaultAvatarIconUri())
-                .combinePositionX(avatarBodyResource.getCombinePositionX())
-                .combinePositionY(avatarBodyResource.getCombinePositionY())
-                .build();
+        return buildDefaultAvatarProfile(userId, new Nickname(generateUniqueGuestNickname()));
     }
 
     public ProfileData createProfileDataForMember(UserId userId) {
@@ -42,18 +32,35 @@ public class UserProfileCommandService {
     }
 
     public ProfileData createProfileDataForSuperAdmin(UserId userId) {
+        return buildDefaultAvatarProfile(userId, new Nickname("Super Admin"));
+    }
+
+    // 디폴트 아바타 바디의 is_combinable 에 따라 BODY_WITH_FACE vs SINGLE_BODY 를 분기.
+    // SINGLE_BODY 일 땐 face URI 는 비우고, icon 은 body 페어 아이콘으로 매단다.
+    private ProfileData buildDefaultAvatarProfile(UserId userId, Nickname nickname) {
         AvatarBodyDto avatarBodyResource = userAvatarQueryService.getDefaultAvatarBody();
-        return ProfileData.builder()
+        boolean combinable = avatarBodyResource.isCombinable();
+        AvatarCompositionType compositionType = combinable
+                ? AvatarCompositionType.BODY_WITH_FACE
+                : AvatarCompositionType.SINGLE_BODY;
+
+        ProfileData.ProfileDataBuilder builder = ProfileData.builder()
                 .userId(userId)
-                .nickname(new Nickname("Super Admin"))
-                .avatarCompositionType(AvatarCompositionType.BODY_WITH_FACE)
+                .nickname(nickname)
+                .avatarCompositionType(compositionType)
                 .faceSourceType(FaceSourceType.INTERNAL_IMAGE)
                 .avatarBodyUri(userAvatarQueryService.getDefaultAvatarBodyUri())
-                .avatarFaceUri(userAvatarQueryService.getDefaultAvatarFaceUri())
-                .avatarIconUri(userAvatarQueryService.getDefaultAvatarIconUri())
                 .combinePositionX(avatarBodyResource.getCombinePositionX())
-                .combinePositionY(avatarBodyResource.getCombinePositionY())
-                .build();
+                .combinePositionY(avatarBodyResource.getCombinePositionY());
+
+        if (combinable) {
+            builder.avatarFaceUri(userAvatarQueryService.getDefaultAvatarFaceUri())
+                    .avatarIconUri(userAvatarQueryService.getDefaultAvatarIconUri());
+        } else {
+            builder.avatarFaceUri(new AvatarFaceUri(""))
+                    .avatarIconUri(userAvatarQueryService.getDefaultAvatarBodyPairIconUri());
+        }
+        return builder.build();
     }
 
     private String generateUniqueGuestNickname() {

--- a/user/src/test/java/com/pfplaybackend/api/user/application/service/UserAvatarQueryServiceTest.java
+++ b/user/src/test/java/com/pfplaybackend/api/user/application/service/UserAvatarQueryServiceTest.java
@@ -11,7 +11,9 @@ import com.pfplaybackend.api.avatar.domain.entity.data.AvatarBodyResourceData;
 import com.pfplaybackend.api.user.domain.enums.ActivityType;
 import com.pfplaybackend.api.avatar.domain.enums.ObtainmentType;
 import com.pfplaybackend.api.user.domain.service.UserAvatarDomainService;
+import com.pfplaybackend.api.avatar.application.dto.AvatarIconDto;
 import com.pfplaybackend.api.avatar.domain.value.AvatarBodyUri;
+import com.pfplaybackend.api.avatar.domain.value.AvatarIconUri;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,6 +26,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -59,6 +62,30 @@ class UserAvatarQueryServiceTest {
 
         // then
         assertThat(result.getValue()).isEqualTo("default-body-uri");
+    }
+
+    @Test
+    @DisplayName("getDefaultAvatarBodyPairIconUri — 기본 바디의 페어 아이콘 URI를 반환한다")
+    void getDefaultAvatarBodyPairIconUriReturnsBodyPairIcon() {
+        // given: default body is the ghost body (non-combinable) — its pair icon is body-pair-icon-uri
+        AvatarBodyDto defaultBody = AvatarBodyDto.builder()
+                .id(3L).name("ava_body_basic_003").resourceUri("ghost-body-uri")
+                .obtainableType(ObtainmentType.BASIC).obtainableScore(0)
+                .combinable(false).defaultSetting(true)
+                .combinePositionX(0).combinePositionY(0)
+                .build();
+        when(avatarResourceQueryService.getDefaultSettingResourceAvatarBody()).thenReturn(defaultBody);
+
+        AvatarIconDto bodyPairIcon = new AvatarIconDto(0L, "ava_icon_body_basic_003", "body-pair-icon-uri", true);
+        when(avatarResourceQueryService.findPairAvatarIconByBodyUri(
+                argThat(uri -> "ghost-body-uri".equals(uri.getValue()))))
+                .thenReturn(bodyPairIcon);
+
+        // when
+        AvatarIconUri result = userAvatarQueryService.getDefaultAvatarBodyPairIconUri();
+
+        // then
+        assertThat(result.getValue()).isEqualTo("body-pair-icon-uri");
     }
 
     @Test

--- a/user/src/test/java/com/pfplaybackend/api/user/application/service/UserProfileCommandServiceTest.java
+++ b/user/src/test/java/com/pfplaybackend/api/user/application/service/UserProfileCommandServiceTest.java
@@ -1,5 +1,6 @@
 package com.pfplaybackend.api.user.application.service;
 
+import com.pfplaybackend.api.common.domain.enums.AvatarCompositionType;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.avatar.application.dto.AvatarBodyDto;
 import com.pfplaybackend.api.user.adapter.out.persistence.UserProfileRepository;
@@ -82,6 +83,35 @@ class UserProfileCommandServiceTest {
         // then
         assertThat(profile.getNicknameValue()).startsWith("Guest_");
         verify(userProfileRepository, times(2)).existsByNickname(any(Nickname.class));
+    }
+
+    @Test
+    @DisplayName("createProfileDataForGuest — 기본 바디가 combinable=false 면 SINGLE_BODY 모드로 face 미할당, icon은 body 페어")
+    void createProfileDataForGuestNonCombinableBodyYieldsSingleBody() {
+        // given: default body is the ghost body (combinable=false)
+        UserId userId = new UserId(10L);
+        AvatarBodyDto ghostBody = AvatarBodyDto.builder()
+                .id(3L).name("ava_body_basic_003").resourceUri("ghost-body-uri")
+                .obtainableType(ObtainmentType.BASIC).obtainableScore(0)
+                .combinable(false).defaultSetting(true)
+                .combinePositionX(0).combinePositionY(0)
+                .build();
+        when(userAvatarQueryService.getDefaultAvatarBody()).thenReturn(ghostBody);
+        when(userAvatarQueryService.getDefaultAvatarBodyUri()).thenReturn(new AvatarBodyUri("ghost-body-uri"));
+        when(userAvatarQueryService.getDefaultAvatarBodyPairIconUri()).thenReturn(new AvatarIconUri("ghost-body-pair-icon-uri"));
+        when(userProfileRepository.existsByNickname(any(Nickname.class))).thenReturn(false);
+
+        // when
+        ProfileData profile = userProfileCommandService.createProfileDataForGuest(userId);
+
+        // then
+        assertThat(profile.getUserId()).isEqualTo(userId);
+        assertThat(profile.getAvatarSetting().getAvatarCompositionType()).isEqualTo(AvatarCompositionType.SINGLE_BODY);
+        assertThat(profile.getAvatarSetting().getAvatarBodyUri().getValue()).isEqualTo("ghost-body-uri");
+        assertThat(profile.getAvatarSetting().getAvatarFaceUri().getValue()).isEmpty();
+        assertThat(profile.getAvatarSetting().getAvatarIconUri().getValue()).isEqualTo("ghost-body-pair-icon-uri");
+        assertThat(profile.getAvatarSetting().getCombinePositionX()).isZero();
+        assertThat(profile.getAvatarSetting().getCombinePositionY()).isZero();
     }
 
     @Test


### PR DESCRIPTION
## 요약

게스트 사용자가 자동으로 받는 기본 아바타 바디를 `ava_body_basic_001`(파란 캐릭터)에서 `ava_body_basic_003`(유령 바디)로 전환.

## 변경 내역

### V20 마이그레이션 (Flyway 자동 적용)
- `avatar_body_resource.is_default_setting` 플래그 이동: `001` → `003`
- 기존 게스트 `user_profile` 일괄 UPDATE: `001` URL 을 가진 행을 `SINGLE_BODY + ava_body_basic_003 + body 페어 아이콘 + combine_position(0,0) + face_uri=''` 으로 전환. `guest` 테이블 JOIN 으로 정식 회원 row 는 영향 없음

### 코드 변경
- `UserAvatarQueryService.getDefaultAvatarBodyPairIconUri()` 신규 — body 의 페어 아이콘을 조회하는 단일 진입점
- `UserProfileCommandService`: `buildDefaultAvatarProfile()` helper 일원화
  - 기본 바디의 `is_combinable` 에 따라 `BODY_WITH_FACE` vs `SINGLE_BODY` 분기
  - `combinable=false` → face URI 를 빈 값으로, icon 은 body 페어 아이콘으로 매단다
  - `createProfileDataForGuest` / `createProfileDataForSuperAdmin` 모두 같은 helper 사용 → fresh env 에서 슈퍼 어드민 시드도 정합성 유지

### 왜 combinable-aware 인가
- `ava_body_basic_003` 은 `is_combinable=0` (face 합성 불가, 유령 바디)
- 단순히 URL 만 바꾸면 `BODY_WITH_FACE + 유령 바디 + face URL` 인 도메인 모순 상태가 만들어짐
- helper 가 combinable 여부를 보고 분기하므로, 향후 기본 바디가 바뀌어도 정합성 자동 유지

## 테스트
- `UserAvatarQueryServiceTest`: 신규 `getDefaultAvatarBodyPairIconUri` 검증
- `UserProfileCommandServiceTest`: `combinable=false` 일 때 `SINGLE_BODY + empty face + body 페어 아이콘 + position(0,0)` 보장
- TDD RED → GREEN 사이클로 진행
- `:user:test`, `:app:test` 모두 GREEN

## 검증 (로컬 docker-compose)
- `docker-compose.local.yml` 부팅 → Flyway V19 + V20 자동 적용 확인 (`flyway_schema_history.installed_rank=20, success=1`)
- `avatar_body_resource`: `001.is_default_setting=0`, `003.is_default_setting=1`
- 기존 게스트 (id=2): `BODY_WITH_FACE + 001` → **`SINGLE_BODY + 003 + body 페어 아이콘 + (0,0)`** 정확히 전환
- 신규 게스트 (`POST /api/v1/users/guests/sign`): 새 코드 경로로 동일 형태 생성 확인

## 영향 범위
- 기존 정식 회원 / 슈퍼 어드민 row: 영향 없음 (`guest` JOIN 필터링)
- fresh env (CI / 새 dev / local reset) 의 슈퍼 어드민 시드: 유령 바디로 시작 — 어드민 콘솔 invisible 영역이라 외부 영향 0
- 향후 정식 회원 가입 흐름은 사용자가 직접 아바타를 선택하므로 디폴트 변경 영향 없음

## Test plan
- [x] `:user:test` GREEN
- [x] `:app:test` GREEN (Flyway V20 실제 적용)
- [x] 로컬 docker-compose 부팅 + 기존 게스트 row 전환 + 신규 가입 흐름 검증
- [ ] dev/stg 배포 후 실제 게스트 row 일괄 전환 확인 (사후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)