### PR TITLE
release 반영: 플레이리스트 트랙 상한 15→100 (#259)

### DIFF
--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackCommandService.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackCommandService.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class TrackCommandService {
 
-    private static final int MAX_PLAYLIST_TRACK_COUNT = 15;
+    private static final int MAX_PLAYLIST_TRACK_COUNT = 100;
 
     private final PlaylistAggregatePort aggregatePort;
     private final PlaylistQueryPort queryPort;

--- a/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/TrackCommandServiceTest.java
+++ b/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/TrackCommandServiceTest.java
@@ -149,7 +149,7 @@ class TrackCommandServiceTest {
     }
 
     @Test
-    @DisplayName("트랙 추가 실패 — 15개 초과 시 ConflictException")
+    @DisplayName("트랙 추가 실패 — 100개 초과 시 ConflictException")
     void addTrackInPlaylistExceededLimit() {
         // given
         Long playlistId = 1L;
@@ -161,11 +161,41 @@ class TrackCommandServiceTest {
         when(aggregatePort.findPlaylistByIdAndOwner(playlistId, userId)).thenReturn(Optional.of(playlistData));
         when(aggregatePort.findTrackByPlaylistAndLink(new PlaylistId(playlistId), LINK_ID)).thenReturn(Optional.empty());
         when(playlistQueryService.getPlaylist(playlistId))
-                .thenReturn(new PlaylistSummaryDto(playlistId, TEST_PLAYLIST_NAME, 0, PlaylistType.PLAYLIST, 15L));
+                .thenReturn(new PlaylistSummaryDto(playlistId, TEST_PLAYLIST_NAME, 0, PlaylistType.PLAYLIST, 100L));
 
         // when & then
         assertThatThrownBy(() -> trackCommandService.addTrackInPlaylist(playlistId, command))
                 .isInstanceOf(ConflictException.class);
+    }
+
+    @Test
+    @DisplayName("트랙 추가 성공 — 상한 직전(99개)이면 추가된다")
+    void addTrackInPlaylistAtLimitBoundary() {
+        // given
+        Long playlistId = 1L;
+        PlaylistData playlistData = PlaylistData.builder()
+                .id(playlistId).ownerId(userId).name(TEST_PLAYLIST_NAME).type(PlaylistType.PLAYLIST).orderNumber(0).build();
+
+        AddTrackCommand command = new AddTrackCommand(SONG_NAME, LINK_ID, DURATION, THUMBNAIL);
+
+        when(aggregatePort.findPlaylistByIdAndOwner(playlistId, userId)).thenReturn(Optional.of(playlistData));
+        when(aggregatePort.findTrackByPlaylistAndLink(new PlaylistId(playlistId), LINK_ID)).thenReturn(Optional.empty());
+        when(playlistQueryService.getPlaylist(playlistId))
+                .thenReturn(new PlaylistSummaryDto(playlistId, TEST_PLAYLIST_NAME, 0, PlaylistType.PLAYLIST, 99L));
+        when(aggregatePort.saveTrack(any())).thenAnswer(invocation -> {
+            TrackData track = invocation.getArgument(0);
+            TrackData saved = TrackData.builder().playlistId(track.getPlaylistId()).name(track.getName())
+                    .linkId(track.getLinkId()).duration(track.getDuration()).orderNumber(track.getOrderNumber())
+                    .thumbnailImage(track.getThumbnailImage()).build();
+            ReflectionTestUtils.setField(saved, "id", 100L);
+            return saved;
+        });
+
+        // when
+        trackCommandService.addTrackInPlaylist(playlistId, command);
+
+        // then — musicCount 99 < 100 이므로 추가되고 orderNumber 는 100
+        verify(aggregatePort, times(1)).saveTrack(argThat(track -> track.getOrderNumber() == 100));
     }
 
     // ========== deleteTrackInPlaylist ==========
@@ -316,7 +346,7 @@ class TrackCommandServiceTest {
     }
 
     @Test
-    @DisplayName("트랙 이동 실패 — 타겟 15개 초과 시 ConflictException")
+    @DisplayName("트랙 이동 실패 — 타겟 100개 초과 시 ConflictException")
     void moveTrackToPlaylistExceededLimit() {
         // given
         Long sourcePlaylistId = 1L;
@@ -339,7 +369,7 @@ class TrackCommandServiceTest {
         when(aggregatePort.findTrackByIdAndPlaylist(trackId, new PlaylistId(sourcePlaylistId))).thenReturn(Optional.of(trackData));
         when(aggregatePort.findTrackByPlaylistAndLink(new PlaylistId(targetPlaylistId), LINK_ID)).thenReturn(Optional.empty());
         when(playlistQueryService.getPlaylist(targetPlaylistId))
-                .thenReturn(new PlaylistSummaryDto(targetPlaylistId, TARGET_PLAYLIST, 1, PlaylistType.PLAYLIST, 15L));
+                .thenReturn(new PlaylistSummaryDto(targetPlaylistId, TARGET_PLAYLIST, 1, PlaylistType.PLAYLIST, 100L));
 
         // when & then
         assertThatThrownBy(() -> trackCommandService.moveTrackToPlaylist(sourcePlaylistId, trackId, command))


### PR DESCRIPTION
## 반영 내용
직전 release 반영(#257) 이후 develop 신규 변경을 stg(release)에 반영한다.

- **#259** 플레이리스트 1개당 트랙 최대 개수 15 → 100
  - `TrackCommandService.MAX_PLAYLIST_TRACK_COUNT` 15 → 100 (상수 1곳, addTrack·moveTrack·peek 일관)
  - peek 페이지 크기 = 트랙 최대 일치 유지 (PlaybackCommandService.doStart 의 total 정확성)
  - TDD(RED→GREEN), CI 전체 pass (app peek 회귀 포함)