### PR TITLE
fix(party): 재생 만료 리스너의 제네릭 예외 처리 정리

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/PlaybackDurationWaitTopicListener.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/PlaybackDurationWaitTopicListener.java
@@ -4,6 +4,7 @@ import com.pfplaybackend.api.party.application.dto.playback.PlaybackDurationWait
 import com.pfplaybackend.api.party.application.port.out.ExpirationTaskPort;
 import com.pfplaybackend.api.party.application.service.PlaybackCommandService;
 import com.pfplaybackend.api.party.application.service.lock.DistributedLockExecutor;
+import com.pfplaybackend.api.common.exception.http.NotFoundException;
 import lombok.AllArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,15 +27,25 @@ public class PlaybackDurationWaitTopicListener implements MessageListener {
             String taskId = expiredKey.split(":")[2];
             try {
                 PlaybackDurationWaitDto deserialized = expirationTaskPort.getTaskArgs(taskId, PlaybackDurationWaitDto.class);
+                if (deserialized == null) {
+                    // 예상된 stale key: 만료 알림은 도착했으나 task args가 이미 정리/소실됨
+                    // (서버 재시작·의도적 DB 초기화 직후 등). 정상 정리 상황이므로 조용히 skip.
+                    logger.debug("Skipping playback expiration for taskId={}: task args already gone (stale key)", taskId);
+                    return;
+                }
                 String suffixId = deserialized.userId().getUid().toString();
                 distributedLockExecutor.performTaskWithLock(suffixId, () -> {
                     expirationTaskPort.clearTaskArgs(taskId);
                     playbackCommandService.complete(deserialized.partyroomId(), deserialized.userId());
                     return null;
                 });
+            } catch (NotFoundException e) {
+                // 예상된 stale key: 만료 처리 시점에 대상(파티룸 등)이 이미 없음
+                // (재시작·DB 초기화 직후 1회성). 정상 정리 상황이므로 DEBUG로만 남긴다.
+                logger.debug("Skipping stale playback expiration for taskId={}: {}", taskId, e.getMessage());
             } catch (Exception e) {
-                logger.warn("Failed to process playback expiration for taskId={} — possibly stale key after server restart: {}",
-                        taskId, e.getMessage());
+                // 예상치 못한 실패는 stack trace까지 남겨 루틴 정리에 묻히지 않게 한다.
+                logger.error("Failed to process playback expiration for taskId={}", taskId, e);
             }
         }
     }


### PR DESCRIPTION
## 배경
stg 로그 점검 중, 서버 재시작 + **의도적 DB 초기화** 직후 `PlaybackDurationWaitTopicListener`에서 `Failed to process playback expiration ... 파티룸을 찾을 수 없습니다` WARN이 다수 발생하는 것을 확인했습니다. 이 자체는 예견된 1회성 정리 상황(stale key)이지만, 예외 처리가 제네릭이라 다듬을 필요가 있어 수정합니다.

## 문제
기존 코드는 `catch (Exception e)` 하나로 모든 예외를 동일한 WARN으로 처리:
- **예상된 stale key**(만료 시점에 대상 파티룸/args가 이미 없음)와 **실제 장애**(락 실패·역직렬화·DB 오류 등)가 같은 레벨로 섞임
- `e.getMessage()`만 기록 → 진짜 실패의 **stack trace 유실**

## 변경
- `getTaskArgs`가 `null` 반환(args 키 이미 소실) → 예상된 stale key로 보고 `DEBUG` skip
  - `RedisExpirationTaskAdapter.getTaskArgs`는 값이 없으면 `objectMapper.convertValue(null, …)` → `null` 반환하므로 가드 추가
- 대상 부재 `NotFoundException`(예: `PartyroomException.NOT_FOUND_ROOM`) → 예상된 stale key로 보고 `DEBUG`
- 그 외 예외 → 예외 객체 전체를 `ERROR`로 기록해 실제 실패가 routine cleanup에 묻히지 않게 함

기능 동작(정상 만료 처리 경로)은 변경 없음. 로그 레벨/예외 분기만 정리.

## 검증
- `./gradlew :app:compileJava` 통과

## 범위 외 메모
같은 점검에서 `/actuator/health` 500이 보였으나, **보안상 actuator를 의도적으로 닫은 결정**임을 확인하여 손대지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)