### PR TITLE
release: release → main (prod 승격, 2026-05-25)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/PlaylistCommandAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/PlaylistCommandAdapter.java
@@ -27,12 +27,12 @@ public class PlaylistCommandAdapter implements PlaylistCommandPort {
     }
 
     @Override
-    public List<PlaybackTrackDto> peekOrderedTracks(PlaylistId playlistId) {
-        return trackCommandService.peekOrderedTracks(playlistId.getId());
+    public List<PlaybackTrackDto> peekTracksFromCursor(PlaylistId playlistId) {
+        return trackCommandService.peekTracksFromCursor(playlistId.getId());
     }
 
     @Override
-    public void rotatePlayed(PlaylistId playlistId, int playedOrderNumber, long totalCount) {
-        trackCommandService.rotatePlayed(playlistId.getId(), playedOrderNumber, totalCount);
+    public void advancePlaybackCursor(PlaylistId playlistId, Long trackId) {
+        trackCommandService.advancePlaybackCursor(playlistId.getId(), trackId);
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/port/out/PlaylistCommandPort.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/port/out/PlaylistCommandPort.java
@@ -6,6 +6,6 @@ import com.pfplaybackend.api.playlist.application.dto.PlaybackTrackDto;
 
 public interface PlaylistCommandPort {
     AddedTrackInfo grabTrack(UserId userId, String linkId);
-    java.util.List<PlaybackTrackDto> peekOrderedTracks(PlaylistId playlistId);
-    void rotatePlayed(PlaylistId playlistId, int playedOrderNumber, long totalCount);
+    java.util.List<PlaybackTrackDto> peekTracksFromCursor(PlaylistId playlistId);
+    void advancePlaybackCursor(PlaylistId playlistId, Long trackId);
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java
@@ -119,7 +119,7 @@ public class PlaybackCommandService implements PlaybackControlPort {
         for (DjData dj : orderedDjs) {
             CrewData djCrew = aggregatePort.findCrewById(dj.getCrewId().getId()).orElseThrow();
             long djCrewId = djCrew.getId();
-            List<PlaybackTrackDto> peeked = playlistCommandPort.peekOrderedTracks(dj.getPlaylistId());
+            List<PlaybackTrackDto> peeked = playlistCommandPort.peekTracksFromCursor(dj.getPlaylistId());
 
             PlaybackTrackDto chosen = peeked.stream()
                     .filter(t -> !partyroom.getPlaybackTimeLimit().exceedsDuration(t.duration()))
@@ -135,7 +135,7 @@ public class PlaybackCommandService implements PlaybackControlPort {
             log.debug("[doStart] PLAYABLE_TRACK - partyroomId={}, djCrewId={}, trackName={}, durationSec={}, orderNumber={}, limitMin={}",
                     partyroomIdValue, djCrewId, chosen.name(), chosen.duration().toSeconds(), chosen.orderNumber(), limitMin);
 
-            startPlaybackFor(partyroom, dj, djCrew, chosen, peeked.size());
+            startPlaybackFor(partyroom, dj, djCrew, chosen);
             return;
         }
 
@@ -144,10 +144,10 @@ public class PlaybackCommandService implements PlaybackControlPort {
         deactivateAndNotify(partyroom);
     }
 
-    private void startPlaybackFor(PartyroomData partyroom, DjData dj, CrewData djCrew, PlaybackTrackDto chosen, long total) {
+    private void startPlaybackFor(PartyroomData partyroom, DjData dj, CrewData djCrew, PlaybackTrackDto chosen) {
         PlaybackData nextPlayback = PlaybackData.create(partyroom.getPartyroomId(), djCrew.getUserId(),
                 chosen.name(), chosen.duration(), chosen.linkId(), chosen.thumbnailImage(), clock.instant());
-        playlistCommandPort.rotatePlayed(dj.getPlaylistId(), chosen.orderNumber(), total);
+        playlistCommandPort.advancePlaybackCursor(dj.getPlaylistId(), chosen.trackId());
 
         PlaybackData playbackData = playbackRepository.save(nextPlayback);
         playbackAggregationRepository.save(PlaybackAggregationData.createFor(new PlaybackId(playbackData.getId())));

--- a/app/src/main/resources/db/migration/V21__add_playlist_playback_cursor.sql
+++ b/app/src/main/resources/db/migration/V21__add_playlist_playback_cursor.sql
@@ -1,0 +1,2 @@
+ALTER TABLE playlist
+    ADD COLUMN last_played_track_id bigint unsigned NULL COMMENT '재생 커서 — 마지막 재생 트랙 id';

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackCommandServiceTest.java
@@ -191,8 +191,8 @@ class PlaybackCommandServiceTest {
                 .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
         when(aggregatePort.findCrewById(1L)).thenReturn(Optional.of(djCrew));
 
-        PlaybackTrackDto trackDto = new PlaybackTrackDto("linkId", "Song", "thumb.jpg", Duration.fromString("3:30"), 1);
-        when(playlistCommandPort.peekOrderedTracks(playlistId)).thenReturn(List.of(trackDto));
+        PlaybackTrackDto trackDto = new PlaybackTrackDto(1000L, "linkId", "Song", "thumb.jpg", Duration.fromString("3:30"), 1);
+        when(playlistCommandPort.peekTracksFromCursor(playlistId)).thenReturn(List.of(trackDto));
 
         PlaybackData savedPlayback = mock(PlaybackData.class);
         lenient().when(savedPlayback.getId()).thenReturn(1L);
@@ -214,10 +214,9 @@ class PlaybackCommandServiceTest {
         verify(userActivityPort).updateDjPointScore(userId, 1);
     }
 
-    // ── #222 회귀 잠금: skip(자의/타의) 시 DJ큐 회전 + 본인 플레이리스트 회전이 함께 wiring 되는지 ──
-    // DJ큐 산술(#1→맨뒤)은 PartyroomAggregateServiceTest.rotatesCorrectly,
-    // 트랙 회전 SQL(played→맨뒤)은 TrackRepositoryReorderIntegrationTest 가 별도로 잠금.
-    // 여기서는 "skip 경로가 rotateDjQueue + peekOrderedTracks/rotatePlayed(현재 DJ 플레이리스트)
+    // ── #222 회귀 잠금: skip(자의/타의) 시 DJ큐 회전 + 본인 플레이리스트 커서 갱신이 함께 wiring 되는지 ──
+    // DJ큐 산술(#1→맨뒤)은 PartyroomAggregateServiceTest.rotatesCorrectly 가 별도로 잠금.
+    // 여기서는 "skip 경로가 rotateDjQueue + peekTracksFromCursor/advancePlaybackCursor(현재 DJ 플레이리스트)
     // 양쪽을 호출한다"는 수렴 지점의 invariant 를 잠근다.
 
     private DjData stubDoStartWithQueuedDj(PlaybackTimeLimit timeLimit, Duration trackDuration) {
@@ -238,13 +237,13 @@ class PlaybackCommandServiceTest {
                 .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
         when(aggregatePort.findCrewById(1L)).thenReturn(Optional.of(djCrew));
 
-        PlaybackTrackDto trackDto = new PlaybackTrackDto("linkId", "Song", "thumb.jpg", trackDuration, 1);
-        when(playlistCommandPort.peekOrderedTracks(playlistId)).thenReturn(List.of(trackDto));
+        PlaybackTrackDto trackDto = new PlaybackTrackDto(1000L, "linkId", "Song", "thumb.jpg", trackDuration, 1);
+        when(playlistCommandPort.peekTracksFromCursor(playlistId)).thenReturn(List.of(trackDto));
         return djData;
     }
 
     @Test
-    @DisplayName("#222 skipPlayback — 큐에 DJ가 있으면 DJ큐 회전과 현재 DJ 플레이리스트 회전(rotatePlayed)이 함께 호출된다")
+    @DisplayName("#222 skipPlayback — 큐에 DJ가 있으면 DJ큐 회전과 현재 DJ 플레이리스트 커서 갱신(advancePlaybackCursor)이 함께 호출된다")
     void skipPlaybackWithQueuedDjRotatesQueueAndPlaylist() {
         // given — 트랙 길이가 제한 이내(재생됨)
         DjData dj = stubDoStartWithQueuedDj(PlaybackTimeLimit.ofMinutes(10), Duration.fromString("3:30"));
@@ -258,16 +257,16 @@ class PlaybackCommandServiceTest {
         // when — 자의 skip (DELETE /playbacks/current → skipPlayback)
         playbackCommandService.skipPlayback(partyroomId);
 
-        // then — 스케줄 취소 + DJ큐 밀림 + 트랙 회전 양쪽 wiring
-        // position-1 트랙(orderNumber=1, size=1)이 제한 이내라 그대로 선택 → rotatePlayed(pl,1,1)
+        // then — 스케줄 취소 + DJ큐 밀림 + 커서 갱신 양쪽 wiring
+        // 커서 다음 첫 재생가능 트랙(trackId=1000)이 제한 이내라 선택 → advancePlaybackCursor(pl,1000)
         verify(expirationTaskPort).cancelExpiration(String.valueOf(partyroomId.getId()));
         verify(partyroomAggregateService).rotateDjQueue(partyroomId);
-        verify(playlistCommandPort).peekOrderedTracks(dj.getPlaylistId());
-        verify(playlistCommandPort).rotatePlayed(dj.getPlaylistId(), 1, 1L);
+        verify(playlistCommandPort).peekTracksFromCursor(dj.getPlaylistId());
+        verify(playlistCommandPort).advancePlaybackCursor(dj.getPlaylistId(), 1000L);
     }
 
     @Test
-    @DisplayName("#222 skipByManager — MODERATOR 타의 skip 도 DJ큐 회전 + 플레이리스트 회전(rotatePlayed)을 함께 호출한다")
+    @DisplayName("#222 skipByManager — MODERATOR 타의 skip 도 DJ큐 회전 + 플레이리스트 커서 갱신(advancePlaybackCursor)을 함께 호출한다")
     void skipByManagerWithQueuedDjRotatesQueueAndPlaylist() {
         // given — MODERATOR 권한 컨텍스트
         ActivePartyroomDto activeDto = new ActivePartyroomDto(partyroomId.getId(), false, 1L, true, new PlaybackId(1L), new CrewId(1L));
@@ -289,14 +288,14 @@ class PlaybackCommandServiceTest {
         // then
         verify(expirationTaskPort).cancelExpiration(String.valueOf(partyroomId.getId()));
         verify(partyroomAggregateService).rotateDjQueue(partyroomId);
-        verify(playlistCommandPort).peekOrderedTracks(dj.getPlaylistId());
-        verify(playlistCommandPort).rotatePlayed(dj.getPlaylistId(), 1, 1L);
+        verify(playlistCommandPort).peekTracksFromCursor(dj.getPlaylistId());
+        verify(playlistCommandPort).advancePlaybackCursor(dj.getPlaylistId(), 1000L);
     }
 
     // ── E/#3 트랙단위 스킵 동작 잠금 ──
 
     @Test
-    @DisplayName("E/#3 singleDj_allOverLimit — 단일 DJ의 트랙이 모두 제한 초과면 deactivate, rotatePlayed 미호출")
+    @DisplayName("E/#3 singleDj_allOverLimit — 단일 DJ의 트랙이 모두 제한 초과면 deactivate, advancePlaybackCursor 미호출")
     void singleDj_allOverLimit_deactivates() {
         // given — 단일 DJ, peek 트랙이 전부 제한(1분=60s) 초과
         PartyroomData partyroom = PartyroomData.builder()
@@ -317,17 +316,17 @@ class PlaybackCommandServiceTest {
         when(aggregatePort.findCrewById(1L)).thenReturn(Optional.of(djCrew));
 
         List<PlaybackTrackDto> overLimit = List.of(
-                new PlaybackTrackDto("l1", "T1", "t1.jpg", Duration.fromString("3:30"), 1),
-                new PlaybackTrackDto("l2", "T2", "t2.jpg", Duration.fromString("4:00"), 2));
-        when(playlistCommandPort.peekOrderedTracks(playlistId)).thenReturn(overLimit);
+                new PlaybackTrackDto(1L, "l1", "T1", "t1.jpg", Duration.fromString("3:30"), 1),
+                new PlaybackTrackDto(2L, "l2", "T2", "t2.jpg", Duration.fromString("4:00"), 2));
+        when(playlistCommandPort.peekTracksFromCursor(playlistId)).thenReturn(overLimit);
 
         // when — 자의 skip
         playbackCommandService.skipPlayback(partyroomId);
 
-        // then — deactivate, save/rotatePlayed 미호출(peek 부수효과 없음)
+        // then — deactivate, save/advancePlaybackCursor 미호출(peek 부수효과 없음)
         verify(partyroomAggregateService).deactivatePlayback(partyroomId);
         verify(playbackRepository, never()).save(any(PlaybackData.class));
-        verify(playlistCommandPort, never()).rotatePlayed(any(PlaylistId.class), anyInt(), anyLong());
+        verify(playlistCommandPort, never()).advancePlaybackCursor(any(PlaylistId.class), anyLong());
 
         // and — DEACTIVATE 이벤트에 changeType + 룸 limit 분(1)이 실린다
         ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
@@ -363,9 +362,9 @@ class PlaybackCommandServiceTest {
                 .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
         when(aggregatePort.findCrewById(1L)).thenReturn(Optional.of(djCrew));
 
-        PlaybackTrackDto overLimit = new PlaybackTrackDto("over", "Over", "o.jpg", Duration.fromString("6:00"), 1);
-        PlaybackTrackDto playable = new PlaybackTrackDto("ok", "Playable", "p.jpg", Duration.fromString("3:00"), 2);
-        when(playlistCommandPort.peekOrderedTracks(playlistId)).thenReturn(List.of(overLimit, playable));
+        PlaybackTrackDto overLimit = new PlaybackTrackDto(1L, "over", "Over", "o.jpg", Duration.fromString("6:00"), 1);
+        PlaybackTrackDto playable = new PlaybackTrackDto(2002L, "ok", "Playable", "p.jpg", Duration.fromString("3:00"), 2);
+        when(playlistCommandPort.peekTracksFromCursor(playlistId)).thenReturn(List.of(overLimit, playable));
 
         PlaybackData savedPlayback = mock(PlaybackData.class);
         lenient().when(savedPlayback.getId()).thenReturn(1L);
@@ -381,11 +380,11 @@ class PlaybackCommandServiceTest {
         // when — 자의 skip
         playbackCommandService.skipPlayback(partyroomId);
 
-        // then — t2(orderNumber=2) 재생 + rotatePlayed(pl,2,2), deactivate 미호출
+        // then — t2(trackId=2002) 재생 + advancePlaybackCursor(pl,2002), deactivate 미호출
         PlaybackData saved = playbackCaptor.getValue();
         assertThat(saved.getLinkId()).isEqualTo("ok");
         assertThat(saved.getName()).isEqualTo("Playable");
-        verify(playlistCommandPort).rotatePlayed(playlistId, 2, 2L);
+        verify(playlistCommandPort).advancePlaybackCursor(playlistId, 2002L);
         verify(eventPublisher).publishEvent(any(PlaybackStartedEvent.class));
         verify(partyroomAggregateService, never()).deactivatePlayback(any(PartyroomId.class));
     }
@@ -418,10 +417,10 @@ class PlaybackCommandServiceTest {
         when(aggregatePort.findCrewById(1L)).thenReturn(Optional.of(djCrew1));
         when(aggregatePort.findCrewById(2L)).thenReturn(Optional.of(djCrew2));
 
-        when(playlistCommandPort.peekOrderedTracks(pl1)).thenReturn(List.of(
-                new PlaybackTrackDto("o1", "Over1", "o1.jpg", Duration.fromString("6:00"), 1)));
-        when(playlistCommandPort.peekOrderedTracks(pl2)).thenReturn(List.of(
-                new PlaybackTrackDto("ok2", "Playable2", "p2.jpg", Duration.fromString("3:00"), 1)));
+        when(playlistCommandPort.peekTracksFromCursor(pl1)).thenReturn(List.of(
+                new PlaybackTrackDto(1L, "o1", "Over1", "o1.jpg", Duration.fromString("6:00"), 1)));
+        when(playlistCommandPort.peekTracksFromCursor(pl2)).thenReturn(List.of(
+                new PlaybackTrackDto(3002L, "ok2", "Playable2", "p2.jpg", Duration.fromString("3:00"), 1)));
 
         PlaybackData savedPlayback = mock(PlaybackData.class);
         lenient().when(savedPlayback.getId()).thenReturn(1L);
@@ -440,8 +439,8 @@ class PlaybackCommandServiceTest {
         // then — dj2 트랙 재생 + rotateDjQueue 정확히 1회(이중 회전 없음), deactivate 미호출
         PlaybackData saved = playbackCaptor.getValue();
         assertThat(saved.getLinkId()).isEqualTo("ok2");
-        verify(playlistCommandPort).rotatePlayed(pl2, 1, 1L);
-        verify(playlistCommandPort, never()).rotatePlayed(eq(pl1), anyInt(), anyLong());
+        verify(playlistCommandPort).advancePlaybackCursor(pl2, 3002L);
+        verify(playlistCommandPort, never()).advancePlaybackCursor(eq(pl1), anyLong());
         verify(partyroomAggregateService, times(1)).rotateDjQueue(partyroomId);
         verify(partyroomAggregateService, never()).deactivatePlayback(any(PartyroomId.class));
     }

--- a/app/src/test/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepositoryReorderIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepositoryReorderIntegrationTest.java
@@ -3,30 +3,31 @@ package com.pfplaybackend.api.playlist.adapter.out.persistence;
 import com.pfplaybackend.api.common.AbstractIntegrationTest;
 import com.pfplaybackend.api.common.domain.value.Duration;
 import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
 import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
+import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * #222 회귀 잠금 — skip(자의/타의/time-limit) 시 "재생된 트랙이 본인 플레이리스트 최하단으로" invariant 의
- * 산술 핵심인 {@link TrackRepository#rotatePlayedOrder} 의 SQL 동작을 잠근다.
+ * 트랙 순서 배치 연산 통합 테스트.
  *
- * <p>E/#3 에서 legacy {@code reorderTracks} 는 단일 CASE {@code rotatePlayedOrder} 로 일반화되어 제거됐다.
- * k=1 케이스가 legacy reorderTracks(pid, total) 와 산술적으로 동일함은
- * {@link #rotatePlayedOrder_k_eq_1_equivalent_to_legacy_reorder} 가 명시적으로 잠근다.
- * DJ 큐 회전 산술은 PartyroomAggregateServiceTest.rotatesCorrectly 가 별도로 잠금.
+ * <p>회전({@code rotatePlayedOrder}) 기반 #222 잠금은 "재생 회전 제거 + 영속 커서" 재설계로 대체됐다.
+ * 신규 모델에서 재생은 {@code order_number} 를 변경하지 않으며(아래 #262 회귀가 잠금),
+ * 신규 곡 추가(add-to-head)의 산술은 {@link TrackRepository#shiftAllOrdersDown} 가 담당한다.
  */
 @Transactional
 class TrackRepositoryReorderIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired
     private TrackRepository trackRepository;
+    @Autowired
+    private PlaylistRepository playlistRepository;
 
     private TrackData saveTrack(long playlistId, int orderNumber, String linkId) {
         return trackRepository.save(TrackData.builder()
@@ -39,63 +40,47 @@ class TrackRepositoryReorderIntegrationTest extends AbstractIntegrationTest {
                 .build());
     }
 
-    // ===== rotatePlayedOrder (E/#3: over-limit skip — k번째 재생 트랙을 최하단으로) =====
-
     @Test
-    @DisplayName("rotatePlayedOrder(k>1) — k번 트랙은 최하단, k 이전은 불변, k 이후는 -1 (갭 없음)")
-    void rotatePlayedOrder_k_gt_1() {
-        // given — 플레이리스트 5트랙 [1,2,3,4,5]
+    @DisplayName("shiftAllOrdersDown — 플레이리스트 전체 order_number 를 +1 한다 (add-to-head 용)")
+    void shiftAllOrdersDown_incrementsAll() {
+        // given — [1,2,3]
         long playlistId = 9500L;
-        TrackData t1 = saveTrack(playlistId, 1, "r-link-1");
-        TrackData t2 = saveTrack(playlistId, 2, "r-link-2");
-        TrackData t3 = saveTrack(playlistId, 3, "r-link-3");
-        TrackData t4 = saveTrack(playlistId, 4, "r-link-4");
-        TrackData t5 = saveTrack(playlistId, 5, "r-link-5");
+        TrackData t1 = saveTrack(playlistId, 1, "h-link-1");
+        TrackData t2 = saveTrack(playlistId, 2, "h-link-2");
+        TrackData t3 = saveTrack(playlistId, 3, "h-link-3");
         flushAndClear();
 
-        // when — k=3 재생 트랙 최하단 이동 (total=5)
-        trackRepository.rotatePlayedOrder(playlistId, 3, 5L);
+        // when
+        trackRepository.shiftAllOrdersDown(playlistId);
         flushAndClear();
 
-        // then — 갭/중복 없음: 결과 orderNumber 집합 = [1,2,3,4,5]
-        List<Integer> allOrders = List.of(
-                trackRepository.findById(t1.getId()).orElseThrow().getOrderNumber(),
-                trackRepository.findById(t2.getId()).orElseThrow().getOrderNumber(),
-                trackRepository.findById(t3.getId()).orElseThrow().getOrderNumber(),
-                trackRepository.findById(t4.getId()).orElseThrow().getOrderNumber(),
-                trackRepository.findById(t5.getId()).orElseThrow().getOrderNumber());
-        assertThat(allOrders).containsExactlyInAnyOrder(1, 2, 3, 4, 5);
-
-        // then — 개별 이동 검증
-        // k < 3: 불변
-        assertThat(trackRepository.findById(t1.getId()).orElseThrow().getOrderNumber()).isEqualTo(1);
-        assertThat(trackRepository.findById(t2.getId()).orElseThrow().getOrderNumber()).isEqualTo(2);
-        // k = 3: 최하단(5)으로
-        assertThat(trackRepository.findById(t3.getId()).orElseThrow().getOrderNumber()).isEqualTo(5);
-        // k > 3: 한 칸씩 앞으로
-        assertThat(trackRepository.findById(t4.getId()).orElseThrow().getOrderNumber()).isEqualTo(3);
-        assertThat(trackRepository.findById(t5.getId()).orElseThrow().getOrderNumber()).isEqualTo(4);
+        // then — [2,3,4]
+        assertThat(trackRepository.findById(t1.getId()).orElseThrow().getOrderNumber()).isEqualTo(2);
+        assertThat(trackRepository.findById(t2.getId()).orElseThrow().getOrderNumber()).isEqualTo(3);
+        assertThat(trackRepository.findById(t3.getId()).orElseThrow().getOrderNumber()).isEqualTo(4);
     }
 
     @Test
-    @DisplayName("rotatePlayedOrder(k=1) — reorderTracks(pid, total)과 산술적으로 동일")
-    void rotatePlayedOrder_k_eq_1_equivalent_to_legacy_reorder() {
-        // given — 플레이리스트 4트랙 [1,2,3,4]
-        long playlistId = 9600L;
-        TrackData t1 = saveTrack(playlistId, 1, "s-link-1");
-        TrackData t2 = saveTrack(playlistId, 2, "s-link-2");
-        TrackData t3 = saveTrack(playlistId, 3, "s-link-3");
-        TrackData t4 = saveTrack(playlistId, 4, "s-link-4");
+    @DisplayName("#262 회귀 — 재생 커서 갱신(advancePlaybackCursor)은 track.order_number 를 변경하지 않는다")
+    void cursorAdvance_doesNotMutateTrackOrder() {
+        // given — 플레이리스트 + 트랙 [1,2,3]
+        PlaylistData playlist = playlistRepository.save(
+                PlaylistData.create(0, "p", PlaylistType.PLAYLIST, new UserId(777L)));
+        long playlistId = playlist.getId();
+        TrackData t1 = saveTrack(playlistId, 1, "c-link-1");
+        TrackData t2 = saveTrack(playlistId, 2, "c-link-2");
+        TrackData t3 = saveTrack(playlistId, 3, "c-link-3");
         flushAndClear();
 
-        // when — k=1 (reorderTracks 와 동등)
-        trackRepository.rotatePlayedOrder(playlistId, 1, 4L);
+        // when — 커서를 여러 번 advance (재생 시뮬레이션)
+        playlistRepository.updateLastPlayedTrackId(playlistId, t1.getId());
+        playlistRepository.updateLastPlayedTrackId(playlistId, t2.getId());
         flushAndClear();
 
-        // then — old-1→4, old-2→1, old-3→2, old-4→3 (legacy reorderTracks 결과와 동일)
-        assertThat(trackRepository.findById(t1.getId()).orElseThrow().getOrderNumber()).isEqualTo(4);
-        assertThat(trackRepository.findById(t2.getId()).orElseThrow().getOrderNumber()).isEqualTo(1);
-        assertThat(trackRepository.findById(t3.getId()).orElseThrow().getOrderNumber()).isEqualTo(2);
-        assertThat(trackRepository.findById(t4.getId()).orElseThrow().getOrderNumber()).isEqualTo(3);
+        // then — order_number 불변(회전 제거로 #262 staleness 소멸), 커서만 갱신
+        assertThat(trackRepository.findById(t1.getId()).orElseThrow().getOrderNumber()).isEqualTo(1);
+        assertThat(trackRepository.findById(t2.getId()).orElseThrow().getOrderNumber()).isEqualTo(2);
+        assertThat(trackRepository.findById(t3.getId()).orElseThrow().getOrderNumber()).isEqualTo(3);
+        assertThat(playlistRepository.findById(playlistId).orElseThrow().getLastPlayedTrackId()).isEqualTo(t2.getId());
     }
 }

--- a/docs/superpowers/plans/2026-05-22-playlist-rotation-cursor-redesign.md
+++ b/docs/superpowers/plans/2026-05-22-playlist-rotation-cursor-redesign.md
@@ -416,7 +416,7 @@ public void advancePlaybackCursor(Long playlistId, Long trackId) {
 Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :playlist:test --tests "*TrackCommandServiceTest" -q`
 Expected: PASS
 
-- [ ] **Step 5: rotatePlayed_delegates 테스트 삭제** (있다면) — 제거된 메서드 검증 테스트.
+- [ ] **Step 5: 회전 관련 테스트 정리** — `rotatePlayed_delegates` 삭제. `peekOrderedTracks_returns_ordered_without_rotation` 는 신규 커서 동작에 맞게 갱신하거나(자연순서 케이스 = 커서 null로 흡수 가능) 신규 peekTracksFromCursor 테스트로 대체.
 
 - [ ] **Step 6: Commit**
 
@@ -512,7 +512,8 @@ git commit -m "feat(party): 재생 곡 선택을 커서 기반으로 교체 (pee
   - `given(playlistCommandPort.peekOrderedTracks(any())).willReturn(...)` → `peekTracksFromCursor`
   - `verify(playlistCommandPort).rotatePlayed(any(), anyInt(), anyLong())` → `verify(playlistCommandPort).advancePlaybackCursor(eq(playlistId), eq(<chosen trackId>))`
   - `verify(...,never()).rotatePlayed(...)` (singleDj_allOverLimit) → `never().advancePlaybackCursor(...)`
-  - peeked 트랙 fixture 의 `PlaybackTrackDto` 생성에 `trackId` 추가(첫 인자).
+  - ⚠️ **`new PlaybackTrackDto(...)` 생성처가 8곳**(대략 line 194, 241, 320/321, 366/367, 422/424) — Task 2에서 record 첫 필드로 `trackId`가 추가되므로 **8곳 모두** 첫 인자에 결정적(deterministic) trackId를 부여한다.
+  - fixture에 부여한 trackId로 advance 검증을 맞춘다. 예: 기존 `verify(...).rotatePlayed(pl, 2, 2L)`(order=2 곡 재생) → 그 order=2 곡 fixture의 trackId가 `T2`라면 `verify(...).advancePlaybackCursor(pl, T2)`. (peekTracksFromCursor stub이 반환하는 목록의 첫 재생가능 곡 = 선택 곡이므로, 그 곡의 trackId가 advance 인자가 됨.)
 
 - [ ] **Step 2: app 테스트 컴파일+실행**
 
@@ -532,7 +533,7 @@ git add -A && git commit -m "test(party): PlaybackCommandServiceTest 커서 기�
 
 - [ ] **Step 1: rotatePlayedOrder 2케이스 삭제, shiftAllOrdersDown 통합 테스트로 교체**
 
-기존 DB 셋업(@DataJpaTest 등) 패턴 유지하고:
+⚠️ 베이스 클래스 `AbstractIntegrationTest` 는 `@SpringBootTest`(풀 컨텍스트)이고 `flushAndClear()` + `entityManager` 를 노출한다(`@DataJpaTest` 아님). 따라서 `@Autowired PlaylistRepository` 주입 가능, flush는 `flushAndClear()` 사용. 기존 셋업 패턴 유지하고:
 
 ```java
 @Test
@@ -587,7 +588,7 @@ git add -A && git commit -m "test: rotate IT를 shiftAllOrdersDown + #262 커서
 Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew build -q`
 Expected: BUILD SUCCESSFUL (모든 모듈 테스트 GREEN)
 
-- [ ] **Step 2: rotatePlayed 잔존 참조 0 확인** — `rotatePlayed`/`rotatePlayedOrder`/`peekOrderedTracks`(party port) 검색해 dead reference 없음 확인.
+- [ ] **Step 2: rotatePlayed 잔존 참조 0 확인** — `rotatePlayed`/`rotatePlayedOrder`/`peekOrderedTracks`(party port) 검색해 dead reference 없음 확인. 또한 playlist-module `TrackCommandService.peekOrderedTracks` 가 party port 제거 후 production 소비자가 없으면(audit) 삭제 결정(테스트만 남으면 dead code).
 
 - [ ] **Step 3: 미세 커밋 정리(squash) — push 전** (메모리: push 전 논리 단위 통합). develop 기준 논리 단위로 정리.
 

--- a/docs/superpowers/plans/2026-05-22-playlist-rotation-cursor-redesign.md
+++ b/docs/superpowers/plans/2026-05-22-playlist-rotation-cursor-redesign.md
@@ -1,0 +1,606 @@
+# 플레이리스트 재생 회전 제거 + 영속 재생 커서 구현 플랜
+
+> **For agentic workers:** REQUIRED: Use @superpowers:executing-plans (in-session, 본 변경은 여러 파일이 함께 바뀌어야 해 cross-file 컨텍스트가 필요) to implement this plan. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** `track.order_number`의 이중 용도(사용자 순서 + 재생 회전 커서)를 분리해, 재생은 `PLAYLIST.last_played_track_id` 커서로 결정하고 회전을 제거한다. 동시에 신규 곡 추가를 맨 위(order 1)로 바꾼다. → #262 + 기획 요청을 한 PR로 해결.
+
+**Architecture:** 헥사고날(party 모듈이 playlist 모듈을 port로 호출). `orderNumber`는 add/delete/reorder에서만 변경(재생은 불변). DJ 턴 곡 선택 = "커서 트랙 다음부터 wrap 정렬한 목록에서 첫 재생가능 곡" → 선택 곡으로 커서 갱신.
+
+**Tech Stack:** Java 21, Spring Boot, JPA/Hibernate(@DynamicUpdate), Flyway, QueryDSL, JUnit5/Mockito, Gradle multi-module.
+
+**빌드/테스트 prefix (필수):** 모든 gradle 호출에 `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7"` 를 붙인다. Bash 툴(git bash)에서 `./gradlew` 사용.
+
+스펙: `docs/superpowers/specs/2026-05-22-playlist-rotation-cursor-redesign-design.md`
+
+---
+
+## File Structure
+
+생성:
+- `app/src/main/resources/db/migration/V21__add_playlist_playback_cursor.sql` — 커서 컬럼 마이그레이션
+- `playlist/src/main/java/com/pfplaybackend/api/playlist/domain/enums/InsertPosition.java` — HEAD/TAIL enum
+
+수정 (main):
+- `playlist/.../domain/entity/data/PlaylistData.java` — `lastPlayedTrackId` 필드
+- `playlist/.../application/dto/PlaybackTrackDto.java` — `trackId` 필드 추가
+- `playlist/.../adapter/out/persistence/TrackRepository.java` — `shiftAllOrdersDown` 추가, `rotatePlayedOrder` 제거
+- `playlist/.../adapter/out/persistence/PlaylistRepository.java` — `updateLastPlayedTrackId` @Modifying 추가
+- `playlist/.../domain/port/PlaylistAggregatePort.java` — `rotatePlayed` 제거; `shiftAllOrdersDown`/`findPlaylistById`/`updateLastPlayedTrackId` 추가
+- `playlist/.../adapter/out/persistence/PlaylistAggregateAdapter.java` — 위 port 구현 반영
+- `playlist/.../application/service/TrackCommandService.java` — `insertTrack`(HEAD/TAIL) 추출, `peekTracksFromCursor`/`advancePlaybackCursor` 추가, `rotatePlayed` 제거
+- `playlist/.../application/service/GrabTrackService.java` — TAIL 보존 호출
+- `app/.../party/application/port/out/PlaylistCommandPort.java` — `rotatePlayed`/`peekOrderedTracks` 제거; `peekTracksFromCursor`/`advancePlaybackCursor` 추가
+- `app/.../party/adapter/out/external/PlaylistCommandAdapter.java` — 위 반영
+- `app/.../party/application/service/PlaybackCommandService.java` — `doStart`/`startPlaybackFor` 커서 기반으로 교체
+
+수정 (test):
+- `playlist/.../application/service/TrackCommandServiceTest.java`
+- `app/.../party/application/service/PlaybackCommandServiceTest.java`
+- `app/.../playlist/adapter/out/persistence/TrackRepositoryReorderIntegrationTest.java` — rotate 제거 → `shiftAllOrdersDown` 검증으로 repurpose
+
+---
+
+## Chunk 1: 스키마 · 엔티티 · DTO
+
+### Task 1: 마이그레이션 V21 + PlaylistData 커서 필드
+
+**Files:**
+- Create: `app/src/main/resources/db/migration/V21__add_playlist_playback_cursor.sql`
+- Modify: `playlist/src/main/java/com/pfplaybackend/api/playlist/domain/entity/data/PlaylistData.java`
+
+- [ ] **Step 1: 마이그레이션 작성**
+
+```sql
+-- V21__add_playlist_playback_cursor.sql
+ALTER TABLE playlist
+    ADD COLUMN last_played_track_id bigint unsigned NULL COMMENT '재생 커서 — 마지막 재생 트랙 id';
+```
+
+- [ ] **Step 2: PlaylistData 에 필드 + 빌더 + 갱신 메서드 추가**
+
+`type` 필드 선언 다음(클래스 내), 빌더 생성자/`create`는 그대로 두고 필드와 도메인 메서드만 추가:
+
+```java
+    @Comment("재생 커서 — 마지막 재생 트랙 id")
+    @Column(name = "last_played_track_id", columnDefinition = "bigint unsigned")
+    private Long lastPlayedTrackId;
+```
+
+(빌더 생성자 파라미터에는 추가하지 않는다 — 생성 시엔 항상 null. `@Getter`가 `getLastPlayedTrackId()` 제공. 영속화는 Task 4의 @Modifying 쿼리로 직접 처리하므로 setter 불필요.)
+
+- [ ] **Step 3: 컴파일 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :playlist:compileJava -q`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/resources/db/migration/V21__add_playlist_playback_cursor.sql playlist/src/main/java/com/pfplaybackend/api/playlist/domain/entity/data/PlaylistData.java
+git commit -m "feat(playlist): V21 재생 커서 컬럼 + PlaylistData.lastPlayedTrackId"
+```
+
+### Task 2: PlaybackTrackDto 에 trackId 추가
+
+**Files:**
+- Modify: `playlist/src/main/java/com/pfplaybackend/api/playlist/application/dto/PlaybackTrackDto.java`
+- Modify: `playlist/.../application/service/TrackCommandService.java` (peekOrderedTracks 매핑)
+
+- [ ] **Step 1: record 에 trackId 추가**
+
+```java
+public record PlaybackTrackDto(
+        Long trackId,
+        String linkId,
+        String name,
+        String thumbnailImage,
+        Duration duration,
+        int orderNumber
+) {
+}
+```
+
+- [ ] **Step 2: 유일 생성처(peekOrderedTracks) 매핑 보강** — `PlaylistTrackDto.trackId()` 사용
+
+`TrackCommandService.peekOrderedTracks` 의 map 람다:
+
+```java
+            .map(dto -> new PlaybackTrackDto(dto.trackId(), dto.linkId(), dto.name(),
+                    dto.thumbnailImage(), dto.duration(), dto.orderNumber()))
+```
+
+- [ ] **Step 3: 전체 컴파일 (생성처 누락 검출)**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew compileJava -q`
+Expected: BUILD SUCCESSFUL. (실패 시 PlaybackTrackDto 생성처가 더 있다는 뜻 → 해당 위치도 trackId 추가)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "feat(playlist): PlaybackTrackDto 에 trackId 추가 (커서 갱신용)"
+```
+
+---
+
+## Chunk 2: 영속화 plumbing (repository · aggregate port)
+
+### Task 3: TrackRepository — shiftAllOrdersDown 추가 + rotatePlayedOrder 제거
+
+**Files:**
+- Modify: `playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepository.java`
+
+- [ ] **Step 1: `rotatePlayedOrder` 메서드(@Query 포함) 삭제하고 `shiftAllOrdersDown` 추가**
+
+```java
+    @Modifying
+    @Query("UPDATE TrackData pm SET pm.orderNumber = pm.orderNumber + 1 " +
+            "WHERE pm.playlistId.id = :playlistId")
+    void shiftAllOrdersDown(@Param("playlistId") Long playlistId);
+```
+
+(shiftUpOrderByDelete / shiftUpOrderByDnD / shiftDownOrderByDnD 는 그대로 유지.)
+
+- [ ] **Step 2: 컴파일** — `rotatePlayedOrder` 호출처(PlaylistAggregateAdapter)가 깨지는 것을 확인
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :playlist:compileJava -q`
+Expected: FAIL — `PlaylistAggregateAdapter` 의 `rotatePlayedOrder` 참조 에러. (Task 4에서 해소)
+
+### Task 4: PlaylistAggregatePort/Adapter + PlaylistRepository 커서 메서드
+
+**Files:**
+- Modify: `playlist/.../domain/port/PlaylistAggregatePort.java`
+- Modify: `playlist/.../adapter/out/persistence/PlaylistAggregateAdapter.java`
+- Modify: `playlist/.../adapter/out/persistence/PlaylistRepository.java`
+
+- [ ] **Step 1: PlaylistRepository 에 커서 업데이트 쿼리 추가** (import `@Modifying`, `@Query`, `@Param`)
+
+```java
+    @Modifying
+    @Query("UPDATE PlaylistData p SET p.lastPlayedTrackId = :trackId WHERE p.id = :playlistId")
+    void updateLastPlayedTrackId(@Param("playlistId") Long playlistId, @Param("trackId") Long trackId);
+```
+
+- [ ] **Step 2: PlaylistAggregatePort 변경** — `rotatePlayed` 제거, 신규 3개 추가
+
+```java
+    // 제거: void rotatePlayed(Long playlistId, int playedOrderNumber, long totalCount);
+
+    // 추가 (Track Reordering 섹션 근처)
+    void shiftAllOrdersDown(Long playlistId);
+
+    // 추가 (Root: PlaylistData 섹션 근처)
+    Optional<PlaylistData> findPlaylistById(Long playlistId);
+    void advancePlaybackCursor(Long playlistId, Long trackId);
+```
+
+- [ ] **Step 3: PlaylistAggregateAdapter 구현** — `rotatePlayed` 삭제, 신규 구현
+
+```java
+    @Override
+    public void shiftAllOrdersDown(Long playlistId) {
+        trackRepository.shiftAllOrdersDown(playlistId);
+    }
+
+    @Override
+    public Optional<PlaylistData> findPlaylistById(Long playlistId) {
+        return playlistRepository.findById(playlistId);
+    }
+
+    @Override
+    public void advancePlaybackCursor(Long playlistId, Long trackId) {
+        playlistRepository.updateLastPlayedTrackId(playlistId, trackId);
+    }
+```
+
+- [ ] **Step 4: 컴파일**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :playlist:compileJava -q`
+Expected: FAIL — 이제 `TrackCommandService.rotatePlayed` 가 제거된 `aggregatePort.rotatePlayed` 를 참조. (Task 5에서 해소)
+
+---
+
+## Chunk 3: TrackCommandService — add-to-head + 커서 선택/갱신
+
+### Task 5: InsertPosition + insertTrack 추출 (add=HEAD, grab=TAIL)
+
+**Files:**
+- Create: `playlist/.../domain/enums/InsertPosition.java`
+- Modify: `playlist/.../application/service/TrackCommandService.java`
+- Modify: `playlist/.../application/service/GrabTrackService.java`
+- Test: `playlist/.../application/service/TrackCommandServiceTest.java`
+
+- [ ] **Step 1: 실패 테스트 작성** — add=HEAD(shift+order1), grab 경로용 TAIL
+
+`TrackCommandServiceTest` 에 추가 (기존 mock 설정 패턴 따름: `aggregatePort`, `playlistQueryService` 등 @Mock):
+
+```java
+@Test
+@DisplayName("addTrackInPlaylist 는 신규 곡을 맨 위(order 1)로 넣고 기존 전체를 +1 shift 한다")
+void addTrack_insertsAtHead() {
+    // given: 소유 플레이리스트 존재, 중복 없음, 3곡 보유
+    // (기존 테스트의 given 셋업 재사용: findPlaylistByIdAndOwner, findTrackByPlaylistAndLink=empty,
+    //  playlistQueryService.getPlaylist → musicCount=3, AuthContext stub)
+    // when
+    trackCommandService.addTrackInPlaylist(playlistId, addCommand);
+    // then
+    verify(aggregatePort).shiftAllOrdersDown(playlistId);
+    ArgumentCaptor<TrackData> captor = ArgumentCaptor.forClass(TrackData.class);
+    verify(aggregatePort).saveTrack(captor.capture());
+    assertThat(captor.getValue().getOrderNumber()).isEqualTo(1);
+}
+```
+
+(정확한 given 스텁은 기존 `addTrackInPlaylist` 성공 케이스 테스트를 복제해 맞춘다. AuthContext 는 기존 테스트의 ThreadLocalContext 셋업 방식 그대로.)
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :playlist:test --tests "*TrackCommandServiceTest" -q`
+Expected: FAIL (shiftAllOrdersDown 미호출 / order!=1)
+
+- [ ] **Step 3: InsertPosition enum 생성**
+
+```java
+package com.pfplaybackend.api.playlist.domain.enums;
+
+public enum InsertPosition {
+    HEAD, TAIL
+}
+```
+
+- [ ] **Step 4: insertTrack 추출 + addTrackInPlaylist=HEAD**
+
+`addTrackInPlaylist` 본문을 `insertTrack(playlistId, command, InsertPosition.HEAD)` 위임으로 바꾸고 공통 로직을 private 으로 추출:
+
+```java
+@Transactional
+public Long addTrackInPlaylist(Long playlistId, AddTrackCommand command) {
+    return insertTrack(playlistId, command, InsertPosition.HEAD);
+}
+
+@Transactional
+public Long insertTrack(Long playlistId, AddTrackCommand command, InsertPosition position) {
+    AuthContext authContext = ThreadLocalContext.getAuthContext();
+    PlaylistData playlistData = aggregatePort.findPlaylistByIdAndOwner(playlistId, authContext.getUserId())
+            .orElseThrow(() -> ExceptionCreator.create(PlaylistException.NOT_FOUND_PLAYLIST));
+    Optional<TrackData> optional = aggregatePort.findTrackByPlaylistAndLink(new PlaylistId(playlistData.getId()), command.linkId());
+    if (optional.isPresent()) throw ExceptionCreator.create(TrackException.DUPLICATE_TRACK_IN_PLAYLIST);
+    PlaylistSummaryDto playlistSummary = playlistQueryService.getPlaylist(playlistId);
+    if (playlistSummary.musicCount() >= MAX_PLAYLIST_TRACK_COUNT) throw ExceptionCreator.create(TrackException.EXCEEDED_TRACK_LIMIT);
+
+    int orderNumber;
+    if (position == InsertPosition.HEAD) {
+        aggregatePort.shiftAllOrdersDown(playlistData.getId());
+        orderNumber = 1;
+    } else { // TAIL — 기존 동작 보존
+        orderNumber = playlistSummary.musicCount() == 0 ? 1 : (int) playlistSummary.musicCount() + 1;
+    }
+
+    TrackData trackData = TrackData.builder()
+            .playlistId(new PlaylistId(playlistData.getId()))
+            .name(command.name())
+            .linkId(command.linkId())
+            .duration(Duration.fromString(command.duration()))
+            .orderNumber(orderNumber)
+            .thumbnailImage(command.thumbnailImage())
+            .build();
+    TrackData saved = aggregatePort.saveTrack(trackData);
+    eventPublisher.publishEvent(new TrackAddedEvent(new PlaylistId(playlistId), command.linkId(), command.name()));
+    return saved.getId();
+}
+```
+
+- [ ] **Step 5: GrabTrackService 가 TAIL 사용하도록 변경**
+
+`GrabTrackService.grabTrack` 의 호출부:
+
+```java
+Long trackId = trackCommandService.insertTrack(playlistData.getId(), command, InsertPosition.TAIL);
+```
+
+(import `InsertPosition` 추가.)
+
+- [ ] **Step 6: 테스트 통과 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :playlist:test --tests "*TrackCommandServiceTest" -q`
+Expected: PASS (단, 아직 rotatePlayed 제거 전이면 컴파일 에러 가능 — Task 6과 함께 통과시킬 것)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat(playlist): 신규 곡 추가를 맨 위로(add-to-head), grab은 tail 보존 (insertTrack/InsertPosition)"
+```
+
+### Task 6: 커서 기반 peekTracksFromCursor + advancePlaybackCursor, rotatePlayed 제거
+
+**Files:**
+- Modify: `playlist/.../application/service/TrackCommandService.java`
+- Test: `playlist/.../application/service/TrackCommandServiceTest.java`
+
+- [ ] **Step 1: 실패 테스트 작성** — wrap 선택 로직
+
+`queryPort.getTracksWithPagination` 가 정렬된 `PlaylistTrackDto` 페이지를 반환하도록 stub, `aggregatePort.findPlaylistById` 로 커서 stub. 헬퍼로 `PlaylistTrackDto(trackId, linkId, name, orderNumber, duration, thumb)` 목록 구성.
+
+```java
+@Test
+@DisplayName("peekTracksFromCursor: 커서 다음부터 wrap 정렬 (커서=B → C,A,B)")
+void peek_wrapsAfterCursor() {
+    // given: 트랙 A(1,id=10),B(2,id=20),C(3,id=30), 커서 last_played=20(B)
+    stubTracks(playlistId, A_1_10, B_2_20, C_3_30);
+    given(aggregatePort.findPlaylistById(playlistId))
+        .willReturn(Optional.of(playlistWithCursor(20L)));
+    // when
+    List<PlaybackTrackDto> result = trackCommandService.peekTracksFromCursor(playlistId);
+    // then: C, A, B 순
+    assertThat(result).extracting(PlaybackTrackDto::trackId).containsExactly(30L, 10L, 20L);
+}
+
+@Test
+@DisplayName("peekTracksFromCursor: 커서 null → 자연 순서(top부터)")
+void peek_nullCursor_naturalOrder() {
+    stubTracks(playlistId, A_1_10, B_2_20, C_3_30);
+    given(aggregatePort.findPlaylistById(playlistId)).willReturn(Optional.of(playlistWithCursor(null)));
+    assertThat(trackCommandService.peekTracksFromCursor(playlistId))
+        .extracting(PlaybackTrackDto::trackId).containsExactly(10L, 20L, 30L);
+}
+
+@Test
+@DisplayName("peekTracksFromCursor: 커서가 가리키던 트랙 삭제됨(목록에 없음) → top부터")
+void peek_deletedCursor_naturalOrder() {
+    stubTracks(playlistId, A_1_10, B_2_20, C_3_30);
+    given(aggregatePort.findPlaylistById(playlistId)).willReturn(Optional.of(playlistWithCursor(999L)));
+    assertThat(trackCommandService.peekTracksFromCursor(playlistId))
+        .extracting(PlaybackTrackDto::trackId).containsExactly(10L, 20L, 30L);
+}
+
+@Test
+@DisplayName("advancePlaybackCursor 는 aggregatePort.advancePlaybackCursor 로 위임")
+void advance_delegates() {
+    trackCommandService.advancePlaybackCursor(playlistId, 30L);
+    verify(aggregatePort).advancePlaybackCursor(playlistId, 30L);
+}
+```
+
+(stubTracks/playlistWithCursor 헬퍼는 테스트 클래스에 작성. `playlistWithCursor` 는 `PlaylistData` 빌드 후 리플렉션/빌더로 cursor 세팅 — 빌더에 없으면 `org.springframework.test.util.ReflectionTestUtils.setField(p,"lastPlayedTrackId",v)` 사용.)
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :playlist:test --tests "*TrackCommandServiceTest" -q`
+Expected: FAIL (메서드 미존재 컴파일 에러)
+
+- [ ] **Step 3: 구현 — rotatePlayed 삭제, peekTracksFromCursor/advancePlaybackCursor 추가**
+
+`rotatePlayed` 메서드 삭제. 추가:
+
+```java
+@Transactional(readOnly = true)
+public List<PlaybackTrackDto> peekTracksFromCursor(Long playlistId) {
+    Pageable pageable = PageRequest.of(0, MAX_PLAYLIST_TRACK_COUNT, Sort.by(Sort.Direction.ASC, "orderNumber"));
+    List<PlaylistTrackDto> ordered = queryPort.getTracksWithPagination(new PlaylistId(playlistId), pageable).getContent();
+
+    Long cursor = aggregatePort.findPlaylistById(playlistId)
+            .map(PlaylistData::getLastPlayedTrackId)
+            .orElse(null);
+
+    int start = 0; // 커서 null 또는 미발견 → top(0)부터
+    if (cursor != null) {
+        for (int i = 0; i < ordered.size(); i++) {
+            if (ordered.get(i).trackId().equals(cursor)) {
+                start = i + 1; // 커서 "다음"부터
+                break;
+            }
+        }
+    }
+
+    int n = ordered.size();
+    List<PlaybackTrackDto> rotated = new java.util.ArrayList<>(n);
+    for (int k = 0; k < n; k++) {
+        PlaylistTrackDto dto = ordered.get((start + k) % n);
+        rotated.add(new PlaybackTrackDto(dto.trackId(), dto.linkId(), dto.name(),
+                dto.thumbnailImage(), dto.duration(), dto.orderNumber()));
+    }
+    return rotated;
+}
+
+@Transactional
+public void advancePlaybackCursor(Long playlistId, Long trackId) {
+    aggregatePort.advancePlaybackCursor(playlistId, trackId);
+}
+```
+
+(`n == 0` 가드: `for` 가 안 돌아 빈 리스트 반환 — `%` 0 호출 안 됨. 안전.)
+
+- [ ] **Step 4: 테스트 통과 + 모듈 컴파일**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :playlist:test --tests "*TrackCommandServiceTest" -q`
+Expected: PASS
+
+- [ ] **Step 5: rotatePlayed_delegates 테스트 삭제** (있다면) — 제거된 메서드 검증 테스트.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat(playlist): 커서 기반 peekTracksFromCursor/advancePlaybackCursor, rotatePlayed 제거"
+```
+
+---
+
+## Chunk 4: party 포트 + PlaybackCommandService 배선
+
+### Task 7: party PlaylistCommandPort/Adapter 교체
+
+**Files:**
+- Modify: `app/.../party/application/port/out/PlaylistCommandPort.java`
+- Modify: `app/.../party/adapter/out/external/PlaylistCommandAdapter.java`
+
+- [ ] **Step 1: 포트 인터페이스 변경** — `peekOrderedTracks`/`rotatePlayed` 제거, 신규 2개 추가
+
+```java
+public interface PlaylistCommandPort {
+    AddedTrackInfo grabTrack(UserId userId, String linkId);
+    java.util.List<PlaybackTrackDto> peekTracksFromCursor(PlaylistId playlistId);
+    void advancePlaybackCursor(PlaylistId playlistId, Long trackId);
+}
+```
+
+- [ ] **Step 2: 어댑터 구현 교체**
+
+```java
+    @Override
+    public List<PlaybackTrackDto> peekTracksFromCursor(PlaylistId playlistId) {
+        return trackCommandService.peekTracksFromCursor(playlistId.getId());
+    }
+
+    @Override
+    public void advancePlaybackCursor(PlaylistId playlistId, Long trackId) {
+        trackCommandService.advancePlaybackCursor(playlistId.getId(), trackId);
+    }
+```
+
+(기존 `peekOrderedTracks`/`rotatePlayed` override 삭제.)
+
+- [ ] **Step 3: 컴파일** — PlaybackCommandService 가 깨지는 것 확인
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:compileJava -q`
+Expected: FAIL — PlaybackCommandService 의 `peekOrderedTracks`/`rotatePlayed` 참조 에러. (Task 8에서 해소)
+
+### Task 8: PlaybackCommandService doStart/startPlaybackFor 커서 기반 교체
+
+**Files:**
+- Modify: `app/.../party/application/service/PlaybackCommandService.java` (lines ~119-150)
+
+- [ ] **Step 1: doStart 의 peek 호출 교체** (line 122)
+
+```java
+            List<PlaybackTrackDto> peeked = playlistCommandPort.peekTracksFromCursor(dj.getPlaylistId());
+```
+
+- [ ] **Step 2: startPlaybackFor 의 rotate → advance 교체** (line 150)
+
+`startPlaybackFor` 시그니처에서 `long total` 파라미터 제거(이제 미사용), 본문 line 150 교체:
+
+```java
+        playlistCommandPort.advancePlaybackCursor(dj.getPlaylistId(), chosen.trackId());
+```
+
+호출부(line 138)도 `startPlaybackFor(partyroom, dj, djCrew, chosen);` 로 수정.
+
+- [ ] **Step 3: app 전체 컴파일**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:compileJava :app:compileTestJava -q`
+Expected: FAIL (테스트가 아직 rotatePlayed/peekOrderedTracks 를 stub/verify → Task 9에서 해소). main 컴파일은 SUCCESS 여야 함.
+
+- [ ] **Step 4: Commit (main 한정)**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party
+git commit -m "feat(party): 재생 곡 선택을 커서 기반으로 교체 (peekTracksFromCursor + advancePlaybackCursor)"
+```
+
+---
+
+## Chunk 5: 테스트 rewire + 회귀 + 품질 게이트
+
+### Task 9: PlaybackCommandServiceTest rewire
+
+**Files:**
+- Modify: `app/.../party/application/service/PlaybackCommandServiceTest.java`
+
+- [ ] **Step 1: stub/verify 치환**
+  - `given(playlistCommandPort.peekOrderedTracks(any())).willReturn(...)` → `peekTracksFromCursor`
+  - `verify(playlistCommandPort).rotatePlayed(any(), anyInt(), anyLong())` → `verify(playlistCommandPort).advancePlaybackCursor(eq(playlistId), eq(<chosen trackId>))`
+  - `verify(...,never()).rotatePlayed(...)` (singleDj_allOverLimit) → `never().advancePlaybackCursor(...)`
+  - peeked 트랙 fixture 의 `PlaybackTrackDto` 생성에 `trackId` 추가(첫 인자).
+
+- [ ] **Step 2: app 테스트 컴파일+실행**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "*PlaybackCommandServiceTest" -q`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "test(party): PlaybackCommandServiceTest 커서 기반으로 rewire"
+```
+
+### Task 10: TrackRepositoryReorderIntegrationTest repurpose + #262 회귀
+
+**Files:**
+- Modify: `app/.../playlist/adapter/out/persistence/TrackRepositoryReorderIntegrationTest.java`
+
+- [ ] **Step 1: rotatePlayedOrder 2케이스 삭제, shiftAllOrdersDown 통합 테스트로 교체**
+
+기존 DB 셋업(@DataJpaTest 등) 패턴 유지하고:
+
+```java
+@Test
+@DisplayName("shiftAllOrdersDown: 플레이리스트 전체 order_number 를 +1 한다")
+void shiftAllOrdersDown_incrementsAll() {
+    // given: 같은 playlist 에 order 1,2,3 트랙 저장
+    // when
+    trackRepository.shiftAllOrdersDown(playlistId);
+    em.flush(); em.clear();
+    // then: 2,3,4
+    List<TrackData> tracks = trackRepository.findAll(); // 또는 playlist 별 조회
+    assertThat(tracks).extracting(TrackData::getOrderNumber)
+        .containsExactlyInAnyOrder(2, 3, 4);
+}
+```
+
+클래스 javadoc 의 "#222 회귀 잠금(rotatePlayedOrder)" 설명은 "회전 제거(재설계)로 대체됨; #262 회귀는 §아래 reorder 안정성 테스트로 이관" 으로 갱신.
+
+- [ ] **Step 2: #262 회귀 — 재생(커서 advance) 후 order 불변 + reorder 일관**
+
+같은 파일 또는 `TrackCommandServiceTest` 에 (mock 레벨이면 후자) 추가:
+
+```java
+@Test
+@DisplayName("#262 회귀: advancePlaybackCursor 는 order_number 를 변경하지 않는다")
+void cursorAdvance_doesNotMutateOrder() {
+    // given order 1,2,3
+    // when: 커서를 여러 번 advance
+    playlistRepository.updateLastPlayedTrackId(playlistId, t1.getId());
+    playlistRepository.updateLastPlayedTrackId(playlistId, t2.getId());
+    em.flush(); em.clear();
+    // then: order_number 그대로 1,2,3
+    assertThat(...).containsExactly(1,2,3);
+}
+```
+
+- [ ] **Step 3: 실행**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "*TrackRepositoryReorderIntegrationTest" -q`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A && git commit -m "test: rotate IT를 shiftAllOrdersDown + #262 커서 불변 회귀로 교체"
+```
+
+### Task 11: 전체 품질 게이트
+
+- [ ] **Step 1: 전체 빌드 + 테스트**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew build -q`
+Expected: BUILD SUCCESSFUL (모든 모듈 테스트 GREEN)
+
+- [ ] **Step 2: rotatePlayed 잔존 참조 0 확인** — `rotatePlayed`/`rotatePlayedOrder`/`peekOrderedTracks`(party port) 검색해 dead reference 없음 확인.
+
+- [ ] **Step 3: 미세 커밋 정리(squash) — push 전** (메모리: push 전 논리 단위 통합). develop 기준 논리 단위로 정리.
+
+---
+
+## 검증 시나리오 (수동/통합 — 선택)
+
+- 1곡 [A] 디제잉 → A 재생 → B 추가 → 다음 턴 B (제보 해결)
+- 멀티 [A,B,C] → A,B 재생 후 D 추가 → 다음 사이클 C → D
+- 디제잉 중 reorder → INVALID_TRACK_ORDER 팝업 없이 일관 동작 (#262)
+- grab → GRABLIST tail 유지(동작 변경 없음)
+
+## PR 노트 (작성 시 포함)
+- `TrackRepositoryReorderIntegrationTest` 의 #222 회귀 의도는 "회전 제거"로 대체되며, #262 회귀(커서 advance가 order 불변)가 후속 커버리지임을 명시.
+- grab(GRABLIST) tail 보존은 의도된 범위 한정 결정(스펙 §9).
+- Closes #262.

--- a/docs/superpowers/specs/2026-05-22-playlist-rotation-cursor-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-22-playlist-rotation-cursor-redesign-design.md
@@ -1,0 +1,129 @@
+# 플레이리스트 재생 회전 제거 + 영속 재생 커서 재설계
+
+- 작성일: 2026-05-22
+- 상태: 설계 승인됨 (구현 전)
+- 관련: pfplay-platform #262 (디제잉 중 순서변경 충돌), 기획 요청(신규 곡 추가 = 맨 위로)
+- 범위: pfplay-platform 단일 PR (백엔드)
+
+## 1. 배경 / 문제
+
+현재 `TrackData.orderNumber` 컬럼은 **두 가지 책임을 동시에** 진다:
+1. 사용자가 큐레이션하는 플레이리스트 순서(표시·드래그 reorder의 기준)
+2. 재생 회전 커서 — 곡이 재생될 때마다 `rotatePlayed`가 재생한 곡을 맨 뒤로 보내고 뒤 곡들을 앞당긴다.
+
+이 이중 용도에서 두 가지 결함이 파생된다.
+
+### 결함 A — 디제잉 중 순서 변경 충돌 (#262)
+재생이 `orderNumber`를 디제잉 중 몰래 바꾸는데 프론트는 재동기화하지 않는다. 사용자는 stale한 순서를 보고 절대 슬롯(`nextOrderNumber`)으로 reorder를 보내고, 서버는 회전된 최신 `orderNumber`를 prev로 읽어 검증 → `prev == nextOrderNumber` 충돌 시 `INVALID_TRACK_ORDER`("유효하지 않은 트랙 순서입니다") 팝업 + 미반영, 충돌하지 않는 곡은 의도와 다른 위치로 silent 재배치.
+
+### 결함 B — 신규 곡이 한 바퀴 뒤에야 재생 (기획 요청 대상)
+신규 곡은 `orderNumber = count + 1`로 **맨 뒤에 append**된다. 특히 **1곡 플레이리스트**에서 디제잉 중 곡을 추가하면, 다음 내 차례에 방금 들은 직전 곡이 다시 재생된다(신규 곡은 맨 뒤라서). 사용자 경험을 해친다.
+
+두 결함의 근본 원인은 동일하다: **재생 회전이 사용자 순서를 파괴적으로 덮어쓴다.** 회전을 제거하고 재생 위치를 별도 커서로 분리하면 두 결함이 동시에 소멸하며, 백엔드 단일 변경으로 한 PR에 담을 수 있다(결함 A가 프론트 변경 없이 백엔드만으로 해결됨).
+
+## 2. 목표 / 비목표
+
+목표:
+- `orderNumber`를 **재생이 절대 변경하지 않는** 안정된 사용자 순서로 만든다.
+- 다음 재생 곡 선택을 **영속 재생 커서**로 결정한다.
+- 신규 곡 추가를 **맨 위(`orderNumber = 1`)** 로 바꾼다.
+- 결함 A(#262)를 프론트 변경 없이 해소한다.
+
+비목표:
+- 프론트엔드 변경(별도 확인 포인트만 둠, §8).
+- DJ 큐 회전(`DjData.orderNumber`) 변경 — 트랙 회전과 무관한 별개 메커니즘이며 손대지 않는다.
+- 멀티탭 동시 편집 동시성 강화(별도 백로그).
+
+## 3. 설계
+
+### 3.1 데이터 모델
+- `TrackData.orderNumber`: 안정된 사용자 순서. **add / delete / reorder(사용자 액션)에서만 변경.** 재생은 변경하지 않는다.
+- 신규 컬럼 `PLAYLIST.last_played_track_id` (nullable `bigint unsigned`, hard FK 없음 — 코드베이스의 application-level FK 스타일 준수) = 재생 커서. **플레이리스트별 영속**(디제잉을 다시 시작해도 중단 지점부터 이어짐).
+
+### 3.2 곡 선택 알고리즘 (DJ 턴, `PlaybackCommandService.doStart`)
+1. 커서가 가리키는 트랙의 현재 `orderNumber` `c`를 조회. 커서가 `null`이거나 가리키던 트랙이 삭제되어 없으면 `c = 0`으로 취급.
+2. `orderNumber` 오름차순 목록에서 **`c` 다음 위치부터 wrap 스캔**하며 첫 재생가능(`playbackTimeLimit` 이내) 트랙을 선택. `playbackTimeLimit` 필터는 party 모듈에 유지(현행 위치 보존), 커서 mechanics는 playlist 모듈이 담당.
+3. 선택된 트랙으로 커서 갱신: `last_played_track_id = chosen.id`.
+4. 재생가능 트랙이 하나도 없으면 현행대로 다음 DJ로 skip(`DJ_NO_PLAYABLE_TRACK`); 모든 DJ가 불가면 deactivate.
+
+over-limit으로 건너뛴 트랙에는 커서가 머물지 않는다(실제 재생된 트랙으로만 커서가 이동).
+
+#### 트레이스 (확정 동작)
+- 1곡 `[A]`, 커서=A → wrap → **A** (1곡은 항상 A)
+- 1곡 `[A]` → B를 top 추가 `[B,A]`, 커서=A → wrap → **B** ✓ (결함 B 해소)
+- 멀티 `[A(1),B(2),C(3)]` 커서=B → **C** → wrap → A → …
+- 멀티 커서=B, D top 추가 `[D(1),A(2),B(3),C(4)]` → 남은 사이클 **C** → 그다음 wrap → **D**
+  - = "다음 사이클 top에서 재생" (결정 Q1). 커서 위치를 흩트리지 않아 깨끗하며, 1곡 케이스는 wrap으로 즉시 다음 재생이 보장된다.
+
+### 3.3 신규 곡 추가 = 맨 위로 (`addTrackInPlaylist`)
+- 기존: `nextMusicOrderNumber = count == 0 ? 1 : count + 1` (tail).
+- 변경: 기존 트랙 전체 `orderNumber + 1` shift 후 신규 곡 `orderNumber = 1` (head).
+- 신규 repository 쿼리 `shiftAllOrdersDown(playlistId)` (`UPDATE TrackData SET orderNumber = orderNumber + 1 WHERE playlistId.id = :playlistId`) 추가.
+- `MAX_PLAYLIST_TRACK_COUNT`(100) 초과 검사, 중복 검사 등 기존 가드 유지.
+- 커서는 track-id 기반이라 renumber 영향 없음.
+
+### 3.4 결함 A(#262) 해소 — 부수 효과
+재생이 `orderNumber`를 더 이상 변경하지 않으므로 디제잉 중 클라이언트 뷰가 stale될 일이 없다 → 기존 `updateTrackOrderInPlaylist`의 절대 슬롯 검증이 그대로 정상 동작한다. **reorder 로직/프론트 변경 불필요.** (멀티탭 동시 편집 시 `prev == nextOrderNumber` 엣지는 잔존하나 허용 범위 — 회전起因 staleness만 제거하면 #262 제보 시나리오는 소멸.)
+
+## 4. 마이그레이션 (V21)
+
+`V21__add_playlist_playback_cursor.sql`:
+```sql
+ALTER TABLE playlist
+    ADD COLUMN last_played_track_id bigint unsigned NULL COMMENT '재생 커서 — 마지막 재생 트랙 id';
+```
+- 기존 `track.order_number`는 그대로 둔다(현재 회전이 남긴 상태가 그대로 안정 순서가 됨). 별도 데이터 보정 없음.
+- 모든 플레이리스트의 커서는 초기 `NULL` → 배포 후 첫 재생은 각자 현재 `orderNumber` 최소값(top)부터 시작.
+- dev/stg는 기존 DB reset 정책 활용 가능.
+
+## 5. 영향 컴포넌트
+
+추가/변경:
+- `PlaylistData`: `lastPlayedTrackId` 필드 + 갱신 메서드.
+- playlist command port: `peekTracksFromCursor(playlistId)`, `advancePlaybackCursor(playlistId, chosenTrackId)` 추가.
+- `TrackCommandService`: `addTrackInPlaylist`(head 삽입), 커서 기반 peek/advance 구현.
+- `TrackRepository`: `shiftAllOrdersDown` 추가.
+- `PlaybackTrackDto`: `trackId` 필드 추가(커서 갱신용).
+- `PlaybackCommandService.doStart` / `startPlaybackFor`: peek+filter+rotate → peek-from-cursor+filter+advance-cursor.
+
+제거:
+- `TrackRepository.rotatePlayedOrder` 쿼리.
+- `TrackCommandService.rotatePlayed` + playlist command port의 `rotatePlayed` + 어댑터.
+- `TrackRepositoryReorderIntegrationTest` 중 **회전(rotate) 전용 케이스만** 제거. shiftUp(delete)/shiftDown(DnD) reorder 케이스는 유지.
+
+`peekOrderedTracks`(자연 순서)는 표시용 등 다른 소비자가 있으면 유지하고, 재생 경로만 커서 변형으로 교체한다(구현 시 usage audit).
+
+## 6. 테스트 전략 (TDD)
+
+커서 선택(playlist/party):
+- 1곡 wrap (A→A)
+- 1곡 add-to-head → 신규 곡이 다음 재생 (결함 B 회귀)
+- 멀티곡 사이클 진행 + wrap
+- 멀티곡 add-to-head → 다음 사이클 top에서 재생 (Q1)
+- over-limit 트랙 skip (커서는 실제 재생곡으로만 이동)
+- 커서 null(최초) → top부터
+- 커서가 가리키던 트랙 삭제됨 → top부터(graceful)
+
+add-to-head:
+- 빈 플레이리스트 추가 → order 1
+- 기존 N곡 → 신규 order 1 + 기존 전체 +1
+
+reorder 회귀(#262):
+- 재생(커서 advance) 시뮬레이션 후에도 `orderNumber` 불변 → 동일 입력 reorder가 일관되게 성공.
+
+## 7. 롤아웃
+
+- 단일 PR(pfplay-platform), 한글 커밋/PR.
+- develop → (release) → main 게이트는 사용자 소관(메모리 정책).
+
+## 8. 프론트엔드 영향 (확인 포인트, 본 PR 범위 밖)
+
+- 플레이리스트 편집기는 `orderNumber` 순 표시 → 디제잉 중에도 안정. 신규 곡 top 추가는 add-track 캐시 invalidate로 자연 반영(현행 추정).
+- **확인 필요**: 클라가 `orderNumber == 1`을 "다음 재생곡"으로 표시하는 마커가 있는지. 있으면 진실원천이 서버 커서이므로 오해 소지 → pfplay-web 후속으로 분리. 없을 것으로 추정(현재곡/현재 DJ는 `PLAYBACK_STARTED` 이벤트 기반).
+
+## 9. 결정 로그
+
+- 모델: **회전 제거 + 영속 재생 커서**(대안: 회전 유지+프론트 resync 2 PR — 기각, 한 PR 불가 + 뷰 스크램블 잔존).
+- Q1 멀티곡 add-to-head: **다음 사이클 top에서 재생**(대안: 무조건 즉시 다음 — 기각, 커서 강제 이동으로 사이클 위치 훼손/starvation).
+- Q2 커서 영속성: **플레이리스트별 영속**(대안: 세션마다 top 리셋 — 기각, 리셋 시점 정의로 범위 증가 + 현 동작과 괴리).
+- 마이그레이션: 기존 `order_number` 보존(현 상태=안정 순서), 커서 NULL 시작.

--- a/docs/superpowers/specs/2026-05-22-playlist-rotation-cursor-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-22-playlist-rotation-cursor-redesign-design.md
@@ -41,7 +41,7 @@
 - 신규 컬럼 `PLAYLIST.last_played_track_id` (nullable `bigint unsigned`, hard FK 없음 — 코드베이스의 application-level FK 스타일 준수) = 재생 커서. **플레이리스트별 영속**(디제잉을 다시 시작해도 중단 지점부터 이어짐).
 
 ### 3.2 곡 선택 알고리즘 (DJ 턴, `PlaybackCommandService.doStart`)
-1. 커서가 가리키는 트랙의 현재 `orderNumber` `c`를 조회. 커서가 `null`이거나 가리키던 트랙이 삭제되어 없으면 `c = 0`으로 취급.
+1. 커서가 가리키는 트랙의 현재 `orderNumber` `c`를 조회. 구현상 `last_played_track_id`를 peek된 목록의 `trackId`와 매칭해 `c`를 얻는다(트랙 id는 `PlaylistTrackDto.trackId`에 이미 존재 → 쿼리 변경 불필요). 커서가 `null`이거나 매칭되는 트랙이 목록에 없으면(삭제됨) `c = 0`으로 취급.
 2. `orderNumber` 오름차순 목록에서 **`c` 다음 위치부터 wrap 스캔**하며 첫 재생가능(`playbackTimeLimit` 이내) 트랙을 선택. `playbackTimeLimit` 필터는 party 모듈에 유지(현행 위치 보존), 커서 mechanics는 playlist 모듈이 담당.
 3. 선택된 트랙으로 커서 갱신: `last_played_track_id = chosen.id`.
 4. 재생가능 트랙이 하나도 없으면 현행대로 다음 DJ로 skip(`DJ_NO_PLAYABLE_TRACK`); 모든 DJ가 불가면 deactivate.
@@ -54,13 +54,16 @@ over-limit으로 건너뛴 트랙에는 커서가 머물지 않는다(실제 재
 - 멀티 `[A(1),B(2),C(3)]` 커서=B → **C** → wrap → A → …
 - 멀티 커서=B, D top 추가 `[D(1),A(2),B(3),C(4)]` → 남은 사이클 **C** → 그다음 wrap → **D**
   - = "다음 사이클 top에서 재생" (결정 Q1). 커서 위치를 흩트리지 않아 깨끗하며, 1곡 케이스는 wrap으로 즉시 다음 재생이 보장된다.
+- over-limit + wrap: 커서=C(order 3)인데 order > 3 트랙이 전부 over-limit이고 A(order 1)가 재생가능 → wrap 스캔이 A를 선택. "wrap"은 "목록 끝에서 멈춤"이 아니라 처음으로 되돌아 계속 스캔함을 의미.
 
 ### 3.3 신규 곡 추가 = 맨 위로 (`addTrackInPlaylist`)
 - 기존: `nextMusicOrderNumber = count == 0 ? 1 : count + 1` (tail).
 - 변경: 기존 트랙 전체 `orderNumber + 1` shift 후 신규 곡 `orderNumber = 1` (head).
-- 신규 repository 쿼리 `shiftAllOrdersDown(playlistId)` (`UPDATE TrackData SET orderNumber = orderNumber + 1 WHERE playlistId.id = :playlistId`) 추가.
+- 신규 repository 쿼리 `shiftAllOrdersDown(playlistId)` (`UPDATE TrackData SET orderNumber = orderNumber + 1 WHERE playlistId.id = :playlistId`) 추가. `(playlist_id, order_number)` unique 제약이 없어(V15는 nickname/link_domain만) 전체 +1 shift 시 transient 충돌 없음.
 - `MAX_PLAYLIST_TRACK_COUNT`(100) 초과 검사, 중복 검사 등 기존 가드 유지.
 - 커서는 track-id 기반이라 renumber 영향 없음.
+
+**grab 경로는 현행(tail) 보존.** `addTrackInPlaylist`는 `GrabTrackService.grabTrack`(GRABLIST에 grab)도 공유하는데, 기획 요청은 DJ가 편집하는 `PLAYLIST` 한정이다. 불필요한 동작 변경을 피하기 위해 head-insert는 명시적 add 경로에만 적용한다. 구현: 공유 내부 메서드 `insertTrack(playlistId, command, InsertPosition)` 로 추출 → 공개 `addTrackInPlaylist`는 `HEAD`, grab은 `TAIL` 전달(중복 검사/한계 검사 로직 공유, inline 분기 없음).
 
 ### 3.4 결함 A(#262) 해소 — 부수 효과
 재생이 `orderNumber`를 더 이상 변경하지 않으므로 디제잉 중 클라이언트 뷰가 stale될 일이 없다 → 기존 `updateTrackOrderInPlaylist`의 절대 슬롯 검증이 그대로 정상 동작한다. **reorder 로직/프론트 변경 불필요.** (멀티탭 동시 편집 시 `prev == nextOrderNumber` 엣지는 잔존하나 허용 범위 — 회전起因 staleness만 제거하면 #262 제보 시나리오는 소멸.)
@@ -80,16 +83,20 @@ ALTER TABLE playlist
 
 추가/변경:
 - `PlaylistData`: `lastPlayedTrackId` 필드 + 갱신 메서드.
-- playlist command port: `peekTracksFromCursor(playlistId)`, `advancePlaybackCursor(playlistId, chosenTrackId)` 추가.
-- `TrackCommandService`: `addTrackInPlaylist`(head 삽입), 커서 기반 peek/advance 구현.
-- `TrackRepository`: `shiftAllOrdersDown` 추가.
-- `PlaybackTrackDto`: `trackId` 필드 추가(커서 갱신용).
+- playlist command port(party측 `PlaylistCommandPort` + 어댑터): `peekTracksFromCursor(playlistId)`, `advancePlaybackCursor(playlistId, chosenTrackId)` 추가.
+- `TrackCommandService`: 내부 `insertTrack(playlistId, command, InsertPosition)` 추출(`addTrackInPlaylist`→HEAD, grab→TAIL), 커서 기반 peek-from-cursor / advance-cursor 구현.
+- `TrackRepository`: `shiftAllOrdersDown(playlistId)` 추가.
+- `PlaybackTrackDto`: `trackId` 필드 추가(커서 갱신용). 소스인 `PlaylistTrackDto`에 `trackId`가 이미 있어 `peekOrderedTracks` 매핑만 보강하면 됨(쿼리 변경 불필요).
 - `PlaybackCommandService.doStart` / `startPlaybackFor`: peek+filter+rotate → peek-from-cursor+filter+advance-cursor.
 
 제거:
 - `TrackRepository.rotatePlayedOrder` 쿼리.
-- `TrackCommandService.rotatePlayed` + playlist command port의 `rotatePlayed` + 어댑터.
-- `TrackRepositoryReorderIntegrationTest` 중 **회전(rotate) 전용 케이스만** 제거. shiftUp(delete)/shiftDown(DnD) reorder 케이스는 유지.
+- `rotatePlayed` 전체 체인: `TrackCommandService.rotatePlayed`, `PlaylistAggregatePort.rotatePlayed` + `PlaylistAggregateAdapter`, party측 `PlaylistCommandPort.rotatePlayed` + `PlaylistCommandAdapter`.
+
+테스트 영향(기존 깨지는 테스트 — 명시):
+- `TrackRepositoryReorderIntegrationTest`: **rotatePlayedOrder 전용 2케이스뿐**이라 파일 전체를 제거(또는 신규 `shiftAllOrdersDown` 검증용으로 repurpose). ⚠️ DnD/delete reorder 커버리지는 이 파일이 아니라 `TrackCommandServiceTest`(mock-verify)에 있고 영향 없음.
+- `PlaybackCommandServiceTest`: `rotatePlayed(...)`를 verify하는 케이스들(`#222 skipPlayback`, `#222 skipByManager`, `E/#3 singleDj_allOverLimit`의 `never().rotatePlayed`, 멀티 DJ over-limit) → `advancePlaybackCursor(...)` 검증으로 rewire.
+- `TrackCommandServiceTest`: `rotatePlayed_delegates` 삭제, `peekOrderedTracks_returns_ordered_without_rotation` 는 신규 커서 peek 동작에 맞게 갱신.
 
 `peekOrderedTracks`(자연 순서)는 표시용 등 다른 소비자가 있으면 유지하고, 재생 경로만 커서 변형으로 교체한다(구현 시 usage audit).
 
@@ -127,3 +134,4 @@ reorder 회귀(#262):
 - Q1 멀티곡 add-to-head: **다음 사이클 top에서 재생**(대안: 무조건 즉시 다음 — 기각, 커서 강제 이동으로 사이클 위치 훼손/starvation).
 - Q2 커서 영속성: **플레이리스트별 영속**(대안: 세션마다 top 리셋 — 기각, 리셋 시점 정의로 범위 증가 + 현 동작과 괴리).
 - 마이그레이션: 기존 `order_number` 보존(현 상태=안정 순서), 커서 NULL 시작.
+- grab 경로: **현행 tail 보존**(head-insert는 명시적 add 한정). 기획 요청 범위(DJ PLAYLIST)에 맞춰 GRABLIST 동작 변경을 회피.

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/PlaylistAggregateAdapter.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/PlaylistAggregateAdapter.java
@@ -57,6 +57,16 @@ public class PlaylistAggregateAdapter implements PlaylistAggregatePort, Playlist
     }
 
     @Override
+    public Optional<PlaylistData> findPlaylistById(Long playlistId) {
+        return playlistRepository.findById(playlistId);
+    }
+
+    @Override
+    public void advancePlaybackCursor(Long playlistId, Long trackId) {
+        playlistRepository.updateLastPlayedTrackId(playlistId, trackId);
+    }
+
+    @Override
     public Long deletePlaylistsByIds(List<Long> playlistIds) {
         return playlistRepository.deleteByListIds(playlistIds);
     }
@@ -96,8 +106,8 @@ public class PlaylistAggregateAdapter implements PlaylistAggregatePort, Playlist
     // ===== Track Reordering =====
 
     @Override
-    public void rotatePlayed(Long playlistId, int playedOrderNumber, long totalCount) {
-        trackRepository.rotatePlayedOrder(playlistId, playedOrderNumber, totalCount);
+    public void shiftAllOrdersDown(Long playlistId) {
+        trackRepository.shiftAllOrdersDown(playlistId);
     }
 
     @Override

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/PlaylistRepository.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/PlaylistRepository.java
@@ -5,12 +5,19 @@ import com.pfplaybackend.api.playlist.adapter.out.persistence.custom.PlaylistRep
 import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
 import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface PlaylistRepository extends JpaRepository<PlaylistData, Long>, PlaylistRepositoryCustom {
     List<PlaylistData> findAllByOwnerId(UserId userId);
+
+    @Modifying
+    @Query("UPDATE PlaylistData p SET p.lastPlayedTrackId = :trackId WHERE p.id = :playlistId")
+    void updateLastPlayedTrackId(@Param("playlistId") Long playlistId, @Param("trackId") Long trackId);
 
     List<PlaylistData> findByOwnerIdAndTypeOrderByOrderNumberDesc(UserId userId, PlaylistType type);
 

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepository.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepository.java
@@ -21,14 +21,9 @@ public interface TrackRepository extends JpaRepository<TrackData, Long>, TrackRe
     boolean existsByPlaylistId(PlaylistId playlistId);
 
     @Modifying
-    @Query("UPDATE TrackData pm SET pm.orderNumber = CASE " +
-            "WHEN pm.orderNumber = :playedOrderNumber THEN :totalElements " +
-            "WHEN pm.orderNumber > :playedOrderNumber THEN pm.orderNumber - 1 " +
-            "ELSE pm.orderNumber END " +
+    @Query("UPDATE TrackData pm SET pm.orderNumber = pm.orderNumber + 1 " +
             "WHERE pm.playlistId.id = :playlistId")
-    void rotatePlayedOrder(@Param("playlistId") Long playlistId,
-                           @Param("playedOrderNumber") int playedOrderNumber,
-                           @Param("totalElements") long totalElements);
+    void shiftAllOrdersDown(@Param("playlistId") Long playlistId);
 
     @Modifying
     @Query("UPDATE TrackData pm " +

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/dto/PlaybackTrackDto.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/dto/PlaybackTrackDto.java
@@ -3,6 +3,7 @@ package com.pfplaybackend.api.playlist.application.dto;
 import com.pfplaybackend.api.common.domain.value.Duration;
 
 public record PlaybackTrackDto(
+        Long trackId,
         String linkId,
         String name,
         String thumbnailImage,

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/GrabTrackService.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/GrabTrackService.java
@@ -7,6 +7,7 @@ import com.pfplaybackend.api.playlist.application.dto.GrabbedTrackDto;
 import com.pfplaybackend.api.playlist.application.dto.command.AddTrackCommand;
 import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
 import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
+import com.pfplaybackend.api.playlist.domain.enums.InsertPosition;
 import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
 import com.pfplaybackend.api.playlist.domain.exception.TrackException;
 import com.pfplaybackend.api.playlist.domain.port.PlaylistAggregatePort;
@@ -39,7 +40,8 @@ public class GrabTrackService {
                 targetTrackData.getDuration().toDisplayString(),
                 targetTrackData.getThumbnailImage()
         );
-        Long trackId = trackCommandService.addTrackInPlaylist(playlistData.getId(), command);
+        // grab(GRABLIST)은 현행 tail 보존 — head-insert는 명시적 add 한정 (스펙 §9).
+        Long trackId = trackCommandService.insertTrack(playlistData.getId(), command, InsertPosition.TAIL);
         return new GrabbedTrackDto(trackId, playlistData.getId());
     }
 }

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackCommandService.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackCommandService.java
@@ -155,7 +155,7 @@ public class TrackCommandService {
         Pageable pageable = PageRequest.of(0, MAX_PLAYLIST_TRACK_COUNT, Sort.by(Sort.Direction.ASC, "orderNumber"));
         Page<PlaylistTrackDto> page = queryPort.getTracksWithPagination(new PlaylistId(playlistId), pageable);
         return page.getContent().stream()
-                .map(dto -> new PlaybackTrackDto(dto.linkId(), dto.name(),
+                .map(dto -> new PlaybackTrackDto(dto.trackId(), dto.linkId(), dto.name(),
                         dto.thumbnailImage(), dto.duration(), dto.orderNumber()))
                 .toList();
     }

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackCommandService.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackCommandService.java
@@ -15,6 +15,7 @@ import com.pfplaybackend.api.playlist.application.dto.command.UpdateTrackOrderCo
 import com.pfplaybackend.api.playlist.application.port.out.PlaylistQueryPort;
 import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
 import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
+import com.pfplaybackend.api.playlist.domain.enums.InsertPosition;
 import com.pfplaybackend.api.playlist.domain.event.TrackAddedEvent;
 import com.pfplaybackend.api.playlist.domain.event.TrackRemovedEvent;
 import com.pfplaybackend.api.playlist.domain.exception.PlaylistException;
@@ -22,13 +23,13 @@ import com.pfplaybackend.api.playlist.domain.exception.TrackException;
 import com.pfplaybackend.api.playlist.domain.port.PlaylistAggregatePort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -46,6 +47,12 @@ public class TrackCommandService {
 
     @Transactional
     public Long addTrackInPlaylist(Long playlistId, AddTrackCommand command) {
+        // 명시적 곡 추가는 맨 위(order 1)로 — 다음 내 차례에 가장 먼저 재생되도록.
+        return insertTrack(playlistId, command, InsertPosition.HEAD);
+    }
+
+    @Transactional
+    public Long insertTrack(Long playlistId, AddTrackCommand command, InsertPosition position) {
         AuthContext authContext = ThreadLocalContext.getAuthContext();
         // 플레이리스트 접근 권한 검사
         PlaylistData playlistData = aggregatePort.findPlaylistByIdAndOwner(playlistId, authContext.getUserId())
@@ -57,14 +64,22 @@ public class TrackCommandService {
         PlaylistSummaryDto playlistSummary = playlistQueryService.getPlaylist(playlistId);
         if (playlistSummary.musicCount() >= MAX_PLAYLIST_TRACK_COUNT) throw ExceptionCreator.create(TrackException.EXCEEDED_TRACK_LIMIT);
 
-        long nextMusicOrderNumber = playlistSummary.musicCount() == 0 ? 1 : playlistSummary.musicCount() + 1;
+        int orderNumber;
+        if (position == InsertPosition.HEAD) {
+            // 기존 전체를 +1 밀고 신규 곡을 맨 위(1)로.
+            aggregatePort.shiftAllOrdersDown(playlistData.getId());
+            orderNumber = 1;
+        } else {
+            // TAIL — 기존 동작 보존 (grab 경로).
+            orderNumber = playlistSummary.musicCount() == 0 ? 1 : (int) (playlistSummary.musicCount() + 1);
+        }
 
         TrackData trackData = TrackData.builder()
                 .playlistId(new PlaylistId(playlistData.getId()))
                 .name(command.name())
                 .linkId(command.linkId())
                 .duration(Duration.fromString(command.duration()))
-                .orderNumber((int) nextMusicOrderNumber)
+                .orderNumber(orderNumber)
                 .thumbnailImage(command.thumbnailImage())
                 .build();
 
@@ -150,18 +165,42 @@ public class TrackCommandService {
         eventPublisher.publishEvent(new TrackRemovedEvent(new PlaylistId(playlistId), trackId, trackData.getLinkId(), trackData.getName()));
     }
 
+    /**
+     * 재생 커서(last_played_track_id) 다음 위치부터 wrap 정렬한 트랙 목록을 반환한다.
+     * 커서가 null이거나 가리키던 트랙이 목록에 없으면(삭제) 자연 순서(top부터)로 반환한다.
+     * 호출자(party)는 이 목록에서 첫 재생가능 곡을 고르고 {@link #advancePlaybackCursor}로 커서를 갱신한다.
+     */
     @Transactional(readOnly = true)
-    public List<PlaybackTrackDto> peekOrderedTracks(Long playlistId) {
+    public List<PlaybackTrackDto> peekTracksFromCursor(Long playlistId) {
         Pageable pageable = PageRequest.of(0, MAX_PLAYLIST_TRACK_COUNT, Sort.by(Sort.Direction.ASC, "orderNumber"));
-        Page<PlaylistTrackDto> page = queryPort.getTracksWithPagination(new PlaylistId(playlistId), pageable);
-        return page.getContent().stream()
-                .map(dto -> new PlaybackTrackDto(dto.trackId(), dto.linkId(), dto.name(),
-                        dto.thumbnailImage(), dto.duration(), dto.orderNumber()))
-                .toList();
+        List<PlaylistTrackDto> ordered = queryPort.getTracksWithPagination(new PlaylistId(playlistId), pageable).getContent();
+
+        Long cursor = aggregatePort.findPlaylistById(playlistId)
+                .map(PlaylistData::getLastPlayedTrackId)
+                .orElse(null);
+
+        int start = 0; // 커서 null 또는 미발견 → top(0)부터
+        if (cursor != null) {
+            for (int i = 0; i < ordered.size(); i++) {
+                if (cursor.equals(ordered.get(i).trackId())) {
+                    start = i + 1; // 커서 "다음"부터
+                    break;
+                }
+            }
+        }
+
+        int n = ordered.size();
+        List<PlaybackTrackDto> rotated = new ArrayList<>(n);
+        for (int k = 0; k < n; k++) {
+            PlaylistTrackDto dto = ordered.get((start + k) % n);
+            rotated.add(new PlaybackTrackDto(dto.trackId(), dto.linkId(), dto.name(),
+                    dto.thumbnailImage(), dto.duration(), dto.orderNumber()));
+        }
+        return rotated;
     }
 
     @Transactional
-    public void rotatePlayed(Long playlistId, int playedOrderNumber, long totalCount) {
-        aggregatePort.rotatePlayed(playlistId, playedOrderNumber, totalCount);
+    public void advancePlaybackCursor(Long playlistId, Long trackId) {
+        aggregatePort.advancePlaybackCursor(playlistId, trackId);
     }
 }

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/entity/data/PlaylistData.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/entity/data/PlaylistData.java
@@ -45,6 +45,10 @@ public class PlaylistData extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private PlaylistType type;
 
+    @Comment("재생 커서 — 마지막 재생 트랙 id")
+    @Column(name = "last_played_track_id", columnDefinition = "bigint unsigned")
+    private Long lastPlayedTrackId;
+
     protected PlaylistData() {
     }
 

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/enums/InsertPosition.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/enums/InsertPosition.java
@@ -1,0 +1,5 @@
+package com.pfplaybackend.api.playlist.domain.enums;
+
+public enum InsertPosition {
+    HEAD, TAIL
+}

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/port/PlaylistAggregatePort.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/port/PlaylistAggregatePort.java
@@ -18,6 +18,8 @@ public interface PlaylistAggregatePort {
     PlaylistData findPlaylistByOwnerAndType(UserId userId, PlaylistType type);
     Optional<PlaylistData> findPlaylistByIdAndOwnerAndType(Long playlistId, UserId userId, PlaylistType type);
     Optional<PlaylistData> findPlaylistByIdAndOwner(Long playlistId, UserId userId);
+    Optional<PlaylistData> findPlaylistById(Long playlistId);
+    void advancePlaybackCursor(Long playlistId, Long trackId);
     Long deletePlaylistsByIds(List<Long> playlistIds);
 
     // ===== Child: TrackData =====
@@ -29,7 +31,7 @@ public interface PlaylistAggregatePort {
     boolean hasTracksByPlaylist(PlaylistId playlistId);
 
     // ===== Track Reordering (batch operations) =====
-    void rotatePlayed(Long playlistId, int playedOrderNumber, long totalCount);
+    void shiftAllOrdersDown(Long playlistId);
     void shiftUpTrackOrderByDelete(Long playlistId, Integer deleteOrderNumber);
     void shiftUpTrackOrderByDnD(Long playlistId, Integer prevOrderNumber, Integer nextOrderNumber);
     void shiftDownTrackOrderByDnD(Long playlistId, Integer prevOrderNumber, Integer nextOrderNumber);

--- a/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/GrabTrackServiceTest.java
+++ b/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/GrabTrackServiceTest.java
@@ -9,6 +9,7 @@ import com.pfplaybackend.api.playlist.application.dto.GrabbedTrackDto;
 import com.pfplaybackend.api.playlist.application.dto.command.AddTrackCommand;
 import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
 import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
+import com.pfplaybackend.api.playlist.domain.enums.InsertPosition;
 import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
 import com.pfplaybackend.api.playlist.domain.port.PlaylistAggregatePort;
 import org.junit.jupiter.api.DisplayName;
@@ -66,13 +67,13 @@ class GrabTrackServiceTest {
         when(aggregatePort.findFirstTrackByLink(LINK_ID)).thenReturn(track);
         when(aggregatePort.findPlaylistByOwnerAndType(USER_ID, PlaylistType.GRABLIST)).thenReturn(grablist);
         when(aggregatePort.findTrackByPlaylistAndLink(new PlaylistId(grablist.getId()), LINK_ID)).thenReturn(Optional.empty());
-        when(trackCommandService.addTrackInPlaylist(eq(grablist.getId()), any(AddTrackCommand.class))).thenReturn(777L);
+        when(trackCommandService.insertTrack(eq(grablist.getId()), any(AddTrackCommand.class), eq(InsertPosition.TAIL))).thenReturn(777L);
 
         // when
         GrabbedTrackDto result = grabTrackService.grabTrack(USER_ID, LINK_ID);
 
-        // then
-        verify(trackCommandService).addTrackInPlaylist(eq(grablist.getId()), any(AddTrackCommand.class));
+        // then — grab 은 GRABLIST 맨 뒤(TAIL)로 추가 (스펙 §9)
+        verify(trackCommandService).insertTrack(eq(grablist.getId()), any(AddTrackCommand.class), eq(InsertPosition.TAIL));
         assertThat(result.trackId()).isEqualTo(777L);
         assertThat(result.playlistId()).isEqualTo(grablist.getId());
     }
@@ -122,7 +123,7 @@ class GrabTrackServiceTest {
         grabTrackService.grabTrack(USER_ID, LINK_ID);
 
         // then
-        verify(trackCommandService).addTrackInPlaylist(eq(grablist.getId()), captor.capture());
+        verify(trackCommandService).insertTrack(eq(grablist.getId()), captor.capture(), eq(InsertPosition.TAIL));
         AddTrackCommand command = captor.getValue();
         assertThat(command.name()).isEqualTo("Test Song");
         assertThat(command.linkId()).isEqualTo(LINK_ID);

--- a/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/TrackCommandServiceTest.java
+++ b/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/TrackCommandServiceTest.java
@@ -18,6 +18,7 @@ import com.pfplaybackend.api.playlist.application.dto.command.UpdateTrackOrderCo
 import com.pfplaybackend.api.playlist.application.port.out.PlaylistQueryPort;
 import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
 import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
+import com.pfplaybackend.api.playlist.domain.enums.InsertPosition;
 import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
 import com.pfplaybackend.api.playlist.domain.port.PlaylistAggregatePort;
 import org.junit.jupiter.api.AfterEach;
@@ -31,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -84,7 +86,7 @@ class TrackCommandServiceTest {
     // ========== addTrackInPlaylist ==========
 
     @Test
-    @DisplayName("트랙 추가 성공 — save 호출 및 orderNumber 정확")
+    @DisplayName("트랙 추가 성공 — 맨 위(order 1) 삽입 + 기존 전체 shift")
     void addTrackInPlaylistSuccess() {
         // given
         Long playlistId = 1L;
@@ -109,10 +111,33 @@ class TrackCommandServiceTest {
         // when
         trackCommandService.addTrackInPlaylist(playlistId, command);
 
-        // then
+        // then — 신규 곡은 맨 위(order 1), 기존 전체 +1 shift
+        verify(aggregatePort).shiftAllOrdersDown(playlistId);
         verify(aggregatePort, times(1)).saveTrack(argThat(track ->
-                track.getOrderNumber() == 4 && LINK_ID.equals(track.getLinkId())
+                track.getOrderNumber() == 1 && LINK_ID.equals(track.getLinkId())
         ));
+    }
+
+    @Test
+    @DisplayName("insertTrack(TAIL) — 맨 뒤(order=count+1) 추가, shift 없음 (grab 경로)")
+    void insertTrack_tail_appendsAtEnd() {
+        // given
+        Long playlistId = 1L;
+        PlaylistData playlistData = PlaylistData.builder()
+                .id(playlistId).ownerId(userId).name(TEST_PLAYLIST_NAME).type(PlaylistType.GRABLIST).orderNumber(0).build();
+        AddTrackCommand command = new AddTrackCommand(SONG_NAME, LINK_ID, DURATION, THUMBNAIL);
+        when(aggregatePort.findPlaylistByIdAndOwner(playlistId, userId)).thenReturn(Optional.of(playlistData));
+        when(aggregatePort.findTrackByPlaylistAndLink(new PlaylistId(playlistId), LINK_ID)).thenReturn(Optional.empty());
+        when(playlistQueryService.getPlaylist(playlistId))
+                .thenReturn(new PlaylistSummaryDto(playlistId, TEST_PLAYLIST_NAME, 0, PlaylistType.GRABLIST, 3L));
+        when(aggregatePort.saveTrack(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        // when
+        trackCommandService.insertTrack(playlistId, command, InsertPosition.TAIL);
+
+        // then — 기존 동작: count(3)+1 = 4, shift 없음
+        verify(aggregatePort, never()).shiftAllOrdersDown(anyLong());
+        verify(aggregatePort).saveTrack(argThat(track -> track.getOrderNumber() == 4));
     }
 
     @Test
@@ -194,8 +219,9 @@ class TrackCommandServiceTest {
         // when
         trackCommandService.addTrackInPlaylist(playlistId, command);
 
-        // then — musicCount 99 < 100 이므로 추가되고 orderNumber 는 100
-        verify(aggregatePort, times(1)).saveTrack(argThat(track -> track.getOrderNumber() == 100));
+        // then — musicCount 99 < 100 이므로 추가됨. add-to-head 라 order 1 + 기존 전체 shift.
+        verify(aggregatePort).shiftAllOrdersDown(playlistId);
+        verify(aggregatePort, times(1)).saveTrack(argThat(track -> track.getOrderNumber() == 1));
     }
 
     // ========== deleteTrackInPlaylist ==========
@@ -560,47 +586,69 @@ class TrackCommandServiceTest {
                 .isInstanceOf(NotFoundException.class);
     }
 
-    // ========== peekOrderedTracks ==========
+    // ========== peekTracksFromCursor ==========
 
-    @Test
-    @DisplayName("peekOrderedTracks — 순서 오름차순으로 반환하며 회전 없음")
-    void peekOrderedTracks_returns_ordered_without_rotation() {
-        // given
-        Long playlistId = 1L;
-        PlaylistTrackDto trackDto1 = new PlaylistTrackDto(10L, LINK_ID, "Song A", 1, Duration.fromString("3:30"), THUMBNAIL);
-        PlaylistTrackDto trackDto2 = new PlaylistTrackDto(11L, "linkId2", "Song B", 2, Duration.fromString("4:00"), THUMBNAIL);
-
-        @SuppressWarnings("unchecked")
-        Page<PlaylistTrackDto> page = mock(Page.class);
-        when(page.getContent()).thenReturn(List.of(trackDto1, trackDto2));
-
-        when(queryPort.getTracksWithPagination(eq(new PlaylistId(playlistId)), any(Pageable.class)))
-                .thenReturn(page);
-
-        // when
-        List<PlaybackTrackDto> result = trackCommandService.peekOrderedTracks(playlistId);
-
-        // then
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).orderNumber()).isEqualTo(1);
-        assertThat(result.get(0).linkId()).isEqualTo(LINK_ID);
-        assertThat(result.get(0).name()).isEqualTo("Song A");
-        assertThat(result.get(0).thumbnailImage()).isEqualTo(THUMBNAIL);
-        assertThat(result.get(0).duration()).isEqualTo(Duration.fromString("3:30"));
-        assertThat(result.get(1).orderNumber()).isEqualTo(2);
-
-        verify(aggregatePort, never()).rotatePlayed(anyLong(), anyInt(), anyLong());
+    private Page<PlaylistTrackDto> pageOf(PlaylistTrackDto... dtos) {
+        return new PageImpl<>(List.of(dtos));
     }
 
-    // ========== rotatePlayed ==========
+    private PlaylistData playlistWithCursor(Long playlistId, Long cursorTrackId) {
+        PlaylistData p = PlaylistData.builder()
+                .id(playlistId).ownerId(userId).name(TEST_PLAYLIST_NAME).type(PlaylistType.PLAYLIST).orderNumber(0).build();
+        ReflectionTestUtils.setField(p, "lastPlayedTrackId", cursorTrackId);
+        return p;
+    }
 
     @Test
-    @DisplayName("rotatePlayed — aggregatePort.rotatePlayed에 위임한다")
-    void rotatePlayed_delegates() {
-        // when
-        trackCommandService.rotatePlayed(1L, 3, 5L);
+    @DisplayName("peekTracksFromCursor — 커서 null이면 자연순서(top부터)")
+    void peek_nullCursor_naturalOrder() {
+        Long playlistId = 1L;
+        PlaylistTrackDto a = new PlaylistTrackDto(10L, "a", "A", 1, Duration.fromString("3:00"), THUMBNAIL);
+        PlaylistTrackDto b = new PlaylistTrackDto(20L, "b", "B", 2, Duration.fromString("3:00"), THUMBNAIL);
+        PlaylistTrackDto c = new PlaylistTrackDto(30L, "c", "C", 3, Duration.fromString("3:00"), THUMBNAIL);
+        when(queryPort.getTracksWithPagination(eq(new PlaylistId(playlistId)), any(Pageable.class))).thenReturn(pageOf(a, b, c));
+        when(aggregatePort.findPlaylistById(playlistId)).thenReturn(Optional.of(playlistWithCursor(playlistId, null)));
 
-        // then
-        verify(aggregatePort).rotatePlayed(1L, 3, 5L);
+        List<PlaybackTrackDto> result = trackCommandService.peekTracksFromCursor(playlistId);
+
+        assertThat(result).extracting(PlaybackTrackDto::trackId).containsExactly(10L, 20L, 30L);
+    }
+
+    @Test
+    @DisplayName("peekTracksFromCursor — 커서=B(20) 다음부터 wrap (C,A,B)")
+    void peek_wrapsAfterCursor() {
+        Long playlistId = 1L;
+        PlaylistTrackDto a = new PlaylistTrackDto(10L, "a", "A", 1, Duration.fromString("3:00"), THUMBNAIL);
+        PlaylistTrackDto b = new PlaylistTrackDto(20L, "b", "B", 2, Duration.fromString("3:00"), THUMBNAIL);
+        PlaylistTrackDto c = new PlaylistTrackDto(30L, "c", "C", 3, Duration.fromString("3:00"), THUMBNAIL);
+        when(queryPort.getTracksWithPagination(eq(new PlaylistId(playlistId)), any(Pageable.class))).thenReturn(pageOf(a, b, c));
+        when(aggregatePort.findPlaylistById(playlistId)).thenReturn(Optional.of(playlistWithCursor(playlistId, 20L)));
+
+        List<PlaybackTrackDto> result = trackCommandService.peekTracksFromCursor(playlistId);
+
+        assertThat(result).extracting(PlaybackTrackDto::trackId).containsExactly(30L, 10L, 20L);
+    }
+
+    @Test
+    @DisplayName("peekTracksFromCursor — 커서 트랙이 목록에 없으면(삭제) 자연순서(top부터)")
+    void peek_deletedCursor_naturalOrder() {
+        Long playlistId = 1L;
+        PlaylistTrackDto a = new PlaylistTrackDto(10L, "a", "A", 1, Duration.fromString("3:00"), THUMBNAIL);
+        PlaylistTrackDto b = new PlaylistTrackDto(20L, "b", "B", 2, Duration.fromString("3:00"), THUMBNAIL);
+        when(queryPort.getTracksWithPagination(eq(new PlaylistId(playlistId)), any(Pageable.class))).thenReturn(pageOf(a, b));
+        when(aggregatePort.findPlaylistById(playlistId)).thenReturn(Optional.of(playlistWithCursor(playlistId, 999L)));
+
+        List<PlaybackTrackDto> result = trackCommandService.peekTracksFromCursor(playlistId);
+
+        assertThat(result).extracting(PlaybackTrackDto::trackId).containsExactly(10L, 20L);
+    }
+
+    // ========== advancePlaybackCursor ==========
+
+    @Test
+    @DisplayName("advancePlaybackCursor — aggregatePort.advancePlaybackCursor에 위임한다")
+    void advance_delegates() {
+        trackCommandService.advancePlaybackCursor(1L, 30L);
+        verify(aggregatePort).advancePlaybackCursor(1L, 30L);
     }
 }


### PR DESCRIPTION
release(stg) 검증분을 prod(main)로 승격. merge commit 으로 PR 커밋 보존.

## 포함
- #263 재생 회전 제거 + 영속 재생 커서 (#262 해소 + add-to-head)  ← develop→release(#265) 경유

## ⚠️ 배포 전 확인
- **Flyway V21__add_playlist_playback_cursor.sql** → main(prod) 배포 시 마이그레이션 적용 (커서 컬럼 추가). prod DB 영향.