### PR TITLE
fix(user): 게스트 provider_type 을 GUEST 로 정정 (#268)

### DIFF
--- a/app/src/main/resources/db/migration/V23__backfill_guest_provider_type.sql
+++ b/app/src/main/resources/db/migration/V23__backfill_guest_provider_type.sql
@@ -1,0 +1,11 @@
+-- =====================================================
+-- V23: 게스트 user_account 의 provider_type 정정 (issue #268)
+--
+-- 게스트(임시 유저)는 OAuth 를 거치지 않으므로 provider_type 에 들어가 있던 'GOOGLE'
+-- 은 의미상 틀린 placeholder 였다. ProviderType 에 GUEST 값을 도입하고, guest 테이블에
+-- 레코드가 있는 user_account 행(= 게스트)을 GUEST 로 backfill 한다.
+-- =====================================================
+
+UPDATE user_account
+SET provider_type = 'GUEST'
+WHERE user_id IN (SELECT user_account_id FROM guest);

--- a/common/src/main/java/com/pfplaybackend/api/common/config/security/enums/ProviderType.java
+++ b/common/src/main/java/com/pfplaybackend/api/common/config/security/enums/ProviderType.java
@@ -3,5 +3,6 @@ package com.pfplaybackend.api.common.config.security.enums;
 public enum ProviderType {
     GOOGLE,
     TWITTER,
-    LOCAL  // Admin local login + virtual users
+    LOCAL, // Admin local login + virtual users
+    GUEST  // 임시 게스트 (OAuth 미사용 — 합성 이메일 guest-...@guest.local)
 }

--- a/user/src/main/java/com/pfplaybackend/api/user/application/service/GuestSignService.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/service/GuestSignService.java
@@ -1,6 +1,5 @@
 package com.pfplaybackend.api.user.application.service;
 
-import com.pfplaybackend.api.common.config.security.enums.ProviderType;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.user.adapter.out.persistence.GuestRepository;
 import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
@@ -30,10 +29,9 @@ public class GuestSignService {
         UserId userId = new UserId();
 
         // Synthetic placeholder email — guests do not log in via OAuth.
-        UserAccountData userAccount = UserAccountData.createForSocial(
+        UserAccountData userAccount = UserAccountData.createForGuest(
                 userId,
-                "guest-" + userId.getUid() + "@guest.local",
-                ProviderType.GOOGLE);
+                "guest-" + userId.getUid() + "@guest.local");
         userAccountRepository.save(userAccount);
 
         GuestData guest = GuestData.createForUserAccount(userId.getUid(), "N/A");

--- a/user/src/main/java/com/pfplaybackend/api/user/domain/entity/data/UserAccountData.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/domain/entity/data/UserAccountData.java
@@ -69,10 +69,25 @@ public class UserAccountData extends BaseEntity {
         if (providerType == ProviderType.LOCAL) {
             throw new IllegalArgumentException("Use createForLocal for LOCAL provider");
         }
+        if (providerType == ProviderType.GUEST) {
+            throw new IllegalArgumentException("Use createForGuest for GUEST provider");
+        }
         return UserAccountData.builder()
             .userId(userId)
             .email(email)
             .providerType(providerType)
+            .build();
+    }
+
+    /**
+     * 임시 게스트 계정. OAuth 를 거치지 않으므로 provider_type 은 GUEST 이며, email 은
+     * NOT NULL UNIQUE 제약을 만족시키기 위한 합성 placeholder({@code guest-...@guest.local})다.
+     */
+    public static UserAccountData createForGuest(UserId userId, String email) {
+        return UserAccountData.builder()
+            .userId(userId)
+            .email(email)
+            .providerType(ProviderType.GUEST)
             .build();
     }
 

--- a/user/src/test/java/com/pfplaybackend/api/user/application/service/GuestSignServiceTest.java
+++ b/user/src/test/java/com/pfplaybackend/api/user/application/service/GuestSignServiceTest.java
@@ -4,10 +4,12 @@ import com.pfplaybackend.api.user.adapter.out.persistence.GuestRepository;
 import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
 import com.pfplaybackend.api.user.domain.entity.data.GuestData;
 import com.pfplaybackend.api.user.domain.entity.data.ProfileData;
+import com.pfplaybackend.api.common.config.security.enums.ProviderType;
 import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -57,5 +59,19 @@ class GuestSignServiceTest {
         // then
         assertThat(result.getProfileData()).isEqualTo(profile);
         assertThat(result.isProfileUpdated()).isTrue();
+    }
+
+    @Test
+    @DisplayName("getGuestOrCreate — provider_type 을 GUEST 로 저장한다 (게스트는 OAuth 미사용)")
+    void getGuestOrCreate_assigns_guest_provider_type() {
+        ProfileData profile = mock(ProfileData.class);
+        when(userProfileCommandService.createProfileDataForGuest(any())).thenReturn(profile);
+        when(guestRepository.save(any(GuestData.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        guestSignService.getGuestOrCreate();
+
+        ArgumentCaptor<UserAccountData> captor = ArgumentCaptor.forClass(UserAccountData.class);
+        verify(userAccountRepository).save(captor.capture());
+        assertThat(captor.getValue().getProviderType()).isEqualTo(ProviderType.GUEST);
     }
 }


### PR DESCRIPTION
## 배경
게스트(임시 유저)는 OAuth 를 거치지 않는데, `GuestSignService` 가 `UserAccountData.createForSocial(..., ProviderType.GOOGLE)` 로 만들어 provider_type 에 placeholder GOOGLE 이 저장됐다. 의미상 틀린 값. (#268, incident #267 과 독립)

## 변경
- `ProviderType` 에 `GUEST` 추가 (@Enumerated(STRING) VARCHAR — 안전한 추가, ordinal 무관).
- `UserAccountData.createForGuest(userId, email)` 팩토리 신설. `createForSocial` 은 GUEST 도 거부(LOCAL 과 동일 가드)해 social 경로 오용 차단.
- `GuestSignService` 가 `createForGuest` 사용 (synthetic email `guest-...@guest.local` 유지).
- **V23** backfill: `UPDATE user_account SET provider_type='GUEST' WHERE user_id IN (SELECT user_account_id FROM guest)` — 기존 게스트 행 정정.

## 검증
- `GuestSignServiceTest` 에 provider_type=GUEST 단언 추가(ArgumentCaptor, RED→GREEN).
- `./gradlew :user:test`, `:app:test` 모두 BUILD SUCCESSFUL.

## 영향
- ⚠️ V23 이 prod `user_account` 의 게스트 행 provider_type 을 GUEST 로 일괄 갱신.
- provider_type 을 표시/매핑하는 admin 응답은 문자열 패스스루라 영향 없음(exhaustive switch 없음).

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)