### PR TITLE
fix(operations): 점검 게이트를 ACTIVE system_announcement 단일소스로 재배선 (#267)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/administration/adapter/out/maintenance/ActiveMaintenanceGate.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/adapter/out/maintenance/ActiveMaintenanceGate.java
@@ -1,0 +1,72 @@
+package com.pfplaybackend.api.administration.adapter.out.maintenance;
+
+import com.pfplaybackend.api.administration.adapter.out.persistence.SystemAnnouncementRepository;
+import com.pfplaybackend.api.administration.domain.entity.data.SystemAnnouncementData;
+import com.pfplaybackend.api.operations.application.port.out.MaintenanceGate;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * {@link MaintenanceGate} 구현 — 현재 ACTIVE 인 system_announcement 점검
+ * ({@code maintenanceStartedAt != null && cancelledAt == null && completedAt == null},
+ * {@link SystemAnnouncementRepository#findCurrentMaintenance})을 단일 진실원천으로 삼는다.
+ * 운영자가 어드민에서 토글하는 바로 그 상태이므로, writer 가 없어 죽어 있던 system_config
+ * {@code maintenance.enabled} 키를 대체한다(issue #267).
+ *
+ * <p>{@code SystemConfigCache} 와 동일한 30s in-memory 스냅샷 캐시 — 필터가 매 요청마다
+ * 호출하므로 요청당 DB 조회를 피한다. 토글 후 최대 30s staleness 는 기존 허용 정책과 동일
+ * (frontend 점검 화면은 Edge Config 로 즉시 전환되고, 백엔드 게이트는 그 안에서 수렴).
+ */
+@Component
+public class ActiveMaintenanceGate implements MaintenanceGate {
+
+    static final Duration SNAPSHOT_TTL = Duration.ofSeconds(30);
+    static final String DEFAULT_MAINTENANCE_MESSAGE = "시스템 점검 중입니다.";
+
+    private final SystemAnnouncementRepository repository;
+    private final Clock clock;
+    private final AtomicReference<Snapshot> snapshotRef = new AtomicReference<>();
+
+    public ActiveMaintenanceGate(SystemAnnouncementRepository repository, Clock clock) {
+        this.repository = repository;
+        this.clock = clock;
+    }
+
+    @Override
+    public boolean isUnderMaintenance() {
+        return current().underMaintenance;
+    }
+
+    @Override
+    public String getMaintenanceMessage() {
+        return current().message;
+    }
+
+    private Snapshot current() {
+        Snapshot existing = snapshotRef.get();
+        Instant now = clock.instant();
+        if (existing != null && Duration.between(existing.fetchedAt, now).compareTo(SNAPSHOT_TTL) < 0) {
+            return existing;
+        }
+        Snapshot fresh = fetch(now);
+        snapshotRef.compareAndSet(existing, fresh);
+        return fresh;
+    }
+
+    private Snapshot fetch(Instant now) {
+        return repository.findCurrentMaintenance()
+            .map(announcement -> new Snapshot(true, messageOf(announcement), now))
+            .orElseGet(() -> new Snapshot(false, DEFAULT_MAINTENANCE_MESSAGE, now));
+    }
+
+    private String messageOf(SystemAnnouncementData announcement) {
+        String message = announcement.getMessageKo();
+        return (message == null || message.isBlank()) ? DEFAULT_MAINTENANCE_MESSAGE : message;
+    }
+
+    private record Snapshot(boolean underMaintenance, String message, Instant fetchedAt) {}
+}

--- a/app/src/main/java/com/pfplaybackend/api/operations/adapter/in/web/MaintenanceModeFilter.java
+++ b/app/src/main/java/com/pfplaybackend/api/operations/adapter/in/web/MaintenanceModeFilter.java
@@ -1,6 +1,6 @@
 package com.pfplaybackend.api.operations.adapter.in.web;
 
-import com.pfplaybackend.api.operations.application.service.SystemConfigCache;
+import com.pfplaybackend.api.operations.application.port.out.MaintenanceGate;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -30,17 +30,17 @@ public class MaintenanceModeFilter extends OncePerRequestFilter {
     );
     private static final AntPathMatcher MATCHER = new AntPathMatcher();
 
-    private final SystemConfigCache cache;
+    private final MaintenanceGate gate;
 
-    public MaintenanceModeFilter(SystemConfigCache cache) {
-        this.cache = cache;
+    public MaintenanceModeFilter(MaintenanceGate gate) {
+        this.gate = gate;
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain chain) throws ServletException, IOException {
-        if (isBypassed(request) || !cache.isMaintenanceMode()) {
+        if (isBypassed(request) || !gate.isUnderMaintenance()) {
             chain.doFilter(request, response);
             return;
         }
@@ -60,7 +60,7 @@ public class MaintenanceModeFilter extends OncePerRequestFilter {
     private void respond503(HttpServletResponse response) throws IOException {
         response.setStatus(HttpStatus.SERVICE_UNAVAILABLE.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
-        String body = "{\"message\":" + jsonString(cache.getMaintenanceMessage()) + "}";
+        String body = "{\"message\":" + jsonString(gate.getMaintenanceMessage()) + "}";
         response.getWriter().write(body);
         response.getWriter().flush();
     }

--- a/app/src/main/java/com/pfplaybackend/api/operations/application/port/out/MaintenanceGate.java
+++ b/app/src/main/java/com/pfplaybackend/api/operations/application/port/out/MaintenanceGate.java
@@ -1,0 +1,18 @@
+package com.pfplaybackend.api.operations.application.port.out;
+
+/**
+ * 점검 모드 여부를 판정하는 outbound 포트.
+ *
+ * <p>구현(어댑터)은 <b>운영자가 실제로 토글하는</b> system_announcement 의 현재 ACTIVE 점검을
+ * 단일 진실원천으로 삼는다. 과거에는 {@code MaintenanceModeFilter} 가 system_config 의
+ * {@code maintenance.enabled} 키를 봤으나 그 키를 write 하는 코드가 없어 백엔드 점검 게이트가
+ * 영원히 열려 있었다(issue #267). 이 포트로 소스를 일원화한다.
+ */
+public interface MaintenanceGate {
+
+    /** 현재 점검 중인가. */
+    boolean isUnderMaintenance();
+
+    /** 점검 중일 때 503 본문에 실을 메시지. */
+    String getMaintenanceMessage();
+}

--- a/app/src/main/java/com/pfplaybackend/api/operations/application/service/SystemConfigCache.java
+++ b/app/src/main/java/com/pfplaybackend/api/operations/application/service/SystemConfigCache.java
@@ -12,19 +12,18 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * In-memory snapshot cache for SystemConfig.
+ * In-memory snapshot cache for SystemConfig (presence grace seconds).
  *
- * 30-second TTL. Per-instance — no distributed invalidation in PR 3.
+ * 30-second TTL. Per-instance — no distributed invalidation.
  * Tolerated staleness window matches spec (§9.3 "system_config 캐시 stale: 캐시 TTL 30~60초").
  *
- * PR 6 will add a SystemConfigUpdated domain event + listener that calls invalidate()
- * when admin endpoints toggle maintenance.
+ * <p>점검(maintenance) 게이팅은 {@code MaintenanceGate} 로 분리됨(issue #267) — writer 가 없어
+ * 죽어 있던 {@code maintenance.enabled} 키 대신, 진실원천은 ACTIVE 인 system_announcement 점검이다.
  */
 @Component
 public class SystemConfigCache {
 
     static final Duration SNAPSHOT_TTL = Duration.ofSeconds(30);
-    static final String DEFAULT_MAINTENANCE_MESSAGE = "시스템 점검 중입니다.";
     static final int DEFAULT_DJ_GRACE_SECONDS = 30;
     static final int DEFAULT_LISTENER_GRACE_SECONDS = 10;
 
@@ -35,14 +34,6 @@ public class SystemConfigCache {
     public SystemConfigCache(SystemConfigRepository repository, Clock clock) {
         this.repository = repository;
         this.clock = clock;
-    }
-
-    public boolean isMaintenanceMode() {
-        return current().maintenanceEnabled;
-    }
-
-    public String getMaintenanceMessage() {
-        return current().maintenanceMessage;
     }
 
     public int getDjGraceSeconds() {
@@ -70,33 +61,9 @@ public class SystemConfigCache {
     }
 
     private Snapshot fetch(Instant now) {
-        boolean enabled = readBool(ConfigKey.MAINTENANCE_ENABLED, false);
-        String message = readString(ConfigKey.MAINTENANCE_MESSAGE, DEFAULT_MAINTENANCE_MESSAGE);
         int djGrace = readInt(ConfigKey.PRESENCE_DJ_GRACE_SECONDS, DEFAULT_DJ_GRACE_SECONDS);
         int listenerGrace = readInt(ConfigKey.PRESENCE_LISTENER_GRACE_SECONDS, DEFAULT_LISTENER_GRACE_SECONDS);
-        return new Snapshot(enabled, message, djGrace, listenerGrace, now);
-    }
-
-    /**
-     * Fail-open by design: missing rows or malformed values fall back to {@code fallback}
-     * (which is {@code false} for maintenance.enabled). A corrupted seed must NOT brick
-     * the platform; operators must explicitly write the literal string "true" to engage
-     * maintenance mode. Inverting this would risk locking everyone out from a typo.
-     */
-    private boolean readBool(ConfigKey key, boolean fallback) {
-        Optional<SystemConfigData> row = repository.findByConfigKey(key.value());
-        if (row.isEmpty()) return fallback;
-        String v = row.get().getConfigValue();
-        if ("true".equalsIgnoreCase(v)) return true;
-        if ("false".equalsIgnoreCase(v)) return false;
-        return fallback;
-    }
-
-    private String readString(ConfigKey key, String fallback) {
-        return repository.findByConfigKey(key.value())
-            .map(SystemConfigData::getConfigValue)
-            .filter(s -> !s.isBlank())
-            .orElse(fallback);
+        return new Snapshot(djGrace, listenerGrace, now);
     }
 
     /**
@@ -116,7 +83,5 @@ public class SystemConfigCache {
         }
     }
 
-    private record Snapshot(boolean maintenanceEnabled, String maintenanceMessage,
-                            int djGraceSeconds, int listenerGraceSeconds,
-                            Instant fetchedAt) {}
+    private record Snapshot(int djGraceSeconds, int listenerGraceSeconds, Instant fetchedAt) {}
 }

--- a/app/src/main/java/com/pfplaybackend/api/operations/config/MaintenanceModeFilterConfig.java
+++ b/app/src/main/java/com/pfplaybackend/api/operations/config/MaintenanceModeFilterConfig.java
@@ -1,7 +1,7 @@
 package com.pfplaybackend.api.operations.config;
 
 import com.pfplaybackend.api.operations.adapter.in.web.MaintenanceModeFilter;
-import com.pfplaybackend.api.operations.application.service.SystemConfigCache;
+import com.pfplaybackend.api.operations.application.port.out.MaintenanceGate;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,9 +19,9 @@ public class MaintenanceModeFilterConfig {
      */
     @Bean
     public FilterRegistrationBean<MaintenanceModeFilter> maintenanceModeFilterRegistration(
-            SystemConfigCache cache) {
+            MaintenanceGate gate) {
         FilterRegistrationBean<MaintenanceModeFilter> bean = new FilterRegistrationBean<>();
-        bean.setFilter(new MaintenanceModeFilter(cache));
+        bean.setFilter(new MaintenanceModeFilter(gate));
         bean.addUrlPatterns("/*");
         bean.setOrder(Ordered.HIGHEST_PRECEDENCE);
         bean.setName("maintenanceModeFilter");

--- a/app/src/main/java/com/pfplaybackend/api/operations/domain/value/ConfigKey.java
+++ b/app/src/main/java/com/pfplaybackend/api/operations/domain/value/ConfigKey.java
@@ -6,7 +6,7 @@ import java.util.regex.Pattern;
  * Value object for SystemConfig PK.
  *
  * Validation: lowercase ASCII letters/digits, dots, and underscores. Max 64 chars.
- * Examples: maintenance.enabled, feature.avatar_v2.enabled
+ * Examples: presence.dj_grace_seconds, feature.avatar_v2.enabled
  *
  * Spec: docs/superpowers/specs/2026-04-19-admin-platform-design.md §3.3.4
  */
@@ -36,8 +36,6 @@ public record ConfigKey(String value) {
     }
 
     // Well-known keys
-    public static final ConfigKey MAINTENANCE_ENABLED = new ConfigKey("maintenance.enabled");
-    public static final ConfigKey MAINTENANCE_MESSAGE = new ConfigKey("maintenance.message");
     public static final ConfigKey PRESENCE_DJ_GRACE_SECONDS = new ConfigKey("presence.dj_grace_seconds");
     public static final ConfigKey PRESENCE_LISTENER_GRACE_SECONDS = new ConfigKey("presence.listener_grace_seconds");
 }

--- a/app/src/main/resources/db/migration/V22__remove_dead_maintenance_config_keys.sql
+++ b/app/src/main/resources/db/migration/V22__remove_dead_maintenance_config_keys.sql
@@ -1,0 +1,11 @@
+-- =====================================================
+-- V22: 죽은 maintenance.* system_config 키 제거 (issue #267)
+--
+-- 백엔드 점검 게이트(MaintenanceModeFilter)를 ACTIVE 인 system_announcement 점검을
+-- 단일 진실원천으로 재배선(MaintenanceGate). 기존 V9 시드 'maintenance.enabled' /
+-- 'maintenance.message' 는 write 하는 코드가 없어 백엔드 503 게이트를 한 번도 켜지
+-- 못한 dead 키였다. 코드에서 제거됨에 맞춰 시드 행도 정리해 system_config 가 권위 있는
+-- 것처럼 보이는 orphan 행을 남기지 않도록 한다.
+-- =====================================================
+
+DELETE FROM system_config WHERE config_key IN ('maintenance.enabled', 'maintenance.message');

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/maintenance/ActiveMaintenanceGateTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/maintenance/ActiveMaintenanceGateTest.java
@@ -1,0 +1,108 @@
+package com.pfplaybackend.api.administration.adapter.out.maintenance;
+
+import com.pfplaybackend.api.administration.adapter.out.persistence.SystemAnnouncementRepository;
+import com.pfplaybackend.api.administration.domain.entity.data.SystemAnnouncementData;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 점검 게이트의 단일 진실원천 = "현재 ACTIVE 인 system_announcement 점검"
+ * ({@code findCurrentMaintenance}). 죽어 있던 system_config maintenance.enabled
+ * 키 대신 이 어댑터가 필터의 소스가 된다. 30s 캐시는 SystemConfigCache 와 동일 정책.
+ */
+@ExtendWith(MockitoExtension.class)
+class ActiveMaintenanceGateTest {
+
+    @Mock
+    SystemAnnouncementRepository repository;
+
+    private SystemAnnouncementData activeWithMessage(String messageKo) {
+        SystemAnnouncementData a = mock(SystemAnnouncementData.class);
+        when(a.getMessageKo()).thenReturn(messageKo);
+        return a;
+    }
+
+    @Test
+    void under_maintenance_with_message_when_active_announcement_present() {
+        SystemAnnouncementData active = activeWithMessage("점검 중입니다");
+        when(repository.findCurrentMaintenance()).thenReturn(Optional.of(active));
+        ActiveMaintenanceGate gate = new ActiveMaintenanceGate(repository, fixed());
+
+        assertThat(gate.isUnderMaintenance()).isTrue();
+        assertThat(gate.getMaintenanceMessage()).isEqualTo("점검 중입니다");
+    }
+
+    @Test
+    void not_under_maintenance_when_no_active_announcement() {
+        when(repository.findCurrentMaintenance()).thenReturn(Optional.empty());
+        ActiveMaintenanceGate gate = new ActiveMaintenanceGate(repository, fixed());
+
+        assertThat(gate.isUnderMaintenance()).isFalse();
+    }
+
+    @Test
+    void blank_message_falls_back_to_default() {
+        SystemAnnouncementData active = activeWithMessage("  ");
+        when(repository.findCurrentMaintenance()).thenReturn(Optional.of(active));
+        ActiveMaintenanceGate gate = new ActiveMaintenanceGate(repository, fixed());
+
+        assertThat(gate.isUnderMaintenance()).isTrue();
+        assertThat(gate.getMaintenanceMessage()).isNotBlank();
+    }
+
+    @Test
+    void second_call_within_ttl_does_not_hit_repository() {
+        when(repository.findCurrentMaintenance()).thenReturn(Optional.empty());
+        ActiveMaintenanceGate gate = new ActiveMaintenanceGate(repository, fixed());
+
+        gate.isUnderMaintenance();
+        gate.isUnderMaintenance();
+
+        verify(repository, times(1)).findCurrentMaintenance();
+    }
+
+    @Test
+    void call_after_ttl_refetches() {
+        SystemAnnouncementData active = activeWithMessage("점검");
+        when(repository.findCurrentMaintenance())
+            .thenReturn(Optional.empty())
+            .thenReturn(Optional.of(active));
+        MutableClock clock = new MutableClock(Instant.parse("2026-05-25T00:00:00Z"));
+        ActiveMaintenanceGate gate = new ActiveMaintenanceGate(repository, clock);
+
+        assertThat(gate.isUnderMaintenance()).isFalse();
+        clock.advanceSeconds(31);
+        assertThat(gate.isUnderMaintenance()).isTrue();
+
+        verify(repository, times(2)).findCurrentMaintenance();
+    }
+
+    private static Clock fixed() {
+        return Clock.fixed(Instant.parse("2026-05-25T00:00:00Z"), ZoneOffset.UTC);
+    }
+
+    /** Test-only mutable clock. */
+    static class MutableClock extends Clock {
+        private Instant now;
+        MutableClock(Instant start) { this.now = start; }
+        @Override public ZoneId getZone() { return ZoneOffset.UTC; }
+        @Override public Clock withZone(ZoneId zone) { return this; }
+        @Override public Instant instant() { return now; }
+        void advanceSeconds(long seconds) { now = now.plusSeconds(seconds); }
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/operations/SystemConfigRepositoryIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/operations/SystemConfigRepositoryIntegrationTest.java
@@ -18,9 +18,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * work against a real MySQL instance (Testcontainers).
  *
  * The test profile disables Flyway (flyway.enabled=false) and uses ddl-auto=create-drop,
- * so V9 seed data is not automatically present. This test inserts the canonical seed rows
- * in @BeforeEach to simulate what V9 delivers in production, then verifies the repository
- * reads/writes correctly.
+ * so this test inserts a row in @BeforeEach and verifies the repository reads/writes correctly.
+ * (system_config 은 범용 key-value 저장소이며, maintenance 게이팅은 issue #267 로 분리되어
+ * 더 이상 이 테이블의 키에 의존하지 않는다 — presence grace 키로 매핑/CRUD 만 검증.)
  *
  * Inherits Testcontainers MySQL + Redis wiring and @Tag("integration") from
  * {@link AbstractIntegrationTest}. Run via: ./gradlew :app:integrationTest
@@ -30,58 +30,42 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Transactional
 class SystemConfigRepositoryIntegrationTest extends AbstractIntegrationTest {
 
+    private static final ConfigKey KEY = ConfigKey.PRESENCE_DJ_GRACE_SECONDS;
+
     @Autowired
     SystemConfigRepository repository;
 
     @BeforeEach
-    void seedV9Rows() {
-        // Mirror the two rows inserted by V9__create_system_config.sql
+    void seedRow() {
         repository.save(SystemConfigData.create(
-                ConfigKey.MAINTENANCE_ENABLED.value(),
-                "false",
-                "유지보수 모드 활성 여부 (true일 때 일반 API 503)",
-                null));
-        repository.save(SystemConfigData.create(
-                ConfigKey.MAINTENANCE_MESSAGE.value(),
-                "시스템 점검 중입니다. 잠시 후 다시 시도해주세요.",
-                "유지보수 안내 메시지",
+                KEY.value(),
+                "30",
+                "DJ 이탈 grace 초",
                 null));
         flushAndClear();
     }
 
     @Test
-    void v9_seeds_two_rows() {
-        assertThat(repository.count()).isGreaterThanOrEqualTo(2L);
-    }
-
-    @Test
-    void maintenance_enabled_seed_present_and_false() {
-        Optional<SystemConfigData> row = repository.findByConfigKey(ConfigKey.MAINTENANCE_ENABLED.value());
+    void seeded_row_present_with_value() {
+        Optional<SystemConfigData> row = repository.findByConfigKey(KEY.value());
         assertThat(row).isPresent();
-        assertThat(row.get().getConfigValue()).isEqualTo("false");
-    }
-
-    @Test
-    void maintenance_message_seed_present_with_default() {
-        Optional<SystemConfigData> row = repository.findByConfigKey(ConfigKey.MAINTENANCE_MESSAGE.value());
-        assertThat(row).isPresent();
-        assertThat(row.get().getConfigValue()).isNotBlank();
+        assertThat(row.get().getConfigValue()).isEqualTo("30");
     }
 
     @Test
     void update_round_trips_via_repository() {
-        SystemConfigData row = repository.findByConfigKey(ConfigKey.MAINTENANCE_ENABLED.value()).orElseThrow();
-        row.updateValue("true", 1L);
+        SystemConfigData row = repository.findByConfigKey(KEY.value()).orElseThrow();
+        row.updateValue("45", 1L);
         repository.saveAndFlush(row);
 
         flushAndClear();
 
-        SystemConfigData reloaded = repository.findByConfigKey(ConfigKey.MAINTENANCE_ENABLED.value()).orElseThrow();
-        assertThat(reloaded.getConfigValue()).isEqualTo("true");
+        SystemConfigData reloaded = repository.findByConfigKey(KEY.value()).orElseThrow();
+        assertThat(reloaded.getConfigValue()).isEqualTo("45");
         assertThat(reloaded.getUpdatedByAdministratorId()).isEqualTo(1L);
 
         // Restore so test ordering doesn't leak (though @Transactional rollback handles this)
-        reloaded.updateValue("false", null);
+        reloaded.updateValue("30", null);
         repository.saveAndFlush(reloaded);
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/operations/adapter/in/web/MaintenanceModeFilterTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/operations/adapter/in/web/MaintenanceModeFilterTest.java
@@ -1,6 +1,6 @@
 package com.pfplaybackend.api.operations.adapter.in.web;
 
-import com.pfplaybackend.api.operations.application.service.SystemConfigCache;
+import com.pfplaybackend.api.operations.application.port.out.MaintenanceGate;
 import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,18 +21,18 @@ import static org.mockito.Mockito.when;
 class MaintenanceModeFilterTest {
 
     @Mock
-    SystemConfigCache cache;
+    MaintenanceGate gate;
 
     MaintenanceModeFilter filter;
 
     @BeforeEach
     void setUp() {
-        filter = new MaintenanceModeFilter(cache);
+        filter = new MaintenanceModeFilter(gate);
     }
 
     @Test
     void passes_through_when_disabled() throws ServletException, IOException {
-        when(cache.isMaintenanceMode()).thenReturn(false);
+        when(gate.isUnderMaintenance()).thenReturn(false);
 
         MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/v1/users/me");
         MockHttpServletResponse res = new MockHttpServletResponse();
@@ -47,8 +47,8 @@ class MaintenanceModeFilterTest {
 
     @Test
     void returns_503_with_message_when_enabled_and_path_not_bypassed() throws ServletException, IOException {
-        when(cache.isMaintenanceMode()).thenReturn(true);
-        when(cache.getMaintenanceMessage()).thenReturn("점검중");
+        when(gate.isUnderMaintenance()).thenReturn(true);
+        when(gate.getMaintenanceMessage()).thenReturn("점검중");
 
         MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/v1/users/me");
         MockHttpServletResponse res = new MockHttpServletResponse();
@@ -64,8 +64,8 @@ class MaintenanceModeFilterTest {
 
     @Test
     void bypasses_admin_paths_even_when_enabled() throws ServletException, IOException {
-        // lenient: bypass check runs before cache lookup — stub may not be consumed
-        lenient().when(cache.isMaintenanceMode()).thenReturn(true);
+        // lenient: bypass check runs before gate lookup — stub may not be consumed
+        lenient().when(gate.isUnderMaintenance()).thenReturn(true);
 
         MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/v1/admin/system/config/maintenance");
         MockHttpServletResponse res = new MockHttpServletResponse();
@@ -80,8 +80,8 @@ class MaintenanceModeFilterTest {
 
     @Test
     void bypasses_actuator_health_even_when_enabled() throws ServletException, IOException {
-        // lenient: bypass check runs before cache lookup — stub may not be consumed
-        lenient().when(cache.isMaintenanceMode()).thenReturn(true);
+        // lenient: bypass check runs before gate lookup — stub may not be consumed
+        lenient().when(gate.isUnderMaintenance()).thenReturn(true);
 
         MockHttpServletRequest req = new MockHttpServletRequest("GET", "/actuator/health");
         MockHttpServletResponse res = new MockHttpServletResponse();
@@ -95,8 +95,8 @@ class MaintenanceModeFilterTest {
 
     @Test
     void does_not_bypass_admin_lookalike_path() throws ServletException, IOException {
-        when(cache.isMaintenanceMode()).thenReturn(true);
-        when(cache.getMaintenanceMessage()).thenReturn("점검중");
+        when(gate.isUnderMaintenance()).thenReturn(true);
+        when(gate.getMaintenanceMessage()).thenReturn("점검중");
 
         // Path contains "admin" but is not under /api/v1/admin
         MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/v1/users/admin-friend-list");

--- a/app/src/test/java/com/pfplaybackend/api/operations/application/service/SystemConfigCacheTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/operations/application/service/SystemConfigCacheTest.java
@@ -6,12 +6,12 @@ import com.pfplaybackend.api.operations.domain.value.ConfigKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Optional;
 
@@ -34,41 +34,7 @@ class SystemConfigCacheTest {
     }
 
     @Test
-    void isMaintenanceMode_reads_repo_on_first_call() {
-        when(repository.findByConfigKey(ConfigKey.MAINTENANCE_ENABLED.value()))
-            .thenReturn(Optional.of(seed("maintenance.enabled", "true")));
-        when(repository.findByConfigKey(ConfigKey.MAINTENANCE_MESSAGE.value()))
-            .thenReturn(Optional.of(seed("maintenance.message", "down")));
-
-        assertThat(cache.isMaintenanceMode()).isTrue();
-        assertThat(cache.getMaintenanceMessage()).isEqualTo("down");
-    }
-
-    @Test
-    void second_call_within_ttl_does_not_hit_repo() {
-        when(repository.findByConfigKey(anyString()))
-            .thenReturn(Optional.of(seed("maintenance.enabled", "false")))
-            .thenReturn(Optional.of(seed("maintenance.message", "")))
-            .thenReturn(Optional.of(seed("presence.dj_grace_seconds", "30")))
-            .thenReturn(Optional.of(seed("presence.listener_grace_seconds", "10")));
-
-        cache.isMaintenanceMode();
-        clock.advanceSeconds(29);
-        cache.isMaintenanceMode();
-        cache.getMaintenanceMessage();
-        cache.getDjGraceSeconds();
-        cache.getListenerGraceSeconds();
-
-        // One snapshot fetch loads all four keys; further reads within TTL hit no repo.
-        verify(repository, times(4)).findByConfigKey(anyString());
-    }
-
-    @Test
     void readInt_returns_value_for_valid_int() {
-        when(repository.findByConfigKey(ConfigKey.MAINTENANCE_ENABLED.value()))
-            .thenReturn(Optional.empty());
-        when(repository.findByConfigKey(ConfigKey.MAINTENANCE_MESSAGE.value()))
-            .thenReturn(Optional.empty());
         when(repository.findByConfigKey(ConfigKey.PRESENCE_DJ_GRACE_SECONDS.value()))
             .thenReturn(Optional.of(seed("presence.dj_grace_seconds", "45")));
         when(repository.findByConfigKey(ConfigKey.PRESENCE_LISTENER_GRACE_SECONDS.value()))
@@ -80,10 +46,6 @@ class SystemConfigCacheTest {
 
     @Test
     void readInt_falls_back_on_garbage() {
-        when(repository.findByConfigKey(ConfigKey.MAINTENANCE_ENABLED.value()))
-            .thenReturn(Optional.empty());
-        when(repository.findByConfigKey(ConfigKey.MAINTENANCE_MESSAGE.value()))
-            .thenReturn(Optional.empty());
         when(repository.findByConfigKey(ConfigKey.PRESENCE_DJ_GRACE_SECONDS.value()))
             .thenReturn(Optional.of(seed("presence.dj_grace_seconds", "thirty")));
         when(repository.findByConfigKey(ConfigKey.PRESENCE_LISTENER_GRACE_SECONDS.value()))
@@ -103,36 +65,32 @@ class SystemConfigCacheTest {
     }
 
     @Test
+    void second_call_within_ttl_does_not_hit_repo() {
+        when(repository.findByConfigKey(anyString()))
+            .thenReturn(Optional.of(seed("presence.dj_grace_seconds", "30")));
+
+        cache.getDjGraceSeconds();
+        clock.advanceSeconds(29);
+        cache.getDjGraceSeconds();
+        cache.getListenerGraceSeconds();
+
+        // One snapshot fetch loads both grace keys; further reads within TTL hit no repo.
+        verify(repository, times(2)).findByConfigKey(anyString());
+    }
+
+    @Test
     void call_after_ttl_re_fetches() {
-        when(repository.findByConfigKey(ConfigKey.MAINTENANCE_ENABLED.value()))
-            .thenReturn(Optional.of(seed("maintenance.enabled", "false")))
-            .thenReturn(Optional.of(seed("maintenance.enabled", "true")));
-        when(repository.findByConfigKey(ConfigKey.MAINTENANCE_MESSAGE.value()))
-            .thenReturn(Optional.of(seed("maintenance.message", "ok")));
+        when(repository.findByConfigKey(ConfigKey.PRESENCE_DJ_GRACE_SECONDS.value()))
+            .thenReturn(Optional.of(seed("presence.dj_grace_seconds", "30")))
+            .thenReturn(Optional.of(seed("presence.dj_grace_seconds", "45")));
+        when(repository.findByConfigKey(ConfigKey.PRESENCE_LISTENER_GRACE_SECONDS.value()))
+            .thenReturn(Optional.of(seed("presence.listener_grace_seconds", "10")));
 
-        assertThat(cache.isMaintenanceMode()).isFalse();
+        assertThat(cache.getDjGraceSeconds()).isEqualTo(30);
         clock.advanceSeconds(31);
-        assertThat(cache.isMaintenanceMode()).isTrue();
+        assertThat(cache.getDjGraceSeconds()).isEqualTo(45);
 
-        verify(repository, times(2)).findByConfigKey(ConfigKey.MAINTENANCE_ENABLED.value());
-    }
-
-    @Test
-    void missing_rows_yield_safe_defaults() {
-        when(repository.findByConfigKey(anyString())).thenReturn(Optional.empty());
-
-        assertThat(cache.isMaintenanceMode()).isFalse();
-        assertThat(cache.getMaintenanceMessage()).isNotBlank();
-    }
-
-    @Test
-    void invalid_value_for_enabled_treated_as_false() {
-        when(repository.findByConfigKey(ConfigKey.MAINTENANCE_ENABLED.value()))
-            .thenReturn(Optional.of(seed("maintenance.enabled", "yes-please")));
-        when(repository.findByConfigKey(ConfigKey.MAINTENANCE_MESSAGE.value()))
-            .thenReturn(Optional.of(seed("maintenance.message", "x")));
-
-        assertThat(cache.isMaintenanceMode()).isFalse();
+        verify(repository, times(2)).findByConfigKey(ConfigKey.PRESENCE_DJ_GRACE_SECONDS.value());
     }
 
     private SystemConfigData seed(String key, String value) {
@@ -143,8 +101,8 @@ class SystemConfigCacheTest {
     static class MutableClock extends Clock {
         private Instant now;
         MutableClock(Instant start) { this.now = start; }
-        @Override public java.time.ZoneId getZone() { return ZoneOffset.UTC; }
-        @Override public Clock withZone(java.time.ZoneId zone) { return this; }
+        @Override public ZoneId getZone() { return ZoneOffset.UTC; }
+        @Override public Clock withZone(ZoneId zone) { return this; }
         @Override public Instant instant() { return now; }
         void advanceSeconds(long seconds) { now = now.plusSeconds(seconds); }
     }

--- a/app/src/test/java/com/pfplaybackend/api/operations/domain/value/ConfigKeyTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/operations/domain/value/ConfigKeyTest.java
@@ -50,7 +50,7 @@ class ConfigKeyTest {
 
     @Test
     void provides_well_known_constants() {
-        assertThat(ConfigKey.MAINTENANCE_ENABLED.value()).isEqualTo("maintenance.enabled");
-        assertThat(ConfigKey.MAINTENANCE_MESSAGE.value()).isEqualTo("maintenance.message");
+        assertThat(ConfigKey.PRESENCE_DJ_GRACE_SECONDS.value()).isEqualTo("presence.dj_grace_seconds");
+        assertThat(ConfigKey.PRESENCE_LISTENER_GRACE_SECONDS.value()).isEqualTo("presence.listener_grace_seconds");
     }
 }


### PR DESCRIPTION
## 문제
프로덕션 점검 중인데도 게스트가 user_account·crew 를 정상 생성. 프론트는 점검 화면이었음.

근본 원인: 백엔드 `MaintenanceModeFilter` 가 `SystemConfigCache.isMaintenanceMode()` → system_config `maintenance.enabled` 키만 봤는데, **그 키를 write 하는 코드가 전혀 없었다.** 어드민 점검 토글은 system_announcement 등록/완료 → WS broadcast + Vercel Edge Config(프론트 화면)만 건드림. 따라서 백엔드 503 게이트는 한 번도 켜지지 않았고 점검 중 API 가 활짝 열려 있었다. (#267)

## 변경 (ACTIVE 점검 단일소스 재배선)
- **포트**: `operations/application/port/out/MaintenanceGate` (isUnderMaintenance / getMaintenanceMessage).
- **어댑터**: `administration/adapter/out/maintenance/ActiveMaintenanceGate` — `SystemAnnouncementRepository.findCurrentMaintenance()`(maintenanceStartedAt≠null & cancelled=null & completed=null = 현재 ACTIVE)를 단일 진실원천으로. 503 메시지는 공지 `messageKo`. SystemConfigCache 와 동일한 **30s 스냅샷 캐시**(필터가 매 요청 호출 → 요청당 DB 조회 회피).
- **필터/Config**: `MaintenanceModeFilter`/`MaintenanceModeFilterConfig` 를 포트에 연결. bypass(`/api/v1/admin/**`, `/actuator/health`) 유지.
- **죽은 코드 제거**: `SystemConfigCache` 를 presence grace 전용으로 축소(isMaintenanceMode/getMaintenanceMessage/readBool/readString 제거), `ConfigKey.MAINTENANCE_ENABLED/MESSAGE` 제거, **V22** 로 V9 시드 행 삭제.

→ 운영자가 실제 토글하는 system_announcement 를 단일 소스로 일원화해 dual-flag drift 원인 제거.

## 동작/영향
- 점검 ACTIVE 시 백엔드가 실제로 503 반환(의도). 토글 후 최대 30s staleness 는 기존 허용 정책과 동일(프론트는 Edge Config 로 즉시 전환).
- ⚠️ V22 가 prod `system_config` 의 maintenance.enabled/message 행 삭제(코드 무참조라 무해).

## 검증
- 신규 `ActiveMaintenanceGateTest`(ACTIVE 유무 / blank 메시지 fallback / 30s 캐시 / TTL refetch), `MaintenanceModeFilterTest`(포트 목으로), `SystemConfigCacheTest`(grace 전용 재타겟), `ConfigKeyTest` 갱신.
- `./gradlew :app:test` BUILD SUCCESSFUL. (통합 테스트는 Testcontainers 라 로컬 미실행 — 컴파일 통과.)

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)