### PR TITLE
fix(party): MAIN 시스템 stage 보호 가드 3 termination 경로 + 부팅 자동 복원 (#280)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomCommandService.java
@@ -44,6 +44,9 @@ public class AdminPartyroomCommandService {
     @Transactional
     public void terminate(PartyroomId partyroomId, String reason, Long administratorId) {
         PartyroomData partyroom = loadPartyroom(partyroomId);
+        // #280 root-cause fix — admin bulk action 으로 partyroom_id=1 받아도 sweep 못 함.
+        // bulkDeactivate 부수효과 차단 위해 가드는 가장 먼저.
+        partyroom.validateNotMainStage();
         LocalDateTime now = LocalDateTime.now(clock);
 
         int crewsDeactivated = crewRepository.bulkDeactivateByPartyroomId(partyroomId, now);

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/impl/PartyroomRepositoryImpl.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/impl/PartyroomRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.pfplaybackend.api.party.application.dto.playback.PlaybackDto;
 import com.pfplaybackend.api.party.domain.entity.data.*;
 import com.pfplaybackend.api.party.domain.enums.DisplayFlag;
 import com.pfplaybackend.api.party.domain.enums.PartyroomStatus;
+import com.pfplaybackend.api.party.domain.enums.StageType;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.ConstructorExpression;
@@ -173,7 +174,11 @@ public class PartyroomRepositoryImpl implements PartyroomRepositoryCustom {
                 .from(qPartyroomData)
                 .where(
                         qPartyroomData.updatedAt.before(LocalDateTime.now(clock).minusDays(days)),
-                        qPartyroomData.status.ne(PartyroomStatus.TERMINATED)
+                        qPartyroomData.status.ne(PartyroomStatus.TERMINATED),
+                        // #280 root-cause fix — MAIN 시스템 stage 는 cleanup 대상 아님.
+                        // 호출자 deleteUnusedPartyroom 가 무가드 terminate forEach 라
+                        // repo level 에서 제외하는 게 가장 깔끔 (load 작아짐 + 의도 명확).
+                        qPartyroomData.stageType.ne(StageType.MAIN)
                 )
                 .fetch();
     }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomCommandService.java
@@ -118,6 +118,9 @@ public class PartyroomCommandService {
         PartyroomData partyroom = aggregatePort.findPartyroomById(partyroomId.getId())
                 .orElseThrow(() -> ExceptionCreator.create(PartyroomException.NOT_FOUND_ROOM));
         partyroom.validateHost(authContext.getUserId());
+        // #280 root-cause fix — MAIN 시스템 stage 는 host 본인 (super-admin) 이라도 종료 불가.
+        // super-admin 토큰 + DELETE /v1/partyrooms/1 footgun 차단.
+        partyroom.validateNotMainStage();
         partyroom.terminate();
         aggregatePort.savePartyroom(partyroom);
         partyroom.pollDomainEvents().forEach(eventPublisher::publishEvent);
@@ -146,13 +149,27 @@ public class PartyroomCommandService {
         aggregatePort.saveDjQueueState(djQueue);
     }
 
+    /**
+     * #280 안전망 — 부팅 시 MAIN 자동 복원.
+     * <p>termination 경로 3곳에 가드 추가 (root-cause fix) 한 위에 추가 layer 로,
+     * 어떤 식으로든 (수동 SQL / 과거 footgun row / 마이그레이션 사고) MAIN 이 비-ACTIVE
+     * 상태로 남아 있어도 다음 부팅에서 자동 ACTIVE 로 복원한다. manual SQL UPDATE 외 자동
+     * 복구 경로 0 이었던 상태 (이슈 #280) 를 해소.
+     */
+    @Transactional
     public void initializeMainStage(UserId adminId) {
         CreatePartyroomCommand command = new CreatePartyroomCommand(
                 "Main Stage",
                 "Welcome to the main stage",
                 "main",
                 10);
-        if (aggregatePort.findByLinkDomain(LinkDomain.of(command.linkDomain())).isPresent()) {
+        Optional<PartyroomData> existing = aggregatePort.findByLinkDomain(LinkDomain.of(command.linkDomain()));
+        if (existing.isPresent()) {
+            PartyroomData mainStage = existing.get();
+            if (!mainStage.isActive()) {
+                mainStage.reactivateAsMainStage();
+                aggregatePort.savePartyroom(mainStage);
+            }
             return;
         }
         createMainStage(command, adminId);

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/PartyroomData.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/PartyroomData.java
@@ -211,6 +211,32 @@ public class PartyroomData extends BaseEntity {
         registerEvent(new PartyroomClosedEvent(this.partyroomId, this.hostId, this.title));
     }
 
+    /**
+     * MAIN 시스템 stage 전용 lifecycle 복원 (#280).
+     * <p>일반 파티룸은 {@link #terminate()} 가 terminal 이지만, MAIN 은 시스템 stage 라
+     * {@code ApplicationReadyEventListener.initializeMainStage} 가 부팅마다 자동 복원해야 한다.
+     * 어떤 비-ACTIVE 상태에서든 ACTIVE 로 idempotent 복원하며, GENERAL stage 에서 호출 시 거부한다.
+     * <p>일반 파티룸의 terminal invariant 는 그대로 보존된다.
+     */
+    public void reactivateAsMainStage() {
+        if (this.stageType != StageType.MAIN) {
+            throw ExceptionCreator.create(PartyroomException.ILLEGAL_STATE_TRANSITION);
+        }
+        this.status = PartyroomStatus.ACTIVE;
+    }
+
+    /**
+     * MAIN 시스템 stage 보호 가드 (#280 root-cause fix).
+     * <p>모든 termination 경로 (host self-delete / cron / admin terminate) 가
+     * MAIN 까지 잡지 않도록 하는 도메인 측 가드. caller 의 호출 의도 컨텍스트와
+     * 결합돼 footgun 을 차단한다 (suspend/setHidden 같은 비-terminal 동작은 정책 미정으로 미적용).
+     */
+    public void validateNotMainStage() {
+        if (this.stageType == StageType.MAIN) {
+            throw ExceptionCreator.create(PartyroomException.MAIN_STAGE_PROTECTED);
+        }
+    }
+
     // ── Display Flag (admin-only via Administration BC; ArchUnit 가드는 별 task) ──
 
     /**

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/exception/PartyroomException.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/exception/PartyroomException.java
@@ -13,7 +13,8 @@ public enum PartyroomException implements DomainException {
     RESTRICTED_AUTHORITY("PTR-005", "권한이 부족합니다", ErrorType.FORBIDDEN),
     ALREADY_HOST("PTR-006", "이미 다른 파티룸의 호스트입니다", ErrorType.FORBIDDEN),
     ILLEGAL_STATE_TRANSITION("PTR-007", "허용되지 않은 파티룸 상태 전이입니다", ErrorType.CONFLICT),
-    LINK_DOMAIN_ALREADY_EXISTS("PTR-008", "이미 사용 중인 파티룸 주소입니다", ErrorType.CONFLICT);
+    LINK_DOMAIN_ALREADY_EXISTS("PTR-008", "이미 사용 중인 파티룸 주소입니다", ErrorType.CONFLICT),
+    MAIN_STAGE_PROTECTED("PTR-009", "메인 스테이지는 보호된 시스템 파티룸입니다", ErrorType.CONFLICT);
 
     private final String errorCode;
     private final String message;

--- a/app/src/test/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomCommandServiceTest.java
@@ -110,6 +110,27 @@ class AdminPartyroomCommandServiceTest {
     }
 
     @Test
+    @DisplayName("terminate - MAIN stage 룸은 거부 (ConflictException, #280 root-cause fix). " +
+            "admin bulk action 으로 partyroom_id=1 받아도 sweep 못 함")
+    void terminate_rejects_main_stage() {
+        PartyroomData mainStage = PartyroomData.builder()
+                .id(1L).partyroomId(PID).hostId(new UserId(1L)).stageType(StageType.MAIN)
+                .title("Main Stage").introduction("Welcome")
+                .linkDomain(LinkDomain.of("main")).playbackTimeLimit(PlaybackTimeLimit.ofMinutes(10))
+                .noticeContent("").status(PartyroomStatus.ACTIVE).build();
+        when(aggregatePort.findPartyroomById(PID.getId())).thenReturn(Optional.of(mainStage));
+
+        assertThatThrownBy(() -> service.terminate(PID, "demo cleanup", ADMIN_ID))
+                .isInstanceOf(ConflictException.class);
+
+        // 가드는 bulkDeactivate 보다 먼저 작동해야 한다 (crew 부수효과 차단).
+        verify(crewRepository, never()).bulkDeactivateByPartyroomId(any(), any());
+        verify(aggregatePort, never()).savePartyroom(any());
+        verify(eventPublisher, never()).publishEvent(any(PartyroomTerminatedEvent.class));
+        assertThat(mainStage.getStatus()).isEqualTo(PartyroomStatus.ACTIVE);
+    }
+
+    @Test
     @DisplayName("suspend - ACTIVE -> SUSPENDED + event")
     void suspend_happy() {
         PartyroomData p = activeRoom();

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomRepositoryAtomicUpdateIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomRepositoryAtomicUpdateIT.java
@@ -38,6 +38,16 @@ class PartyroomRepositoryAtomicUpdateIT extends AbstractIntegrationTest {
         return partyroomRepository.saveAndFlush(p);
     }
 
+    private PartyroomData createAndSaveMainStage(long hostUid) {
+        // #280 — MAIN stage 별도 row. link_domain 은 cross-class pollution 회피 위해
+        // hostUid 기반 unique. ApplicationReadyEventListener 가 띄우는 link="main" 과 분리.
+        PartyroomData p = PartyroomData.create(
+                "main-test-" + hostUid, "intro", LinkDomain.of("main-test-" + hostUid),
+                PlaybackTimeLimit.ofMinutes(10), StageType.MAIN,
+                new UserId(hostUid));
+        return partyroomRepository.saveAndFlush(p);
+    }
+
     // ── incrementCrewCount ─────────────────────────────────────────
 
     @Test
@@ -231,5 +241,22 @@ class PartyroomRepositoryAtomicUpdateIT extends AbstractIntegrationTest {
         assertThat(unused).extracting(PartyroomData::getId)
                 .contains(active.getId())
                 .doesNotContain(terminated.getId());
+    }
+
+    @Test
+    @DisplayName("findAllUnusedPartyroomDataByDay — MAIN stage 룸은 결과에서 제외 (#280 root-cause fix). " +
+            "cron 03:00 sweep 가 MAIN 까지 잡지 않도록 repo level 가드")
+    void unused_excludes_main_stage() {
+        // given: GENERAL ACTIVE room + MAIN stage room
+        PartyroomData generalActive = createAndSaveActive(2020L);
+        PartyroomData mainActive = createAndSaveMainStage(2021L);
+
+        // when: same days=-1 시간축 변동성 흡수 패턴 (DATETIME(0) 라운딩 flake 회피)
+        List<PartyroomData> unused = partyroomRepository.findAllUnusedPartyroomDataByDay(-1);
+
+        // then: GENERAL 은 결과에 포함, MAIN 은 결과에서 제외
+        assertThat(unused).extracting(PartyroomData::getId)
+                .contains(generalActive.getId())
+                .doesNotContain(mainActive.getId());
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomCommandServiceTest.java
@@ -366,4 +366,84 @@ class PartyroomCommandServiceTest {
         assertThat(djQueue.isClosed()).isFalse();
         verify(aggregatePort).saveDjQueueState(djQueue);
     }
+
+    // ========== #280 MAIN 보호 가드 + initializeMainStage idempotent ==========
+
+    @Test
+    @DisplayName("deletePartyRoom — MAIN stage 룸은 거부 (ConflictException, terminate 호출 안 함)")
+    void deletePartyRoomRejectsMainStage() {
+        // given — host 본인이지만 MAIN stage
+        PartyroomId partyroomId = new PartyroomId(1L);
+        PartyroomData mainStage = PartyroomData.builder()
+                .id(1L).partyroomId(partyroomId).hostId(userId).stageType(StageType.MAIN)
+                .title("Main Stage").introduction("Welcome")
+                .linkDomain(LinkDomain.of("main")).playbackTimeLimit(PlaybackTimeLimit.ofMinutes(10))
+                .noticeContent("").status(PartyroomStatus.ACTIVE).build();
+        when(aggregatePort.findPartyroomById(1L)).thenReturn(Optional.of(mainStage));
+
+        // when & then — validateHost 통과 후 validateNotMainStage 에서 차단
+        assertThatThrownBy(() -> partyroomCommandService.deletePartyRoom(partyroomId))
+                .isInstanceOf(ConflictException.class);
+        assertThat(mainStage.isTerminated()).isFalse();
+        verify(aggregatePort, never()).savePartyroom(any());
+    }
+
+    @Test
+    @DisplayName("initializeMainStage — MAIN 없으면 새로 생성 (기존 동작 유지)")
+    void initializeMainStageCreatesWhenAbsent() {
+        // given
+        when(aggregatePort.findByLinkDomain(LinkDomain.of("main"))).thenReturn(Optional.empty());
+        when(aggregatePort.savePartyroom(any(PartyroomData.class))).thenAnswer(invocation -> {
+            PartyroomData p = invocation.getArgument(0);
+            return PartyroomData.builder()
+                    .id(1L).hostId(p.getHostId()).stageType(p.getStageType())
+                    .title(p.getTitle()).introduction(p.getIntroduction())
+                    .linkDomain(p.getLinkDomain()).playbackTimeLimit(p.getPlaybackTimeLimit())
+                    .noticeContent("").status(PartyroomStatus.ACTIVE).build();
+        });
+
+        // when
+        partyroomCommandService.initializeMainStage(userId);
+
+        // then — createMainStage 경로로 새 partyroom 생성
+        verify(aggregatePort).savePartyroom(any(PartyroomData.class));
+    }
+
+    @Test
+    @DisplayName("initializeMainStage — 기존 MAIN 이 ACTIVE 면 no-op (idempotent)")
+    void initializeMainStageNoOpWhenActive() {
+        // given
+        PartyroomData existingActive = PartyroomData.builder()
+                .id(1L).hostId(userId).stageType(StageType.MAIN)
+                .title("Main Stage").introduction("Welcome")
+                .linkDomain(LinkDomain.of("main")).playbackTimeLimit(PlaybackTimeLimit.ofMinutes(10))
+                .noticeContent("").status(PartyroomStatus.ACTIVE).build();
+        when(aggregatePort.findByLinkDomain(LinkDomain.of("main"))).thenReturn(Optional.of(existingActive));
+
+        // when
+        partyroomCommandService.initializeMainStage(userId);
+
+        // then — save 호출 없음
+        verify(aggregatePort, never()).savePartyroom(any());
+    }
+
+    @Test
+    @DisplayName("initializeMainStage — 기존 MAIN 이 TERMINATED 면 reactivate 후 save (#280 안전망)")
+    void initializeMainStageReactivatesWhenTerminated() {
+        // given — 어떤 footgun 으로 MAIN 이 TERMINATED 된 상태
+        PartyroomData terminatedMain = PartyroomData.builder()
+                .id(1L).hostId(userId).stageType(StageType.MAIN)
+                .title("Main Stage").introduction("Welcome")
+                .linkDomain(LinkDomain.of("main")).playbackTimeLimit(PlaybackTimeLimit.ofMinutes(10))
+                .noticeContent("").status(PartyroomStatus.TERMINATED).build();
+        when(aggregatePort.findByLinkDomain(LinkDomain.of("main"))).thenReturn(Optional.of(terminatedMain));
+
+        // when
+        partyroomCommandService.initializeMainStage(userId);
+
+        // then — reactivate + save (createMainStage 는 호출되지 않음)
+        assertThat(terminatedMain.isActive()).isTrue();
+        verify(aggregatePort).savePartyroom(terminatedMain);
+        verify(partyroomAccessCommandService, never()).enterByHost(any(), any());
+    }
 }

--- a/app/src/test/java/com/pfplaybackend/api/party/domain/entity/data/PartyroomDataTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/domain/entity/data/PartyroomDataTest.java
@@ -243,6 +243,88 @@ class PartyroomDataTest {
     }
 
     @Nested
+    @DisplayName("validateNotMainStage() — MAIN stage 보호 가드 (#280 root-cause fix)")
+    class ValidateNotMainStage {
+        // 모든 termination 경로 (host self-delete / cron / admin) 가 MAIN 까지 잡지 않도록
+        // 도메인 측 가드. 일반 파티룸은 그대로 통과.
+
+        private PartyroomData mainStage() {
+            return PartyroomData.builder()
+                    .id(1L)
+                    .hostId(new UserId(1L))
+                    .stageType(StageType.MAIN)
+                    .title("Main Stage")
+                    .introduction("Welcome")
+                    .linkDomain(LinkDomain.of("main"))
+                    .playbackTimeLimit(PlaybackTimeLimit.ofMinutes(10))
+                    .noticeContent("")
+                    .status(PartyroomStatus.ACTIVE)
+                    .build();
+        }
+
+        @Test @DisplayName("MAIN stage → ConflictException (MAIN_STAGE_PROTECTED)")
+        void rejectsMainStage() {
+            PartyroomData p = mainStage();
+            assertThatThrownBy(p::validateNotMainStage).isInstanceOf(ConflictException.class);
+        }
+
+        @Test @DisplayName("GENERAL stage → 통과 (예외 없음)")
+        void acceptsGeneralStage() {
+            assertThatNoException().isThrownBy(() -> newPartyroom().validateNotMainStage());
+        }
+    }
+
+    @Nested
+    @DisplayName("reactivateAsMainStage() — MAIN 시스템 stage 전용 lifecycle 복원 (#280 안전망)")
+    class ReactivateAsMainStage {
+        // 일반 파티룸은 TERMINATED 가 terminal invariant 이지만, MAIN 은 시스템 stage 라
+        // ApplicationReadyEventListener.initializeMainStage 가 부팅마다 자동 복원해야 한다.
+
+        private PartyroomData mainWithStatus(PartyroomStatus status) {
+            return PartyroomData.builder()
+                    .id(1L)
+                    .hostId(new UserId(1L))
+                    .stageType(StageType.MAIN)
+                    .title("Main Stage")
+                    .introduction("Welcome")
+                    .linkDomain(LinkDomain.of("main"))
+                    .playbackTimeLimit(PlaybackTimeLimit.ofMinutes(10))
+                    .noticeContent("")
+                    .status(status)
+                    .build();
+        }
+
+        @Test @DisplayName("MAIN + TERMINATED → ACTIVE 복원")
+        void mainTerminatedToActive() {
+            PartyroomData p = mainWithStatus(PartyroomStatus.TERMINATED);
+            p.reactivateAsMainStage();
+            assertThat(p.isActive()).isTrue();
+            assertThat(p.isTerminated()).isFalse();
+        }
+
+        @Test @DisplayName("MAIN + SUSPENDED → ACTIVE 복원")
+        void mainSuspendedToActive() {
+            PartyroomData p = mainWithStatus(PartyroomStatus.SUSPENDED);
+            p.reactivateAsMainStage();
+            assertThat(p.isActive()).isTrue();
+        }
+
+        @Test @DisplayName("MAIN + ACTIVE → no-op (idempotent)")
+        void mainActiveIdempotent() {
+            PartyroomData p = mainWithStatus(PartyroomStatus.ACTIVE);
+            assertThatNoException().isThrownBy(p::reactivateAsMainStage);
+            assertThat(p.isActive()).isTrue();
+        }
+
+        @Test @DisplayName("GENERAL stage → ConflictException (일반 파티룸 terminal invariant 보호)")
+        void rejectsGeneralStage() {
+            PartyroomData p = newPartyroom();
+            p.terminate();
+            assertThatThrownBy(p::reactivateAsMainStage).isInstanceOf(ConflictException.class);
+        }
+    }
+
+    @Nested
     @DisplayName("validateNotTerminated() — 기존 시맨틱 유지 (TERMINATED만 거부)")
     class ValidateNotTerminated {
         @Test @DisplayName("ACTIVE 통과")


### PR DESCRIPTION
## 배경

이슈 #280 본문은 증상 (id=1 MAIN + GENERAL 룸 일괄 TERMINATED) 만 보고 `ApplicationReadyEventListener.initializeMainStage` 의 idempotent 강화 (옵션 A) 를 권장. 단 root cause 추적 결과 termination 경로 3 곳 모두에 MAIN 거부 가드가 없음 — 옵션 A 만으로는 증상만 사후복구하고 새 sweep 다시 발생.

## Root cause (Phase 1 추적)

MAIN 의 host_id 는 super-admin (user_id=1). 다음 3 경로 어디에도 MAIN 거부 가드 없음:

| 경로 | 기존 가드 | 발화 조건 |
|---|---|---|
| `PartyroomCommandService.deletePartyRoom` | validateHost 만 | super-admin 토큰 + DELETE /v1/partyrooms/1 |
| `PartyroomCommandService.deleteUnusedPartyroom` (cron `0 0 3 * * *`) | TERMINATED 제외만 | MAIN.updated_at < now-30days |
| `AdminPartyroomCommandService.terminate` (+ Bulk outer/unit) | 0 | admin bulk action 에 `partyroomId=1` 포함 |

**사용자 가설 ("e2e 가 MAIN 건드림") 1차 검증**: e2e cleanup 의 title 필터 `/^(E2EA|E2EB|E2EC|E2ED|MTOS|MOBILE-TOS-|MDJ|MAT)/` 가 `"Main Stage"` 와 안 매칭 → e2e cleanup 은 MAIN 안 잡음. **반박**.

## 변경 (3 layer 이중방어)

### P1 root-cause — 도메인 가드 + 호출 위치 2 곳

- `PartyroomData.validateNotMainStage()` 신규 — MAIN 이면 `ConflictException`
- `PartyroomException.MAIN_STAGE_PROTECTED` (PTR-009) — 의도 명확화 + audit 가시성 (기존 `ILLEGAL_STATE_TRANSITION` 재사용 시 다른 위반과 섞임)
- 호출 위치:
  - `PartyroomCommandService.deletePartyRoom` → `validateHost` 다음
  - `AdminPartyroomCommandService.terminate` → `bulkDeactivate` **전** (crew 부수효과 차단)

### P2 cron-level — repo query 에서 MAIN 제외

- `PartyroomRepositoryImpl.findAllUnusedPartyroomDataByDay` 에 `stageType.ne(StageType.MAIN)` 추가
  - `deleteUnusedPartyroom` 가 forEach + 무가드 terminate 라 호출자 측 추가 가드보다 repo level 이 깔끔
  - load 작아짐 + 의도 명확

### P3 안전망 — 부팅 시 자동 복원 (이슈 옵션 A)

- `PartyroomData.reactivateAsMainStage()` — MAIN 만 허용, 어떤 비-ACTIVE 상태에서든 ACTIVE 로 복원, ACTIVE 면 idempotent no-op. GENERAL 호출 시 `ConflictException` (terminal invariant 보존)
- `PartyroomCommandService.initializeMainStage` — existing 발견 시 `isActive()` 분기:
  - ACTIVE → no-op (기존 동작 유지)
  - 비-ACTIVE → reactivate + save
- 수동 SQL / 과거 footgun row / 마이그레이션 사고로 MAIN 이 비-ACTIVE 면 다음 부팅에서 자동 복원. manual SQL `UPDATE` 외 자동 복구 경로 0 이었던 상태 해소.

## 정책 미적용 영역

- `AdminPartyroomCommandService.suspend` / `setDisplayFlag` 는 가드 미추가
- 이슈 #280 가 terminate 만 추적한 범위라 동일 스코프 유지. 운영 정책 (MAIN 일시 점검 등) 결정 보류.

## 검증

- **단위**: `PartyroomDataTest` (validateNotMainStage 2 + reactivateAsMainStage 4) / `PartyroomCommandServiceTest` (deletePartyRoom reject + initializeMainStage 3 분기) / `AdminPartyroomCommandServiceTest` (terminate reject)
- **IT**: `PartyroomRepositoryAtomicUpdateIT.unused_excludes_main_stage`
- **전체**: `:app:test` + `:app:integrationTest` GREEN, 회귀 0
- **로컬 docker compose verify**: `MAIN.status=TERMINATED` 강제 set → 새 이미지 빌드 + app 재기동 → p6spy 로그에 부팅 직후 `UPDATE partyroom SET status='ACTIVE' WHERE partyroom_id=1` 자동 발화 + DB 최종 `status=ACTIVE` 확정

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)