### PR TITLE
fix(party): deletePartyRoom 의 tier 비대칭 회귀 — host 본인 검증만 (AM·FM 대칭)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomCommandService.java
@@ -3,7 +3,6 @@ package com.pfplaybackend.api.party.application.service;
 import com.pfplaybackend.api.common.ThreadLocalContext;
 import com.pfplaybackend.api.common.aspect.context.AuthContext;
 import com.pfplaybackend.api.common.domain.value.UserId;
-import com.pfplaybackend.api.common.enums.AuthorityTier;
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
 import com.pfplaybackend.api.party.application.dto.command.CreatePartyroomCommand;
 import com.pfplaybackend.api.party.application.dto.command.UpdateDjQueueStatusCommand;
@@ -111,12 +110,14 @@ public class PartyroomCommandService {
 
     @Transactional
     public void deletePartyRoom(PartyroomId partyroomId) {
+        // 권한 체크: host 본인만 삭제 가능. AuthorityTier 비대칭 fix —
+        // createGeneralPartyRoom 은 PartyroomCreationPolicy (FM || AM) 허용이지만
+        // 종전 deletePartyRoom 은 하드코딩 FM 만 허용해 AM 가 만든 룸을 본인이 종료 못 했음.
+        // updatePartyroom (line 105) 의 host validate 와 동일 패턴.
         AuthContext authContext = ThreadLocalContext.getAuthContext();
-        if (authContext.getAuthorityTier() != AuthorityTier.FM) {
-            throw ExceptionCreator.create(PartyroomException.RESTRICTED_AUTHORITY);
-        }
         PartyroomData partyroom = aggregatePort.findPartyroomById(partyroomId.getId())
                 .orElseThrow(() -> ExceptionCreator.create(PartyroomException.NOT_FOUND_ROOM));
+        partyroom.validateHost(authContext.getUserId());
         partyroom.terminate();
         aggregatePort.savePartyroom(partyroom);
         partyroom.pollDomainEvents().forEach(eventPublisher::publishEvent);

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomCommandServiceTest.java
@@ -229,18 +229,47 @@ class PartyroomCommandServiceTest {
     }
 
     @Test
-    @DisplayName("deletePartyRoom — FM이 아닌 사용자는 파티룸을 삭제할 수 없다")
-    void deletePartyRoomRestrictedAuthority() {
-        // given
-        AuthContext authContext = mock(AuthContext.class);
-        when(authContext.getAuthorityTier()).thenReturn(AuthorityTier.AM);
-        ThreadLocalContext.setContext(authContext);
-
+    @DisplayName("deletePartyRoom — host 가 아닌 사용자는 파티룸을 삭제할 수 없다 (validateHost)")
+    void deletePartyRoomNonHost() {
+        // given — partyroom 의 host 는 다른 사용자
         PartyroomId partyroomId = new PartyroomId(1L);
+        UserId otherHostId = new UserId(999L);
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(1L).partyroomId(partyroomId).hostId(otherHostId).stageType(StageType.GENERAL)
+                .title("Room").introduction("Intro")
+                .linkDomain(LinkDomain.of("link")).playbackTimeLimit(PlaybackTimeLimit.ofMinutes(5))
+                .noticeContent("").status(PartyroomStatus.ACTIVE).build();
+        when(aggregatePort.findPartyroomById(1L)).thenReturn(Optional.of(partyroom));
 
         // when & then
         assertThatThrownBy(() -> partyroomCommandService.deletePartyRoom(partyroomId))
                 .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("deletePartyRoom — AM 권한 사용자도 본인 host 인 파티룸은 삭제 가능 (tier 비대칭 fix)")
+    void deletePartyRoomAsAmHost() {
+        // given — AuthContext 를 AM 으로 override (host 는 본인)
+        AuthContext authContext = mock(AuthContext.class);
+        when(authContext.getUserId()).thenReturn(userId);
+        // NOTE: deletePartyRoom 는 더이상 authorityTier 를 검사하지 않음 — validateHost 만 의존.
+        ThreadLocalContext.setContext(authContext);
+
+        PartyroomId partyroomId = new PartyroomId(1L);
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(1L).partyroomId(partyroomId).hostId(userId).stageType(StageType.GENERAL)
+                .title("Room").introduction("Intro")
+                .linkDomain(LinkDomain.of("link")).playbackTimeLimit(PlaybackTimeLimit.ofMinutes(5))
+                .noticeContent("").status(PartyroomStatus.ACTIVE).build();
+        when(aggregatePort.findPartyroomById(1L)).thenReturn(Optional.of(partyroom));
+
+        // when
+        partyroomCommandService.deletePartyRoom(partyroomId);
+
+        // then
+        assertThat(partyroom.isTerminated()).isTrue();
+        verify(aggregatePort).savePartyroom(partyroom);
+        verify(eventPublisher, atLeastOnce()).publishEvent(any(Object.class));
     }
 
     // ========== deleteUnusedPartyroom ==========


### PR DESCRIPTION
## 발견

권한 비대칭:

\`\`\`java
// PartyroomCommandService.createGeneralPartyRoom (line 55)
new PartyroomCreationPolicy().enforce(authContext.getAuthorityTier());

// PartyroomCreationPolicy.enforce
if (tier != FM && tier != AM) throw RESTRICTED_AUTHORITY;  // ✅ FM + AM 허용

// PartyroomCommandService.deletePartyRoom (line 115-117, fix 전)
if (authContext.getAuthorityTier() != AuthorityTier.FM) {  // ❌ FM only
    throw RESTRICTED_AUTHORITY;
}
\`\`\`

**증상**: AM 권한 사용자가 본인 host 인 partyroom 을 자체적으로 종료 못 함.

## 영향 (재현 사례)

pfplay-web 의 e2e 시나리오:

1. \`a-user1\` (= AM) 가 createPartyroom 성공 → host 등록
2. afterAll DELETE → 'AuthorityTier != FM' fail → 403 → silent catch → partyroom 잔존
3. 다음 run beforeAll createPartyroom → backend \`findNonTerminatedHostRoom\` 에서 ALREADY_HOST 403
4. 결과: pfplay-web chunk 3.1 e2e CI 가 **5번 반복 fail** (run #1~#5 모두 동일 원인)

frontend 측 우회 시도 다수 (PR #358 ~ #365) 모두 실패한 진짜 root cause.

## 수정

\`updatePartyroom\` (line 105) 과 동일 패턴 — tier 무관, host 본인만:

\`\`\`java
@Transactional
public void deletePartyRoom(PartyroomId partyroomId) {
    AuthContext authContext = ThreadLocalContext.getAuthContext();
    PartyroomData partyroom = aggregatePort.findPartyroomById(partyroomId.getId())
            .orElseThrow(() -> ExceptionCreator.create(PartyroomException.NOT_FOUND_ROOM));
    partyroom.validateHost(authContext.getUserId());   // ✅ host 본인만
    partyroom.terminate();
    aggregatePort.savePartyroom(partyroom);
    partyroom.pollDomainEvents().forEach(eventPublisher::publishEvent);
}
\`\`\`

- 하드코딩 'AuthorityTier != FM' 체크 3행 제거
- \`partyroom.validateHost(userId)\` 추가 — host 가 아니면 \`GradeException.GRADE_INSUFFICIENT_FOR_OPERATION\`
- AM·FM 대칭. host 본인만 자기 룸 삭제 가능 (의도 명확)
- 미사용 \`AuthorityTier\` import 제거

## 테스트

\`PartyroomCommandServiceTest\`:

- 기존 \`deletePartyRoomRestrictedAuthority\` (FM 아니면 fail) → \`deletePartyRoomNonHost\` (host 아니면 fail) 로 의도 변경. 회귀 가드.
- 신규 \`deletePartyRoomAsAmHost\` (AM 권한도 본인 host 면 삭제 가능) — 비대칭 fix 회귀 가드.
- \`./gradlew :app:test --tests *PartyroomCommandService*\` GREEN.

## 인접 영향 확인

- \`updatePartyroom\` (line 100-110): 이미 \`partyroom.validateHost\` 만 사용 — tier 비대칭 없음
- \`createGeneralPartyRoom\` (line 53-): \`PartyroomCreationPolicy\` 로 FM·AM 허용. 동일 정책 (Member 등급)
- \`deleteUnusedPartyroom\` (cron, line 127): authContext 무관 (시스템 cron). 영향 없음
- Admin path (\`AdminPartyroomCommandService.terminate\`): 별도 권한 체계. 영향 없음

## 후속

- pfplay-web e2e: backend deploy 후 stale partyrooms 가 자동 cleanup 됨. chunk 3.1 e2e CI GREEN 예상
- 일반 사용자 시나리오: AM 가 본인 룸 닫는 정상 use case 가 회복