### PR TITLE
fix(user): dev full member 디폴트 아바타 combinable-aware (유령 몸통+001 face/icon 모순)

### DIFF
--- a/user/src/main/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeService.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeService.java
@@ -1,6 +1,7 @@
 package com.pfplaybackend.api.user.application.service.initialize;
 
 import com.pfplaybackend.api.avatar.application.dto.AvatarBodyDto;
+import com.pfplaybackend.api.avatar.domain.value.AvatarFaceUri;
 import com.pfplaybackend.api.common.config.security.enums.ProviderType;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.user.adapter.out.persistence.GuestRepository;
@@ -128,11 +129,20 @@ public class TemporaryUserInitializeService {
                 userAvatarQueryService.getDefaultAvatarBodyUri(),
                 bodyResource.getCombinePositionX(),
                 bodyResource.getCombinePositionY());
-        member.updateAvatarFace(
-                userAvatarQueryService.getDefaultAvatarFaceUri(),
-                FaceSourceType.INTERNAL_IMAGE,
-                0.0, 0.0, 100.0);
-        member.updateAvatarIcon(userAvatarQueryService.getDefaultAvatarIconUri());
+        // 디폴트 바디의 is_combinable 에 따라 분기. combinable=0(유령 등)은 face 합성 불가이므로
+        // SINGLE_BODY: face 를 비우고 body 페어 아이콘을 매단다 (createProfileDataForGuest 와 동일 정책).
+        // V20 에서 디폴트 바디를 유령(ava_body_basic_003, combinable=0)으로 바꿨는데 이 경로만 누락돼
+        // '유령 몸통 + 과거 디폴트 바디(001) 세트 face/icon' 모순이 발생했던 것을 바로잡는다.
+        if (bodyResource.isCombinable()) {
+            member.updateAvatarFace(
+                    userAvatarQueryService.getDefaultAvatarFaceUri(),
+                    FaceSourceType.INTERNAL_IMAGE,
+                    0.0, 0.0, 100.0);
+            member.updateAvatarIcon(userAvatarQueryService.getDefaultAvatarIconUri());
+        } else {
+            member.updateAvatarFace(new AvatarFaceUri());
+            member.updateAvatarIcon(userAvatarQueryService.getDefaultAvatarBodyPairIconUri());
+        }
         memberRepository.save(member);
         return member;
     }

