### PR TITLE
feat(party): AM(준회원)도 파티룸 생성 가능하도록 권한 허들 낮춤

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/domain/policy/PartyroomCreationPolicy.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/policy/PartyroomCreationPolicy.java
@@ -7,7 +7,9 @@ import com.pfplaybackend.api.party.domain.exception.PartyroomException;
 public class PartyroomCreationPolicy {
 
     public void enforce(AuthorityTier authorityTier) {
-        if (!authorityTier.equals(AuthorityTier.FM)) {
+        // Member 등급(FM, AM) 만 허용. GT(게스트)는 차단.
+        // 파티룸 신고(PartyroomReportCommandService.guardMemberOnly) 와 동일한 허용선.
+        if (authorityTier != AuthorityTier.FM && authorityTier != AuthorityTier.AM) {
             throw ExceptionCreator.create(PartyroomException.RESTRICTED_AUTHORITY);
         }
     }

--- a/app/src/test/java/com/pfplaybackend/api/party/domain/policy/PartyroomCreationPolicyTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/domain/policy/PartyroomCreationPolicyTest.java
@@ -25,10 +25,9 @@ class PartyroomCreationPolicyTest {
     }
 
     @Test
-    @DisplayName("AM 회원은 파티룸 생성 불가")
-    void amCannotCreate() {
-        assertThatThrownBy(() -> policy.enforce(AuthorityTier.AM))
-                .isInstanceOf(ForbiddenException.class);
+    @DisplayName("AM 회원도 파티룸 생성 가능")
+    void amCanCreate() {
+        assertThatNoException().isThrownBy(() -> policy.enforce(AuthorityTier.AM));
     }
 
     @Test


### PR DESCRIPTION
## 요약

파티룸 생성 권한을 **FM(정회원) only** → **FM + AM(준회원)** 으로 확장. GT(게스트) 는 그대로 차단.

## 변경 내역

### `PartyroomCreationPolicy`
- 1줄 조건 변경. AM 도 통과시킴
- GT 는 그대로 throw

```java
if (authorityTier != AuthorityTier.FM && authorityTier != AuthorityTier.AM) {
    throw ExceptionCreator.create(PartyroomException.RESTRICTED_AUTHORITY);
}
```

### 테스트
- `PartyroomCreationPolicyTest`: 기존 "AM 회원은 파티룸 생성 불가" 잠금을 "AM 회원도 파티룸 생성 가능" 으로 반전
- TDD RED → GREEN 사이클로 진행
- FM 허용 / GT 차단 케이스는 그대로 유지

## 근거

### 도메인
- AM 은 정식 회원 가입 직후 자동 부여되는 등급 (지갑 주소 설정 시 FM 으로 자동 승격)
- AM/FM 모두 가입 시 다음이 자동 초기화 → 파티룸 생성에 필요한 사전 데이터 모두 존재
  - `UserProfileCommandService.createProfileDataForMember()` — 프로필 row
  - `PlaylistSetupPort.createDefaultPlaylist()` — 기본 플레이리스트
  - `UserActivityCommandService.createUserActivities()` — DJ_PNT / REF_LINK / ROOM_ACT 활동점수 0행

### 일관성
- `PartyroomReportCommandService.guardMemberOnly()` 이 이미 **AM + FM 허용 / GT 차단**
- "방을 만들 권한 = 신고할 권한" 으로 도메인 정책 정렬

### AM 의 아바타 우려에 대한 정리
- 메모리 [project_member_signup_avatar_default_irrelevant] 에 따르면 정식 회원 가입 흐름은 사용자가 직접 아바타를 셋팅 → AM 단계에서 아바타가 비어있을 가능성 매우 낮음
- 만약 잠재 미설정 가능성이 우려되면 후속 가드 (PartyroomCommandController 진입 시 아바타 null-check) 로 보강 가능 — 이번 PR 범위 밖

## Test plan
- [x] `PartyroomCreationPolicyTest` 3 케이스 GREEN (FM 허용, AM 허용, GT 차단)
- [x] `:app:test` 전체 회귀 GREEN
- [ ] dev/stg 배포 후 실제 AM 사용자로 POST /api/v1/partyrooms 호출 검증 (사후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)