### PR TITLE
release: deletePartyRoom tier 비대칭 fix (#276) → stg

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomCommandService.java
@@ -3,7 +3,6 @@ package com.pfplaybackend.api.party.application.service;
 import com.pfplaybackend.api.common.ThreadLocalContext;
 import com.pfplaybackend.api.common.aspect.context.AuthContext;
 import com.pfplaybackend.api.common.domain.value.UserId;
-import com.pfplaybackend.api.common.enums.AuthorityTier;
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
 import com.pfplaybackend.api.party.application.dto.command.CreatePartyroomCommand;
 import com.pfplaybackend.api.party.application.dto.command.UpdateDjQueueStatusCommand;
@@ -111,12 +110,14 @@ public class PartyroomCommandService {
 
     @Transactional
     public void deletePartyRoom(PartyroomId partyroomId) {
+        // 권한 체크: host 본인만 삭제 가능. AuthorityTier 비대칭 fix —
+        // createGeneralPartyRoom 은 PartyroomCreationPolicy (FM || AM) 허용이지만
+        // 종전 deletePartyRoom 은 하드코딩 FM 만 허용해 AM 가 만든 룸을 본인이 종료 못 했음.
+        // updatePartyroom (line 105) 의 host validate 와 동일 패턴.
         AuthContext authContext = ThreadLocalContext.getAuthContext();
-        if (authContext.getAuthorityTier() != AuthorityTier.FM) {
-            throw ExceptionCreator.create(PartyroomException.RESTRICTED_AUTHORITY);
-        }
         PartyroomData partyroom = aggregatePort.findPartyroomById(partyroomId.getId())
                 .orElseThrow(() -> ExceptionCreator.create(PartyroomException.NOT_FOUND_ROOM));
+        partyroom.validateHost(authContext.getUserId());
         partyroom.terminate();
         aggregatePort.savePartyroom(partyroom);
         partyroom.pollDomainEvents().forEach(eventPublisher::publishEvent);

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomCommandServiceTest.java
@@ -229,18 +229,47 @@ class PartyroomCommandServiceTest {
     }
 
     @Test
-    @DisplayName("deletePartyRoom — FM이 아닌 사용자는 파티룸을 삭제할 수 없다")
-    void deletePartyRoomRestrictedAuthority() {
-        // given
-        AuthContext authContext = mock(AuthContext.class);
-        when(authContext.getAuthorityTier()).thenReturn(AuthorityTier.AM);
-        ThreadLocalContext.setContext(authContext);
-
+    @DisplayName("deletePartyRoom — host 가 아닌 사용자는 파티룸을 삭제할 수 없다 (validateHost)")
+    void deletePartyRoomNonHost() {
+        // given — partyroom 의 host 는 다른 사용자
         PartyroomId partyroomId = new PartyroomId(1L);
+        UserId otherHostId = new UserId(999L);
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(1L).partyroomId(partyroomId).hostId(otherHostId).stageType(StageType.GENERAL)
+                .title("Room").introduction("Intro")
+                .linkDomain(LinkDomain.of("link")).playbackTimeLimit(PlaybackTimeLimit.ofMinutes(5))
+                .noticeContent("").status(PartyroomStatus.ACTIVE).build();
+        when(aggregatePort.findPartyroomById(1L)).thenReturn(Optional.of(partyroom));
 
         // when & then
         assertThatThrownBy(() -> partyroomCommandService.deletePartyRoom(partyroomId))
                 .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("deletePartyRoom — AM 권한 사용자도 본인 host 인 파티룸은 삭제 가능 (tier 비대칭 fix)")
+    void deletePartyRoomAsAmHost() {
+        // given — AuthContext 를 AM 으로 override (host 는 본인)
+        AuthContext authContext = mock(AuthContext.class);
+        when(authContext.getUserId()).thenReturn(userId);
+        // NOTE: deletePartyRoom 는 더이상 authorityTier 를 검사하지 않음 — validateHost 만 의존.
+        ThreadLocalContext.setContext(authContext);
+
+        PartyroomId partyroomId = new PartyroomId(1L);
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(1L).partyroomId(partyroomId).hostId(userId).stageType(StageType.GENERAL)
+                .title("Room").introduction("Intro")
+                .linkDomain(LinkDomain.of("link")).playbackTimeLimit(PlaybackTimeLimit.ofMinutes(5))
+                .noticeContent("").status(PartyroomStatus.ACTIVE).build();
+        when(aggregatePort.findPartyroomById(1L)).thenReturn(Optional.of(partyroom));
+
+        // when
+        partyroomCommandService.deletePartyRoom(partyroomId);
+
+        // then
+        assertThat(partyroom.isTerminated()).isTrue();
+        verify(aggregatePort).savePartyroom(partyroom);
+        verify(eventPublisher, atLeastOnce()).publishEvent(any(Object.class));
     }
 
     // ========== deleteUnusedPartyroom ==========


### PR DESCRIPTION
## 포함 (1 commit)

- #276 fix(party): deletePartyRoom 의 tier 비대칭 회귀 — host 본인 검증만 (AM·FM 대칭)

## 배경

createGeneralPartyRoom 은 \`PartyroomCreationPolicy\` 로 FM·AM 모두 허용하나, deletePartyRoom 은 하드코딩 \`AuthorityTier != FM\` 으로 AM 거부. AM 가 만든 룸을 본인이 종료 못 함.

## 영향

- AM 권한 사용자가 본인 host partyroom 종료 회복
- pfplay-web e2e (a-user1 = AM) 가 partyroom cleanup 가능 — chunk 3.1 e2e CI 의 5번 반복 fail 의 root cause 해소

## stg deploy 트리거

release 브랜치 머지 시 stg-api.pfplay.xyz 자동 배포 (도커 + GCP).

## 후속

- pfplay-web 의 다음 development push 시 E2E run GREEN 예상 (defensive cleanup + 추적 강화 PR #365 머지 상태)