### PR TITLE
fix(voc): 버그 리포트 제출 시 'AuthContext not available' 예외 수정 (#253)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/BugReportCommandController.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/BugReportCommandController.java
@@ -6,6 +6,7 @@ import com.pfplaybackend.api.administration.application.service.BugReportCommand
 import com.pfplaybackend.api.administration.domain.exception.BugReportException;
 import com.pfplaybackend.api.common.ApiCommonResponse;
 import com.pfplaybackend.api.common.config.swagger.ApiErrorCodes;
+import com.pfplaybackend.api.common.domain.value.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -37,10 +39,12 @@ public class BugReportCommandController {
     @PostMapping
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiCommonResponse<SubmitBugReportResponse>> submit(
+            @AuthenticationPrincipal UserId userId,
             @Valid @RequestBody SubmitBugReportRequest request,
             @RequestHeader(value = "Referer", required = false) String referer,
             @RequestHeader(value = "User-Agent", required = false) String userAgent) {
         Long id = bugReportCommandService.submit(
+                userId.getUid(),
                 request.getContent(),
                 referer,
                 userAgent,

--- a/app/src/main/java/com/pfplaybackend/api/administration/application/service/BugReportCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/application/service/BugReportCommandService.java
@@ -3,9 +3,7 @@ package com.pfplaybackend.api.administration.application.service;
 import com.pfplaybackend.api.administration.adapter.out.persistence.BugReportRepository;
 import com.pfplaybackend.api.administration.application.ratelimit.BugReportRateLimiter;
 import com.pfplaybackend.api.administration.domain.entity.data.BugReportData;
-import com.pfplaybackend.api.common.ThreadLocalContext;
 import com.pfplaybackend.api.common.adapter.in.web.RequestIdInterceptor;
-import com.pfplaybackend.api.common.aspect.context.AuthContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,6 +20,10 @@ import java.time.LocalDateTime;
  * - pageUrl/userAgent server-side truncate to 500
  * - Clock 주입 (KST TZ 정책 [[project_jvm_tz_kst_policy]])
  * - INFO 로그 (observability A4 정합)
+ *
+ * reporterUserId 는 호출자(controller)가 인증 주체에서 추출해 전달한다. administration 모듈은
+ * AuthContext set aspect 가 없으므로(party/user 모듈 한정) ThreadLocalContext 를 쓰지 않고,
+ * AdminContext helper 와 동일하게 SecurityContext → controller 경계에서 인증 주체를 넘긴다.
  */
 @Slf4j
 @Service
@@ -35,16 +37,14 @@ public class BugReportCommandService {
     private final Clock clock;
 
     @Transactional
-    public Long submit(String content, String pageUrl, String userAgent, Long partyroomId) {
-        AuthContext authContext = ThreadLocalContext.getAuthContext();
-        Long userId = authContext.getUserId().getUid();
+    public Long submit(Long reporterUserId, String content, String pageUrl, String userAgent, Long partyroomId) {
         log.info("[bugReport.submit] ENTER requestId={} reporterUserId={} partyroomId={}",
-                RequestIdInterceptor.current(), userId, partyroomId);
+                RequestIdInterceptor.current(), reporterUserId, partyroomId);
 
-        rateLimiter.acquireOrThrow(userId);
+        rateLimiter.acquireOrThrow(reporterUserId);
 
         BugReportData data = BugReportData.create(
-                userId,
+                reporterUserId,
                 content,
                 truncate(pageUrl, META_MAX_LENGTH),
                 truncate(userAgent, META_MAX_LENGTH),
@@ -53,7 +53,7 @@ public class BugReportCommandService {
         BugReportData saved = repository.save(data);
 
         log.info("[bugReport.submit] OK requestId={} reporterUserId={} bugReportId={}",
-                RequestIdInterceptor.current(), userId, saved.getBugReportId());
+                RequestIdInterceptor.current(), reporterUserId, saved.getBugReportId());
         return saved.getBugReportId();
     }
 

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/web/AbstractVocCommandWebMvcTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/web/AbstractVocCommandWebMvcTest.java
@@ -2,17 +2,27 @@ package com.pfplaybackend.api.administration.adapter.in.web;
 
 import com.pfplaybackend.api.administration.application.service.BugReportCommandService;
 import com.pfplaybackend.api.common.config.security.jwt.AdminCookieWriter;
+import com.pfplaybackend.api.common.config.security.jwt.CustomJwtAuthenticationToken;
 import com.pfplaybackend.api.common.config.security.jwt.JwtService;
 import com.pfplaybackend.api.common.config.security.jwt.SharedSessionCookieWriter;
 import com.pfplaybackend.api.common.config.security.jwt.properties.JwtProperties;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.enums.AuthorityTier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 
 @WebMvcTest(BugReportCommandController.class)
 @Import(AbstractVocCommandWebMvcTest.SharedMethodSecurityConfig.class)
@@ -29,4 +39,21 @@ abstract class AbstractVocCommandWebMvcTest {
     @MockBean protected JwtProperties jwtProperties;
     @MockBean protected SharedSessionCookieWriter sharedSessionCookieWriter;
     @MockBean protected AdminCookieWriter adminCookieWriter;
+
+    /**
+     * 인증 주체를 {@link CustomJwtAuthenticationToken} 으로 주입한다. principal 이 {@link UserId} 이므로
+     * 컨트롤러의 {@code @AuthenticationPrincipal UserId} 가 채워진다. (Spring Security test 의 jwt()
+     * post-processor 는 principal 이 Jwt 라 @AuthenticationPrincipal UserId 가 null — 실제 토큰 형태 미러)
+     */
+    protected static RequestPostProcessor authedUser(long userId) {
+        Jwt jwt = Jwt.withTokenValue("test-token").header("alg", "none")
+                .claim("sub", String.valueOf(userId)).build();
+        CustomJwtAuthenticationToken token = new CustomJwtAuthenticationToken(
+                jwt,
+                List.of(new SimpleGrantedAuthority("ROLE_MEMBER")),
+                new UserId(userId),
+                "tester@pfplay.local",
+                AuthorityTier.AM);
+        return authentication(token);
+    }
 }

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/web/BugReportCommandControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/web/BugReportCommandControllerTest.java
@@ -7,10 +7,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -20,10 +21,10 @@ class BugReportCommandControllerTest extends AbstractVocCommandWebMvcTest {
     @Test
     @DisplayName("submit — 201 Created + bugReportId 반환")
     void submitReturns201() throws Exception {
-        when(bugReportCommandService.submit(any(), any(), any(), any())).thenReturn(42L);
+        when(bugReportCommandService.submit(any(), any(), any(), any(), any())).thenReturn(42L);
 
         mockMvc.perform(post("/api/v1/voc/bug-reports")
-                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(authedUser(100L))
                         .with(csrf())
                         .header("Referer", "https://pfplay.xyz/parties/7")
                         .header("User-Agent", "Mozilla/5.0")
@@ -34,10 +35,27 @@ class BugReportCommandControllerTest extends AbstractVocCommandWebMvcTest {
     }
 
     @Test
+    @DisplayName("submit — 인증 주체 userId 가 service 로 전달된다 (AuthContext aspect 부재 회귀 가드)")
+    void submitPassesAuthenticatedUserId() throws Exception {
+        when(bugReportCommandService.submit(eq(100L), any(), any(), any(), any())).thenReturn(42L);
+
+        mockMvc.perform(post("/api/v1/voc/bug-reports")
+                        .with(authedUser(100L))
+                        .with(csrf())
+                        .header("Referer", "https://pfplay.xyz/parties/7")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"재생이 안 됩니다\",\"partyroomId\":7}"))
+                .andExpect(status().isCreated());
+
+        verify(bugReportCommandService).submit(eq(100L), eq("재생이 안 됩니다"),
+                eq("https://pfplay.xyz/parties/7"), any(), eq(7L));
+    }
+
+    @Test
     @DisplayName("submit — content 너무 짧으면 400")
     void submitShortContentReturns400() throws Exception {
         mockMvc.perform(post("/api/v1/voc/bug-reports")
-                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(authedUser(100L))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"content\":\"abcd\"}"))
@@ -48,7 +66,7 @@ class BugReportCommandControllerTest extends AbstractVocCommandWebMvcTest {
     @DisplayName("submit — content blank 400")
     void submitBlankContentReturns400() throws Exception {
         mockMvc.perform(post("/api/v1/voc/bug-reports")
-                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(authedUser(100L))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"content\":\"\"}"))
@@ -59,7 +77,7 @@ class BugReportCommandControllerTest extends AbstractVocCommandWebMvcTest {
     @DisplayName("submit — partyroomId 0/negative 400")
     void submitInvalidPartyroomIdReturns400() throws Exception {
         mockMvc.perform(post("/api/v1/voc/bug-reports")
-                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(authedUser(100L))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"content\":\"long enough content\",\"partyroomId\":0}"))
@@ -80,10 +98,10 @@ class BugReportCommandControllerTest extends AbstractVocCommandWebMvcTest {
     @DisplayName("submit — rate-limit 시 429 + BUG-001")
     void submitRateLimitReturns429() throws Exception {
         doThrow(ExceptionCreator.create(BugReportException.RATE_LIMIT_EXCEEDED))
-                .when(bugReportCommandService).submit(any(), any(), any(), any());
+                .when(bugReportCommandService).submit(any(), any(), any(), any(), any());
 
         mockMvc.perform(post("/api/v1/voc/bug-reports")
-                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(authedUser(100L))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"content\":\"valid content\"}"))

--- a/app/src/test/java/com/pfplaybackend/api/administration/application/service/BugReportCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/application/service/BugReportCommandServiceTest.java
@@ -4,12 +4,8 @@ import com.pfplaybackend.api.administration.adapter.out.persistence.BugReportRep
 import com.pfplaybackend.api.administration.application.ratelimit.BugReportRateLimiter;
 import com.pfplaybackend.api.administration.domain.entity.data.BugReportData;
 import com.pfplaybackend.api.administration.domain.exception.BugReportException;
-import com.pfplaybackend.api.common.ThreadLocalContext;
-import com.pfplaybackend.api.common.aspect.context.AuthContext;
-import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
 import com.pfplaybackend.api.common.exception.http.TooManyRequestsException;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,16 +31,13 @@ class BugReportCommandServiceTest {
 
     private BugReportCommandService service;
 
-    private final UserId userId = new UserId(100L);
+    private static final Long REPORTER_USER_ID = 100L;
     private final Clock fixedClock = Clock.fixed(
             Instant.parse("2026-05-21T10:00:00Z"), ZoneId.of("Asia/Seoul"));
 
     @BeforeEach
     void setUp() {
         service = new BugReportCommandService(repository, rateLimiter, fixedClock);
-        AuthContext ctx = mock(AuthContext.class);
-        lenient().when(ctx.getUserId()).thenReturn(userId);
-        ThreadLocalContext.setContext(ctx);
         lenient().when(repository.save(any(BugReportData.class))).thenAnswer(inv -> {
             BugReportData input = inv.getArgument(0);
             java.lang.reflect.Field idField = BugReportData.class.getDeclaredField("bugReportId");
@@ -54,15 +47,10 @@ class BugReportCommandServiceTest {
         });
     }
 
-    @AfterEach
-    void tearDown() {
-        ThreadLocalContext.clearContext();
-    }
-
     @Test
     @DisplayName("submit — happy: 모든 필드 채워 save + id 반환")
     void submitHappy() {
-        Long id = service.submit("재생 안 됨", "https://pfplay.xyz/parties/7",
+        Long id = service.submit(REPORTER_USER_ID, "재생 안 됨", "https://pfplay.xyz/parties/7",
                 "Mozilla/5.0", 7L);
 
         verify(rateLimiter).acquireOrThrow(100L);
@@ -80,7 +68,7 @@ class BugReportCommandServiceTest {
     @Test
     @DisplayName("submit — pageUrl/UA null 허용")
     void submitWithNullMeta() {
-        service.submit("buggy", null, null, null);
+        service.submit(REPORTER_USER_ID, "buggy", null, null, null);
 
         ArgumentCaptor<BugReportData> captor = ArgumentCaptor.forClass(BugReportData.class);
         verify(repository).save(captor.capture());
@@ -93,7 +81,7 @@ class BugReportCommandServiceTest {
     @DisplayName("submit — pageUrl 600자 → server-side truncate to 500")
     void submitTruncatesLongPageUrl() {
         String longUrl = "https://x.com/" + "a".repeat(700);
-        service.submit("buggy", longUrl, null, null);
+        service.submit(REPORTER_USER_ID, "buggy", longUrl, null, null);
 
         ArgumentCaptor<BugReportData> captor = ArgumentCaptor.forClass(BugReportData.class);
         verify(repository).save(captor.capture());
@@ -107,7 +95,7 @@ class BugReportCommandServiceTest {
         doThrow(ExceptionCreator.create(BugReportException.RATE_LIMIT_EXCEEDED))
                 .when(rateLimiter).acquireOrThrow(100L);
 
-        assertThatThrownBy(() -> service.submit("buggy", null, null, null))
+        assertThatThrownBy(() -> service.submit(REPORTER_USER_ID, "buggy", null, null, null))
                 .isInstanceOf(TooManyRequestsException.class);
         verify(repository, never()).save(any());
     }


### PR DESCRIPTION
## 요약
VOC 버그 리포트 제출(`POST /api/v1/voc/bug-reports`)이 staging 에서 **100% 실패**하던 문제 수정. `Refs #253`.

## 근본 원인
`AuthContext` 를 ThreadLocal 에 set 하는 AOP aspect 는 **`party`/`partyview`/`playlist`/`user` 모듈에만** 있고 **`administration` 모듈에는 없음**. administration 모듈은 의도적으로 aspect 대신 **`AdminContext` helper(SecurityContext 직접 읽기)** 패턴을 씀 (announcement/penalty/avatar/partyroom/tier 등 전부).

그런데 `BugReportCommandService` 만 이 관례를 어기고 `ThreadLocalContext.getAuthContext()` (party/user 패턴)를 차용 → 빈 ThreadLocal → `IllegalStateException: AuthContext not available in current thread`. **admin 콘솔 기능들이 멀쩡한 이유 = 전부 `AdminContext` 를 쓰기 때문.**

## 수정 (administration 모듈 관례에 정렬)
- `BugReportCommandService.submit()` 가 `reporterUserId` 를 첫 인자로 받도록 변경, `ThreadLocalContext` 의존 제거
- `BugReportCommandController` 가 `@AuthenticationPrincipal UserId` 로 인증 주체 추출 (`CustomJwtAuthenticationToken.getPrincipal() == UserId`) 후 service 로 전달

## 회귀 가드 (mock-gap 해소)
기존 controller test 는 `jwt()` post-processor(principal=`Jwt`)를 써서 실제 토큰 형태를 미러하지 못해 AuthContext 누락을 못 잡았음 (그래서 CI 통과했지만 런타임 실패).
- `authedUser()` 헬퍼로 `CustomJwtAuthenticationToken`(principal=`UserId`) 주입 + **userId 가 service 로 전달되는지 검증** (`submitPassesAuthenticatedUserId`)
- service test 는 `ThreadLocalContext` 수동 mock 제거 → userId 인자로 실제 경로 검증

## 검증
- `:app:test` 전체 GREEN (회귀 없음)
- **로컬 docker-compose 실증**: 게스트 가입 → `POST /api/v1/voc/bug-reports`
  - 영문 content → **HTTP 201** `bugReportId:1`
  - 한글 content (다른 게스트) → **HTTP 201** `bugReportId:2`
  - DB `bug_report.reporter_user_account_id` 에 각 게스트 userId 정확히 기록 → `@AuthenticationPrincipal` 추출·전달 정상
  - 이전 500(AuthContext) → 201 전환 확인

## Test plan
- [x] `BugReportCommandServiceTest` (userId 인자, ThreadLocal mock 제거)
- [x] `BugReportCommandControllerTest` (CustomJwtAuthenticationToken 주입 + userId 전달 검증)
- [x] `:app:test` 회귀
- [x] docker-compose 실증 (게스트·한글 201, DB row, userId 정확)
- [ ] dev/stg 배포 후 실제 제출 확인 (사후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)