### PR TITLE
release: dev/stg 누적 반영 (재생만료 예외처리/VOC AuthContext/아바타 scale·combinable)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/BugReportCommandController.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/BugReportCommandController.java
@@ -6,6 +6,7 @@ import com.pfplaybackend.api.administration.application.service.BugReportCommand
 import com.pfplaybackend.api.administration.domain.exception.BugReportException;
 import com.pfplaybackend.api.common.ApiCommonResponse;
 import com.pfplaybackend.api.common.config.swagger.ApiErrorCodes;
+import com.pfplaybackend.api.common.domain.value.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -37,10 +39,12 @@ public class BugReportCommandController {
     @PostMapping
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiCommonResponse<SubmitBugReportResponse>> submit(
+            @AuthenticationPrincipal UserId userId,
             @Valid @RequestBody SubmitBugReportRequest request,
             @RequestHeader(value = "Referer", required = false) String referer,
             @RequestHeader(value = "User-Agent", required = false) String userAgent) {
         Long id = bugReportCommandService.submit(
+                userId.getUid(),
                 request.getContent(),
                 referer,
                 userAgent,

--- a/app/src/main/java/com/pfplaybackend/api/administration/application/service/BugReportCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/application/service/BugReportCommandService.java
@@ -3,9 +3,7 @@ package com.pfplaybackend.api.administration.application.service;
 import com.pfplaybackend.api.administration.adapter.out.persistence.BugReportRepository;
 import com.pfplaybackend.api.administration.application.ratelimit.BugReportRateLimiter;
 import com.pfplaybackend.api.administration.domain.entity.data.BugReportData;
-import com.pfplaybackend.api.common.ThreadLocalContext;
 import com.pfplaybackend.api.common.adapter.in.web.RequestIdInterceptor;
-import com.pfplaybackend.api.common.aspect.context.AuthContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,6 +20,10 @@ import java.time.LocalDateTime;
  * - pageUrl/userAgent server-side truncate to 500
  * - Clock 주입 (KST TZ 정책 [[project_jvm_tz_kst_policy]])
  * - INFO 로그 (observability A4 정합)
+ *
+ * reporterUserId 는 호출자(controller)가 인증 주체에서 추출해 전달한다. administration 모듈은
+ * AuthContext set aspect 가 없으므로(party/user 모듈 한정) ThreadLocalContext 를 쓰지 않고,
+ * AdminContext helper 와 동일하게 SecurityContext → controller 경계에서 인증 주체를 넘긴다.
  */
 @Slf4j
 @Service
@@ -35,16 +37,14 @@ public class BugReportCommandService {
     private final Clock clock;
 
     @Transactional
-    public Long submit(String content, String pageUrl, String userAgent, Long partyroomId) {
-        AuthContext authContext = ThreadLocalContext.getAuthContext();
-        Long userId = authContext.getUserId().getUid();
+    public Long submit(Long reporterUserId, String content, String pageUrl, String userAgent, Long partyroomId) {
         log.info("[bugReport.submit] ENTER requestId={} reporterUserId={} partyroomId={}",
-                RequestIdInterceptor.current(), userId, partyroomId);
+                RequestIdInterceptor.current(), reporterUserId, partyroomId);
 
-        rateLimiter.acquireOrThrow(userId);
+        rateLimiter.acquireOrThrow(reporterUserId);
 
         BugReportData data = BugReportData.create(
-                userId,
+                reporterUserId,
                 content,
                 truncate(pageUrl, META_MAX_LENGTH),
                 truncate(userAgent, META_MAX_LENGTH),
@@ -53,7 +53,7 @@ public class BugReportCommandService {
         BugReportData saved = repository.save(data);
 
         log.info("[bugReport.submit] OK requestId={} reporterUserId={} bugReportId={}",
-                RequestIdInterceptor.current(), userId, saved.getBugReportId());
+                RequestIdInterceptor.current(), reporterUserId, saved.getBugReportId());
         return saved.getBugReportId();
     }
 

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/PlaybackDurationWaitTopicListener.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/PlaybackDurationWaitTopicListener.java
@@ -4,6 +4,7 @@ import com.pfplaybackend.api.party.application.dto.playback.PlaybackDurationWait
 import com.pfplaybackend.api.party.application.port.out.ExpirationTaskPort;
 import com.pfplaybackend.api.party.application.service.PlaybackCommandService;
 import com.pfplaybackend.api.party.application.service.lock.DistributedLockExecutor;
+import com.pfplaybackend.api.common.exception.http.NotFoundException;
 import lombok.AllArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,15 +27,25 @@ public class PlaybackDurationWaitTopicListener implements MessageListener {
             String taskId = expiredKey.split(":")[2];
             try {
                 PlaybackDurationWaitDto deserialized = expirationTaskPort.getTaskArgs(taskId, PlaybackDurationWaitDto.class);
+                if (deserialized == null) {
+                    // 예상된 stale key: 만료 알림은 도착했으나 task args가 이미 정리/소실됨
+                    // (서버 재시작·의도적 DB 초기화 직후 등). 정상 정리 상황이므로 조용히 skip.
+                    logger.debug("Skipping playback expiration for taskId={}: task args already gone (stale key)", taskId);
+                    return;
+                }
                 String suffixId = deserialized.userId().getUid().toString();
                 distributedLockExecutor.performTaskWithLock(suffixId, () -> {
                     expirationTaskPort.clearTaskArgs(taskId);
                     playbackCommandService.complete(deserialized.partyroomId(), deserialized.userId());
                     return null;
                 });
+            } catch (NotFoundException e) {
+                // 예상된 stale key: 만료 처리 시점에 대상(파티룸 등)이 이미 없음
+                // (재시작·DB 초기화 직후 1회성). 정상 정리 상황이므로 DEBUG로만 남긴다.
+                logger.debug("Skipping stale playback expiration for taskId={}: {}", taskId, e.getMessage());
             } catch (Exception e) {
-                logger.warn("Failed to process playback expiration for taskId={} — possibly stale key after server restart: {}",
-                        taskId, e.getMessage());
+                // 예상치 못한 실패는 stack trace까지 남겨 루틴 정리에 묻히지 않게 한다.
+                logger.error("Failed to process playback expiration for taskId={}", taskId, e);
             }
         }
     }

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/web/AbstractVocCommandWebMvcTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/web/AbstractVocCommandWebMvcTest.java
@@ -2,17 +2,27 @@ package com.pfplaybackend.api.administration.adapter.in.web;
 
 import com.pfplaybackend.api.administration.application.service.BugReportCommandService;
 import com.pfplaybackend.api.common.config.security.jwt.AdminCookieWriter;
+import com.pfplaybackend.api.common.config.security.jwt.CustomJwtAuthenticationToken;
 import com.pfplaybackend.api.common.config.security.jwt.JwtService;
 import com.pfplaybackend.api.common.config.security.jwt.SharedSessionCookieWriter;
 import com.pfplaybackend.api.common.config.security.jwt.properties.JwtProperties;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.enums.AuthorityTier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 
 @WebMvcTest(BugReportCommandController.class)
 @Import(AbstractVocCommandWebMvcTest.SharedMethodSecurityConfig.class)
@@ -29,4 +39,21 @@ abstract class AbstractVocCommandWebMvcTest {
     @MockBean protected JwtProperties jwtProperties;
     @MockBean protected SharedSessionCookieWriter sharedSessionCookieWriter;
     @MockBean protected AdminCookieWriter adminCookieWriter;
+
+    /**
+     * 인증 주체를 {@link CustomJwtAuthenticationToken} 으로 주입한다. principal 이 {@link UserId} 이므로
+     * 컨트롤러의 {@code @AuthenticationPrincipal UserId} 가 채워진다. (Spring Security test 의 jwt()
+     * post-processor 는 principal 이 Jwt 라 @AuthenticationPrincipal UserId 가 null — 실제 토큰 형태 미러)
+     */
+    protected static RequestPostProcessor authedUser(long userId) {
+        Jwt jwt = Jwt.withTokenValue("test-token").header("alg", "none")
+                .claim("sub", String.valueOf(userId)).build();
+        CustomJwtAuthenticationToken token = new CustomJwtAuthenticationToken(
+                jwt,
+                List.of(new SimpleGrantedAuthority("ROLE_MEMBER")),
+                new UserId(userId),
+                "tester@pfplay.local",
+                AuthorityTier.AM);
+        return authentication(token);
+    }
 }

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/web/BugReportCommandControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/web/BugReportCommandControllerTest.java
@@ -7,10 +7,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -20,10 +21,10 @@ class BugReportCommandControllerTest extends AbstractVocCommandWebMvcTest {
     @Test
     @DisplayName("submit — 201 Created + bugReportId 반환")
     void submitReturns201() throws Exception {
-        when(bugReportCommandService.submit(any(), any(), any(), any())).thenReturn(42L);
+        when(bugReportCommandService.submit(any(), any(), any(), any(), any())).thenReturn(42L);
 
         mockMvc.perform(post("/api/v1/voc/bug-reports")
-                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(authedUser(100L))
                         .with(csrf())
                         .header("Referer", "https://pfplay.xyz/parties/7")
                         .header("User-Agent", "Mozilla/5.0")
@@ -34,10 +35,27 @@ class BugReportCommandControllerTest extends AbstractVocCommandWebMvcTest {
     }
 
     @Test
+    @DisplayName("submit — 인증 주체 userId 가 service 로 전달된다 (AuthContext aspect 부재 회귀 가드)")
+    void submitPassesAuthenticatedUserId() throws Exception {
+        when(bugReportCommandService.submit(eq(100L), any(), any(), any(), any())).thenReturn(42L);
+
+        mockMvc.perform(post("/api/v1/voc/bug-reports")
+                        .with(authedUser(100L))
+                        .with(csrf())
+                        .header("Referer", "https://pfplay.xyz/parties/7")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"재생이 안 됩니다\",\"partyroomId\":7}"))
+                .andExpect(status().isCreated());
+
+        verify(bugReportCommandService).submit(eq(100L), eq("재생이 안 됩니다"),
+                eq("https://pfplay.xyz/parties/7"), any(), eq(7L));
+    }
+
+    @Test
     @DisplayName("submit — content 너무 짧으면 400")
     void submitShortContentReturns400() throws Exception {
         mockMvc.perform(post("/api/v1/voc/bug-reports")
-                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(authedUser(100L))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"content\":\"abcd\"}"))
@@ -48,7 +66,7 @@ class BugReportCommandControllerTest extends AbstractVocCommandWebMvcTest {
     @DisplayName("submit — content blank 400")
     void submitBlankContentReturns400() throws Exception {
         mockMvc.perform(post("/api/v1/voc/bug-reports")
-                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(authedUser(100L))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"content\":\"\"}"))
@@ -59,7 +77,7 @@ class BugReportCommandControllerTest extends AbstractVocCommandWebMvcTest {
     @DisplayName("submit — partyroomId 0/negative 400")
     void submitInvalidPartyroomIdReturns400() throws Exception {
         mockMvc.perform(post("/api/v1/voc/bug-reports")
-                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(authedUser(100L))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"content\":\"long enough content\",\"partyroomId\":0}"))
@@ -80,10 +98,10 @@ class BugReportCommandControllerTest extends AbstractVocCommandWebMvcTest {
     @DisplayName("submit — rate-limit 시 429 + BUG-001")
     void submitRateLimitReturns429() throws Exception {
         doThrow(ExceptionCreator.create(BugReportException.RATE_LIMIT_EXCEEDED))
-                .when(bugReportCommandService).submit(any(), any(), any(), any());
+                .when(bugReportCommandService).submit(any(), any(), any(), any(), any());
 
         mockMvc.perform(post("/api/v1/voc/bug-reports")
-                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(authedUser(100L))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"content\":\"valid content\"}"))

--- a/app/src/test/java/com/pfplaybackend/api/administration/application/service/BugReportCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/application/service/BugReportCommandServiceTest.java
@@ -4,12 +4,8 @@ import com.pfplaybackend.api.administration.adapter.out.persistence.BugReportRep
 import com.pfplaybackend.api.administration.application.ratelimit.BugReportRateLimiter;
 import com.pfplaybackend.api.administration.domain.entity.data.BugReportData;
 import com.pfplaybackend.api.administration.domain.exception.BugReportException;
-import com.pfplaybackend.api.common.ThreadLocalContext;
-import com.pfplaybackend.api.common.aspect.context.AuthContext;
-import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
 import com.pfplaybackend.api.common.exception.http.TooManyRequestsException;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,16 +31,13 @@ class BugReportCommandServiceTest {
 
     private BugReportCommandService service;
 
-    private final UserId userId = new UserId(100L);
+    private static final Long REPORTER_USER_ID = 100L;
     private final Clock fixedClock = Clock.fixed(
             Instant.parse("2026-05-21T10:00:00Z"), ZoneId.of("Asia/Seoul"));
 
     @BeforeEach
     void setUp() {
         service = new BugReportCommandService(repository, rateLimiter, fixedClock);
-        AuthContext ctx = mock(AuthContext.class);
-        lenient().when(ctx.getUserId()).thenReturn(userId);
-        ThreadLocalContext.setContext(ctx);
         lenient().when(repository.save(any(BugReportData.class))).thenAnswer(inv -> {
             BugReportData input = inv.getArgument(0);
             java.lang.reflect.Field idField = BugReportData.class.getDeclaredField("bugReportId");
@@ -54,15 +47,10 @@ class BugReportCommandServiceTest {
         });
     }
 
-    @AfterEach
-    void tearDown() {
-        ThreadLocalContext.clearContext();
-    }
-
     @Test
     @DisplayName("submit — happy: 모든 필드 채워 save + id 반환")
     void submitHappy() {
-        Long id = service.submit("재생 안 됨", "https://pfplay.xyz/parties/7",
+        Long id = service.submit(REPORTER_USER_ID, "재생 안 됨", "https://pfplay.xyz/parties/7",
                 "Mozilla/5.0", 7L);
 
         verify(rateLimiter).acquireOrThrow(100L);
@@ -80,7 +68,7 @@ class BugReportCommandServiceTest {
     @Test
     @DisplayName("submit — pageUrl/UA null 허용")
     void submitWithNullMeta() {
-        service.submit("buggy", null, null, null);
+        service.submit(REPORTER_USER_ID, "buggy", null, null, null);
 
         ArgumentCaptor<BugReportData> captor = ArgumentCaptor.forClass(BugReportData.class);
         verify(repository).save(captor.capture());
@@ -93,7 +81,7 @@ class BugReportCommandServiceTest {
     @DisplayName("submit — pageUrl 600자 → server-side truncate to 500")
     void submitTruncatesLongPageUrl() {
         String longUrl = "https://x.com/" + "a".repeat(700);
-        service.submit("buggy", longUrl, null, null);
+        service.submit(REPORTER_USER_ID, "buggy", longUrl, null, null);
 
         ArgumentCaptor<BugReportData> captor = ArgumentCaptor.forClass(BugReportData.class);
         verify(repository).save(captor.capture());
@@ -107,7 +95,7 @@ class BugReportCommandServiceTest {
         doThrow(ExceptionCreator.create(BugReportException.RATE_LIMIT_EXCEEDED))
                 .when(rateLimiter).acquireOrThrow(100L);
 
-        assertThatThrownBy(() -> service.submit("buggy", null, null, null))
+        assertThatThrownBy(() -> service.submit(REPORTER_USER_ID, "buggy", null, null, null))
                 .isInstanceOf(TooManyRequestsException.class);
         verify(repository, never()).save(any());
     }

--- a/user/src/main/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeService.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeService.java
@@ -134,10 +134,12 @@ public class TemporaryUserInitializeService {
         // V20 에서 디폴트 바디를 유령(ava_body_basic_003, combinable=0)으로 바꿨는데 이 경로만 누락돼
         // '유령 몸통 + 과거 디폴트 바디(001) 세트 face/icon' 모순이 발생했던 것을 바로잡는다.
         if (bodyResource.isCombinable()) {
+            // scale 은 배율 단위(1.0=원본). 과거 100.0(=100배) 이라 프론트에서 face 가
+            // 100배 확대돼 까맣게 보이고 가로 스크롤이 생겼다. 기본은 1.0(원본).
             member.updateAvatarFace(
                     userAvatarQueryService.getDefaultAvatarFaceUri(),
                     FaceSourceType.INTERNAL_IMAGE,
-                    0.0, 0.0, 100.0);
+                    0.0, 0.0, 1.0);
             member.updateAvatarIcon(userAvatarQueryService.getDefaultAvatarIconUri());
         } else {
             member.updateAvatarFace(new AvatarFaceUri());

--- a/user/src/main/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeService.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeService.java
@@ -1,6 +1,7 @@
 package com.pfplaybackend.api.user.application.service.initialize;
 
 import com.pfplaybackend.api.avatar.application.dto.AvatarBodyDto;
+import com.pfplaybackend.api.avatar.domain.value.AvatarFaceUri;
 import com.pfplaybackend.api.common.config.security.enums.ProviderType;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.user.adapter.out.persistence.GuestRepository;
@@ -128,11 +129,20 @@ public class TemporaryUserInitializeService {
                 userAvatarQueryService.getDefaultAvatarBodyUri(),
                 bodyResource.getCombinePositionX(),
                 bodyResource.getCombinePositionY());
-        member.updateAvatarFace(
-                userAvatarQueryService.getDefaultAvatarFaceUri(),
-                FaceSourceType.INTERNAL_IMAGE,
-                0.0, 0.0, 100.0);
-        member.updateAvatarIcon(userAvatarQueryService.getDefaultAvatarIconUri());
+        // 디폴트 바디의 is_combinable 에 따라 분기. combinable=0(유령 등)은 face 합성 불가이므로
+        // SINGLE_BODY: face 를 비우고 body 페어 아이콘을 매단다 (createProfileDataForGuest 와 동일 정책).
+        // V20 에서 디폴트 바디를 유령(ava_body_basic_003, combinable=0)으로 바꿨는데 이 경로만 누락돼
+        // '유령 몸통 + 과거 디폴트 바디(001) 세트 face/icon' 모순이 발생했던 것을 바로잡는다.
+        if (bodyResource.isCombinable()) {
+            member.updateAvatarFace(
+                    userAvatarQueryService.getDefaultAvatarFaceUri(),
+                    FaceSourceType.INTERNAL_IMAGE,
+                    0.0, 0.0, 100.0);
+            member.updateAvatarIcon(userAvatarQueryService.getDefaultAvatarIconUri());
+        } else {
+            member.updateAvatarFace(new AvatarFaceUri());
+            member.updateAvatarIcon(userAvatarQueryService.getDefaultAvatarBodyPairIconUri());
+        }
         memberRepository.save(member);
         return member;
     }

--- a/user/src/test/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeServiceTest.java
+++ b/user/src/test/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeServiceTest.java
@@ -29,6 +29,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -94,6 +96,7 @@ class TemporaryUserInitializeServiceTest {
         AvatarIconUri iconUri = new AvatarIconUri("https://cdn/icon.png");
         when(userProfileRepository.existsByNickname(any(Nickname.class))).thenReturn(false);
         when(userAvatarQueryService.getDefaultAvatarBody()).thenReturn(bodyResource);
+        when(bodyResource.isCombinable()).thenReturn(true);
         when(bodyResource.getCombinePositionX()).thenReturn(60);
         when(bodyResource.getCombinePositionY()).thenReturn(41);
         when(userAvatarQueryService.getDefaultAvatarBodyUri()).thenReturn(bodyUri);
@@ -122,6 +125,33 @@ class TemporaryUserInitializeServiceTest {
     }
 
     @Test
+    @DisplayName("upgradeMember — default body 가 combinable=false(유령) 면 SINGLE_BODY: face 비우고 body 페어 아이콘")
+    void upgradeMemberSingleBodyWhenDefaultBodyNotCombinable() {
+        // given: default body 가 유령(combinable=false)
+        MemberData member = mock(MemberData.class);
+        AvatarBodyDto bodyResource = mock(AvatarBodyDto.class);
+        AvatarBodyUri bodyUri = new AvatarBodyUri("https://cdn/ghost-body.png");
+        AvatarIconUri bodyPairIcon = new AvatarIconUri("https://cdn/ghost-body-pair-icon.png");
+        when(userProfileRepository.existsByNickname(any(Nickname.class))).thenReturn(false);
+        when(userAvatarQueryService.getDefaultAvatarBody()).thenReturn(bodyResource);
+        when(bodyResource.isCombinable()).thenReturn(false);
+        when(bodyResource.getCombinePositionX()).thenReturn(0);
+        when(bodyResource.getCombinePositionY()).thenReturn(0);
+        when(userAvatarQueryService.getDefaultAvatarBodyUri()).thenReturn(bodyUri);
+        when(userAvatarQueryService.getDefaultAvatarBodyPairIconUri()).thenReturn(bodyPairIcon);
+
+        // when
+        temporaryUserInitializeService.upgradeMember(member);
+
+        // then: SINGLE_BODY — face 빈 값(single-arg), body 페어 아이콘. face+transform(BODY_WITH_FACE) 미호출.
+        verify(member).updateAvatarBody(eq(bodyUri), eq(0), eq(0));
+        verify(member).updateAvatarFace(argThat((AvatarFaceUri u) -> u.getValue().isEmpty()));
+        verify(member).updateAvatarIcon(eq(bodyPairIcon));
+        verify(member, never()).updateAvatarFace(any(), any(), anyDouble(), anyDouble(), anyDouble());
+        verify(userAvatarQueryService, never()).getDefaultAvatarFaceUri();
+    }
+
+    @Test
     @DisplayName("upgradeMember — nickname 충돌 시 재시도 후 unique 후보를 채택한다")
     void upgradeMemberRetriesOnNicknameCollision() {
         // given
@@ -132,6 +162,7 @@ class TemporaryUserInitializeServiceTest {
                 .thenReturn(true)
                 .thenReturn(false);
         when(userAvatarQueryService.getDefaultAvatarBody()).thenReturn(bodyResource);
+        when(bodyResource.isCombinable()).thenReturn(true);
         when(userAvatarQueryService.getDefaultAvatarBodyUri()).thenReturn(new AvatarBodyUri("u"));
         when(userAvatarQueryService.getDefaultAvatarFaceUri()).thenReturn(new AvatarFaceUri("u"));
         when(userAvatarQueryService.getDefaultAvatarIconUri()).thenReturn(new AvatarIconUri("u"));

--- a/user/src/test/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeServiceTest.java
+++ b/user/src/test/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeServiceTest.java
@@ -117,8 +117,10 @@ class TemporaryUserInitializeServiceTest {
         verify(member).updateWalletAddress(any());
         // avatar default attach (broadcaster NPE 방지)
         verify(member).updateAvatarBody(eq(bodyUri), eq(60), eq(41));
+        // scale 은 배율 단위(1.0=원본). 과거 100.0(=100배) 은 프론트에서 face 가
+        // 100배 확대돼 까맣게/가로스크롤을 유발했다. 기본은 1.0(원본).
         verify(member).updateAvatarFace(eq(faceUri), eq(FaceSourceType.INTERNAL_IMAGE),
-                eq(0.0), eq(0.0), eq(100.0));
+                eq(0.0), eq(0.0), eq(1.0));
         verify(member).updateAvatarIcon(eq(iconUri));
         // profile / wallet / avatar 각각 save
         verify(memberRepository, times(3)).save(member);


### PR DESCRIPTION
## stg(release) 반영 — develop 누적분
- #252 재생 만료 리스너의 제네릭 예외 처리 정리 (stale key debug, 예상치 못한 오류 error 격상)
- #256 dev full member 디폴트 아바타 scale 100→1 (face 100배 확대 버그)
- #255 dev full member 디폴트 아바타 combinable-aware (유령 몸통+001 모순 수정)
- #254 VOC 버그리포트 'AuthContext not available' 예외 수정

(#248 V20 게스트 유령바디, #249 AM 파티룸 생성은 release 기반영)

stg 에서 최종 확인 예정.