### PR TITLE
fix(operations): 점검 중 어드민 로그인 bypass 추가 — 잠금 방지 (#267 후속)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/operations/adapter/in/web/MaintenanceModeFilter.java
+++ b/app/src/main/java/com/pfplaybackend/api/operations/adapter/in/web/MaintenanceModeFilter.java
@@ -16,8 +16,12 @@ import java.util.List;
 /**
  * Returns HTTP 503 for non-admin traffic when maintenance mode is enabled.
  *
- * Bypass paths: /api/v1/admin/** , /actuator/health.
+ * Bypass paths: /api/v1/admin/** , /api/v1/auth/admin/** , /actuator/health.
  * Bypass means "always pass through to next filter" — ignores maintenance flag.
+ *
+ * <p>/api/v1/auth/admin/** (어드민 로그인/로그아웃) 도 bypass — 세션 없는 운영자가 점검 중
+ * 콘솔에 로그인해 점검을 종료할 수 있어야 한다(잠금 방지). 일반 유저 OAuth(/api/v1/auth/oauth/**)
+ * 는 bypass 대상이 아니므로 점검 중 차단된다.
  *
  * Spec: docs/superpowers/specs/2026-04-19-admin-platform-features.md §6.E-1
  *       docs/superpowers/specs/2026-04-19-admin-platform-schema.md §4.6.2
@@ -26,6 +30,7 @@ public class MaintenanceModeFilter extends OncePerRequestFilter {
 
     private static final List<String> BYPASS_PATTERNS = List.of(
         "/api/v1/admin/**",
+        "/api/v1/auth/admin/**",
         "/actuator/health"
     );
     private static final AntPathMatcher MATCHER = new AntPathMatcher();

--- a/app/src/test/java/com/pfplaybackend/api/operations/adapter/in/web/MaintenanceModeFilterTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/operations/adapter/in/web/MaintenanceModeFilterTest.java
@@ -94,6 +94,37 @@ class MaintenanceModeFilterTest {
     }
 
     @Test
+    void bypasses_admin_auth_login_even_when_enabled() throws ServletException, IOException {
+        // 점검 중에도 어드민은 콘솔에 로그인해 점검을 끌 수 있어야 한다(잠금 방지).
+        // 어드민 로그인은 /api/v1/auth/admin/** (운영 엔드포인트 /api/v1/admin/** 와 별도 경로).
+        lenient().when(gate.isUnderMaintenance()).thenReturn(true);
+
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/api/v1/auth/admin/login");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        assertThat(chain.getRequest()).isSameAs(req);
+        assertThat(res.getContentAsString()).isEmpty();
+    }
+
+    @Test
+    void does_not_bypass_regular_user_oauth_even_when_enabled() throws ServletException, IOException {
+        when(gate.isUnderMaintenance()).thenReturn(true);
+        when(gate.getMaintenanceMessage()).thenReturn("점검중");
+
+        // 일반 유저 OAuth 로그인은 점검 중 차단되어야 한다(어드민 인증만 예외).
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/api/v1/auth/oauth/callback");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        assertThat(res.getStatus()).isEqualTo(503);
+    }
+
+    @Test
     void does_not_bypass_admin_lookalike_path() throws ServletException, IOException {
         when(gate.isUnderMaintenance()).thenReturn(true);
         when(gate.getMaintenanceMessage()).thenReturn("점검중");


### PR DESCRIPTION
## 문제
#267 로 백엔드 점검 게이트(`MaintenanceModeFilter`)가 실제로 동작하게 되면서, **어드민 로그인** 엔드포인트 `/api/v1/auth/admin/login`·`/logout` 이 bypass 목록(`/api/v1/admin/**`, `/actuator/health`)에 없어 **점검 중 503 으로 막힌다.**

→ 세션이 없는(쿠키 만료/다른 기기) 운영자가 점검 중 콘솔에 **로그인할 수 없어 점검을 종료하지 못하는 잠금** 위험. (#267 이전엔 게이트가 dead 라 안 터졌으나 이제 실재함.)

## 변경
- `BYPASS_PATTERNS` 에 `/api/v1/auth/admin/**` 추가.
- 어드민 운영(`/api/v1/admin/**`, must-change `password/change` 포함)·헬스체크는 기존대로 bypass.
- 일반 유저 OAuth(`/api/v1/auth/oauth/**`)는 bypass 아님 → 점검 중 차단 유지.

## 검증 (TDD)
- `bypasses_admin_auth_login_even_when_enabled` (RED→GREEN), `does_not_bypass_regular_user_oauth_even_when_enabled` (과차단 가드) 추가.
- `:app:test --tests *MaintenanceModeFilterTest` 9개 GREEN.

후속: #267 (PR #270)

🤖 Generated with [Claude Code](https://claude.com/claude-code)