--- a/user/src/test/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeServiceTest.java
+++ b/user/src/test/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeServiceTest.java
@@ -29,6 +29,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -94,6 +96,7 @@ class TemporaryUserInitializeServiceTest {
         AvatarIconUri iconUri = new AvatarIconUri("https://cdn/icon.png");
         when(userProfileRepository.existsByNickname(any(Nickname.class))).thenReturn(false);
         when(userAvatarQueryService.getDefaultAvatarBody()).thenReturn(bodyResource);
+        when(bodyResource.isCombinable()).thenReturn(true);
         when(bodyResource.getCombinePositionX()).thenReturn(60);
         when(bodyResource.getCombinePositionY()).thenReturn(41);
         when(userAvatarQueryService.getDefaultAvatarBodyUri()).thenReturn(bodyUri);
@@ -122,6 +125,33 @@ class TemporaryUserInitializeServiceTest {
     }
 
     @Test
+    @DisplayName("upgradeMember — default body 가 combinable=false(유령) 면 SINGLE_BODY: face 비우고 body 페어 아이콘")
+    void upgradeMemberSingleBodyWhenDefaultBodyNotCombinable() {
+        // given: default body 가 유령(combinable=false)
+        MemberData member = mock(MemberData.class);
+        AvatarBodyDto bodyResource = mock(AvatarBodyDto.class);
+        AvatarBodyUri bodyUri = new AvatarBodyUri("https://cdn/ghost-body.png");
+        AvatarIconUri bodyPairIcon = new AvatarIconUri("https://cdn/ghost-body-pair-icon.png");
+        when(userProfileRepository.existsByNickname(any(Nickname.class))).thenReturn(false);
+        when(userAvatarQueryService.getDefaultAvatarBody()).thenReturn(bodyResource);
+        when(bodyResource.isCombinable()).thenReturn(false);
+        when(bodyResource.getCombinePositionX()).thenReturn(0);
+        when(bodyResource.getCombinePositionY()).thenReturn(0);
+        when(userAvatarQueryService.getDefaultAvatarBodyUri()).thenReturn(bodyUri);
+        when(userAvatarQueryService.getDefaultAvatarBodyPairIconUri()).thenReturn(bodyPairIcon);
+
+        // when
+        temporaryUserInitializeService.upgradeMember(member);
+
+        // then: SINGLE_BODY — face 빈 값(single-arg), body 페어 아이콘. face+transform(BODY_WITH_FACE) 미호출.
+        verify(member).updateAvatarBody(eq(bodyUri), eq(0), eq(0));
+        verify(member).updateAvatarFace(argThat((AvatarFaceUri u) -> u.getValue().isEmpty()));
+        verify(member).updateAvatarIcon(eq(bodyPairIcon));
+        verify(member, never()).updateAvatarFace(any(), any(), anyDouble(), anyDouble(), anyDouble());
+        verify(userAvatarQueryService, never()).getDefaultAvatarFaceUri();
+    }
+
+    @Test
     @DisplayName("upgradeMember — nickname 충돌 시 재시도 후 unique 후보를 채택한다")
     void upgradeMemberRetriesOnNicknameCollision() {
         // given
@@ -132,6 +162,7 @@ class TemporaryUserInitializeServiceTest {
                 .thenReturn(true)
                 .thenReturn(false);
         when(userAvatarQueryService.getDefaultAvatarBody()).thenReturn(bodyResource);
+        when(bodyResource.isCombinable()).thenReturn(true);
         when(userAvatarQueryService.getDefaultAvatarBodyUri()).thenReturn(new AvatarBodyUri("u"));
         when(userAvatarQueryService.getDefaultAvatarFaceUri()).thenReturn(new AvatarFaceUri("u"));
         when(userAvatarQueryService.getDefaultAvatarIconUri()).thenReturn(new AvatarIconUri("u"));


### PR DESCRIPTION
## 요약
dev 계정으로 Full Member 생성 시 프로필이 **유령 몸통(ava_body_basic_003) + 과거 디폴트 바디(001) 세트였던 face/icon** 으로 모순 할당되던 버그 수정.

## 원인
V20(PR #248)에서 디폴트 바디를 유령(`ava_body_basic_003`, `is_combinable=0`)으로 변경하면서 `createProfileDataForGuest`/`createProfileDataForSuperAdmin` 은 combinable-aware 로 고쳤지만, **`upgradeMember`(`EasyUserManagementController` → dev full member 생성 경로)는 누락**:

```java
member.updateAvatarBody(getDefaultAvatarBodyUri(), ...);          // body = 003 유령
member.updateAvatarFace(getDefaultAvatarFaceUri(), INTERNAL_IMAGE, ...);  // face = 001 세트 ← 모순
member.updateAvatarIcon(getDefaultAvatarIconUri());              // icon = 001 face pair ← 모순
```

유령 바디는 `is_combinable=0`(face 합성 불가)인데 BODY_WITH_FACE + 001 face/icon 을 할당.

## 수정
`createProfileDataForGuest` 와 동일한 combinable-aware 분기:
- `combinable=true`: BODY_WITH_FACE + default face/icon (기존)
- `combinable=false`(유령): **SINGLE_BODY** → face 비우고(`new AvatarFaceUri()`) body 페어 아이콘(`getDefaultAvatarBodyPairIconUri`)

## 범위
**dev 한정** — 실제 소셜 Full Member 는 가입 흐름에서 사용자가 직접 아바타를 셋팅하므로 이 경로의 default 가 노출되지 않습니다(prod 영향 없음). dev seed / EasyUserManagement 의 모순 프로필만 해소.

## 검증
- `TemporaryUserInitializeServiceTest`: 기존 `upgradeMemberSuccess`/nickname-충돌 케이스에 `combinable=true` 명시(BODY_WITH_FACE 유지) + `combinable=false` SINGLE_BODY 케이스(face 빈값 + body 페어 아이콘) 신규
- `:user:test` 전체 GREEN
- [ ] dev 계정 full member 재생성 후 프로필 확인 (backend 재배포 후, 사후)

Refs #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)