### PR TITLE
fix(user): dev full member 디폴트 아바타 scale 100→1 (face 100배 확대 버그)

### DIFF
--- a/user/src/main/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeService.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeService.java
@@ -134,10 +134,12 @@ public class TemporaryUserInitializeService {
         // V20 에서 디폴트 바디를 유령(ava_body_basic_003, combinable=0)으로 바꿨는데 이 경로만 누락돼
         // '유령 몸통 + 과거 디폴트 바디(001) 세트 face/icon' 모순이 발생했던 것을 바로잡는다.
         if (bodyResource.isCombinable()) {
+            // scale 은 배율 단위(1.0=원본). 과거 100.0(=100배) 이라 프론트에서 face 가
+            // 100배 확대돼 까맣게 보이고 가로 스크롤이 생겼다. 기본은 1.0(원본).
             member.updateAvatarFace(
                     userAvatarQueryService.getDefaultAvatarFaceUri(),
                     FaceSourceType.INTERNAL_IMAGE,
-                    0.0, 0.0, 100.0);
+                    0.0, 0.0, 1.0);
             member.updateAvatarIcon(userAvatarQueryService.getDefaultAvatarIconUri());
         } else {
             member.updateAvatarFace(new AvatarFaceUri());

--- a/user/src/test/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeServiceTest.java
+++ b/user/src/test/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeServiceTest.java
@@ -117,8 +117,10 @@ class TemporaryUserInitializeServiceTest {
         verify(member).updateWalletAddress(any());
         // avatar default attach (broadcaster NPE 방지)
         verify(member).updateAvatarBody(eq(bodyUri), eq(60), eq(41));
+        // scale 은 배율 단위(1.0=원본). 과거 100.0(=100배) 은 프론트에서 face 가
+        // 100배 확대돼 까맣게/가로스크롤을 유발했다. 기본은 1.0(원본).
         verify(member).updateAvatarFace(eq(faceUri), eq(FaceSourceType.INTERNAL_IMAGE),
-                eq(0.0), eq(0.0), eq(100.0));
+                eq(0.0), eq(0.0), eq(1.0));
         verify(member).updateAvatarIcon(eq(iconUri));
         // profile / wallet / avatar 각각 save
         verify(memberRepository, times(3)).save(member);


### PR DESCRIPTION
## 증상
dev full member 의 아바타 설정 페이지에서 (1) '페이스 위치 조절 공간'에 face 가 **까맣게**만 보이고, (2) face 선택 시 **가로 스크롤바**가 길게 생김. 그대로 저장하면 파티룸에 face 가 까만 아바타로 입장.

## 원인 (Playwright 측정으로 규명)
`GET /users/me/profile/summary` 의 `scale: 100`. 프론트 scale 단위는 **배율**(react-moveable `e.scale[0]`, 1.0=원본)인데, `upgradeMember` 가 combinable 디폴트 face 의 scale 을 `100.0`(=100배)으로 설정 → 프론트 `transform: scale(100)` → face 가 100배 확대돼 중앙 1/100만 노출(까맣게) + react-moveable 이 거대 bounding box 를 잡아 가로 스크롤.

## 수정
- `TemporaryUserInitializeService.upgradeMember`: combinable 분기의 face scale `100.0 → 1.0`
- 테스트 `eq(100.0) → eq(1.0)`

## 범위
**dev 계정(EasyUserManagement seed) 한정** — 정상 게스트/회원 default 는 `buildDefaultAvatarProfile` 이 scale 을 설정하지 않습니다(미설정). temporary user 경로는 `@Profile("!prod")` 라 **prod 무관**.

기존 dev DB 의 `scale=100` 레코드(full member 11건)는 별도 SQL(`UPDATE user_profile SET scale=1 WHERE scale=100`)로 즉시 정정 완료. 프론트(pfplay-web)에는 비정상 scale 방어(`scale<=0 → 1`)를 별도 PR 로 추가.

## 검증
- `:user:test` `TemporaryUserInitializeServiceTest` GREEN