### PR TITLE
[Feature] 가상 사용자 능동 디제잉 (P2) — 백엔드 (#282)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/operations/application/service/SystemConfigCache.java
+++ b/app/src/main/java/com/pfplaybackend/api/operations/application/service/SystemConfigCache.java
@@ -26,6 +26,9 @@ public class SystemConfigCache {
     static final Duration SNAPSHOT_TTL = Duration.ofSeconds(30);
     static final int DEFAULT_DJ_GRACE_SECONDS = 30;
     static final int DEFAULT_LISTENER_GRACE_SECONDS = 10;
+    static final int DEFAULT_BOT_YIELD_DEBOUNCE_MS = 5_000;
+    static final int DEFAULT_BOT_MIN_DWELL_MS = 10_000;
+    static final boolean DEFAULT_VIRTUALDJ_DISTINGUISHABLE = false;
 
     private final SystemConfigRepository repository;
     private final Clock clock;
@@ -42,6 +45,24 @@ public class SystemConfigCache {
 
     public int getListenerGraceSeconds() {
         return current().listenerGraceSeconds;
+    }
+
+    /** 봇 양보(제거) debounce — 제거 의도가 이 시간 이상 지속돼야 실제 제거. Chunk 5 anti-flap. */
+    public int getBotYieldDebounceMs() {
+        return current().botYieldDebounceMs;
+    }
+
+    /** 봇 최소 체류시간 — 투입 후 이 시간 이내 봇은 제거 보호. Chunk 5 anti-flap. */
+    public int getBotMinDwellMs() {
+        return current().botMinDwellMs;
+    }
+
+    /**
+     * 가상 DJ 식별 가능 여부 토글 — pre-seed 전용(이번 chunk 에서는 접근자만 제공, DTO 노출은 Plan B).
+     * fail-open false.
+     */
+    public boolean isVirtualDjDistinguishable() {
+        return current().virtualDjDistinguishable;
     }
 
     /** Public so PR 6's event listener can force-invalidate after admin toggle. */
@@ -63,7 +84,10 @@ public class SystemConfigCache {
     private Snapshot fetch(Instant now) {
         int djGrace = readInt(ConfigKey.PRESENCE_DJ_GRACE_SECONDS, DEFAULT_DJ_GRACE_SECONDS);
         int listenerGrace = readInt(ConfigKey.PRESENCE_LISTENER_GRACE_SECONDS, DEFAULT_LISTENER_GRACE_SECONDS);
-        return new Snapshot(djGrace, listenerGrace, now);
+        int botYieldDebounce = readInt(ConfigKey.VIRTUALDJ_BOT_YIELD_DEBOUNCE_MS, DEFAULT_BOT_YIELD_DEBOUNCE_MS);
+        int botMinDwell = readInt(ConfigKey.VIRTUALDJ_BOT_MIN_DWELL_MS, DEFAULT_BOT_MIN_DWELL_MS);
+        boolean distinguishable = readBoolean(ConfigKey.VIRTUALDJ_DISTINGUISHABLE, DEFAULT_VIRTUALDJ_DISTINGUISHABLE);
+        return new Snapshot(djGrace, listenerGrace, botYieldDebounce, botMinDwell, distinguishable, now);
     }
 
     /**
@@ -83,5 +107,22 @@ public class SystemConfigCache {
         }
     }
 
-    private record Snapshot(int djGraceSeconds, int listenerGraceSeconds, Instant fetchedAt) {}
+    /**
+     * Fail-open: missing/blank rows fall back to {@code fallback}. Accepts {@code true}/{@code false}
+     * (case-insensitive, trimmed); any other value falls back. A typo must not flip a feature toggle.
+     */
+    private boolean readBoolean(ConfigKey key, boolean fallback) {
+        Optional<SystemConfigData> row = repository.findByConfigKey(key.value());
+        if (row.isEmpty()) return fallback;
+        String v = row.get().getConfigValue();
+        if (v == null || v.isBlank()) return fallback;
+        String trimmed = v.trim();
+        if (trimmed.equalsIgnoreCase("true")) return true;
+        if (trimmed.equalsIgnoreCase("false")) return false;
+        return fallback;
+    }
+
+    private record Snapshot(int djGraceSeconds, int listenerGraceSeconds,
+                            int botYieldDebounceMs, int botMinDwellMs,
+                            boolean virtualDjDistinguishable, Instant fetchedAt) {}
 }

--- a/app/src/main/java/com/pfplaybackend/api/operations/domain/value/ConfigKey.java
+++ b/app/src/main/java/com/pfplaybackend/api/operations/domain/value/ConfigKey.java
@@ -38,4 +38,9 @@ public record ConfigKey(String value) {
     // Well-known keys
     public static final ConfigKey PRESENCE_DJ_GRACE_SECONDS = new ConfigKey("presence.dj_grace_seconds");
     public static final ConfigKey PRESENCE_LISTENER_GRACE_SECONDS = new ConfigKey("presence.listener_grace_seconds");
+
+    // Virtual-DJ anti-flap / 식별 토글 (Chunk 5)
+    public static final ConfigKey VIRTUALDJ_BOT_YIELD_DEBOUNCE_MS = new ConfigKey("virtualdj.bot_yield_debounce_ms");
+    public static final ConfigKey VIRTUALDJ_BOT_MIN_DWELL_MS = new ConfigKey("virtualdj.bot_min_dwell_ms");
+    public static final ConfigKey VIRTUALDJ_DISTINGUISHABLE = new ConfigKey("virtualdj.distinguishable");
 }

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/event/VirtualDjEventListener.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/event/VirtualDjEventListener.java
@@ -1,0 +1,77 @@
+package com.pfplaybackend.api.virtualdj.adapter.in.event;
+
+import com.pfplaybackend.api.party.domain.event.CrewAccessedEvent;
+import com.pfplaybackend.api.party.domain.event.DjQueueChangedEvent;
+import com.pfplaybackend.api.party.domain.event.PartyroomTerminatedEvent;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.PartyroomVirtualDjConfigRepository;
+import com.pfplaybackend.api.virtualdj.application.port.VirtualDjOrchestrator;
+import com.pfplaybackend.api.virtualdj.application.service.FlapGuard;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.PartyroomVirtualDjConfigData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.Optional;
+
+/**
+ * 도메인 이벤트 → {@link VirtualDjOrchestrator#reconcileRoom} 트리거 (Chunk 5).
+ *
+ * <p>{@link DomainEventRedisRelay} 와 동일한 {@code @TransactionalEventListener(AFTER_COMMIT)} 스타일.
+ * AFTER_COMMIT 이 <b>필수</b>인 이유: reconcile 읽기 경로({@code ActiveDjSnapshotService})는
+ * {@code @Transactional(readOnly=true)} 로 커밋된 상태를 읽으므로, 입퇴장/DJ 큐 변경이 커밋된 뒤에
+ * 트리거돼야 정확한 현재 수를 본다. 각 핸들러는 발행 트랜잭션과 분리된
+ * {@code REQUIRES_NEW} 로 실행된다.
+ *
+ * <p><b>무한루프 가드:</b> reconcile 내부의 봇 enqueue/exit 가 다시 {@link DjQueueChangedEvent} 를
+ * 발행 → 또 다른 reconcile 을 부른다. Chunk 4 의 멱등성(목표 수렴 시 add/remove 없음) 덕분에
+ * 두 번째 reconcile 은 no-op 으로 즉시 수렴한다. ({@code VirtualDjEventListenerIT} 가 재트리거 시
+ * enqueue/exit 가 추가로 일어나지 않음을 spy 로 검증.)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VirtualDjEventListener {
+
+    private final VirtualDjOrchestrator orchestrator;
+    private final PartyroomVirtualDjConfigRepository configRepository;
+    private final FlapGuard flapGuard;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void onCrewAccessed(CrewAccessedEvent event) {
+        log.debug("[vdj-event] CrewAccessed → reconcile partyroomId={}", event.getPartyroomId().getId());
+        orchestrator.reconcileRoom(event.getPartyroomId());
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void onDjQueueChanged(DjQueueChangedEvent event) {
+        log.debug("[vdj-event] DjQueueChanged({}) → reconcile partyroomId={}",
+                event.getChangeType(), event.getPartyroomId().getId());
+        orchestrator.reconcileRoom(event.getPartyroomId());
+    }
+
+    /**
+     * 룸 종료 시 config 정리 — 종료된 룸은 reconcile 하지 않고 {@code turnOff} 로 OFF 전환한다.
+     * config 가 없으면(가상 DJ 미사용 룸) 아무 것도 하지 않는다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void onTerminated(PartyroomTerminatedEvent event) {
+        Long partyroomId = event.getPartyroomId().getId();
+        // config 존재 여부와 무관하게 removal-intent 누수를 방지한다(clearRemovalIntent 는 멱등).
+        flapGuard.clearRemovalIntent(event.getPartyroomId());
+        Optional<PartyroomVirtualDjConfigData> optConfig = configRepository.findByPartyroomId(partyroomId);
+        if (optConfig.isEmpty()) {
+            return;
+        }
+        PartyroomVirtualDjConfigData cfg = optConfig.get();
+        cfg.turnOff();
+        configRepository.save(cfg);
+        log.info("[vdj-event] PartyroomTerminated → config OFF partyroomId={}", partyroomId);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/AdminVirtualDjController.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/AdminVirtualDjController.java
@@ -1,0 +1,166 @@
+package com.pfplaybackend.api.virtualdj.adapter.in.web;
+
+import com.pfplaybackend.api.common.ApiCommonResponse;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.AddPackTrackRequest;
+import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.ApplyVirtualDjConfigRequest;
+import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.BulkApplyVirtualDjConfigRequest;
+import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.CreateSongPackRequest;
+import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.CreatedIdResponse;
+import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.ProvisionPoolRequest;
+import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.RenameSongPackRequest;
+import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.VirtualDjLiveStatusResponse;
+import com.pfplaybackend.api.virtualdj.application.service.VirtualDjAdminService;
+import com.pfplaybackend.api.virtualdj.application.service.VirtualSongPackService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 어드민 가상 DJ(P2) API — 봇 풀 / 송 팩 CRUD / 룸별 config / 일괄 / live status.
+ *
+ * <p>feature-cohesive 배치: administration BC 가 아니라 {@code virtualdj} feature 의 inbound adapter 에 둔다
+ * (송 팩·봇 풀·reconcile 이 모두 이 feature 응집). 공통 {@code @adminAuth.canManageVirtualDj()} SpEL 로 게이팅하고
+ * {@code @SecurityRequirement(name="cookieAuth")} + {@link ApiCommonResponse} 봉투를 쓴다. 도메인 예외
+ * (CONFIG_NOT_FOUND 404, SONG_PACK_* 409/404, INVALID_CONFIG 400)는 GlobalExceptionHandler 가 매핑한다.
+ */
+@Tag(name = "Admin Virtual DJ API", description = "P2 가상 DJ 어드민 운영 (봇 풀/송 팩/룸 config/일괄)")
+@RestController
+@RequestMapping("/api/v1/admin")
+@RequiredArgsConstructor
+public class AdminVirtualDjController {
+
+    private final VirtualDjAdminService adminService;
+    private final VirtualSongPackService songPackService;
+
+    // ── 봇 풀 ──
+
+    @Operation(summary = "봇 풀 프로비저닝")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @PostMapping("/virtual-dj/pool")
+    public ResponseEntity<ApiCommonResponse<Void>> provisionPool(
+            @Valid @RequestBody ProvisionPoolRequest req) {
+        adminService.provisionPool(req.count());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiCommonResponse.ok());
+    }
+
+    // ── 송 팩 CRUD ──
+
+    @Operation(summary = "송 팩 생성")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @PostMapping("/virtual-dj/song-packs")
+    public ResponseEntity<ApiCommonResponse<CreatedIdResponse>> createSongPack(
+            @Valid @RequestBody CreateSongPackRequest req) {
+        Long id = songPackService.createPack(req.name(), req.description());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiCommonResponse.success(new CreatedIdResponse(id)));
+    }
+
+    @Operation(summary = "송 팩 이름 변경")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @PutMapping("/virtual-dj/song-packs/{id}")
+    public ResponseEntity<Void> renameSongPack(@PathVariable("id") Long id,
+                                               @Valid @RequestBody RenameSongPackRequest req) {
+        songPackService.renamePack(id, req.name());
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "송 팩 삭제")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @DeleteMapping("/virtual-dj/song-packs/{id}")
+    public ResponseEntity<Void> deleteSongPack(@PathVariable("id") Long id) {
+        songPackService.deletePack(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "송 팩 트랙 추가", description = "어드민 프론트의 music-search 로 선택된 트랙을 그대로 수신")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @PostMapping("/virtual-dj/song-packs/{id}/tracks")
+    public ResponseEntity<ApiCommonResponse<CreatedIdResponse>> addSongPackTrack(
+            @PathVariable("id") Long id, @Valid @RequestBody AddPackTrackRequest req) {
+        Long trackId = songPackService.addTrack(id, req.toCommand());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiCommonResponse.success(new CreatedIdResponse(trackId)));
+    }
+
+    @Operation(summary = "송 팩 트랙 삭제")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @DeleteMapping("/virtual-dj/song-packs/{id}/tracks/{trackId}")
+    public ResponseEntity<Void> removeSongPackTrack(@PathVariable("id") Long id,
+                                                    @PathVariable("trackId") Long trackId) {
+        songPackService.removeTrack(id, trackId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ── 룸별 config ──
+
+    @Operation(summary = "룸 가상 DJ config 적용", description = "MANAGED 적용 후 reconcile 즉시 트리거, OFF 면 drain")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @PutMapping("/partyrooms/{partyroomId}/virtual-dj")
+    public ResponseEntity<Void> applyConfig(@PathVariable("partyroomId") Long partyroomId,
+                                            @Valid @RequestBody ApplyVirtualDjConfigRequest req) {
+        adminService.applyConfig(new PartyroomId(partyroomId), req.status(),
+                req.targetCount(), req.companionFloor(), req.songPackId());
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "룸 비우기(drain)", description = "config OFF + 모든 봇 즉시 제거(anti-flap dwell 무시, exit 경로)")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @PostMapping("/partyrooms/{partyroomId}/virtual-dj/drain")
+    public ResponseEntity<Void> drain(@PathVariable("partyroomId") Long partyroomId) {
+        adminService.drain(new PartyroomId(partyroomId));
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "룸 가상 DJ 동결(freeze)", description = "현재 봇 수 유지, 신규 조정 금지")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @PostMapping("/partyrooms/{partyroomId}/virtual-dj/freeze")
+    public ResponseEntity<Void> freeze(@PathVariable("partyroomId") Long partyroomId) {
+        adminService.freeze(new PartyroomId(partyroomId));
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "룸 가상 DJ live 상태 조회")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @GetMapping("/partyrooms/{partyroomId}/virtual-dj")
+    public ResponseEntity<ApiCommonResponse<VirtualDjLiveStatusResponse>> liveStatus(
+            @PathVariable("partyroomId") Long partyroomId) {
+        VirtualDjAdminService.LiveStatus s = adminService.liveStatus(new PartyroomId(partyroomId));
+        return ResponseEntity.ok(ApiCommonResponse.success(VirtualDjLiveStatusResponse.from(s)));
+    }
+
+    // ── 일괄 ──
+
+    @Operation(summary = "여러 룸 config 일괄 적용", description = "체크박스 일괄 — MANAGED 는 각각 reconcile")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @PutMapping("/virtual-dj/bulk")
+    public ResponseEntity<Void> applyBulk(@Valid @RequestBody BulkApplyVirtualDjConfigRequest req) {
+        adminService.applyBulk(req.partyroomIds(), req.status(),
+                req.targetCount(), req.companionFloor(), req.songPackId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/AddPackTrackRequest.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/AddPackTrackRequest.java
@@ -1,0 +1,19 @@
+package com.pfplaybackend.api.virtualdj.adapter.in.web.payload;
+
+import com.pfplaybackend.api.virtualdj.application.dto.command.AddPackTrackCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 송 팩 트랙 추가 요청 — 어드민 프론트의 music-search 로 이미 선택된 트랙을 그대로 받는다.
+ */
+public record AddPackTrackRequest(
+        @NotBlank @Size(max = 200) String name,
+        @NotBlank @Size(max = 100) String linkId,
+        @NotBlank String duration,
+        @Size(max = 1000) String thumbnailImage
+) {
+    public AddPackTrackCommand toCommand() {
+        return new AddPackTrackCommand(name, linkId, duration, thumbnailImage);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/ApplyVirtualDjConfigRequest.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/ApplyVirtualDjConfigRequest.java
@@ -1,0 +1,21 @@
+package com.pfplaybackend.api.virtualdj.adapter.in.web.payload;
+
+import com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 룸별 가상 DJ config 적용 요청.
+ *
+ * <p>{@code status=MANAGED} 면 {@code targetCount}/{@code companionFloor} 가 필요하고
+ * (서비스에서 단언), {@code songPackId} 는 nullable(미설정 시 reconcile 이 SKIP_NO_SONG_PACK).
+ * FROZEN/OFF 면 나머지 필드는 무시된다.
+ *
+ * <p>{@code targetCount} 는 1 이상 — 0 은 봇 없는 MANAGED 로 의미가 없다(OFF + drain 경로 사용).
+ */
+public record ApplyVirtualDjConfigRequest(
+        @NotNull VirtualDjStatus status,
+        @Min(1) Integer targetCount,
+        @Min(0) Integer companionFloor,
+        Long songPackId
+) {}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/BulkApplyVirtualDjConfigRequest.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/BulkApplyVirtualDjConfigRequest.java
@@ -1,0 +1,20 @@
+package com.pfplaybackend.api.virtualdj.adapter.in.web.payload;
+
+import com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+/**
+ * 여러 룸에 같은 가상 DJ config 를 일괄 적용(체크박스).
+ */
+public record BulkApplyVirtualDjConfigRequest(
+        @NotEmpty @Size(min = 1, max = 100) List<Long> partyroomIds,
+        @NotNull VirtualDjStatus status,
+        @Min(1) Integer targetCount,
+        @Min(0) Integer companionFloor,
+        Long songPackId
+) {}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/CreateSongPackRequest.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/CreateSongPackRequest.java
@@ -1,0 +1,12 @@
+package com.pfplaybackend.api.virtualdj.adapter.in.web.payload;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 송 팩 생성 요청.
+ */
+public record CreateSongPackRequest(
+        @NotBlank @Size(max = 100) String name,
+        @Size(max = 500) String description
+) {}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/CreatedIdResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/CreatedIdResponse.java
@@ -1,0 +1,6 @@
+package com.pfplaybackend.api.virtualdj.adapter.in.web.payload;
+
+/**
+ * 생성 결과로 부여된 식별자(송 팩 id / 트랙 id 등) 응답.
+ */
+public record CreatedIdResponse(Long id) {}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/ProvisionPoolRequest.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/ProvisionPoolRequest.java
@@ -1,0 +1,12 @@
+package com.pfplaybackend.api.virtualdj.adapter.in.web.payload;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 봇 풀 프로비저닝 요청 — {@code count} 명의 봇 계정을 생성한다.
+ */
+public record ProvisionPoolRequest(
+        @NotNull @Min(1) @Max(500) Integer count
+) {}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/RenameSongPackRequest.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/RenameSongPackRequest.java
@@ -1,0 +1,11 @@
+package com.pfplaybackend.api.virtualdj.adapter.in.web.payload;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 송 팩 이름 변경 요청.
+ */
+public record RenameSongPackRequest(
+        @NotBlank @Size(max = 100) String name
+) {}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/VirtualDjLiveStatusResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/VirtualDjLiveStatusResponse.java
@@ -1,0 +1,20 @@
+package com.pfplaybackend.api.virtualdj.adapter.in.web.payload;
+
+import com.pfplaybackend.api.virtualdj.application.service.VirtualDjAdminService;
+import com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus;
+
+/**
+ * 룸의 가상 DJ live 상태 응답.
+ */
+public record VirtualDjLiveStatusResponse(
+        VirtualDjStatus status,
+        Integer targetCount,
+        Integer companionFloor,
+        Long songPackId,
+        int currentBotDjCount
+) {
+    public static VirtualDjLiveStatusResponse from(VirtualDjAdminService.LiveStatus s) {
+        return new VirtualDjLiveStatusResponse(
+                s.status(), s.targetCount(), s.companionFloor(), s.songPackId(), s.currentBotDjCount());
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/ActiveDjSnapshotQueryRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/ActiveDjSnapshotQueryRepository.java
@@ -1,0 +1,28 @@
+package com.pfplaybackend.api.virtualdj.adapter.out.persistence;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+
+import java.util.List;
+
+/**
+ * 룸의 커밋된 활성 DJ 집합을 사람/봇으로 나눠 조회한다 (Chunk 4 reconcile 읽기 경로).
+ *
+ * <p>{@code DJ} → {@code CREW} → {@code user_account.is_dummy} 를 가로지르는 조회라
+ * app 모듈 adapter 에 둔다(기존 {@link BotPoolQueryRepository} 와 동일한 cross-BC 패턴).
+ * 오케스트레이터는 이 repo 를 직접 주입하지 않고 query 서비스를 거친다.
+ */
+public interface ActiveDjSnapshotQueryRepository {
+
+    /**
+     * 룸의 활성 DJ(= 활성 crew 를 가진 DJ) 중 봇(is_dummy=true)의 {@link UserId} 를
+     * 가장 최근에 등록된 순서(= {@code dj.order_number} 내림차순)로 반환한다.
+     * 제거는 가장 최근 합류 봇부터 수행되므로 이 정렬이 결정성을 보장한다.
+     */
+    List<UserId> findActiveBotDjUserIdsByJoinedDesc(PartyroomId partyroomId);
+
+    /**
+     * 룸의 활성 DJ 중 사람(is_dummy=false)의 수.
+     */
+    long countActiveHumanDjs(PartyroomId partyroomId);
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/BotPoolQueryRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/BotPoolQueryRepository.java
@@ -1,0 +1,20 @@
+package com.pfplaybackend.api.virtualdj.adapter.out.persistence;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+
+import java.util.List;
+
+/**
+ * 봇 풀 조회 — is_dummy 계정 중 현재 어느 방에도 활성 crew 가 없는(=idle) 봇을 찾는다.
+ *
+ * <p>{@code user_account}(user 모듈)와 {@code CREW}(party 도메인, app 모듈)를 가로지르는 조회라
+ * app 모듈에 둔다. cross-BC 엔티티 참조는 이 adapter 안에서만 일어난다(기존 admin 조회 패턴과 동일).
+ */
+public interface BotPoolQueryRepository {
+
+    /**
+     * 활성 crew 가 없는 봇 최대 {@code limit} 명의 {@link UserId} 를 반환한다.
+     * 탈퇴(withdrawn) 계정은 제외한다. {@code limit <= 0} 이면 빈 리스트.
+     */
+    List<UserId> findIdleBotUserIds(int limit);
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/PartyroomVirtualDjConfigRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/PartyroomVirtualDjConfigRepository.java
@@ -1,0 +1,21 @@
+package com.pfplaybackend.api.virtualdj.adapter.out.persistence;
+
+import com.pfplaybackend.api.virtualdj.domain.entity.data.PartyroomVirtualDjConfigData;
+import com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PartyroomVirtualDjConfigRepository extends JpaRepository<PartyroomVirtualDjConfigData, Long> {
+
+    Optional<PartyroomVirtualDjConfigData> findByPartyroomId(Long partyroomId);
+
+    List<PartyroomVirtualDjConfigData> findByStatus(VirtualDjStatus status);
+
+    /**
+     * 주어진 송 팩을 참조하는 config row 가 하나라도 존재하는지(삭제 가드용).
+     * 기존 {@code findAll()} 전체 스캔을 대체 — song_pack_id 인덱스로 즉시 판정한다.
+     */
+    boolean existsBySongPackId(Long songPackId);
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/VirtualSongPackRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/VirtualSongPackRepository.java
@@ -1,0 +1,9 @@
+package com.pfplaybackend.api.virtualdj.adapter.out.persistence;
+
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackData;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VirtualSongPackRepository extends JpaRepository<VirtualSongPackData, Long> {
+
+    boolean existsByName(String name);
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/VirtualSongPackTrackRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/VirtualSongPackTrackRepository.java
@@ -1,0 +1,11 @@
+package com.pfplaybackend.api.virtualdj.adapter.out.persistence;
+
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackTrackData;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface VirtualSongPackTrackRepository extends JpaRepository<VirtualSongPackTrackData, Long> {
+
+    List<VirtualSongPackTrackData> findBySongPackIdOrderByOrderNumberAsc(Long songPackId);
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/impl/ActiveDjSnapshotQueryRepositoryImpl.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/impl/ActiveDjSnapshotQueryRepositoryImpl.java
@@ -1,0 +1,61 @@
+package com.pfplaybackend.api.virtualdj.adapter.out.persistence.impl;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.ActiveDjSnapshotQueryRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.pfplaybackend.api.party.domain.entity.data.QCrewData.crewData;
+import static com.pfplaybackend.api.party.domain.entity.data.QDjData.djData;
+import static com.pfplaybackend.api.user.domain.entity.data.QUserAccountData.userAccountData;
+
+/**
+ * QueryDSL impl — {@code DJ} ⨝ {@code CREW}(is_active) ⨝ {@code user_account}(is_dummy) 조인.
+ *
+ * <p>"활성 DJ" 는 DJ 행이 가리키는 crew 가 현재 활성({@code is_active=true})인 경우다.
+ * exit 경로({@code removeDjFromQueue})가 DJ 행을 지우므로 일반적으로 DJ 행은 곧 활성이지만,
+ * 안전하게 crew 의 is_active 까지 단언한다(stale DJ 방어). cross-BC 참조는 이 adapter 안에만 둔다.
+ */
+@Repository
+@RequiredArgsConstructor
+public class ActiveDjSnapshotQueryRepositoryImpl implements ActiveDjSnapshotQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<UserId> findActiveBotDjUserIdsByJoinedDesc(PartyroomId partyroomId) {
+        List<Long> uids = queryFactory
+                .select(crewData.userId.uid)
+                .from(djData)
+                .join(crewData).on(crewData.id.eq(djData.crewId.id))
+                .join(userAccountData).on(userAccountData.userId.uid.eq(crewData.userId.uid))
+                .where(
+                        djData.partyroomId.id.eq(partyroomId.getId()),
+                        crewData.isActive.isTrue(),
+                        userAccountData.isDummy.isTrue())
+                // 가장 최근 등록된 봇부터 (order_number 내림차순) — 제거 결정성 보장.
+                .orderBy(djData.orderNumber.desc())
+                .fetch();
+
+        return uids.stream().map(UserId::new).toList();
+    }
+
+    @Override
+    public long countActiveHumanDjs(PartyroomId partyroomId) {
+        Long count = queryFactory
+                .select(djData.count())
+                .from(djData)
+                .join(crewData).on(crewData.id.eq(djData.crewId.id))
+                .join(userAccountData).on(userAccountData.userId.uid.eq(crewData.userId.uid))
+                .where(
+                        djData.partyroomId.id.eq(partyroomId.getId()),
+                        crewData.isActive.isTrue(),
+                        userAccountData.isDummy.isFalse())
+                .fetchOne();
+        return count == null ? 0L : count;
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/impl/BotPoolQueryRepositoryImpl.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/impl/BotPoolQueryRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.pfplaybackend.api.virtualdj.adapter.out.persistence.impl;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.BotPoolQueryRepository;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.pfplaybackend.api.party.domain.entity.data.QCrewData.crewData;
+import static com.pfplaybackend.api.user.domain.entity.data.QUserAccountData.userAccountData;
+
+/**
+ * QueryDSL impl — is_dummy 계정 중 활성 crew 가 없는 봇을 조회한다.
+ *
+ * <p>"활성 crew 없음" 은 NOT EXISTS 서브쿼리로 표현한다(deactivate 된 과거 crew row 가 남아도
+ * idle 로 본다). cross-BC(User↔Party) 엔티티 참조는 이 adapter 안에서만 발생한다.
+ */
+@Repository
+@RequiredArgsConstructor
+public class BotPoolQueryRepositoryImpl implements BotPoolQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<UserId> findIdleBotUserIds(int limit) {
+        if (limit <= 0) {
+            return Collections.emptyList();
+        }
+        List<Long> uids = queryFactory
+                .select(userAccountData.userId.uid)
+                .from(userAccountData)
+                .where(
+                        userAccountData.isDummy.isTrue(),
+                        userAccountData.withdrawnAt.isNull(),
+                        JPAExpressions.selectOne()
+                                .from(crewData)
+                                .where(crewData.userId.uid.eq(userAccountData.userId.uid)
+                                        .and(crewData.isActive.isTrue()))
+                                .notExists())
+                // uid 오름차순 = 가장 먼저 프로비저닝된 봇부터 (deterministic oldest-first FIFO).
+                // 동일 입력에 동일 봇을 고르게 해 reconcile 의 멱등성·재현성을 보장한다.
+                .orderBy(userAccountData.userId.uid.asc())
+                .limit(limit)
+                .fetch();
+
+        return uids.stream().map(UserId::new).toList();
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/provision/VirtualMemberProvisionAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/provision/VirtualMemberProvisionAdapter.java
@@ -1,0 +1,25 @@
+package com.pfplaybackend.api.virtualdj.adapter.out.provision;
+
+import com.pfplaybackend.api.admin.application.service.AdminUserService;
+import com.pfplaybackend.api.user.domain.entity.data.MemberData;
+import com.pfplaybackend.api.virtualdj.application.port.VirtualMemberProvisionPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link VirtualMemberProvisionPort} 의 유일한 구현체 — admin 레이어로 나가는 경계.
+ *
+ * <p>이 클래스는 virtualdj 패키지 중 {@code ..admin..} 를 import 하도록 허용되는 유일한 곳이다.
+ * 봇 계정 생성은 실유저와 동일한 {@link AdminUserService#createVirtualMember} 경로를 그대로 재사용한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class VirtualMemberProvisionAdapter implements VirtualMemberProvisionPort {
+
+    private final AdminUserService adminUserService;
+
+    @Override
+    public MemberData createVirtualMember(String nickname) {
+        return adminUserService.createVirtualMember(nickname, null, null);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/dto/command/AddPackTrackCommand.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/dto/command/AddPackTrackCommand.java
@@ -1,0 +1,16 @@
+package com.pfplaybackend.api.virtualdj.application.dto.command;
+
+/**
+ * 송 팩에 트랙을 추가할 때 사용하는 커맨드 DTO.
+ *
+ * @param name           곡 이름
+ * @param linkId         YouTube videoId
+ * @param duration       MM:SS 또는 H:MM:SS 형식 재생 시간
+ * @param thumbnailImage 썸네일 이미지 URL (nullable)
+ */
+public record AddPackTrackCommand(
+        String name,
+        String linkId,
+        String duration,
+        String thumbnailImage
+) {}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/identity/BotIdentityExecutor.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/identity/BotIdentityExecutor.java
@@ -1,0 +1,48 @@
+package com.pfplaybackend.api.virtualdj.application.identity;
+
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.aspect.context.AuthContext;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.enums.AuthorityTier;
+import org.springframework.stereotype.Component;
+
+/**
+ * 봇(가상 사용자) 신원으로 도메인 명령을 실행하기 위한 임퍼소네이션 유틸 (= path A).
+ *
+ * <p>봇은 실제 {@code user_account}(is_dummy=true)이며, 오케스트레이터는 봇의
+ * {@link AuthContext} 를 {@link ThreadLocalContext} 에 심은 뒤 실유저가 쓰는 동일한 public
+ * 명령 서비스({@code tryEnter}/{@code enqueueDj}/{@code exit} 등)를 그대로 호출한다. 이로써
+ * 기존 가드·캐스케이드를 한 줄도 우회하지 않는다.
+ *
+ * <p>봇의 권한 계층은 일반 정식 회원과 동일한 {@link AuthorityTier#FM} 이다 — 봇은
+ * {@code AdminUserService.createVirtualMember} 와 같은 경로로 만들어진 FM 멤버이기 때문이다.
+ */
+@Component
+public class BotIdentityExecutor {
+
+    private static final AuthorityTier BOT_AUTHORITY_TIER = AuthorityTier.FM;
+
+    /**
+     * {@code botUserId} 의 {@link AuthContext} 를 현재 스레드에 설정하고 {@code action} 을
+     * 실행한다. 실행 전후로 ThreadLocal 을 항상 정리한다 — 이전 컨텍스트가 있었으면 복원하고,
+     * 없었으면 비운다. {@code action} 이 예외를 던지면 그 예외를 전파하되 정리는 반드시 수행한다.
+     */
+    public void runAs(UserId botUserId, Runnable action) {
+        // getAuthContext() 는 컨텍스트가 없으면 throw 하므로 raw getContext() 로 이전 값을 보존한다.
+        Object previous = ThreadLocalContext.getContext();
+        try {
+            ThreadLocalContext.setContext(buildBotAuthContext(botUserId));
+            action.run();
+        } finally {
+            if (previous != null) {
+                ThreadLocalContext.setContext(previous);
+            } else {
+                ThreadLocalContext.clearContext();
+            }
+        }
+    }
+
+    private AuthContext buildBotAuthContext(UserId botUserId) {
+        return new AuthContext(botUserId, BOT_AUTHORITY_TIER);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/port/VirtualDjOrchestrator.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/port/VirtualDjOrchestrator.java
@@ -1,0 +1,29 @@
+package com.pfplaybackend.api.virtualdj.application.port;
+
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+
+/**
+ * 한 룸의 봇 DJ 수를 설정 목표에 수렴시키는 오케스트레이터 (Chunk 4).
+ *
+ * <p>봇 신원으로 실유저와 동일한 명령 서비스(tryEnter/enqueueDj/exit)를 호출하여 투입/제거한다.
+ * 도메인 가드를 한 줄도 우회하지 않는다. Chunk 5 의 이벤트 반응·anti-flap·안전망 cron 이 이
+ * {@link #reconcileRoom} 을 트리거한다.
+ */
+public interface VirtualDjOrchestrator {
+
+    /**
+     * 룸의 봇 DJ 수를 설정({@code partyroom_virtual_dj_config}) 목표에 수렴시킨다.
+     * 분산 락으로 직렬화되며, 목표와 현재가 같으면 아무 것도 하지 않는다(멱등).
+     */
+    void reconcileRoom(PartyroomId partyroomId);
+
+    /**
+     * 어드민의 비우기(drain) — 룸의 <b>모든</b> 봇 DJ 를 즉시 제거한다.
+     *
+     * <p>reconcile 과 달리 anti-flap dwell/​debounce 를 건너뛰는 어드민 의도적 액션이지만, 제거 자체는
+     * 봇 신원으로 동일한 {@code exit} 명령 경로(path A)를 거치므로 도메인 가드/캐스케이드는 우회하지 않는다.
+     * config 상태 전환(OFF)은 호출자(어드민 서비스)가 담당하고, 본 메서드는 봇 제거 + FlapGuard 상태 정리만 한다.
+     * 분산 락으로 reconcile 과 직렬화된다.
+     */
+    void drainRoom(PartyroomId partyroomId);
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/port/VirtualMemberProvisionPort.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/port/VirtualMemberProvisionPort.java
@@ -1,0 +1,20 @@
+package com.pfplaybackend.api.virtualdj.application.port;
+
+import com.pfplaybackend.api.user.domain.entity.data.MemberData;
+
+/**
+ * virtualdj 가 봇 계정 프로비저닝을 위해 admin 바운디드 컨텍스트로 나가는 outbound port.
+ *
+ * <p>이 seam 의 목적은 {@code virtualdj.application.*}(현재 풀 서비스 + Chunk 4 오케스트레이터)가
+ * {@code ..admin..} 패키지를 직접 import 하지 못하게 막는 것이다. 구현체
+ * ({@code virtualdj.adapter.out.provision.VirtualMemberProvisionAdapter}) 만 admin 레이어를
+ * 만질 수 있다 — Chunk 6 의 ArchUnit 규칙을 미리 만족시킨다.
+ */
+public interface VirtualMemberProvisionPort {
+
+    /**
+     * 실유저와 동일한 경로로 완전히 초기화된 LOCAL 가상 멤버를 생성하고 그 신원을 반환한다
+     * (FM 승격 + 프로필·기본 아바타 + activity 행 + GRABLIST 포함).
+     */
+    MemberData createVirtualMember(String nickname);
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/ActiveDjSnapshotService.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/ActiveDjSnapshotService.java
@@ -1,0 +1,44 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.ActiveDjSnapshotQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 룸의 커밋된 활성 DJ 집합을 사람/봇으로 나눠 제공하는 query 헬퍼 (Chunk 4 reconcile 읽기 경로).
+ *
+ * <p>오케스트레이터({@code *Orchestrator*})는 도메인 repo 를 직접 주입할 수 없으므로(Chunk 6 ArchUnit)
+ * 이 서비스를 거쳐 사람 DJ 수와 제거 대상 봇 목록을 읽는다. 이 클래스는 {@code *Orchestrator*} 가
+ * 아니므로 persistence 접근이 허용된다.
+ */
+@Service
+@RequiredArgsConstructor
+public class ActiveDjSnapshotService {
+
+    private final ActiveDjSnapshotQueryRepository repository;
+
+    /**
+     * 룸의 활성 DJ 스냅샷 — 사람 DJ 수 + 봇 DJ 의 {@link UserId}(가장 최근 합류 봇 먼저).
+     */
+    @Transactional(readOnly = true)
+    public ActiveDjSnapshot snapshot(PartyroomId partyroomId) {
+        long humanCount = repository.countActiveHumanDjs(partyroomId);
+        List<UserId> bots = repository.findActiveBotDjUserIdsByJoinedDesc(partyroomId);
+        return new ActiveDjSnapshot((int) humanCount, bots);
+    }
+
+    /**
+     * @param humanCount             사람(비-봇) 활성 DJ 수
+     * @param botUserIdsByJoinedDesc 봇 활성 DJ 의 userId — 가장 최근 합류 먼저(제거 우선순위 순서)
+     */
+    public record ActiveDjSnapshot(int humanCount, List<UserId> botUserIdsByJoinedDesc) {
+        public int botCount() {
+            return botUserIdsByJoinedDesc.size();
+        }
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/FlapGuard.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/FlapGuard.java
@@ -1,0 +1,85 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.operations.application.service.SystemConfigCache;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 봇 DJ thrash 방지(anti-flap) 가드 — <b>제거(removal)만</b> 게이팅한다. 추가는 음악 연속성을 위해
+ * 즉시 수행되므로 이 가드를 거치지 않는다.
+ *
+ * <p>두 축의 방어:
+ * <ul>
+ *   <li><b>yield debounce</b>: 룸 단위 "제거하고 싶다"는 의도가 {@code bot_yield_debounce_ms} 이상
+ *       지속돼야 실제 제거를 허용. 사람 DJ 가 잠깐 들어왔다 나가는 깜빡임에 봇을 즉시 내보내지 않는다.</li>
+ *   <li><b>min dwell</b>: 방금 투입된 봇은 {@code bot_min_dwell_ms} 이내 제거 보호. 갓 들어온 봇이
+ *       바로 다시 나가는 churn 방지.</li>
+ * </ul>
+ *
+ * <p><b>상태는 in-memory(ConcurrentHashMap)</b>다. 단일 인스턴스 백엔드 가정에서 정확하며,
+ * 다중 인스턴스로 확장하면 인스턴스별 타이머가 분리된다(그 경우 reconcile 직렬화는 분산락이
+ * 담당하므로 안전성은 유지되나 debounce 가 인스턴스별로 독립 측정됨 — 현 단계 범위 밖).
+ *
+ * <p>시각은 호출자가 DI 된 {@code Clock} 으로 산출한 {@link Instant} 를 주입한다(테스트 결정성).
+ */
+@Component
+@RequiredArgsConstructor
+public class FlapGuard {
+
+    private final SystemConfigCache configCache;
+
+    /** 룸별 "제거하고 싶다" 의도 시작 시각. */
+    private final ConcurrentHashMap<PartyroomId, Instant> removalIntentStartedAt = new ConcurrentHashMap<>();
+    /** 봇별 투입 시각. */
+    private final ConcurrentHashMap<UserId, Instant> botAddedAt = new ConcurrentHashMap<>();
+
+    /**
+     * 봇 제거 의도가 debounce 를 넘겼는지. 첫 호출은 의도 시각만 기록하고 {@code false}; 이후
+     * {@code now - intentStart >= bot_yield_debounce_ms} 가 되면 {@code true}.
+     */
+    public boolean shouldRemove(PartyroomId roomId, Instant now) {
+        Instant start = removalIntentStartedAt.putIfAbsent(roomId, now);
+        if (start == null) {
+            // 이번이 첫 의도 — 기록만 하고 보류.
+            return false;
+        }
+        long elapsed = now.toEpochMilli() - start.toEpochMilli();
+        return elapsed >= configCache.getBotYieldDebounceMs();
+    }
+
+    /**
+     * 제거가 더 이상 필요 없을 때(botCount &lt;= desired) 룸의 제거 의도를 해제한다. 다음에 다시
+     * 제거 의도가 생기면 debounce 가 처음부터 다시 측정된다.
+     */
+    public void clearRemovalIntent(PartyroomId roomId) {
+        removalIntentStartedAt.remove(roomId);
+    }
+
+    /**
+     * 봇이 투입 후 최소 체류시간({@code bot_min_dwell_ms})을 채웠는지. {@link #markAdded} 기록이 없는
+     * 봇(부팅 전 투입분 등)은 보수적으로 제거 가능({@code true}) 처리한다.
+     */
+    public boolean canRemoveBot(UserId botUserId, Instant now) {
+        Instant added = botAddedAt.get(botUserId);
+        if (added == null) {
+            return true;
+        }
+        long dwell = now.toEpochMilli() - added.toEpochMilli();
+        return dwell >= configCache.getBotMinDwellMs();
+    }
+
+    /** 봇 투입 시각 기록 — 오케스트레이터가 봇을 추가한 직후 호출한다. */
+    public void markAdded(UserId botUserId, Instant now) {
+        botAddedAt.put(botUserId, now);
+    }
+
+    /** 봇 투입 기록 제거 — 봇이 제거되면 호출(누수 방지). */
+    public void clearAdded(UserId botUserId) {
+        botAddedAt.remove(botUserId);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/SongPackApplier.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/SongPackApplier.java
@@ -1,0 +1,84 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.common.domain.value.Duration;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.PlaylistRepository;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.TrackRepository;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
+import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackTrackRepository;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackTrackData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 송 팩의 트랙을 봇 playlist 에 복사하는 서비스.
+ *
+ * <p>Chunk 4 오케스트레이터가 봇을 룸에 투입하기 전에 호출한다.
+ * 기존 봇 playlist 트랙을 완전히 비우고, 송 팩에서 룸의
+ * {@code roomPlaybackTimeLimitMinutes} 이하인 트랙만 순서대로 복사한다.
+ *
+ * <p>ArchUnit: {@code *Orchestrator*} 클래스가 아니므로 persistence 직접 접근 허용.
+ */
+@Service
+@RequiredArgsConstructor
+public class SongPackApplier {
+
+    private final VirtualUserPoolService virtualUserPoolService;
+    private final VirtualSongPackTrackRepository songPackTrackRepository;
+    private final PlaylistRepository playlistRepository;
+    private final TrackRepository trackRepository;
+
+    /**
+     * 봇의 DJ playlist 에 송 팩 트랙을 복사한다.
+     *
+     * @param botUserId                      봇 사용자 id
+     * @param songPackId                     적용할 송 팩 id
+     * @param roomPlaybackTimeLimitMinutes   룸의 재생 시간 제한 (분). 0 이하 = unlimited.
+     */
+    @Transactional
+    public void applyToBot(UserId botUserId, Long songPackId, int roomPlaybackTimeLimitMinutes) {
+        // 1. 봇 playlist id 조회
+        Long playlistId = virtualUserPoolService.playlistIdOf(botUserId);
+        PlaylistData playlist = playlistRepository.findById(playlistId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Bot playlist not found for playlistId=" + playlistId + " — bot not provisioned correctly"));
+
+        // 2. 기존 트랙 전체 삭제 (봇 playlist 소속만)
+        trackRepository.deleteAllByPlaylistIdValue(playlistId);
+
+        // 3. 송 팩 트랙 (정렬됨) 필터 후 복사
+        List<VirtualSongPackTrackData> packTracks =
+                songPackTrackRepository.findBySongPackIdOrderByOrderNumberAsc(songPackId);
+
+        PlaybackTimeLimit timeLimit = PlaybackTimeLimit.ofMinutes(roomPlaybackTimeLimitMinutes);
+
+        List<TrackData> toSave = new ArrayList<>();
+        int orderCounter = 1;
+        for (VirtualSongPackTrackData packTrack : packTracks) {
+            Duration duration = Duration.fromString(packTrack.getDuration());
+            if (timeLimit.exceedsDuration(duration)) {
+                continue; // 초과 트랙 제외
+            }
+            toSave.add(TrackData.builder()
+                    .playlistId(new PlaylistId(playlistId))
+                    .name(packTrack.getName())
+                    .linkId(packTrack.getLinkId())
+                    .duration(duration)
+                    .orderNumber(orderCounter++)
+                    .thumbnailImage(packTrack.getThumbnailImage())
+                    .build());
+        }
+        trackRepository.saveAll(toSave);
+
+        // 4. playlist 에 sourceSongPackId 바인딩
+        playlist.bindSongPackSource(songPackId);
+        playlistRepository.save(playlist);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualDjAdminService.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualDjAdminService.java
@@ -1,0 +1,169 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.common.exception.ExceptionCreator;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.PartyroomVirtualDjConfigRepository;
+import com.pfplaybackend.api.virtualdj.application.port.VirtualDjOrchestrator;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.PartyroomVirtualDjConfigData;
+import com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus;
+import com.pfplaybackend.api.virtualdj.domain.exception.VirtualDjException;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 어드민 가상 DJ 운영 서비스 — config 적용/freeze/drain + 단건/일괄 reconcile + live status 조회.
+ *
+ * <p>config 전환은 도메인 메서드({@link PartyroomVirtualDjConfigData#applyManaged}/{@code freeze}/{@code turnOff})를
+ * 통해서만 수행하고, 봇 투입/제거는 모두 {@link VirtualDjOrchestrator}(봇 신원 path A)에 위임한다.
+ * 이 서비스는 도메인 crew/dj/playback persistence 를 직접 건드리지 않는다.
+ *
+ * <p>트랜잭션 경계: config save + reconcile/drain 을 한 트랜잭션에 둔다 — reconcile/drain 은
+ * 봇 신원으로 {@code @Transactional(REQUIRED)} 명령 서비스를 호출하므로 같은 트랜잭션에 join 된다
+ * (orchestrator IT 와 동일 패턴: apply config → 같은 tx 안에서 reconcile → 봇 enqueue 가 즉시 반영).
+ * 분산 락은 reconcile/drain 의 동시 호출을 직렬화한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VirtualDjAdminService {
+
+    private final PartyroomVirtualDjConfigRepository configRepository;
+    private final VirtualDjOrchestrator orchestrator;
+    private final ActiveDjSnapshotService activeDjSnapshotService;
+    private final VirtualUserPoolService poolService;
+
+    /**
+     * applyBulk 의 per-room 격리를 위한 self-proxy 참조.
+     * {@code @Lazy} 로 순환 의존성을 방지하고, setter 주입으로 Spring AOP 프록시를 통해
+     * {@link #applyConfig} 의 {@code @Transactional} 경계가 룸마다 독립적으로 적용되도록 한다.
+     */
+    @Setter(onMethod_ = {@Autowired, @Lazy})
+    private VirtualDjAdminService self;
+
+    // ── pool ──
+
+    public void provisionPool(int count) {
+        poolService.provision(count);
+    }
+
+    // ── per-room config ──
+
+    /** 단일 룸 config 적용 후 MANAGED 면 reconcile, OFF 면 drain 을 같은 트랜잭션에서 트리거. */
+    @Transactional
+    public void applyConfig(PartyroomId partyroomId, VirtualDjStatus status, Integer targetCount,
+                            Integer companionFloor, Long songPackId) {
+        PartyroomVirtualDjConfigData cfg = loadOrCreate(partyroomId);
+        applyStatus(cfg, status, targetCount, companionFloor, songPackId);
+        // saveAndFlush: reconcile/drain 의 봇 명령 경로가 영속성 컨텍스트를 clear 할 수 있어,
+        // config 변경을 즉시 DB 에 확정한 뒤 reconcile(자기 config 재조회)/drain 을 트리거한다.
+        configRepository.saveAndFlush(cfg);
+        log.info("[VirtualDjAdmin.applyConfig] partyroomId={} status={} target={} floor={} songPackId={}",
+                partyroomId.getId(), status, targetCount, companionFloor, songPackId);
+
+        if (status == VirtualDjStatus.MANAGED) {
+            orchestrator.reconcileRoom(partyroomId);
+        } else if (status == VirtualDjStatus.OFF) {
+            orchestrator.drainRoom(partyroomId);
+        }
+    }
+
+    /** 룸 비우기 — config OFF + 모든 봇 제거(drain, path A) + FlapGuard 정리. */
+    @Transactional
+    public void drain(PartyroomId partyroomId) {
+        PartyroomVirtualDjConfigData cfg = loadOrCreate(partyroomId);
+        cfg.turnOff();
+        // OFF 를 즉시 flush — drainRoom 의 봇 exit 경로가 영속성 컨텍스트를 clear 할 수 있어,
+        // 미flush 된 dirty 변경이 detach 되어 유실되는 것을 방지한다(DB 에 OFF 확정).
+        configRepository.saveAndFlush(cfg);
+        orchestrator.drainRoom(partyroomId);
+        log.info("[VirtualDjAdmin.drain] partyroomId={}", partyroomId.getId());
+    }
+
+    /** 동결 — 현재 봇 수 유지, 신규 조정 금지. reconcile/drain 트리거 없음. */
+    @Transactional
+    public void freeze(PartyroomId partyroomId) {
+        PartyroomVirtualDjConfigData cfg = loadOrCreate(partyroomId);
+        cfg.freeze();
+        configRepository.save(cfg);
+        log.info("[VirtualDjAdmin.freeze] partyroomId={}", partyroomId.getId());
+    }
+
+    // ── bulk ──
+
+    /**
+     * 여러 룸에 같은 config 를 적용(체크박스 일괄). MANAGED 는 각각 reconcile, OFF 는 각각 drain.
+     *
+     * <p>per-room 트랜잭션 격리: {@code self} 프록시를 통해 룸마다 {@link #applyConfig} 의
+     * {@code @Transactional} 경계를 독립적으로 적용한다. 한 룸의 reconcile/drain 예외가 다른 룸의
+     * config 저장을 롤백하지 않도록, 각 룸의 실패를 try/catch 로 격리하고 배치를 계속 진행한다.
+     */
+    public void applyBulk(List<Long> partyroomIds, VirtualDjStatus status, Integer targetCount,
+                          Integer companionFloor, Long songPackId) {
+        List<Long> failedIds = new ArrayList<>();
+        for (Long id : partyroomIds) {
+            try {
+                self.applyConfig(new PartyroomId(id), status, targetCount, companionFloor, songPackId);
+            } catch (Exception e) {
+                log.warn("[VirtualDjAdmin.applyBulk] ROOM_FAILED - partyroomId={}, reason={}",
+                        id, e.getMessage());
+                failedIds.add(id);
+            }
+        }
+        log.info("[VirtualDjAdmin.applyBulk] rooms={} status={} failed={}", partyroomIds.size(), status, failedIds.size());
+        if (!failedIds.isEmpty()) {
+            log.warn("[VirtualDjAdmin.applyBulk] PARTIAL_FAILURE - failedPartyroomIds={}", failedIds);
+        }
+    }
+
+    // ── live status ──
+
+    @Transactional(readOnly = true)
+    public LiveStatus liveStatus(PartyroomId partyroomId) {
+        PartyroomVirtualDjConfigData cfg = configRepository.findByPartyroomId(partyroomId.getId())
+                .orElseThrow(() -> ExceptionCreator.create(VirtualDjException.CONFIG_NOT_FOUND));
+        int currentBotDjCount = activeDjSnapshotService.snapshot(partyroomId).botCount();
+        return new LiveStatus(cfg.getStatus(), cfg.getTargetCount(), cfg.getCompanionFloor(),
+                cfg.getSongPackId(), currentBotDjCount);
+    }
+
+    // ── helpers ──
+
+    private PartyroomVirtualDjConfigData loadOrCreate(PartyroomId partyroomId) {
+        return configRepository.findByPartyroomId(partyroomId.getId())
+                .orElseGet(() -> PartyroomVirtualDjConfigData.create(partyroomId.getId()));
+    }
+
+    private void applyStatus(PartyroomVirtualDjConfigData cfg, VirtualDjStatus status,
+                             Integer targetCount, Integer companionFloor, Long songPackId) {
+        switch (status) {
+            case MANAGED -> {
+                if (targetCount == null || companionFloor == null) {
+                    throw ExceptionCreator.create(VirtualDjException.INVALID_CONFIG);
+                }
+                cfg.applyManaged(targetCount, companionFloor, songPackId);
+            }
+            case FROZEN -> cfg.freeze();
+            case OFF -> cfg.turnOff();
+        }
+    }
+
+    /**
+     * 룸의 가상 DJ live 상태.
+     *
+     * @param status            현재 config 상태(OFF/MANAGED/FROZEN)
+     * @param targetCount       목표 봇 수
+     * @param companionFloor    동반 진입 하한선
+     * @param songPackId        적용 송 팩 id (nullable)
+     * @param currentBotDjCount 현재 활성 봇 DJ 수
+     */
+    public record LiveStatus(VirtualDjStatus status, Integer targetCount, Integer companionFloor,
+                             Long songPackId, int currentBotDjCount) {}
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualDjOrchestratorImpl.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualDjOrchestratorImpl.java
@@ -1,0 +1,188 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.application.service.DjCommandService;
+import com.pfplaybackend.api.party.application.service.PartyroomAccessCommandService;
+import com.pfplaybackend.api.party.application.service.PartyroomQueryService;
+import com.pfplaybackend.api.party.application.service.lock.DistributedLockExecutor;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.PartyroomVirtualDjConfigRepository;
+import com.pfplaybackend.api.virtualdj.application.identity.BotIdentityExecutor;
+import com.pfplaybackend.api.virtualdj.application.port.VirtualDjOrchestrator;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.PartyroomVirtualDjConfigData;
+import com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus;
+import com.pfplaybackend.api.virtualdj.domain.service.DesiredBotCalculator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * {@link VirtualDjOrchestrator} 구현 — 봇 임퍼소네이션으로 룸의 봇 DJ 수를 목표에 수렴시킨다.
+ *
+ * <p><b>의존성 제약(Chunk 6 ArchUnit 사전 충족):</b> 이 {@code *Orchestrator*} 는 application
+ * 명령/query 서비스, {@link BotIdentityExecutor}, {@link VirtualUserPoolService},
+ * {@link SongPackApplier}, {@link DistributedLockExecutor}, 순수 {@link DesiredBotCalculator},
+ * 그리고 설정 읽기용 {@link PartyroomVirtualDjConfigRepository} 만 의존한다. crew/dj/playback 의
+ * 도메인 {@code *Repository}/{@code *AggregatePort} 를 주입하지 않으며 {@code ..admin..} 도 import 하지 않는다.
+ * 활성 DJ 사람/봇 분리 같은 읽기는 query 서비스({@link ActiveDjSnapshotService})를 거친다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VirtualDjOrchestratorImpl implements VirtualDjOrchestrator {
+
+    private final DistributedLockExecutor lock;
+    private final PartyroomVirtualDjConfigRepository configRepository;
+    private final PartyroomQueryService partyroomQueryService;
+    private final ActiveDjSnapshotService activeDjSnapshotService;
+    private final VirtualUserPoolService poolService;
+    private final SongPackApplier songPackApplier;
+    private final BotIdentityExecutor botIdentity;
+    private final PartyroomAccessCommandService accessCommandService;
+    private final DjCommandService djCommandService;
+    private final FlapGuard flapGuard;
+    private final Clock clock;
+
+    @Override
+    public void reconcileRoom(PartyroomId partyroomId) {
+        lock.performTaskWithLock("virtualdj:" + partyroomId.getId(), () -> {
+            doReconcile(partyroomId);
+            return null;
+        });
+    }
+
+    @Override
+    public void drainRoom(PartyroomId partyroomId) {
+        lock.performTaskWithLock("virtualdj:" + partyroomId.getId(), () -> {
+            doDrain(partyroomId);
+            return null;
+        });
+    }
+
+    private void doDrain(PartyroomId partyroomId) {
+        ActiveDjSnapshotService.ActiveDjSnapshot snapshot = activeDjSnapshotService.snapshot(partyroomId);
+        List<UserId> bots = snapshot.botUserIdsByJoinedDesc();
+        log.info("[drain] partyroomId={}, botsToRemove={}", partyroomId.getId(), bots.size());
+
+        for (UserId bot : bots) {
+            // 어드민 drain 은 dwell/debounce 를 건너뛴다(canRemoveBot/shouldRemove 미적용) — 단,
+            // 제거는 봇 신원으로 동일한 exit 명령 경로(path A)를 거쳐 가드/캐스케이드를 우회하지 않는다.
+            // 단건 실패(예: crew 행 소실로 INVALID_ACTIVE_ROOM)가 나머지 봇 제거를 중단하지 않도록
+            // 개별 봇을 try/catch 로 격리한다(best-effort drain — config 는 이미 OFF 확정).
+            try {
+                botIdentity.runAs(bot, () -> accessCommandService.exit(partyroomId));
+                log.info("[drain] BOT_REMOVED - partyroomId={}, botUserId={}", partyroomId.getId(), bot.getUid());
+            } catch (Exception e) {
+                log.warn("[drain] BOT_REMOVE_FAILED - partyroomId={}, botUserId={}, reason={}",
+                        partyroomId.getId(), bot.getUid(), e.getMessage());
+            }
+            // 성공/실패 무관하게 FlapGuard 항목은 정리 — 다음 MANAGED 전환 시 새로 측정되도록.
+            flapGuard.clearAdded(bot);
+        }
+        // 제거 의도 타이머도 정리 — 다음 MANAGED 전환 시 debounce 가 처음부터 측정되도록(FlapGuard 누수 방지).
+        flapGuard.clearRemovalIntent(partyroomId);
+    }
+
+    private void doReconcile(PartyroomId partyroomId) {
+        Optional<PartyroomVirtualDjConfigData> optConfig =
+                configRepository.findByPartyroomId(partyroomId.getId());
+        if (optConfig.isEmpty() || optConfig.get().getStatus() != VirtualDjStatus.MANAGED) {
+            // OFF / FROZEN / 미설정 → 아무 것도 하지 않는다.
+            log.debug("[reconcile] SKIP - partyroomId={}, status={}", partyroomId.getId(),
+                    optConfig.map(c -> c.getStatus().name()).orElse("ABSENT"));
+            return;
+        }
+        PartyroomVirtualDjConfigData cfg = optConfig.get();
+
+        if (cfg.getSongPackId() == null) {
+            log.warn("[reconcile] SKIP_NO_SONG_PACK - partyroomId={}", partyroomId.getId());
+            return;
+        }
+
+        ActiveDjSnapshotService.ActiveDjSnapshot snapshot = activeDjSnapshotService.snapshot(partyroomId);
+        int humanCount = snapshot.humanCount();
+        int botCount = snapshot.botCount();
+        int desired = DesiredBotCalculator.desiredBot(humanCount, cfg.getTargetCount(), cfg.getCompanionFloor());
+
+        log.info("[reconcile] partyroomId={}, human={}, bot={}, target={}, floor={}, desired={}",
+                partyroomId.getId(), humanCount, botCount, cfg.getTargetCount(), cfg.getCompanionFloor(), desired);
+
+        if (botCount < desired) {
+            // 추가는 즉시 — 음악 연속성 우선(anti-flap 게이팅 없음).
+            addBots(partyroomId, cfg, desired - botCount);
+            // 추가 방향이면 제거 의도는 더 이상 유효하지 않다.
+            flapGuard.clearRemovalIntent(partyroomId);
+        } else if (botCount > desired) {
+            removeBots(partyroomId, snapshot.botUserIdsByJoinedDesc(), botCount - desired);
+        } else {
+            // botCount == desired → no-op (멱등 수렴). 제거가 더는 필요 없으므로 의도 해제.
+            flapGuard.clearRemovalIntent(partyroomId);
+        }
+    }
+
+    private void addBots(PartyroomId partyroomId, PartyroomVirtualDjConfigData cfg, int howMany) {
+        // getPartyroomById reads no ThreadLocal AuthContext — safe to call outside the bot-identity block
+        PartyroomData room = partyroomQueryService.getPartyroomById(partyroomId);
+        int timeLimitMinutes = room.getPlaybackTimeLimit().getMinutes();
+
+        List<UserId> idleBots = poolService.findIdleBots(howMany);
+        if (idleBots.size() < howMany) {
+            // idle 풀 부족 — 가능한 만큼만 투입한다(나머지는 다음 reconcile 에서 풀이 보충되면 처리).
+            log.warn("[reconcile] INSUFFICIENT_IDLE_BOTS - partyroomId={}, requested={}, available={}",
+                    partyroomId.getId(), howMany, idleBots.size());
+        }
+
+        for (UserId bot : idleBots) {
+            // 1) 송 팩을 봇 playlist 에 적용 (룸 시간제한 필터) — 봇 신원 밖에서 수행해도 무방하나
+            //    enqueue 전에 비어 있지 않은 playlist 를 보장해야 한다.
+            songPackApplier.applyToBot(bot, cfg.getSongPackId(), timeLimitMinutes);
+
+            // 2) 봇 신원으로 실유저와 동일한 명령 경로 호출 (입장 → DJ 등록).
+            botIdentity.runAs(bot, () -> {
+                accessCommandService.tryEnter(partyroomId, null);
+                djCommandService.enqueueDj(partyroomId, new PlaylistId(poolService.playlistIdOf(bot)));
+            });
+            // anti-flap: 투입 시각 기록 — min dwell 동안 제거 보호.
+            flapGuard.markAdded(bot, Instant.now(clock));
+            log.info("[reconcile] BOT_ADDED - partyroomId={}, botUserId={}", partyroomId.getId(), bot.getUid());
+        }
+    }
+
+    private void removeBots(PartyroomId partyroomId, List<UserId> botsByJoinedDesc, int howMany) {
+        Instant now = Instant.now(clock);
+
+        // anti-flap (1): 룸 단위 제거 의도가 debounce 를 넘기지 못했으면 이번 사이클은 제거하지 않는다.
+        // (의도 시각은 shouldRemove 가 첫 호출 시 기록 — 다음 이벤트/안전망이 재시도한다.)
+        if (!flapGuard.shouldRemove(partyroomId, now)) {
+            log.info("[reconcile] REMOVE_DEBOUNCED - partyroomId={}, want={}", partyroomId.getId(), howMany);
+            return;
+        }
+
+        int removed = 0;
+        for (UserId bot : botsByJoinedDesc) {
+            if (removed >= howMany) break;
+            // anti-flap (2): 최소 체류시간을 채우지 못한 봇은 건너뛴다(다음 사이클 재시도).
+            if (!flapGuard.canRemoveBot(bot, now)) {
+                log.debug("[reconcile] REMOVE_DWELL_PROTECTED - partyroomId={}, botUserId={}",
+                        partyroomId.getId(), bot.getUid());
+                continue;
+            }
+            // 봇 신원으로 exit — handleDjQueueOnLeave 가 DJ 큐 정리 + (현재 DJ 였다면) playback skip 처리.
+            botIdentity.runAs(bot, () -> accessCommandService.exit(partyroomId));
+            flapGuard.clearAdded(bot);
+            log.info("[reconcile] BOT_REMOVED - partyroomId={}, botUserId={}", partyroomId.getId(), bot.getUid());
+            removed++;
+        }
+        if (removed == 0) {
+            log.info("[reconcile] REMOVE_ALL_DWELL_PROTECTED - partyroomId={}, want={}",
+                    partyroomId.getId(), howMany);
+        }
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualDjReconcileScheduler.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualDjReconcileScheduler.java
@@ -1,0 +1,49 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.PartyroomVirtualDjConfigRepository;
+import com.pfplaybackend.api.virtualdj.application.port.VirtualDjOrchestrator;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.PartyroomVirtualDjConfigData;
+import com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 가상 DJ 안전망 reconcile cron (Chunk 5) — {@link PartyroomPresenceService#reconcileStalePending} 스타일.
+ *
+ * <p>이벤트 기반 reconcile 이 유실되거나(이벤트 listener 실패/앱 재시작 중 발생한 변경) anti-flap
+ * debounce 로 보류된 제거가 후속 이벤트를 받지 못한 경우를 대비한 저빈도 보정. MANAGED 룸을 훑어
+ * 각각 {@link VirtualDjOrchestrator#reconcileRoom} 을 호출한다(멱등이므로 수렴 상태면 no-op).
+ *
+ * <p>부팅 직후 첫 tick 은 다운타임 동안 어긋난 룸의 복구도 겸한다. 룸별 예외는 격리되어 한 룸의
+ * 실패가 전체 sweep 을 막지 않는다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VirtualDjReconcileScheduler {
+
+    private final PartyroomVirtualDjConfigRepository configRepository;
+    private final VirtualDjOrchestrator orchestrator;
+
+    @Scheduled(fixedDelay = 60_000)
+    public void reconcileManagedRooms() {
+        List<PartyroomVirtualDjConfigData> managed = configRepository.findByStatus(VirtualDjStatus.MANAGED);
+        if (managed.isEmpty()) {
+            return;
+        }
+        log.info("[vdj-cron] safety-net sweep over {} MANAGED room(s)", managed.size());
+        for (PartyroomVirtualDjConfigData cfg : managed) {
+            try {
+                orchestrator.reconcileRoom(new PartyroomId(cfg.getPartyroomId()));
+            } catch (Exception e) {
+                log.warn("[vdj-cron] reconcile failed for partyroomId={} : {}",
+                        cfg.getPartyroomId(), e.getMessage());
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualSongPackService.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualSongPackService.java
@@ -1,0 +1,122 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.common.domain.value.Duration;
+import com.pfplaybackend.api.common.exception.ExceptionCreator;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.PlaylistRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.PartyroomVirtualDjConfigRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackTrackRepository;
+import com.pfplaybackend.api.virtualdj.application.dto.command.AddPackTrackCommand;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.PartyroomVirtualDjConfigData;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackData;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackTrackData;
+import com.pfplaybackend.api.virtualdj.domain.exception.VirtualDjException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 송 팩(VirtualSongPack) CRUD 서비스.
+ *
+ * <p>팩 빌드 시점 duration 검증: playbackTimeLimit 은 방마다 다를 수 있으나(0=unlimited 포함),
+ * 어드민이 팩을 구성할 때는 방의 limit 을 알 수 없으므로 시스템 허용 상한인
+ * {@link #MAX_PLAYBACK_LIMIT_MINUTES 60분}을 보수적 상한으로 사용한다.
+ * 이 상한은 {@code UpdatePartyroomMetaRequest}의 {@code @Max(60)} 검증과 일치한다.
+ *
+ * <p>적용 시점(SongPackApplier)에서 실제 방의 playbackTimeLimit 으로 재필터링한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class VirtualSongPackService {
+
+    /**
+     * 송 팩 트랙의 보수적 재생시간 상한 (분).
+     * 출처: {@code UpdatePartyroomMetaRequest#playbackTimeLimit @Max(60)}.
+     */
+    static final int MAX_PLAYBACK_LIMIT_MINUTES = 60;
+
+    private final VirtualSongPackRepository packRepository;
+    private final VirtualSongPackTrackRepository trackRepository;
+    private final PartyroomVirtualDjConfigRepository configRepository;
+    private final PlaylistRepository playlistRepository;
+
+    // ── Pack CRUD ──
+
+    @Transactional
+    public Long createPack(String name, String description) {
+        if (packRepository.existsByName(name)) {
+            throw ExceptionCreator.create(VirtualDjException.SONG_PACK_DUPLICATE_NAME);
+        }
+        VirtualSongPackData saved = packRepository.save(VirtualSongPackData.create(name, description));
+        return saved.getId();
+    }
+
+    @Transactional
+    public void renamePack(Long packId, String name) {
+        VirtualSongPackData pack = packRepository.findById(packId)
+                .orElseThrow(() -> ExceptionCreator.create(VirtualDjException.SONG_PACK_NOT_FOUND));
+        if (!name.equals(pack.getName()) && packRepository.existsByName(name)) {
+            throw ExceptionCreator.create(VirtualDjException.SONG_PACK_DUPLICATE_NAME);
+        }
+        pack.rename(name);
+        packRepository.save(pack);
+    }
+
+    @Transactional
+    public void deletePack(Long packId) {
+        VirtualSongPackData pack = packRepository.findById(packId)
+                .orElseThrow(() -> ExceptionCreator.create(VirtualDjException.SONG_PACK_NOT_FOUND));
+
+        // Delete guard: config 참조 여부 — song_pack_id 인덱스 활용 (full-scan findAll 제거).
+        if (configRepository.existsBySongPackId(packId)) {
+            throw ExceptionCreator.create(VirtualDjException.SONG_PACK_IN_USE);
+        }
+
+        // Delete guard: playlist 참조 여부
+        if (playlistRepository.existsBySourceSongPackId(packId)) {
+            throw ExceptionCreator.create(VirtualDjException.SONG_PACK_IN_USE);
+        }
+
+        List<VirtualSongPackTrackData> tracks = trackRepository.findBySongPackIdOrderByOrderNumberAsc(packId);
+        trackRepository.deleteAll(tracks);
+        packRepository.delete(pack);
+    }
+
+    // ── Track CRUD ──
+
+    @Transactional
+    public Long addTrack(Long packId, AddPackTrackCommand cmd) {
+        packRepository.findById(packId)
+                .orElseThrow(() -> ExceptionCreator.create(VirtualDjException.SONG_PACK_NOT_FOUND));
+
+        // duration 보수적 상한 검증 (60분)
+        Duration duration = Duration.fromString(cmd.duration());
+        if (PlaybackTimeLimit.ofMinutes(MAX_PLAYBACK_LIMIT_MINUTES).exceedsDuration(duration)) {
+            throw ExceptionCreator.create(VirtualDjException.TRACK_EXCEEDS_PLAYBACK_LIMIT);
+        }
+
+        // order_number: 기존 트랙의 마지막 order_number + 1
+        List<VirtualSongPackTrackData> existing = trackRepository.findBySongPackIdOrderByOrderNumberAsc(packId);
+        int nextOrder = existing.isEmpty()
+                ? 1
+                : existing.get(existing.size() - 1).getOrderNumber() + 1;
+
+        VirtualSongPackTrackData track = VirtualSongPackTrackData.create(
+                packId, nextOrder, cmd.linkId(), cmd.name(), cmd.duration(), cmd.thumbnailImage());
+        VirtualSongPackTrackData saved = trackRepository.save(track);
+        return saved.getId();
+    }
+
+    @Transactional
+    public void removeTrack(Long packId, Long packTrackId) {
+        packRepository.findById(packId)
+                .orElseThrow(() -> ExceptionCreator.create(VirtualDjException.SONG_PACK_NOT_FOUND));
+        VirtualSongPackTrackData track = trackRepository.findById(packTrackId)
+                .filter(t -> packId.equals(t.getSongPackId()))
+                .orElseThrow(() -> ExceptionCreator.create(VirtualDjException.PACK_TRACK_NOT_FOUND));
+        trackRepository.delete(track);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualUserPoolService.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualUserPoolService.java
@@ -1,0 +1,90 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.PlaylistRepository;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
+import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
+import com.pfplaybackend.api.user.domain.entity.data.MemberData;
+import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.BotPoolQueryRepository;
+import com.pfplaybackend.api.virtualdj.application.port.VirtualMemberProvisionPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 봇(가상 사용자) 풀 — 봇 계정 프로비저닝 + idle 봇 조회 + 봇 playlist 조회.
+ *
+ * <p>봇은 실제 정식 회원과 동일한 경로({@link VirtualMemberProvisionPort#createVirtualMember})로 만들어진다:
+ * LOCAL provider 계정 + 프로필(닉네임·기본 아바타) + activity 행 + GRABLIST + FM 승격. 그 위에
+ * 두 가지만 더한다 — (1) {@code is_dummy=true} 표시, (2) DJ 가 사용할 {@link PlaylistType#PLAYLIST}
+ * 타입 playlist 1개 생성(Chunk 3 의 송팩 복사 대상, Chunk 4 의 enqueueDj 대상).
+ *
+ * <p>오케스트레이션 로직(reconcile/투입/제거)은 여기 두지 않는다 — Chunk 4 책임.
+ */
+@Service
+@RequiredArgsConstructor
+public class VirtualUserPoolService {
+
+    private static final String BOT_PLAYLIST_NAME = "Bot DJ Playlist";
+
+    private final VirtualMemberProvisionPort virtualMemberProvisionPort;
+    private final UserAccountRepository userAccountRepository;
+    private final PlaylistRepository playlistRepository;
+    private final BotPoolQueryRepository botPoolQueryRepository;
+
+    /**
+     * 봇 {@code n} 명을 생성한다. 각 봇은 실 {@code user_account}(is_dummy=true, LOCAL),
+     * 고유 닉네임·기본 아바타 프로필, 그리고 DJ 용 {@link PlaylistType#PLAYLIST} playlist 를 가진다.
+     */
+    @Transactional
+    public List<UserId> provision(int n) {
+        List<UserId> created = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            // 1) 실유저와 동일한 회원 생성 경로 재사용 (FM, 프로필+아바타+activity+GRABLIST).
+            //    닉네임은 V15 UNIQUE(user_profile.nickname) 충돌을 피하도록 고엔트로피 UUID 로 명시.
+            MemberData member = virtualMemberProvisionPort.createVirtualMember(generateBotNickname());
+            UserId botUserId = new UserId(member.getUserAccountId());
+
+            // 2) is_dummy 표시 (가산적).
+            UserAccountData account = userAccountRepository.findById(botUserId).orElseThrow();
+            account.markAsDummy();
+
+            // 3) DJ 가 enqueue 할 PLAYLIST 타입 playlist 1개 생성 (송팩 복사 대상).
+            playlistRepository.save(
+                    PlaylistData.create(1, BOT_PLAYLIST_NAME, PlaylistType.PLAYLIST, botUserId));
+
+            created.add(botUserId);
+        }
+        return created;
+    }
+
+    /**
+     * 활성 crew 가 없는(=어느 방에도 없는) 봇 최대 {@code n} 명을 반환한다.
+     */
+    @Transactional(readOnly = true)
+    public List<UserId> findIdleBots(int n) {
+        return botPoolQueryRepository.findIdleBotUserIds(n);
+    }
+
+    /**
+     * 봇의 DJ 용 {@link PlaylistType#PLAYLIST} playlist id 를 반환한다(Chunk 4 enqueueDj 에서 사용).
+     */
+    @Transactional(readOnly = true)
+    public Long playlistIdOf(UserId botUserId) {
+        PlaylistData playlist = playlistRepository.findByOwnerIdAndType(botUserId, PlaylistType.PLAYLIST);
+        if (playlist == null) {
+            throw new IllegalStateException("Bot playlist not found for userId=" + botUserId.getUid() + " — bot not provisioned correctly");
+        }
+        return playlist.getId();
+    }
+
+    private String generateBotNickname() {
+        return "DJ_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/domain/entity/data/PartyroomVirtualDjConfigData.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/domain/entity/data/PartyroomVirtualDjConfigData.java
@@ -1,0 +1,94 @@
+package com.pfplaybackend.api.virtualdj.domain.entity.data;
+
+import com.pfplaybackend.api.common.entity.BaseEntity;
+import com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Getter
+@DynamicInsert
+@DynamicUpdate
+@Table(name = "partyroom_virtual_dj_config")
+@Entity
+public class PartyroomVirtualDjConfigData extends BaseEntity {
+
+    @Id
+    @Column(name = "partyroom_id", columnDefinition = "bigint unsigned")
+    private Long partyroomId;
+
+    @Comment("OFF/MANAGED/FROZEN")
+    @Column(name = "status", nullable = false, length = 16)
+    @Enumerated(EnumType.STRING)
+    private VirtualDjStatus status;
+
+    @Comment("목표 가상 DJ 수")
+    @Column(name = "target_count", nullable = false, columnDefinition = "int unsigned")
+    private Integer targetCount;
+
+    @Comment("동반 진입 하한선 (사람 DJ 수가 이 값 미만이면 봇 진입 보류)")
+    @Column(name = "companion_floor", nullable = false, columnDefinition = "int unsigned")
+    private Integer companionFloor;
+
+    @Comment("이 룸에 사용할 송 팩 id")
+    @Column(name = "song_pack_id", columnDefinition = "bigint unsigned")
+    private Long songPackId;
+
+    protected PartyroomVirtualDjConfigData() {
+    }
+
+    @Builder
+    public PartyroomVirtualDjConfigData(Long partyroomId, VirtualDjStatus status,
+                                         Integer targetCount, Integer companionFloor,
+                                         Long songPackId) {
+        this.partyroomId = partyroomId;
+        this.status = status;
+        this.targetCount = targetCount;
+        this.companionFloor = companionFloor;
+        this.songPackId = songPackId;
+    }
+
+    // ── Factory ──
+
+    /**
+     * 새 룸용 기본 config: status=OFF, target_count=2, companion_floor=1.
+     */
+    public static PartyroomVirtualDjConfigData create(Long partyroomId) {
+        return PartyroomVirtualDjConfigData.builder()
+                .partyroomId(partyroomId)
+                .status(VirtualDjStatus.OFF)
+                .targetCount(2)
+                .companionFloor(1)
+                .build();
+    }
+
+    // ── Domain Methods ──
+
+    /**
+     * 가상 DJ 관리 모드 전환.
+     */
+    public void applyManaged(int targetCount, int companionFloor, Long songPackId) {
+        this.status = VirtualDjStatus.MANAGED;
+        this.targetCount = targetCount;
+        this.companionFloor = companionFloor;
+        this.songPackId = songPackId;
+    }
+
+    /**
+     * 가상 DJ 동결 — 현재 봇 수 유지, 신규 조정 금지.
+     */
+    public void freeze() {
+        this.status = VirtualDjStatus.FROZEN;
+    }
+
+    /**
+     * 가상 DJ 비활성화.
+     */
+    public void turnOff() {
+        this.status = VirtualDjStatus.OFF;
+    }
+
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/domain/entity/data/VirtualSongPackData.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/domain/entity/data/VirtualSongPackData.java
@@ -1,0 +1,52 @@
+package com.pfplaybackend.api.virtualdj.domain.entity.data;
+
+import com.pfplaybackend.api.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Getter
+@DynamicInsert
+@DynamicUpdate
+@Table(name = "virtual_song_pack")
+@Entity
+public class VirtualSongPackData extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "bigint unsigned")
+    private Long id;
+
+    @Comment("송 팩 이름 (유니크)")
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Comment("송 팩 설명")
+    @Column(name = "description", length = 255)
+    private String description;
+
+    protected VirtualSongPackData() {
+    }
+
+    @Builder
+    public VirtualSongPackData(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    public static VirtualSongPackData create(String name, String description) {
+        return VirtualSongPackData.builder()
+                .name(name)
+                .description(description)
+                .build();
+    }
+
+    // ── Business Methods ──
+
+    public void rename(String newName) {
+        this.name = newName;
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/domain/entity/data/VirtualSongPackTrackData.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/domain/entity/data/VirtualSongPackTrackData.java
@@ -1,0 +1,78 @@
+package com.pfplaybackend.api.virtualdj.domain.entity.data;
+
+import com.pfplaybackend.api.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Getter
+@DynamicInsert
+@DynamicUpdate
+@Table(
+        name = "virtual_song_pack_track",
+        indexes = {
+                @Index(name = "idx_vspt_song_pack_id", columnList = "song_pack_id")
+        }
+)
+@Entity
+public class VirtualSongPackTrackData extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "bigint unsigned")
+    private Long id;
+
+    @Comment("소속 송 팩 id")
+    @Column(name = "song_pack_id", nullable = false, columnDefinition = "bigint unsigned")
+    private Long songPackId;
+
+    @Comment("송 팩 내 재생 순서")
+    @Column(name = "order_number", nullable = false, columnDefinition = "int unsigned")
+    private Integer orderNumber;
+
+    @Comment("YouTube videoId")
+    @Column(name = "link_id", nullable = false, length = 255)
+    private String linkId;
+
+    @Comment("곡 이름")
+    @Column(name = "name", nullable = false, length = 255)
+    private String name;
+
+    @Comment("MM:SS 형식 재생 시간, playbackTimeLimit 사전 검증됨")
+    @Column(name = "duration", nullable = false, length = 255)
+    private String duration;
+
+    @Comment("썸네일 이미지 URL")
+    @Column(name = "thumbnail_image", length = 255)
+    private String thumbnailImage;
+
+    protected VirtualSongPackTrackData() {
+    }
+
+    @Builder
+    public VirtualSongPackTrackData(Long songPackId, Integer orderNumber, String linkId,
+                                    String name, String duration, String thumbnailImage) {
+        this.songPackId = songPackId;
+        this.orderNumber = orderNumber;
+        this.linkId = linkId;
+        this.name = name;
+        this.duration = duration;
+        this.thumbnailImage = thumbnailImage;
+    }
+
+    public static VirtualSongPackTrackData create(Long songPackId, int orderNumber,
+                                                   String linkId, String name,
+                                                   String duration, String thumbnailImage) {
+        return VirtualSongPackTrackData.builder()
+                .songPackId(songPackId)
+                .orderNumber(orderNumber)
+                .linkId(linkId)
+                .name(name)
+                .duration(duration)
+                .thumbnailImage(thumbnailImage)
+                .build();
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/domain/enums/VirtualDjStatus.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/domain/enums/VirtualDjStatus.java
@@ -1,0 +1,10 @@
+package com.pfplaybackend.api.virtualdj.domain.enums;
+
+public enum VirtualDjStatus {
+    /** 가상 DJ 비활성화 */
+    OFF,
+    /** 가상 DJ 활성화 — 봇 수 자동 관리 */
+    MANAGED,
+    /** 가상 DJ 동결 — 현재 상태 유지 (봇 수 변경 금지) */
+    FROZEN
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/domain/exception/VirtualDjException.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/domain/exception/VirtualDjException.java
@@ -1,0 +1,27 @@
+package com.pfplaybackend.api.virtualdj.domain.exception;
+
+import com.pfplaybackend.api.common.exception.DomainException;
+import com.pfplaybackend.api.common.exception.ErrorType;
+import lombok.Getter;
+
+@Getter
+public enum VirtualDjException implements DomainException {
+
+    SONG_PACK_NOT_FOUND("VDJ-001", "송 팩을 찾을 수 없습니다", ErrorType.NOT_FOUND),
+    SONG_PACK_DUPLICATE_NAME("VDJ-002", "이미 사용 중인 송 팩 이름입니다", ErrorType.CONFLICT),
+    SONG_PACK_IN_USE("VDJ-003", "송 팩이 사용 중이어서 삭제할 수 없습니다", ErrorType.CONFLICT),
+    TRACK_EXCEEDS_PLAYBACK_LIMIT("VDJ-004", "트랙의 재생 시간이 playbackTimeLimit을 초과합니다", ErrorType.BAD_REQUEST),
+    PACK_TRACK_NOT_FOUND("VDJ-005", "송 팩 트랙을 찾을 수 없습니다", ErrorType.NOT_FOUND),
+    CONFIG_NOT_FOUND("VDJ-006", "해당 룸의 가상 DJ 설정을 찾을 수 없습니다", ErrorType.NOT_FOUND),
+    INVALID_CONFIG("VDJ-007", "MANAGED 전환에는 targetCount/companionFloor 가 필요합니다", ErrorType.BAD_REQUEST);
+
+    private final String errorCode;
+    private final String message;
+    private final ErrorType errorType;
+
+    VirtualDjException(String errorCode, String message, ErrorType errorType) {
+        this.errorCode = errorCode;
+        this.message = message;
+        this.errorType = errorType;
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/domain/service/DesiredBotCalculator.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/domain/service/DesiredBotCalculator.java
@@ -1,0 +1,36 @@
+package com.pfplaybackend.api.virtualdj.domain.service;
+
+/**
+ * 룸의 목표 봇 DJ 수를 결정하는 순수 산식 (Chunk 4 reconcile 핵심).
+ *
+ * <p>입력은 모두 정수이며 부작용·의존성이 없다 — 단위 테스트로 전 경우를 고정한다.
+ * 오케스트레이터({@code *Orchestrator*})는 사람 DJ 수를 query 서비스로 읽은 뒤 이 산식으로
+ * 목표 봇 수를 구하고, 현재 봇 수와의 차이만큼 투입/제거한다.
+ *
+ * <p>의미:
+ * <ul>
+ *   <li>사람 DJ 가 0명이면 목표만큼 봇을 채운다.</li>
+ *   <li>사람 DJ 가 1명이면 사람이 외롭지 않게 동반 하한선(floor) 은 지키되, 가급적
+ *       {@code target - 1} 로 사람에게 자리를 양보한다 (둘 중 큰 값을 target 으로 캡).</li>
+ *   <li>사람 DJ 가 2명 이상이면 단순히 부족분({@code target - human}, 음수면 0)만 채운다.</li>
+ * </ul>
+ */
+public final class DesiredBotCalculator {
+
+    private DesiredBotCalculator() {
+    }
+
+    /**
+     * 목표 봇 DJ 수.
+     *
+     * @param human  현재 사람(비-봇) DJ 수
+     * @param target 룸의 목표 총 DJ 수(설정값)
+     * @param floor  동반 진입 하한선(설정값)
+     * @return 룸이 가져야 할 봇 DJ 수 (0 이상)
+     */
+    public static int desiredBot(int human, int target, int floor) {
+        if (human == 0) return target;
+        if (human == 1) return Math.min(target, Math.max(floor, target - 1));
+        return Math.max(0, target - human);
+    }
+}

--- a/app/src/main/resources/db/migration/V24__create_virtual_dj.sql
+++ b/app/src/main/resources/db/migration/V24__create_virtual_dj.sql
@@ -1,0 +1,49 @@
+-- =====================================================
+-- V24: 가상 사용자 능동 디제잉 (P2)
+--
+-- 봇(가상 사용자) 플래그, 송 팩 테이블, 파티룸별 가상 DJ 설정 테이블,
+-- 플레이리스트↔송 팩 연결 컬럼을 추가한다.
+-- =====================================================
+
+ALTER TABLE user_account
+    ADD COLUMN is_dummy TINYINT(1) NOT NULL DEFAULT 0
+        COMMENT '가상 사용자(봇) 여부';
+
+ALTER TABLE playlist
+    ADD COLUMN source_song_pack_id BIGINT UNSIGNED NULL
+        COMMENT '이 playlist 가 복사된 송 팩 (봇 전용)';
+
+CREATE TABLE virtual_song_pack (
+    id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    name        VARCHAR(100)    NOT NULL,
+    description VARCHAR(255)    NULL,
+    created_at  DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at  DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_virtual_song_pack_name (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE virtual_song_pack_track (
+    id               BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    song_pack_id     BIGINT UNSIGNED NOT NULL,
+    order_number     INT UNSIGNED    NOT NULL,
+    link_id          VARCHAR(255)    NOT NULL COMMENT 'YouTube videoId',
+    name             VARCHAR(255)    NOT NULL,
+    duration         VARCHAR(255)    NOT NULL COMMENT 'MM:SS, playbackTimeLimit 사전검증됨',
+    thumbnail_image  VARCHAR(255)    NULL,
+    created_at       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    KEY idx_vspt_song_pack_id (song_pack_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE partyroom_virtual_dj_config (
+    partyroom_id     BIGINT UNSIGNED NOT NULL,
+    status           VARCHAR(16)     NOT NULL DEFAULT 'OFF' COMMENT 'OFF/MANAGED/FROZEN',
+    target_count     INT UNSIGNED    NOT NULL DEFAULT 2,
+    companion_floor  INT UNSIGNED    NOT NULL DEFAULT 1,
+    song_pack_id     BIGINT UNSIGNED NULL,
+    created_at       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (partyroom_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/app/src/test/java/com/pfplaybackend/api/architecture/VirtualDjArchitectureTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/architecture/VirtualDjArchitectureTest.java
@@ -1,0 +1,130 @@
+package com.pfplaybackend.api.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * 가상 DJ 아키텍처 의존성 가드 (Chunk 6 + 패키지 범위 확장).
+ *
+ * <h2>규칙 A — {@code *Orchestrator*} 한정 가드</h2>
+ * <ul>
+ *   <li>{@code ..administration..} / {@code ..admin..} (어드민 BC 역참조 금지)</li>
+ *   <li>crew/dj/playback 의 도메인 {@code *AggregatePort} / persistence {@code *Repository}
+ *       (이 경로로 엔티티를 직접 mutate 하면 tryEnter/enqueueDj/exit 가드를 건너뛴다)</li>
+ *   <li>메시지 publisher / Redis publish 클래스 ({@code *Publisher}, {@code *MessagePublisher})</li>
+ * </ul>
+ *
+ * <h2>규칙 B — {@code ..virtualdj..} 패키지 전체 가드</h2>
+ * virtualdj 패키지의 어떤 클래스도 다음에 직접 의존해서는 안 된다:
+ * <ul>
+ *   <li>단순명이 {@code MessagePublisher} 로 끝나는 클래스 — 현재 구체: {@code RedisMessagePublisher}.
+ *       봇은 도메인 메시지를 직접 발행하지 않는다. 이벤트는 party application service 가 발행한다.</li>
+ *   <li>단순명이 {@code AggregatePort} 로 끝나는 인터페이스 — 현재 구체: {@code PartyroomAggregatePort}.
+ *       봇이 party aggregate 를 직접 mutate 하면 tryEnter/enqueueDj/exit 도메인 가드를 우회한다.</li>
+ * </ul>
+ *
+ * <p>오케스트레이터는 봇 신원({@link com.pfplaybackend.api.virtualdj.application.identity.BotIdentityExecutor})
+ * 으로 실유저와 동일한 application 명령/query 서비스를 호출하는 경로(path A)만 사용해야 한다.
+ * 허용 협력자: command/query application service, {@code BotIdentityExecutor},
+ * {@code VirtualUserPoolService}, {@code SongPackApplier}, {@code ActiveDjSnapshotService},
+ * {@code DistributedLockExecutor}, {@code FlapGuard}, {@code DesiredBotCalculator}, 그리고 자기
+ * feature 의 config repo({@code PartyroomVirtualDjConfigRepository}, 단일 row 설정 읽기 — 허용).
+ */
+@DisplayName("가상 DJ 아키텍처 의존성 가드 (Chunk 6 ArchUnit)")
+class VirtualDjArchitectureTest {
+
+    static JavaClasses allClasses;
+
+    @BeforeAll
+    static void setUp() {
+        allClasses = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("com.pfplaybackend.api");
+    }
+
+    @Test
+    @DisplayName("*Orchestrator* 는 admin/administration BC 를 참조하지 않는다")
+    void orchestratorMustNotDependOnAdmin() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage("..virtualdj..")
+                .and().haveSimpleNameContaining("Orchestrator")
+                .should().dependOnClassesThat().resideInAnyPackage(
+                        "com.pfplaybackend.api.admin..",
+                        "com.pfplaybackend.api.administration..");
+        rule.check(allClasses);
+    }
+
+    @Test
+    @DisplayName("*Orchestrator* 는 crew/dj/playback 도메인 AggregatePort/Repository 를 직접 주입하지 않는다 (자기 config repo 만 허용)")
+    void orchestratorMustNotDependOnDomainPersistence() {
+        // PartyroomVirtualDjConfigRepository(자기 feature 의 단일 row 설정 읽기)는 허용 —
+        // 이름에 'VirtualDjConfig' 가 들어가므로 매처에서 제외한다.
+        ArchRule rule = noClasses()
+                .that().resideInAPackage("..virtualdj..")
+                .and().haveSimpleNameContaining("Orchestrator")
+                .should().dependOnClassesThat()
+                .haveNameMatching(".*(AggregatePort|(?<!VirtualDjConfig)Repository)$");
+        rule.check(allClasses);
+    }
+
+    @Test
+    @DisplayName("*Orchestrator* 는 메시지 publisher / Redis publish 클래스를 참조하지 않는다")
+    void orchestratorMustNotDependOnMessagePublisher() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage("..virtualdj..")
+                .and().haveSimpleNameContaining("Orchestrator")
+                .should().dependOnClassesThat()
+                .haveNameMatching(".*(MessagePublisher|Publisher)$");
+        rule.check(allClasses);
+    }
+
+    // ── 규칙 B: 패키지 전체 가드 ────────────────────────────────────────────────────────────────
+
+    /**
+     * {@code ..virtualdj..} 의 어떤 클래스도 {@code *MessagePublisher} 를 직접 의존하지 않는다.
+     *
+     * <p>현재 해당 타입: {@code RedisMessagePublisher} (패키지: {@code ..common.config.redis..}).
+     * 봇이 도메인 메시지를 직접 publish 하는 것은 party BC 이벤트 경로를 우회한다.
+     * 이벤트는 party application service 호출의 부작용으로만 발행돼야 한다.
+     *
+     * <p><b>예외 없음:</b> 현재 virtualdj 헬퍼({@code VirtualSongPackService}, {@code SongPackApplier},
+     * {@code VirtualUserPoolService}, {@code ActiveDjSnapshotService}, {@code VirtualMemberProvisionAdapter},
+     * {@code *RepositoryImpl} 등)는 모두 자체 virtualdj repo + playlist/track/user repo 만 사용한다.
+     */
+    @Test
+    @DisplayName("virtualdj 패키지 전체: *MessagePublisher 를 직접 의존하지 않는다")
+    void virtualDjPackageMustNotDependOnMessagePublisher() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage("..virtualdj..")
+                .should().dependOnClassesThat()
+                .haveSimpleNameEndingWith("MessagePublisher");
+        rule.check(allClasses);
+    }
+
+    /**
+     * {@code ..virtualdj..} 의 어떤 클래스도 party {@code *AggregatePort} 를 직접 의존하지 않는다.
+     *
+     * <p>현재 해당 타입: {@code PartyroomAggregatePort} (패키지: {@code ..party.domain.port..}).
+     * 봇이 aggregate port 를 직접 주입하면 {@code tryEnter}/{@code enqueueDj}/{@code exit} 도메인
+     * 가드를 건너뛰어 파티룸 상태를 직접 mutate 할 수 있다.
+     *
+     * <p><b>예외 없음:</b> virtualdj 는 party BC 와 상호작용할 때 반드시 application service 를
+     * 경유해야 한다. 봇은 {@code BotIdentityExecutor} 로 실유저와 동일한 명령 경로를 탄다.
+     */
+    @Test
+    @DisplayName("virtualdj 패키지 전체: party *AggregatePort 를 직접 의존하지 않는다")
+    void virtualDjPackageMustNotDependOnPartyAggregatePort() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage("..virtualdj..")
+                .should().dependOnClassesThat()
+                .haveSimpleNameEndingWith("AggregatePort");
+        rule.check(allClasses);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/operations/application/service/SystemConfigCacheTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/operations/application/service/SystemConfigCacheTest.java
@@ -74,8 +74,9 @@ class SystemConfigCacheTest {
         cache.getDjGraceSeconds();
         cache.getListenerGraceSeconds();
 
-        // One snapshot fetch loads both grace keys; further reads within TTL hit no repo.
-        verify(repository, times(2)).findByConfigKey(anyString());
+        // One snapshot fetch loads all config keys (2 grace + 2 anti-flap + 1 toggle);
+        // further reads within TTL hit no repo.
+        verify(repository, times(5)).findByConfigKey(anyString());
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/AdminVirtualDjControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/AdminVirtualDjControllerTest.java
@@ -1,0 +1,315 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.common.config.security.authorization.AdminAuthorizationSpEL;
+import com.pfplaybackend.api.common.config.security.jwt.AdminCookieWriter;
+import com.pfplaybackend.api.common.config.security.jwt.JwtService;
+import com.pfplaybackend.api.common.config.security.jwt.SharedSessionCookieWriter;
+import com.pfplaybackend.api.common.config.security.jwt.properties.JwtProperties;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.virtualdj.adapter.in.web.AdminVirtualDjController;
+import com.pfplaybackend.api.virtualdj.application.service.VirtualDjAdminService;
+import com.pfplaybackend.api.virtualdj.application.service.VirtualSongPackService;
+import com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * WebMvcTest — {@link AdminVirtualDjController} 보안/검증/위임 검증.
+ *
+ * <p>ADMIN happy-path 위임 + non-admin(MEMBER) 403 + anonymous 401 + CSRF 누락 403 + 검증(400).
+ * mirror {@code PartyroomReportCommandControllerTest}: 자체 {@link SecurityFilterChain} 으로 슬라이스 보안
+ * 명시(기본 슬라이스 보안 대신) — {@code @adminAuth} 메서드 시큐리티는 {@link EnableMethodSecurity} 로 활성.
+ */
+@WebMvcTest(AdminVirtualDjController.class)
+@Import({
+        AdminVirtualDjControllerTest.TestSecurityConfig.class,
+        AdminAuthorizationSpEL.class
+})
+class AdminVirtualDjControllerTest {
+
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+            http
+                    .authorizeHttpRequests(request -> request
+                            .requestMatchers("/api/**").authenticated())
+                    .csrf(csrf -> {})
+                    .exceptionHandling(eh -> eh
+                            .authenticationEntryPoint((req, res, ex) ->
+                                    res.setStatus(jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED)));
+            return http.build();
+        }
+    }
+
+    @Autowired private MockMvc mockMvc;
+    @MockBean private VirtualDjAdminService adminService;
+    @MockBean private VirtualSongPackService songPackService;
+
+    // SecurityConfig autoconfig deps — @MockBean shims so the slice context loads.
+    @MockBean private JwtDecoder jwtDecoder;
+    @MockBean private JwtService jwtService;
+    @MockBean private JwtProperties jwtProperties;
+    @MockBean private SharedSessionCookieWriter sharedSessionCookieWriter;
+    @MockBean private AdminCookieWriter adminCookieWriter;
+
+    // ── pool ──
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void provisionPool_admin_returns201() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/virtual-dj/pool")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"count":5}
+                                """))
+                .andExpect(status().isCreated());
+        verify(adminService).provisionPool(5);
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    void provisionPool_member_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/virtual-dj/pool")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"count":5}
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithAnonymousUser
+    void provisionPool_anonymous_returns401() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/virtual-dj/pool")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"count":5}
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void provisionPool_invalidCount_returns400() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/virtual-dj/pool")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"count":0}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── song packs ──
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createSongPack_admin_returns201() throws Exception {
+        org.mockito.BDDMockito.given(songPackService.createPack("Pack", "desc")).willReturn(10L);
+        mockMvc.perform(post("/api/v1/admin/virtual-dj/song-packs")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"name":"Pack","description":"desc"}
+                                """))
+                .andExpect(status().isCreated());
+        verify(songPackService).createPack("Pack", "desc");
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createSongPack_blankName_returns400() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/virtual-dj/song-packs")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"name":""}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void renameSongPack_admin_returns204() throws Exception {
+        mockMvc.perform(put("/api/v1/admin/virtual-dj/song-packs/3")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"name":"New"}
+                                """))
+                .andExpect(status().isNoContent());
+        verify(songPackService).renamePack(3L, "New");
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void deleteSongPack_admin_returns204() throws Exception {
+        mockMvc.perform(delete("/api/v1/admin/virtual-dj/song-packs/3").with(csrf()))
+                .andExpect(status().isNoContent());
+        verify(songPackService).deletePack(3L);
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void addSongPackTrack_admin_returns201() throws Exception {
+        org.mockito.BDDMockito.given(songPackService.addTrack(org.mockito.ArgumentMatchers.eq(3L),
+                org.mockito.ArgumentMatchers.any())).willReturn(99L);
+        mockMvc.perform(post("/api/v1/admin/virtual-dj/song-packs/3/tracks")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"name":"Song","linkId":"vid1","duration":"3:00","thumbnailImage":null}
+                                """))
+                .andExpect(status().isCreated());
+        verify(songPackService).addTrack(org.mockito.ArgumentMatchers.eq(3L), org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void removeSongPackTrack_admin_returns204() throws Exception {
+        mockMvc.perform(delete("/api/v1/admin/virtual-dj/song-packs/3/tracks/9").with(csrf()))
+                .andExpect(status().isNoContent());
+        verify(songPackService).removeTrack(3L, 9L);
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    void createSongPack_member_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/virtual-dj/song-packs")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"name":"Pack"}
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── per-room config ──
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void applyConfig_admin_returns204() throws Exception {
+        mockMvc.perform(put("/api/v1/admin/partyrooms/7/virtual-dj")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"status":"MANAGED","targetCount":2,"companionFloor":1,"songPackId":5}
+                                """))
+                .andExpect(status().isNoContent());
+        verify(adminService).applyConfig(new PartyroomId(7L), VirtualDjStatus.MANAGED, 2, 1, 5L);
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void applyConfig_invalidStatusEnum_returns400() throws Exception {
+        mockMvc.perform(put("/api/v1/admin/partyrooms/7/virtual-dj")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"status":"NONSENSE"}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    void applyConfig_member_returns403() throws Exception {
+        mockMvc.perform(put("/api/v1/admin/partyrooms/7/virtual-dj")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"status":"OFF"}
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void drain_admin_returns204() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/partyrooms/7/virtual-dj/drain").with(csrf()))
+                .andExpect(status().isNoContent());
+        verify(adminService).drain(new PartyroomId(7L));
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    void drain_member_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/partyrooms/7/virtual-dj/drain").with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void freeze_admin_returns204() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/partyrooms/7/virtual-dj/freeze").with(csrf()))
+                .andExpect(status().isNoContent());
+        verify(adminService).freeze(new PartyroomId(7L));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void liveStatus_admin_returns200() throws Exception {
+        org.mockito.BDDMockito.given(adminService.liveStatus(new PartyroomId(7L)))
+                .willReturn(new VirtualDjAdminService.LiveStatus(VirtualDjStatus.MANAGED, 2, 1, 5L, 2));
+        mockMvc.perform(get("/api/v1/admin/partyrooms/7/virtual-dj"))
+                .andExpect(status().isOk());
+        verify(adminService).liveStatus(new PartyroomId(7L));
+    }
+
+    // ── bulk ──
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void applyBulk_admin_returns204() throws Exception {
+        mockMvc.perform(put("/api/v1/admin/virtual-dj/bulk")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"partyroomIds":[1,2,3],"status":"MANAGED","targetCount":2,"companionFloor":1,"songPackId":5}
+                                """))
+                .andExpect(status().isNoContent());
+        verify(adminService).applyBulk(java.util.List.of(1L, 2L, 3L), VirtualDjStatus.MANAGED, 2, 1, 5L);
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void applyBulk_emptyIds_returns400() throws Exception {
+        mockMvc.perform(put("/api/v1/admin/virtual-dj/bulk")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"partyroomIds":[],"status":"OFF","reason":"r"}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    void applyBulk_member_returns403() throws Exception {
+        mockMvc.perform(put("/api/v1/admin/virtual-dj/bulk")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"partyroomIds":[1],"status":"OFF"}
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── CSRF ──
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void drain_missingCsrf_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/partyrooms/7/virtual-dj/drain"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/BotIdentityExecutorTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/BotIdentityExecutorTest.java
@@ -1,0 +1,83 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.aspect.context.AuthContext;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.virtualdj.application.identity.BotIdentityExecutor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BotIdentityExecutorTest {
+
+    private final BotIdentityExecutor executor = new BotIdentityExecutor();
+
+    @AfterEach
+    void cleanUp() {
+        // Defensive: never let a leaked context bleed into the next test.
+        ThreadLocalContext.clearContext();
+    }
+
+    @Test
+    @DisplayName("봇 신원으로 실행하고 종료 후 정리한다")
+    void 봇_신원으로_실행하고_종료후_정리한다() {
+        UserId bot = new UserId(1_000_000_001L);
+        Long[] inside = new Long[1];
+
+        executor.runAs(bot, () ->
+                inside[0] = ThreadLocalContext.getAuthContext().getUserId().getUid());
+
+        assertThat(inside[0]).isEqualTo(1_000_000_001L);
+        // 실행이 끝나면 ThreadLocal 은 비어 있어야 한다.
+        assertThatThrownBy(ThreadLocalContext::getAuthContext)
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("기존 컨텍스트가 있으면 종료 후 복원한다")
+    void 기존_컨텍스트가_있으면_복원한다() {
+        AuthContext previous = new AuthContext(new UserId(42L), null);
+        ThreadLocalContext.setContext(previous);
+
+        UserId bot = new UserId(1_000_000_002L);
+        Long[] inside = new Long[1];
+
+        executor.runAs(bot, () ->
+                inside[0] = ThreadLocalContext.getAuthContext().getUserId().getUid());
+
+        // 실행 중에는 봇이 컨텍스트의 주인.
+        assertThat(inside[0]).isEqualTo(1_000_000_002L);
+        // 종료 후에는 이전 컨텍스트가 그대로 복원되어야 한다.
+        assertThat(ThreadLocalContext.getAuthContext()).isSameAs(previous);
+    }
+
+    @Test
+    @DisplayName("action 이 예외를 던져도 예외는 전파되고 ThreadLocal 은 정리된다")
+    void 예외가_나도_ThreadLocal_정리된다() {
+        UserId bot = new UserId(1L);
+
+        assertThatThrownBy(() -> executor.runAs(bot, () -> {
+            throw new IllegalStateException("boom");
+        })).isInstanceOf(IllegalStateException.class)
+                .hasMessage("boom");
+
+        assertThatThrownBy(ThreadLocalContext::getAuthContext)
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("action 예외 시에도 이전 컨텍스트는 복원된다")
+    void 예외가_나도_이전_컨텍스트_복원() {
+        AuthContext previous = new AuthContext(new UserId(7L), null);
+        ThreadLocalContext.setContext(previous);
+
+        assertThatThrownBy(() -> executor.runAs(new UserId(99L), () -> {
+            throw new RuntimeException("x");
+        })).isInstanceOf(RuntimeException.class);
+
+        assertThat(ThreadLocalContext.getAuthContext()).isSameAs(previous);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/DesiredBotCalculatorTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/DesiredBotCalculatorTest.java
@@ -1,0 +1,30 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.virtualdj.domain.service.DesiredBotCalculator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DesiredBotCalculatorTest {
+
+    @DisplayName("desiredBot 산식 — (human, target, floor) → 목표 봇 수")
+    @ParameterizedTest(name = "human={0}, target={1}, floor={2} → {3}")
+    @CsvSource({
+            // (T=2, floor=1)
+            "0, 2, 1, 2",
+            "1, 2, 1, 1",
+            "2, 2, 1, 0",
+            "3, 2, 1, 0",
+            // edge: (T=2, floor=3, human=1) → min(2, max(3,1)) = 2
+            "1, 2, 3, 2",
+            // general subtraction branch: human=3, target=5, floor=1 → max(0, 5-3) = 2
+            "3, 5, 1, 2",
+            // degenerate: human=0, target=0, floor=0 → 0
+            "0, 0, 0, 0",
+    })
+    void desiredBot(int human, int target, int floor, int expected) {
+        assertThat(DesiredBotCalculator.desiredBot(human, target, floor)).isEqualTo(expected);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/FlapGuardTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/FlapGuardTest.java
@@ -1,0 +1,98 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.operations.application.service.SystemConfigCache;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.virtualdj.application.service.FlapGuard;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * {@link FlapGuard} 단위 테스트 — 제어된 시각({@link Instant})으로 debounce/dwell 경계를 검증한다.
+ *
+ * <p>FlapGuard 는 제거(removal)만 게이팅한다(추가는 즉시). 시간은 호출자가 {@link Instant} 로
+ * 주입하므로 별도 Clock mock 없이 경계 진위만 검사한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class FlapGuardTest {
+
+    private static final long DEBOUNCE_MS = 5_000;
+    private static final long DWELL_MS = 10_000;
+
+    @Mock
+    SystemConfigCache configCache;
+
+    FlapGuard flapGuard;
+
+    private final PartyroomId room = new PartyroomId(1L);
+    private final Instant t0 = Instant.parse("2026-06-01T00:00:00Z");
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(configCache.getBotYieldDebounceMs()).thenReturn((int) DEBOUNCE_MS);
+        lenient().when(configCache.getBotMinDwellMs()).thenReturn((int) DWELL_MS);
+        flapGuard = new FlapGuard(configCache);
+    }
+
+    @Test
+    @DisplayName("shouldRemove — 첫 호출은 의도만 기록하고 false")
+    void shouldRemove_first_call_records_intent_and_returns_false() {
+        assertThat(flapGuard.shouldRemove(room, t0)).isFalse();
+    }
+
+    @Test
+    @DisplayName("shouldRemove — debounce 경과 전 false, 경과 후 true")
+    void shouldRemove_debounce_boundary() {
+        assertThat(flapGuard.shouldRemove(room, t0)).isFalse();
+        // 4.999s — 아직 미경과
+        assertThat(flapGuard.shouldRemove(room, t0.plusMillis(DEBOUNCE_MS - 1))).isFalse();
+        // 정확히 5s — 경과
+        assertThat(flapGuard.shouldRemove(room, t0.plusMillis(DEBOUNCE_MS))).isTrue();
+        // 그 이후도 true
+        assertThat(flapGuard.shouldRemove(room, t0.plusMillis(DEBOUNCE_MS + 1000))).isTrue();
+    }
+
+    @Test
+    @DisplayName("clearRemovalIntent — 의도 해제 후 다시 호출하면 debounce 가 재시작된다")
+    void clearRemovalIntent_resets_debounce() {
+        assertThat(flapGuard.shouldRemove(room, t0)).isFalse();
+        assertThat(flapGuard.shouldRemove(room, t0.plusMillis(DEBOUNCE_MS))).isTrue();
+
+        // 제거 불필요 판정 → 의도 해제
+        flapGuard.clearRemovalIntent(room);
+
+        // 이후 다시 제거 의도가 생기면 debounce 가 처음부터 다시 시작
+        Instant t1 = t0.plusMillis(20_000);
+        assertThat(flapGuard.shouldRemove(room, t1)).isFalse();
+        assertThat(flapGuard.shouldRemove(room, t1.plusMillis(DEBOUNCE_MS - 1))).isFalse();
+        assertThat(flapGuard.shouldRemove(room, t1.plusMillis(DEBOUNCE_MS))).isTrue();
+    }
+
+    @Test
+    @DisplayName("canRemoveBot — dwell 미경과면 false, 경과면 true")
+    void canRemoveBot_dwell_boundary() {
+        UserId bot = new UserId(7001L);
+        flapGuard.markAdded(bot, t0);
+
+        // dwell 미경과
+        assertThat(flapGuard.canRemoveBot(bot, t0.plusMillis(DWELL_MS - 1))).isFalse();
+        // 정확히 dwell 경과
+        assertThat(flapGuard.canRemoveBot(bot, t0.plusMillis(DWELL_MS))).isTrue();
+    }
+
+    @Test
+    @DisplayName("canRemoveBot — markAdded 기록이 없는 봇은 제거 가능(보수적 fail-open)")
+    void canRemoveBot_unknown_bot_is_removable() {
+        UserId unknown = new UserId(9999L);
+        assertThat(flapGuard.canRemoveBot(unknown, t0)).isTrue();
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/SongPackApplierIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/SongPackApplierIT.java
@@ -1,0 +1,150 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.avatar.adapter.out.persistence.AvatarBodyResourceRepository;
+import com.pfplaybackend.api.avatar.domain.entity.data.AvatarBodyResourceData;
+import com.pfplaybackend.api.avatar.domain.enums.ObtainmentType;
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.PlaylistRepository;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.TrackRepository;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
+import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackTrackRepository;
+import com.pfplaybackend.api.virtualdj.application.service.SongPackApplier;
+import com.pfplaybackend.api.virtualdj.application.service.VirtualUserPoolService;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackData;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackTrackData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+class SongPackApplierIT extends AbstractIntegrationTest {
+
+    private static final String DEFAULT_BODY_URI =
+            "https://firebasestorage.googleapis.com/v0/b/pfplay-firebase.appspot.com/o/ava_basic%2Fava_basic_001.png?alt=media";
+
+    @Autowired private SongPackApplier applier;
+    @Autowired private VirtualUserPoolService poolService;
+    @Autowired private VirtualSongPackRepository packRepository;
+    @Autowired private VirtualSongPackTrackRepository trackRepository;
+    @Autowired private PlaylistRepository playlistRepository;
+    @Autowired private TrackRepository playlistTrackRepository;
+    @Autowired private AvatarBodyResourceRepository avatarBodyResourceRepository;
+
+    @BeforeEach
+    void seedDefaultAvatarBody() {
+        if (avatarBodyResourceRepository.findOneAvatarResourceByResourceUri(DEFAULT_BODY_URI) != null) {
+            return;
+        }
+        AvatarBodyResourceData body = AvatarBodyResourceData.draft(
+                "ava_body_basic_001", DEFAULT_BODY_URI,
+                "https://example.test/icon_basic_001.png",
+                ObtainmentType.BASIC, 0, false, true, 60, 41, null);
+        avatarBodyResourceRepository.save(body);
+    }
+
+    @Test
+    @DisplayName("applyToBot — in-limit 트랙만 복사되고 sourceSongPackId 가 바인딩된다")
+    void applyToBot_인리밋_트랙만_복사() {
+        // 봇 프로비저닝
+        List<UserId> bots = poolService.provision(1);
+        UserId botUserId = bots.get(0);
+        flushAndClear();
+
+        // 송 팩 생성 (3 트랙: 2분 / 4분 / 6분)
+        VirtualSongPackData pack = packRepository.save(VirtualSongPackData.create("Test Pack", "IT 테스트용"));
+        trackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 1, "vid1", "Song A", "2:00", null));
+        trackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 2, "vid2", "Song B", "4:00", null));
+        trackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 3, "vid3", "Song C", "6:00", null));
+        flushAndClear();
+
+        // playbackTimeLimit = 5분 → 6분 트랙(Song C) 제외
+        applier.applyToBot(botUserId, pack.getId(), 5);
+
+        flushAndClear();
+
+        Long playlistId = poolService.playlistIdOf(botUserId);
+        PlaylistData playlist = playlistRepository.findById(playlistId).orElseThrow();
+
+        // source_song_pack_id 바인딩 확인
+        assertThat(playlist.getSourceSongPackId()).isEqualTo(pack.getId());
+
+        // 복사된 트랙 목록 확인
+        List<TrackData> tracks = playlistTrackRepository.findAllByPlaylistId(new PlaylistId(playlistId))
+                .stream()
+                .sorted(Comparator.comparingInt(TrackData::getOrderNumber))
+                .toList();
+
+        assertThat(tracks).hasSize(2);
+        assertThat(tracks.get(0).getLinkId()).isEqualTo("vid1");
+        assertThat(tracks.get(0).getOrderNumber()).isEqualTo(1);
+        assertThat(tracks.get(1).getLinkId()).isEqualTo("vid2");
+        assertThat(tracks.get(1).getOrderNumber()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("applyToBot — 기존 트랙이 있으면 clear 후 새 트랙으로 교체된다")
+    void applyToBot_기존트랙_clear_후_교체() {
+        List<UserId> bots = poolService.provision(1);
+        UserId botUserId = bots.get(0);
+        flushAndClear();
+
+        Long playlistId = poolService.playlistIdOf(botUserId);
+
+        // 봇 playlist 에 기존 트랙 삽입
+        PlaylistData playlist = playlistRepository.findById(playlistId).orElseThrow();
+        playlistTrackRepository.save(TrackData.builder()
+                .playlistId(new PlaylistId(playlistId))
+                .name("Old Song")
+                .linkId("oldVid")
+                .duration(com.pfplaybackend.api.common.domain.value.Duration.fromString("3:00"))
+                .orderNumber(1)
+                .thumbnailImage(null)
+                .build());
+        flushAndClear();
+
+        // 새 송 팩 생성 (1 트랙)
+        VirtualSongPackData pack = packRepository.save(VirtualSongPackData.create("New Pack", "교체 테스트"));
+        trackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 1, "newVid", "New Song", "2:00", null));
+        flushAndClear();
+
+        applier.applyToBot(botUserId, pack.getId(), 10);
+        flushAndClear();
+
+        List<TrackData> replacedTracks = playlistTrackRepository.findAllByPlaylistId(new PlaylistId(playlistId));
+        assertThat(replacedTracks).hasSize(1);
+        assertThat(replacedTracks.get(0).getLinkId()).isEqualTo("newVid");
+    }
+
+    @Test
+    @DisplayName("applyToBot — roomPlaybackTimeLimit=0(unlimited)이면 모든 트랙 포함")
+    void applyToBot_unlimited_모든트랙_포함() {
+        List<UserId> bots = poolService.provision(1);
+        UserId botUserId = bots.get(0);
+        flushAndClear();
+
+        VirtualSongPackData pack = packRepository.save(VirtualSongPackData.create("All Pack", "무제한 테스트"));
+        trackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 1, "v1", "Song 1", "30:00", null));
+        trackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 2, "v2", "Song 2", "59:00", null));
+        flushAndClear();
+
+        // 0 = unlimited
+        applier.applyToBot(botUserId, pack.getId(), 0);
+        flushAndClear();
+
+        Long playlistId = poolService.playlistIdOf(botUserId);
+        List<TrackData> unlimitedTracks = playlistTrackRepository.findAllByPlaylistId(new PlaylistId(playlistId));
+
+        assertThat(unlimitedTracks).hasSize(2);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjAdminServiceIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjAdminServiceIT.java
@@ -1,0 +1,218 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.avatar.adapter.out.persistence.AvatarBodyResourceRepository;
+import com.pfplaybackend.api.avatar.domain.entity.data.AvatarBodyResourceData;
+import com.pfplaybackend.api.avatar.domain.enums.ObtainmentType;
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomRepository;
+import com.pfplaybackend.api.party.application.port.out.UserProfileQueryPort;
+import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
+import com.pfplaybackend.api.party.domain.enums.StageType;
+import com.pfplaybackend.api.party.domain.value.LinkDomain;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.PartyroomVirtualDjConfigRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackTrackRepository;
+import com.pfplaybackend.api.virtualdj.application.service.VirtualDjAdminService;
+import com.pfplaybackend.api.virtualdj.application.service.VirtualUserPoolService;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.PartyroomVirtualDjConfigData;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackData;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackTrackData;
+import com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+/**
+ * 어드민 가상 DJ 서비스 통합 테스트 — config 적용→MANAGED+reconcile, drain 봇 제거, bulk 다중 룸, freeze.
+ *
+ * <p>fixture 패턴은 {@link VirtualDjOrchestratorIT} 와 동일 — {@link UserProfileQueryPort} mock 으로
+ * assertHasProfile 게이트만 통과시키고 나머지는 실 빈/실 DB(Testcontainers).
+ */
+@Transactional
+class VirtualDjAdminServiceIT extends AbstractIntegrationTest {
+
+    private static final String DEFAULT_BODY_URI =
+            "https://firebasestorage.googleapis.com/v0/b/pfplay-firebase.appspot.com/o/ava_basic%2Fava_basic_001.png?alt=media";
+
+    @Autowired private VirtualDjAdminService adminService;
+    @Autowired private VirtualUserPoolService poolService;
+    @Autowired private PartyroomRepository partyroomRepository;
+    @Autowired private PartyroomVirtualDjConfigRepository configRepository;
+    @Autowired private VirtualSongPackRepository packRepository;
+    @Autowired private VirtualSongPackTrackRepository packTrackRepository;
+    @Autowired private AvatarBodyResourceRepository avatarBodyResourceRepository;
+
+    @MockBean private UserProfileQueryPort userProfileQueryPort;
+
+    @BeforeEach
+    void seedGatesAndAvatar() {
+        lenient().when(userProfileQueryPort.getUsersProfileSetting(any()))
+                .thenAnswer(inv -> {
+                    List<UserId> ids = inv.getArgument(0);
+                    Map<UserId, ProfileSettingDto> result = new HashMap<>();
+                    for (UserId id : ids) {
+                        result.put(id, mock(ProfileSettingDto.class));
+                    }
+                    return result;
+                });
+        if (avatarBodyResourceRepository.findOneAvatarResourceByResourceUri(DEFAULT_BODY_URI) == null) {
+            avatarBodyResourceRepository.save(AvatarBodyResourceData.draft(
+                    "ava_body_basic_001", DEFAULT_BODY_URI,
+                    "https://example.test/icon_basic_001.png",
+                    ObtainmentType.BASIC, 0, false, true, 60, 41, null));
+        }
+    }
+
+    @AfterEach
+    void clearContext() {
+        ThreadLocalContext.clearContext();
+    }
+
+    @Test
+    @DisplayName("applyConfig MANAGED — config 가 MANAGED 로 전환되고 reconcile 로 봇이 T까지 채워진다")
+    void applyConfig_MANAGED_transitions_and_fills() {
+        long roomId = seedRoom(5);
+        Long packId = seedSongPack();
+        poolService.provision(3);
+        flushAndClear();
+
+        adminService.applyConfig(new PartyroomId(roomId), VirtualDjStatus.MANAGED, 2, 1, packId);
+        flushAndClear();
+
+        PartyroomVirtualDjConfigData cfg = configRepository.findByPartyroomId(roomId).orElseThrow();
+        assertThat(cfg.getStatus()).isEqualTo(VirtualDjStatus.MANAGED);
+        assertThat(cfg.getTargetCount()).isEqualTo(2);
+        assertThat(activeBotDjCount(roomId)).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("drain — config OFF + 모든 봇 제거")
+    void drain_removesAllBots_andTurnsOff() {
+        long roomId = seedRoom(5);
+        Long packId = seedSongPack();
+        poolService.provision(3);
+        flushAndClear();
+
+        adminService.applyConfig(new PartyroomId(roomId), VirtualDjStatus.MANAGED, 2, 1, packId);
+        flushAndClear();
+        assertThat(activeBotDjCount(roomId)).isEqualTo(2);
+
+        adminService.drain(new PartyroomId(roomId));
+        flushAndClear();
+
+        assertThat(activeBotDjCount(roomId)).isZero();
+        assertThat(configRepository.findByPartyroomId(roomId).orElseThrow().getStatus())
+                .isEqualTo(VirtualDjStatus.OFF);
+    }
+
+    @Test
+    @DisplayName("freeze — status FROZEN 전환, 봇 수 불변")
+    void freeze_setsFrozen() {
+        long roomId = seedRoom(5);
+        Long packId = seedSongPack();
+        poolService.provision(3);
+        flushAndClear();
+
+        adminService.applyConfig(new PartyroomId(roomId), VirtualDjStatus.MANAGED, 2, 1, packId);
+        flushAndClear();
+        long botsBefore = activeBotDjCount(roomId);
+
+        adminService.freeze(new PartyroomId(roomId));
+        flushAndClear();
+
+        assertThat(configRepository.findByPartyroomId(roomId).orElseThrow().getStatus())
+                .isEqualTo(VirtualDjStatus.FROZEN);
+        assertThat(activeBotDjCount(roomId)).isEqualTo(botsBefore);
+    }
+
+    @Test
+    @DisplayName("applyBulk MANAGED — 여러 룸에 동일 config 적용 + 각 룸 reconcile")
+    void applyBulk_appliesToMultipleRooms() {
+        long roomA = seedRoom(5);
+        long roomB = seedRoom(5);
+        Long packId = seedSongPack();
+        poolService.provision(6);
+        flushAndClear();
+
+        adminService.applyBulk(List.of(roomA, roomB), VirtualDjStatus.MANAGED, 2, 1, packId);
+        flushAndClear();
+
+        assertThat(configRepository.findByPartyroomId(roomA).orElseThrow().getStatus())
+                .isEqualTo(VirtualDjStatus.MANAGED);
+        assertThat(configRepository.findByPartyroomId(roomB).orElseThrow().getStatus())
+                .isEqualTo(VirtualDjStatus.MANAGED);
+        assertThat(activeBotDjCount(roomA)).isEqualTo(2);
+        assertThat(activeBotDjCount(roomB)).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("liveStatus — config + 현재 봇 수 반영")
+    void liveStatus_reflectsConfigAndBotCount() {
+        long roomId = seedRoom(5);
+        Long packId = seedSongPack();
+        poolService.provision(3);
+        flushAndClear();
+
+        adminService.applyConfig(new PartyroomId(roomId), VirtualDjStatus.MANAGED, 2, 1, packId);
+        flushAndClear();
+
+        VirtualDjAdminService.LiveStatus status = adminService.liveStatus(new PartyroomId(roomId));
+        assertThat(status.status()).isEqualTo(VirtualDjStatus.MANAGED);
+        assertThat(status.targetCount()).isEqualTo(2);
+        assertThat(status.songPackId()).isEqualTo(packId);
+        assertThat(status.currentBotDjCount()).isEqualTo(2);
+    }
+
+    // ── fixtures (mirror VirtualDjOrchestratorIT) ──
+
+    private long seedRoom(int playbackTimeLimitMinutes) {
+        PartyroomData p = PartyroomData.create(
+                "vdj", "intro", LinkDomain.of("link-vdj-" + System.nanoTime()),
+                PlaybackTimeLimit.ofMinutes(playbackTimeLimitMinutes), StageType.GENERAL,
+                new UserId(8000L));
+        long id = partyroomRepository.saveAndFlush(p).getId();
+        PartyroomId pid = new PartyroomId(id);
+        entityManager.persist(PartyroomPlaybackData.createFor(pid));
+        entityManager.persist(DjQueueData.createFor(pid));
+        entityManager.flush();
+        return id;
+    }
+
+    private Long seedSongPack() {
+        VirtualSongPackData pack = packRepository.save(VirtualSongPackData.create("Pack-" + System.nanoTime(), "IT"));
+        packTrackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 1, "vidA", "Song A", "2:00", null));
+        packTrackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 2, "vidB", "Song B", "3:00", null));
+        return pack.getId();
+    }
+
+    private long activeBotDjCount(long roomId) {
+        Number n = (Number) entityManager.createNativeQuery(
+                        "SELECT COUNT(*) FROM dj d " +
+                        "JOIN crew c ON c.crew_id = d.crew_id " +
+                        "JOIN user_account u ON u.user_id = c.user_id " +
+                        "WHERE d.partyroom_id = :rid AND c.is_active = 1 AND u.is_dummy = 1")
+                .setParameter("rid", roomId)
+                .getSingleResult();
+        return n.longValue();
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjEventListenerIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjEventListenerIT.java
@@ -1,0 +1,208 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.avatar.adapter.out.persistence.AvatarBodyResourceRepository;
+import com.pfplaybackend.api.avatar.domain.entity.data.AvatarBodyResourceData;
+import com.pfplaybackend.api.avatar.domain.enums.ObtainmentType;
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.adapter.out.persistence.CrewRepository;
+import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomRepository;
+import com.pfplaybackend.api.party.application.port.out.UserProfileQueryPort;
+import com.pfplaybackend.api.party.application.service.DjCommandService;
+import com.pfplaybackend.api.party.application.service.PartyroomAccessCommandService;
+import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
+import com.pfplaybackend.api.party.domain.enums.AccessType;
+import com.pfplaybackend.api.party.domain.enums.StageType;
+import com.pfplaybackend.api.party.domain.event.CrewAccessedEvent;
+import com.pfplaybackend.api.party.domain.event.PartyroomTerminatedEvent;
+import com.pfplaybackend.api.party.domain.value.CrewId;
+import com.pfplaybackend.api.party.domain.value.LinkDomain;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.PartyroomVirtualDjConfigRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackTrackRepository;
+import com.pfplaybackend.api.virtualdj.application.service.FlapGuard;
+import com.pfplaybackend.api.virtualdj.application.service.VirtualUserPoolService;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.PartyroomVirtualDjConfigData;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackData;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackTrackData;
+import com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Chunk 5 이벤트 반응 통합 테스트 — 실 AFTER_COMMIT 경로로 listener → reconcile wiring 을 검증한다.
+ *
+ * <p><b>commit 경계 처리:</b> {@code @TransactionalEventListener(AFTER_COMMIT)} 는 커밋이 일어나야
+ * 발화하므로 클래스-레벨 {@code @Transactional} 로는 트리거되지 않는다(롤백 only). 따라서 이 IT 는
+ * 비-{@code @Transactional} 로 두고 {@link TransactionTemplate} 안에서 도메인 이벤트를 publish 하여
+ * 실제 커밋 → listener 발화 경로를 그대로 탄다. 정리는 명시적으로 한다(UserActivityLogListener*IT 패턴).
+ *
+ * <p><b>무한루프/churn 가드 검증:</b> {@link DjCommandService} 를 {@link SpyBean} 으로 감싸
+ * 재트리거 시 {@code enqueueDj} 가 추가로 호출되지 않음(멱등 수렴)을 {@code verify(..., times(n))} 로
+ * 증명한다 — 최종 봇 수가 안정적이라는 것만이 아니라 churn 자체가 없음을 보인다.
+ */
+class VirtualDjEventListenerIT extends AbstractIntegrationTest {
+
+    private static final String DEFAULT_BODY_URI =
+            "https://firebasestorage.googleapis.com/v0/b/pfplay-firebase.appspot.com/o/ava_basic%2Fava_basic_001.png?alt=media";
+
+    @Autowired private ApplicationEventPublisher eventPublisher;
+    @Autowired private TransactionTemplate transactionTemplate;
+    @Autowired private VirtualUserPoolService poolService;
+    @Autowired private PartyroomRepository partyroomRepository;
+    @Autowired private PartyroomVirtualDjConfigRepository configRepository;
+    @Autowired private VirtualSongPackRepository packRepository;
+    @Autowired private VirtualSongPackTrackRepository packTrackRepository;
+    @Autowired private CrewRepository crewRepository;
+    @Autowired private AvatarBodyResourceRepository avatarBodyResourceRepository;
+
+    @SpyBean private DjCommandService djCommandService;
+    @SpyBean private FlapGuard flapGuard;
+
+    @MockBean private UserProfileQueryPort userProfileQueryPort;
+
+    private Long roomId;
+
+    @BeforeEach
+    void seed() {
+        lenient().when(userProfileQueryPort.getUsersProfileSetting(any()))
+                .thenAnswer(inv -> {
+                    List<UserId> ids = inv.getArgument(0);
+                    Map<UserId, ProfileSettingDto> result = new HashMap<>();
+                    for (UserId id : ids) {
+                        result.put(id, mock(ProfileSettingDto.class));
+                    }
+                    return result;
+                });
+        if (avatarBodyResourceRepository.findOneAvatarResourceByResourceUri(DEFAULT_BODY_URI) == null) {
+            avatarBodyResourceRepository.save(AvatarBodyResourceData.draft(
+                    "ava_body_basic_001", DEFAULT_BODY_URI,
+                    "https://example.test/icon_basic_001.png",
+                    ObtainmentType.BASIC, 0, false, true, 60, 41, null));
+        }
+
+        transactionTemplate.executeWithoutResult(status -> {
+            PartyroomData p = PartyroomData.create(
+                    "vdj-evt", "intro", LinkDomain.of("link-vdj-evt-" + System.nanoTime()),
+                    PlaybackTimeLimit.ofMinutes(5), StageType.GENERAL, new UserId(8500L));
+            Long id = partyroomRepository.saveAndFlush(p).getId();
+            PartyroomId pid = new PartyroomId(id);
+            entityManager.persist(PartyroomPlaybackData.createFor(pid));
+            entityManager.persist(DjQueueData.createFor(pid));
+
+            Long songPackId = seedSongPack();
+            configRepository.save(PartyroomVirtualDjConfigData.builder()
+                    .partyroomId(id).status(VirtualDjStatus.MANAGED)
+                    .targetCount(2).companionFloor(1).songPackId(songPackId).build());
+            this.roomId = id;
+        });
+
+        // 풀 충분(≥2 idle bots).
+        poolService.provision(3);
+    }
+
+    @AfterEach
+    void cleanup() {
+        ThreadLocalContext.clearContext();
+        transactionTemplate.executeWithoutResult(status -> {
+            entityManager.createNativeQuery("DELETE FROM dj").executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM crew").executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM partyroom_playback").executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM dj_queue").executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM partyroom_virtual_dj_config").executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM partyroom").executeUpdate();
+        });
+    }
+
+    @Test
+    @DisplayName("CrewAccessedEvent(AFTER_COMMIT) → reconcile 봇 T(=2)까지 채움 + 재트리거는 churn 없음")
+    void crewAccessed_triggers_reconcile_and_converges_without_churn() {
+        // 1) 실제 커밋 후 listener 발화 → reconcile 봇 2명 투입.
+        publishCrewEnterCommitted();
+
+        Awaitility.await().atMost(Duration.ofSeconds(10)).pollInterval(Duration.ofMillis(200))
+                .untilAsserted(() -> assertThat(activeBotDjCount(roomId)).isEqualTo(2));
+
+        // 봇 2명 투입 = enqueueDj 2회.
+        verify(djCommandService, times(2)).enqueueDj(any(PartyroomId.class), any(PlaylistId.class));
+
+        // 2) 재트리거 — 멱등 수렴 상태이므로 enqueueDj 가 한 번도 더 일어나면 안 된다(churn 없음).
+        publishCrewEnterCommitted();
+
+        // 약간 대기 후에도 카운트 불변 + enqueue 누적 불변.
+        Awaitility.await().during(Duration.ofSeconds(1)).atMost(Duration.ofSeconds(3))
+                .untilAsserted(() -> assertThat(activeBotDjCount(roomId)).isEqualTo(2));
+        verify(djCommandService, times(2)).enqueueDj(any(PartyroomId.class), any(PlaylistId.class));
+    }
+
+    @Test
+    @DisplayName("PartyroomTerminatedEvent(AFTER_COMMIT) → config OFF 전환, reconcile 안 함")
+    void terminated_turns_config_off_and_skips_reconcile() {
+        transactionTemplate.executeWithoutResult(status ->
+                eventPublisher.publishEvent(new PartyroomTerminatedEvent(
+                        new PartyroomId(roomId), 9000L, "test-terminate")));
+
+        Awaitility.await().atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(200))
+                .untilAsserted(() -> {
+                    PartyroomVirtualDjConfigData cfg = configRepository.findByPartyroomId(roomId).orElseThrow();
+                    assertThat(cfg.getStatus()).isEqualTo(VirtualDjStatus.OFF);
+                });
+        // 종료 룸은 reconcile 하지 않으므로 봇이 추가되지 않는다.
+        assertThat(activeBotDjCount(roomId)).isZero();
+        // 종료 경로가 FlapGuard removal-intent 를 정리한다.
+        verify(flapGuard).clearRemovalIntent(new PartyroomId(roomId));
+    }
+
+    // ── helpers ──
+
+    private void publishCrewEnterCommitted() {
+        transactionTemplate.executeWithoutResult(status ->
+                eventPublisher.publishEvent(new CrewAccessedEvent(
+                        new PartyroomId(roomId), new CrewId(1L), new UserId(8500L), AccessType.ENTER)));
+    }
+
+    private Long seedSongPack() {
+        VirtualSongPackData pack = packRepository.save(VirtualSongPackData.create("Pack", "IT"));
+        packTrackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 1, "vidA", "Song A", "2:00", null));
+        packTrackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 2, "vidB", "Song B", "3:00", null));
+        return pack.getId();
+    }
+
+    private long activeBotDjCount(long rid) {
+        Number n = (Number) entityManager.createNativeQuery(
+                        "SELECT COUNT(*) FROM dj d " +
+                        "JOIN crew c ON c.crew_id = d.crew_id " +
+                        "JOIN user_account u ON u.user_id = c.user_id " +
+                        "WHERE d.partyroom_id = :rid AND c.is_active = 1 AND u.is_dummy = 1")
+                .setParameter("rid", rid)
+                .getSingleResult();
+        return n.longValue();
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjOrchestratorIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjOrchestratorIT.java
@@ -1,0 +1,296 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.avatar.adapter.out.persistence.AvatarBodyResourceRepository;
+import com.pfplaybackend.api.avatar.domain.entity.data.AvatarBodyResourceData;
+import com.pfplaybackend.api.avatar.domain.enums.ObtainmentType;
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.aspect.context.AuthContext;
+import com.pfplaybackend.api.common.config.security.enums.ProviderType;
+import com.pfplaybackend.api.common.domain.value.Duration;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.enums.AuthorityTier;
+import com.pfplaybackend.api.party.adapter.out.persistence.CrewRepository;
+import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomRepository;
+import com.pfplaybackend.api.party.application.port.out.UserProfileQueryPort;
+import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
+import com.pfplaybackend.api.party.domain.enums.StageType;
+import com.pfplaybackend.api.party.domain.value.LinkDomain;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.PlaylistRepository;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.TrackRepository;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
+import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
+import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
+import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.PartyroomVirtualDjConfigRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackTrackRepository;
+import com.pfplaybackend.api.virtualdj.application.port.VirtualDjOrchestrator;
+import com.pfplaybackend.api.virtualdj.application.service.VirtualUserPoolService;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.PartyroomVirtualDjConfigData;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackData;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackTrackData;
+import com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Chunk 4 오케스트레이터 통합 테스트 — 실 DB(Testcontainers) 위에서 봇 임퍼소네이션 투입/제거를 검증한다.
+ *
+ * <p>격리: {@link UserProfileQueryPort} mock 으로 assertHasProfile 게이트만 통과시킨다(race IT 와
+ * 동일 패턴; 실제 ProfileData 행 구성이 fragile 하기 때문). 그 외 playback/scheduler/이벤트 인프라는
+ * 실 빈을 그대로 쓴다 — enqueueDj 의 startPlayback 은 실제로 동작하되 scheduleTask 타이머는 테스트
+ * 윈도우 내 발화하지 않아 무해하다. 봇 playlist 소유/비공백 검증도 실 데이터(SongPackApplier 가 봇
+ * playlist 에 실제 트랙을 채움)로 통과시킨다.
+ */
+@Transactional
+class VirtualDjOrchestratorIT extends AbstractIntegrationTest {
+
+    private static final String DEFAULT_BODY_URI =
+            "https://firebasestorage.googleapis.com/v0/b/pfplay-firebase.appspot.com/o/ava_basic%2Fava_basic_001.png?alt=media";
+
+    @Autowired private VirtualDjOrchestrator orchestrator;
+    @Autowired private VirtualUserPoolService poolService;
+    @Autowired private PartyroomRepository partyroomRepository;
+    @Autowired private PartyroomVirtualDjConfigRepository configRepository;
+    @Autowired private VirtualSongPackRepository packRepository;
+    @Autowired private VirtualSongPackTrackRepository packTrackRepository;
+    @Autowired private CrewRepository crewRepository;
+    @Autowired private UserAccountRepository userAccountRepository;
+    @Autowired private PlaylistRepository playlistRepository;
+    @Autowired private TrackRepository trackRepository;
+    @Autowired private AvatarBodyResourceRepository avatarBodyResourceRepository;
+
+    @MockBean private UserProfileQueryPort userProfileQueryPort;
+
+    @BeforeEach
+    void seedGatesAndAvatar() {
+        // 어떤 userId 든 프로필 보유 상태로 — assertHasProfile 통과.
+        lenient().when(userProfileQueryPort.getUsersProfileSetting(any()))
+                .thenAnswer(inv -> {
+                    List<UserId> ids = inv.getArgument(0);
+                    Map<UserId, ProfileSettingDto> result = new HashMap<>();
+                    for (UserId id : ids) {
+                        result.put(id, mock(ProfileSettingDto.class));
+                    }
+                    return result;
+                });
+        // 봇 프로비저닝이 쓰는 기본 아바타 바디 시드 (test 프로파일은 Flyway 비활성).
+        if (avatarBodyResourceRepository.findOneAvatarResourceByResourceUri(DEFAULT_BODY_URI) == null) {
+            avatarBodyResourceRepository.save(AvatarBodyResourceData.draft(
+                    "ava_body_basic_001", DEFAULT_BODY_URI,
+                    "https://example.test/icon_basic_001.png",
+                    ObtainmentType.BASIC, 0, false, true, 60, 41, null));
+        }
+    }
+
+    @AfterEach
+    void clearContext() {
+        ThreadLocalContext.clearContext();
+    }
+
+    @Test
+    @DisplayName("사람0명_MANAGED — 봇이 T(=2)까지 채워진다")
+    void 사람0명_MANAGED_봇이_T까지_채워진다() {
+        long roomId = seedRoom(5);
+        seedManagedConfig(roomId, /*target*/2, /*floor*/1, seedSongPack());
+        poolService.provision(3); // ≥ 2 idle bots
+        flushAndClear();
+
+        orchestrator.reconcileRoom(new PartyroomId(roomId));
+        flushAndClear();
+
+        assertThat(activeBotDjCount(roomId)).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("사람1명DJ — 봇은 floor(=1)만 채운다")
+    void 사람1명DJ_봇은_floor1만() {
+        long roomId = seedRoom(5);
+        seedManagedConfig(roomId, /*target*/2, /*floor*/1, seedSongPack());
+        poolService.provision(3);
+        flushAndClear();
+
+        // 사람 DJ 1명을 활성 DJ 로 등록.
+        seedHumanDj(roomId, 9100L);
+        flushAndClear();
+
+        orchestrator.reconcileRoom(new PartyroomId(roomId));
+        flushAndClear();
+
+        // desiredBot(human=1, T=2, floor=1) = min(2, max(1, 1)) = 1
+        assertThat(activeBotDjCount(roomId)).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("FROZEN방 — reconcile 무변경 (no-op)")
+    void FROZEN방_무변경() {
+        long roomId = seedRoom(5);
+        PartyroomVirtualDjConfigData cfg = PartyroomVirtualDjConfigData.builder()
+                .partyroomId(roomId).status(VirtualDjStatus.FROZEN)
+                .targetCount(2).companionFloor(1).songPackId(seedSongPack()).build();
+        configRepository.save(cfg);
+        poolService.provision(3);
+        flushAndClear();
+
+        orchestrator.reconcileRoom(new PartyroomId(roomId));
+        flushAndClear();
+
+        assertThat(activeBotDjCount(roomId)).isZero();
+    }
+
+    @Test
+    @DisplayName("MANAGED_송팩없음 — 봇 추가 없음 (SKIP_NO_SONG_PACK)")
+    void MANAGED_송팩없음_무변경() {
+        long roomId = seedRoom(5);
+        // songPackId = null: MANAGED 상태지만 송팩 미설정
+        seedManagedConfig(roomId, /*target*/2, /*floor*/1, /*songPackId*/null);
+        poolService.provision(3);
+        flushAndClear();
+
+        orchestrator.reconcileRoom(new PartyroomId(roomId));
+        flushAndClear();
+
+        // 송팩 없으므로 봇이 한 명도 추가되면 안 된다.
+        assertThat(activeBotDjCount(roomId)).isZero();
+    }
+
+    @Test
+    @DisplayName("idempotent — T 충족 후 재호출해도 봇 수 불변·추가 churn 없음")
+    void idempotent_재호출_무변경() {
+        long roomId = seedRoom(5);
+        seedManagedConfig(roomId, 2, 1, seedSongPack());
+        poolService.provision(3);
+        flushAndClear();
+
+        orchestrator.reconcileRoom(new PartyroomId(roomId));
+        flushAndClear();
+        assertThat(activeBotDjCount(roomId)).isEqualTo(2);
+        long djRowsAfterFirst = djRowCount(roomId);
+
+        // 재호출 — 수렴 상태이므로 enqueue/exit 가 한 번도 일어나면 안 된다.
+        orchestrator.reconcileRoom(new PartyroomId(roomId));
+        flushAndClear();
+
+        assertThat(activeBotDjCount(roomId)).isEqualTo(2);
+        assertThat(djRowCount(roomId)).isEqualTo(djRowsAfterFirst);
+    }
+
+    // ── fixtures ──
+
+    private long seedRoom(int playbackTimeLimitMinutes) {
+        PartyroomData p = PartyroomData.create(
+                "vdj", "intro", LinkDomain.of("link-vdj-" + System.nanoTime()),
+                PlaybackTimeLimit.ofMinutes(playbackTimeLimitMinutes), StageType.GENERAL,
+                new UserId(8000L));
+        long id = partyroomRepository.saveAndFlush(p).getId();
+        // enqueueDj 가 findPlaybackState/findDjQueueState 를 orElseThrow 로 읽으므로 부속 행 시드.
+        PartyroomId pid = new PartyroomId(id);
+        entityManager.persist(PartyroomPlaybackData.createFor(pid));
+        entityManager.persist(DjQueueData.createFor(pid));
+        entityManager.flush();
+        return id;
+    }
+
+    private void seedManagedConfig(long roomId, int target, int floor, Long songPackId) {
+        PartyroomVirtualDjConfigData cfg = PartyroomVirtualDjConfigData.builder()
+                .partyroomId(roomId).status(VirtualDjStatus.MANAGED)
+                .targetCount(target).companionFloor(floor).songPackId(songPackId).build();
+        configRepository.save(cfg);
+    }
+
+    private Long seedSongPack() {
+        VirtualSongPackData pack = packRepository.save(VirtualSongPackData.create("Pack", "IT"));
+        packTrackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 1, "vidA", "Song A", "2:00", null));
+        packTrackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 2, "vidB", "Song B", "3:00", null));
+        return pack.getId();
+    }
+
+    /** 사람(is_dummy=false) 사용자 1명을 만들어 활성 crew + DJ 로 등록한다. */
+    private void seedHumanDj(long roomId, long humanUid) {
+        UserId humanId = new UserId(humanUid);
+        userAccountRepository.save(UserAccountData.createForSocial(
+                humanId, "human-" + humanUid + "@test.local", ProviderType.GOOGLE));
+
+        // 사람 소유의 비-공백 playlist (enqueueDj 의 isOwnedBy/isEmptyPlaylist 통과용).
+        PlaylistData playlist = playlistRepository.save(
+                PlaylistData.create(1, "Human PL", PlaylistType.PLAYLIST, humanId));
+        trackRepository.save(TrackData.builder()
+                .playlistId(new PlaylistId(playlist.getId()))
+                .name("H1").linkId("hvid1")
+                .duration(Duration.fromString("2:00"))
+                .orderNumber(1).thumbnailImage(null).build());
+        flushAndClear();
+
+        Long playlistId = playlistRepository.findByOwnerIdAndType(humanId, PlaylistType.PLAYLIST).getId();
+
+        // 사람 신원으로 입장 + DJ 등록.
+        ThreadLocalContext.setContext(new AuthContext(humanId, AuthorityTier.FM));
+        try {
+            accessEnterAndEnqueue(roomId, playlistId);
+        } finally {
+            ThreadLocalContext.clearContext();
+        }
+    }
+
+    private void accessEnterAndEnqueue(long roomId, Long playlistId) {
+        // 명령 서비스 직접 호출 (오케스트레이터가 봇에 대해 하는 것과 동일 경로).
+        com.pfplaybackend.api.party.application.service.PartyroomAccessCommandService access =
+                getBean(com.pfplaybackend.api.party.application.service.PartyroomAccessCommandService.class);
+        com.pfplaybackend.api.party.application.service.DjCommandService dj =
+                getBean(com.pfplaybackend.api.party.application.service.DjCommandService.class);
+        PartyroomId pid = new PartyroomId(roomId);
+        access.tryEnter(pid, null);
+        dj.enqueueDj(pid, new PlaylistId(playlistId));
+    }
+
+    private <T> T getBean(Class<T> type) {
+        return applicationContext.getBean(type);
+    }
+
+    @Autowired private org.springframework.context.ApplicationContext applicationContext;
+
+    // ── assertions ──
+
+    /** 룸의 활성 DJ 중 봇(is_dummy=true) 수. */
+    private long activeBotDjCount(long roomId) {
+        Number n = (Number) entityManager.createNativeQuery(
+                        "SELECT COUNT(*) FROM dj d " +
+                        "JOIN crew c ON c.crew_id = d.crew_id " +
+                        "JOIN user_account u ON u.user_id = c.user_id " +
+                        "WHERE d.partyroom_id = :rid AND c.is_active = 1 AND u.is_dummy = 1")
+                .setParameter("rid", roomId)
+                .getSingleResult();
+        return n.longValue();
+    }
+
+    private long djRowCount(long roomId) {
+        Number n = (Number) entityManager.createNativeQuery(
+                        "SELECT COUNT(*) FROM dj WHERE partyroom_id = :rid")
+                .setParameter("rid", roomId)
+                .getSingleResult();
+        return n.longValue();
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjPersistenceIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjPersistenceIT.java
@@ -1,0 +1,66 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.PartyroomVirtualDjConfigRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackTrackRepository;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.PartyroomVirtualDjConfigData;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackData;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackTrackData;
+import com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+class VirtualDjPersistenceIT extends AbstractIntegrationTest {
+
+    @Autowired private VirtualSongPackRepository virtualSongPackRepository;
+    @Autowired private VirtualSongPackTrackRepository virtualSongPackTrackRepository;
+    @Autowired private PartyroomVirtualDjConfigRepository partyroomVirtualDjConfigRepository;
+
+    @Test
+    @DisplayName("송팩과 트랙 저장·조회")
+    void 송팩과_트랙_저장_조회() {
+        VirtualSongPackData pack = virtualSongPackRepository.save(
+                VirtualSongPackData.create("K-POP Hot", "케이팝"));
+
+        virtualSongPackTrackRepository.save(
+                VirtualSongPackTrackData.create(
+                        pack.getId(), 1, "POe9SOEKotk", "Shut Down", "03:01",
+                        "https://i.ytimg.com/x"));
+
+        flushAndClear();
+
+        List<VirtualSongPackTrackData> tracks =
+                virtualSongPackTrackRepository.findBySongPackIdOrderByOrderNumberAsc(pack.getId());
+
+        assertThat(tracks).hasSize(1);
+        assertThat(tracks.get(0).getLinkId()).isEqualTo("POe9SOEKotk");
+    }
+
+    @Test
+    @DisplayName("config 기본값과 전이")
+    void config_기본값과_전이() {
+        PartyroomVirtualDjConfigData cfg = PartyroomVirtualDjConfigData.create(1L);
+
+        assertThat(cfg.getStatus()).isEqualTo(VirtualDjStatus.OFF);
+
+        cfg.applyManaged(2, 1, 10L);
+        assertThat(cfg.getStatus()).isEqualTo(VirtualDjStatus.MANAGED);
+
+        partyroomVirtualDjConfigRepository.save(cfg);
+        flushAndClear();
+        assertThat(partyroomVirtualDjConfigRepository.findByPartyroomId(1L)).isPresent();
+
+        cfg.freeze();
+        assertThat(cfg.getStatus()).isEqualTo(VirtualDjStatus.FROZEN);
+        cfg.turnOff();
+        assertThat(cfg.getStatus()).isEqualTo(VirtualDjStatus.OFF);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualSongPackServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualSongPackServiceTest.java
@@ -1,0 +1,223 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.common.exception.http.BadRequestException;
+import com.pfplaybackend.api.common.exception.http.ConflictException;
+import com.pfplaybackend.api.common.exception.http.NotFoundException;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.PlaylistRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.PartyroomVirtualDjConfigRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackTrackRepository;
+import com.pfplaybackend.api.virtualdj.application.dto.command.AddPackTrackCommand;
+import com.pfplaybackend.api.virtualdj.application.service.VirtualSongPackService;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackData;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackTrackData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class VirtualSongPackServiceTest {
+
+    @Mock private VirtualSongPackRepository packRepository;
+    @Mock private VirtualSongPackTrackRepository trackRepository;
+    @Mock private PartyroomVirtualDjConfigRepository configRepository;
+    @Mock private PlaylistRepository playlistRepository;
+
+    @InjectMocks
+    private VirtualSongPackService service;
+
+    // ── createPack ──
+
+    @Test
+    @DisplayName("중복 이름으로 createPack 시 ConflictException")
+    void createPack_중복이름_거부() {
+        when(packRepository.existsByName("K-Pop Mix")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.createPack("K-Pop Mix", "설명"))
+                .isInstanceOf(ConflictException.class);
+    }
+
+    @Test
+    @DisplayName("새 이름으로 createPack 시 저장 후 id 반환")
+    void createPack_새이름_저장후_id_반환() {
+        when(packRepository.existsByName("EDM Mix")).thenReturn(false);
+        VirtualSongPackData saved = VirtualSongPackData.create("EDM Mix", "설명");
+        // Reflect id via builder (simulate DB-assigned id)
+        VirtualSongPackData withId = VirtualSongPackData.builder()
+                .name("EDM Mix").description("설명").build();
+        when(packRepository.save(any())).thenAnswer(inv -> {
+            // Return a pack that looks saved — id check omitted (integration covers it)
+            return withId;
+        });
+
+        service.createPack("EDM Mix", "설명");
+
+        verify(packRepository).save(any(VirtualSongPackData.class));
+    }
+
+    // ── renamePack ──
+
+    @Test
+    @DisplayName("존재하지 않는 packId로 renamePack 시 NotFoundException")
+    void renamePack_존재하지않는_팩_거부() {
+        when(packRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.renamePack(99L, "New Name"))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("이미 사용 중인 이름으로 renamePack 시 ConflictException")
+    void renamePack_중복이름_거부() {
+        VirtualSongPackData pack = VirtualSongPackData.create("Old Name", "desc");
+        when(packRepository.findById(1L)).thenReturn(Optional.of(pack));
+        when(packRepository.existsByName("Taken Name")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.renamePack(1L, "Taken Name"))
+                .isInstanceOf(ConflictException.class);
+
+        verify(packRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("현재 이름과 동일한 이름으로 renamePack 시 중복 검사 없이 허용")
+    void renamePack_같은이름_허용() {
+        VirtualSongPackData pack = VirtualSongPackData.create("Same Name", "desc");
+        when(packRepository.findById(1L)).thenReturn(Optional.of(pack));
+        when(packRepository.save(any())).thenReturn(pack);
+
+        // existsByName 호출 없이 정상 완료되어야 함
+        service.renamePack(1L, "Same Name");
+
+        verify(packRepository, never()).existsByName(anyString());
+        verify(packRepository).save(pack);
+    }
+
+    // ── addTrack — duration guard ──
+
+    @Test
+    @DisplayName("재생시간이 60분 초과 트랙 추가 시 BadRequestException(TRACK_EXCEEDS_PLAYBACK_LIMIT)")
+    void addTrack_재생시간_60분_초과_거부() {
+        VirtualSongPackData pack = VirtualSongPackData.create("Pack", "desc");
+        when(packRepository.findById(1L)).thenReturn(Optional.of(pack));
+        // 서비스는 duration 검증 실패 시 trackRepository 호출 전 예외를 던진다 — stub 불필요
+
+        // 61분 = 3660초
+        AddPackTrackCommand cmd = new AddPackTrackCommand("Long Song", "abc123", "61:00", null);
+
+        assertThatThrownBy(() -> service.addTrack(1L, cmd))
+                .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    @DisplayName("재생시간이 정확히 60분인 트랙은 허용")
+    void addTrack_재생시간_60분_허용() {
+        VirtualSongPackData pack = VirtualSongPackData.create("Pack", "desc");
+        when(packRepository.findById(1L)).thenReturn(Optional.of(pack));
+        when(trackRepository.findBySongPackIdOrderByOrderNumberAsc(1L)).thenReturn(List.of());
+
+        VirtualSongPackTrackData saved = VirtualSongPackTrackData.create(1L, 1, "vid1", "60-min song", "60:00", null);
+        when(trackRepository.save(any())).thenReturn(saved);
+
+        // Should not throw
+        service.addTrack(1L, new AddPackTrackCommand("60-min song", "vid1", "60:00", null));
+
+        verify(trackRepository).save(any(VirtualSongPackTrackData.class));
+    }
+
+    @Test
+    @DisplayName("정상 트랙 추가 시 order_number는 기존 max + 1")
+    void addTrack_order_number_기존_max_plus_1() {
+        VirtualSongPackData pack = VirtualSongPackData.create("Pack", "desc");
+        when(packRepository.findById(1L)).thenReturn(Optional.of(pack));
+
+        VirtualSongPackTrackData existing = VirtualSongPackTrackData.create(1L, 3, "existId", "Existing", "3:00", null);
+        when(trackRepository.findBySongPackIdOrderByOrderNumberAsc(1L)).thenReturn(List.of(existing));
+
+        VirtualSongPackTrackData saved = VirtualSongPackTrackData.create(1L, 4, "newId", "New Song", "4:00", null);
+        when(trackRepository.save(any())).thenReturn(saved);
+
+        service.addTrack(1L, new AddPackTrackCommand("New Song", "newId", "4:00", null));
+
+        ArgumentCaptor<VirtualSongPackTrackData> captor = ArgumentCaptor.forClass(VirtualSongPackTrackData.class);
+        verify(trackRepository).save(captor.capture());
+        assertThat(captor.getValue().getOrderNumber()).isEqualTo(4);
+    }
+
+    // ── removeTrack ──
+
+    @Test
+    @DisplayName("다른 팩에 속한 트랙 id 로 removeTrack 호출 시 NotFoundException")
+    void removeTrack_다른팩_트랙_거부() {
+        VirtualSongPackData pack = VirtualSongPackData.create("Pack 1", "desc");
+        when(packRepository.findById(1L)).thenReturn(Optional.of(pack));
+
+        // 트랙은 존재하지만 packId=2 소속
+        VirtualSongPackTrackData trackOfOtherPack = VirtualSongPackTrackData.create(2L, 1, "vid", "Song", "3:00", null);
+        when(trackRepository.findById(99L)).thenReturn(Optional.of(trackOfOtherPack));
+
+        assertThatThrownBy(() -> service.removeTrack(1L, 99L))
+                .isInstanceOf(NotFoundException.class);
+
+        verify(trackRepository, never()).delete(any());
+    }
+
+    // ── deletePack — delete guard ──
+
+    @Test
+    @DisplayName("partyroom_virtual_dj_config 가 참조 중인 팩 삭제 시 ConflictException(SONG_PACK_IN_USE)")
+    void deletePack_config_참조중_거부() {
+        VirtualSongPackData pack = VirtualSongPackData.create("Used Pack", "desc");
+        when(packRepository.findById(1L)).thenReturn(Optional.of(pack));
+
+        // config references this pack — 인덱스 활용 existsBySongPackId 로 검사(full-scan findAll 제거).
+        when(configRepository.existsBySongPackId(1L)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.deletePack(1L))
+                .isInstanceOf(ConflictException.class);
+
+        // full-scan findAll() 은 더 이상 호출되면 안 된다.
+        verify(configRepository, never()).findAll();
+    }
+
+    @Test
+    @DisplayName("playlist.source_song_pack_id 가 참조 중인 팩 삭제 시 ConflictException(SONG_PACK_IN_USE)")
+    void deletePack_playlist_참조중_거부() {
+        VirtualSongPackData pack = VirtualSongPackData.create("Used Pack", "desc");
+        when(packRepository.findById(2L)).thenReturn(Optional.of(pack));
+        when(configRepository.existsBySongPackId(2L)).thenReturn(false); // no config reference
+
+        when(playlistRepository.existsBySourceSongPackId(2L)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.deletePack(2L))
+                .isInstanceOf(ConflictException.class);
+    }
+
+    @Test
+    @DisplayName("아무도 참조하지 않는 팩은 정상 삭제")
+    void deletePack_미참조_정상삭제() {
+        VirtualSongPackData pack = VirtualSongPackData.create("Free Pack", "desc");
+        when(packRepository.findById(3L)).thenReturn(Optional.of(pack));
+        when(configRepository.existsBySongPackId(3L)).thenReturn(false);
+        when(playlistRepository.existsBySourceSongPackId(3L)).thenReturn(false);
+
+        service.deletePack(3L);
+
+        verify(trackRepository).deleteAll(any());
+        verify(packRepository).delete(pack);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualUserPoolServiceIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualUserPoolServiceIT.java
@@ -1,0 +1,101 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.avatar.adapter.out.persistence.AvatarBodyResourceRepository;
+import com.pfplaybackend.api.avatar.domain.entity.data.AvatarBodyResourceData;
+import com.pfplaybackend.api.avatar.domain.enums.ObtainmentType;
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.adapter.out.persistence.CrewRepository;
+import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.enums.GradeType;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
+import com.pfplaybackend.api.virtualdj.application.service.VirtualUserPoolService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+class VirtualUserPoolServiceIT extends AbstractIntegrationTest {
+
+    // AdminProfileService.getDefaultAvatarBodyUri() 가 사용하는 고정 디폴트 바디 URI.
+    // test 프로파일은 Flyway 비활성(create-drop + 시드 없음)이라 이 IT 에서 직접 시드한다.
+    private static final String DEFAULT_BODY_URI =
+            "https://firebasestorage.googleapis.com/v0/b/pfplay-firebase.appspot.com/o/ava_basic%2Fava_basic_001.png?alt=media";
+
+    @Autowired private VirtualUserPoolService poolService;
+    @Autowired private UserAccountRepository userAccountRepository;
+    @Autowired private CrewRepository crewRepository;
+    @Autowired private AvatarBodyResourceRepository avatarBodyResourceRepository;
+
+    @BeforeEach
+    void seedDefaultAvatarBody() {
+        if (avatarBodyResourceRepository.findOneAvatarResourceByResourceUri(DEFAULT_BODY_URI) != null) {
+            return;
+        }
+        // SINGLE_BODY 경로(face 비움)만 타도록 combinable=false + icon_uri 보유.
+        AvatarBodyResourceData body = AvatarBodyResourceData.draft(
+                "ava_body_basic_001", DEFAULT_BODY_URI,
+                "https://example.test/icon_basic_001.png",
+                ObtainmentType.BASIC, 0, false, true, 60, 41, null);
+        avatarBodyResourceRepository.save(body);
+    }
+
+    @Test
+    @DisplayName("봇 N명 생성 — 실계정(is_dummy)·playlist 보유")
+    void 봇_N명_생성_실계정과_playlist_보유() {
+        List<UserId> bots = poolService.provision(3);
+
+        flushAndClear();
+
+        assertThat(bots).hasSize(3);
+        for (UserId bot : bots) {
+            UserAccountData account = userAccountRepository.findById(bot).orElseThrow();
+            assertThat(account.isDummy()).isTrue();
+
+            Long playlistId = poolService.playlistIdOf(bot);
+            assertThat(playlistId).isNotNull();
+        }
+    }
+
+    @Test
+    @DisplayName("idle 봇 조회 — 활성 crew 가 있는 봇은 제외")
+    void idle_봇_조회_방에_없는_봇만() {
+        List<UserId> bots = poolService.provision(3);
+        flushAndClear();
+
+        // 봇 1명을 임의 파티룸의 활성 crew 로 만든다.
+        UserId busyBot = bots.get(0);
+        crewRepository.save(CrewData.create(
+                new PartyroomId(999L), busyBot, GradeType.LISTENER, null));
+        flushAndClear();
+
+        List<UserId> idle = poolService.findIdleBots(10);
+
+        assertThat(idle).contains(bots.get(1), bots.get(2));
+        assertThat(idle).doesNotContain(busyBot);
+    }
+
+    @Test
+    @DisplayName("findIdleBots 는 비활성 crew 만 가진 봇은 idle 로 본다")
+    void 비활성_crew_봇은_idle() {
+        List<UserId> bots = poolService.provision(1);
+        flushAndClear();
+
+        UserId bot = bots.get(0);
+        CrewData crew = CrewData.create(new PartyroomId(998L), bot, GradeType.LISTENER, null);
+        crew.deactivatePresence();
+        crewRepository.save(crew);
+        flushAndClear();
+
+        List<UserId> idle = poolService.findIdleBots(10);
+        assertThat(idle).contains(bot);
+    }
+}

--- a/common/src/main/java/com/pfplaybackend/api/common/config/security/authorization/AdminAuthorizationSpEL.java
+++ b/common/src/main/java/com/pfplaybackend/api/common/config/security/authorization/AdminAuthorizationSpEL.java
@@ -53,6 +53,10 @@ public class AdminAuthorizationSpEL {
         return isSuperAdmin();
     }
 
+    public boolean canManageVirtualDj() {
+        return isAdmin();
+    }
+
     private boolean hasAuthority(String authority) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || !auth.isAuthenticated()) return false;

--- a/docs/superpowers/plans/2026-06-01-virtual-dj-p2-backend.md
+++ b/docs/superpowers/plans/2026-06-01-virtual-dj-p2-backend.md
@@ -1,0 +1,526 @@
+# 가상 사용자 능동 디제잉 (P2) — 백엔드 구현 플랜 (Plan A)
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 어드민이 파티룸에 "가상 DJ(봇)"를 두어 빈 방에서도 음악·머릿수가 유지되고, 진짜 사람이 DJ를 하면 봇이 동반자만 남기고 양보하도록, 봇을 **실제 계정**으로 만들어 **기존 도메인 진입점**을 통해 구동하는 백엔드를 만든다.
+
+**Architecture:** 봇 = 실제 `user_account`(`is_dummy=true`). in-process `VirtualDjOrchestrator`가 도메인 이벤트(`CrewAccessedEvent`/`DjQueueChangedEvent`/`PartyroomTerminatedEvent`)에 반응해 방별 `reconcileRoom`을 실행, **ThreadLocal 봇 임퍼소네이션**으로 실유저가 쓰는 `tryEnter`/`enqueueDj`/`dequeueDj`/`exit`를 그대로 호출(=path A). persistence/publisher 직접 접근은 **ArchUnit으로 금지**. 룸 직렬화는 기존 `DistributedLockExecutor` 재사용. anti-flap(디바운스/최소체류) + 저빈도 안전망 reconcile.
+
+**Tech Stack:** Java/Spring (멀티모듈 Gradle: `common, realtime, playlist, user, avatar, app`), JPA + QueryDSL, Flyway(MySQL), Redis(분산락), JUnit5 + Mockito + Testcontainers, ArchUnit(`archunit-junit5:1.2.1`).
+
+**Spec:** `docs/superpowers/specs/2026-06-01-virtual-dj-p2-design.md` (결정 D1~D6, §4.1 산식/anti-flap, §5.1 송팩 복사).
+
+**전제 / 컨벤션:**
+- 빌드/테스트는 JDK 21: 모든 gradle 호출에 `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7"` prefix.
+- 단위: `./gradlew test`  / 통합: `./gradlew integrationTest`(또는 `-Pinclude-integration`). 통합 테스트는 `AbstractIntegrationTest`(Testcontainers MySQL+Redis) 상속.
+- 신규 코드 배치 모듈: **`app`** (party aggregate와 강결합). 패키지 루트: `com.pfplaybackend.api.virtualdj.*`, 기존 헥사고날 구조(`adapter.in.web` / `application` / `domain` / `adapter.out.persistence`) 따른다.
+- 커밋: TDD 마이크로 커밋(로컬 OK), push/PR 직전 논리단위 squash. 한글 커밋 메시지. git 브랜치/이슈는 사용자 게이트(아직 X).
+- 이름 컨벤션: 엔티티 `*Data`(예 `VirtualSongPackData`), value `*Id`, repo 인터페이스 + `*RepositoryImpl`(QueryDSL).
+
+---
+
+## Chunk 1: 스키마 · 엔티티 · 리포지토리
+
+**책임:** P2가 쓸 영속 구조를 만든다. 가산적·최소. 봇 식별 플래그, 송 팩(+트랙), 방별 가상 DJ config, 봇 playlist의 송팩 출처 추적.
+
+**Files:**
+- Create: `app/src/main/resources/db/migration/V24__create_virtual_dj.sql`
+- Modify: `user/src/main/java/com/pfplaybackend/api/user/domain/entity/data/UserAccountData.java` (`isDummy` 필드)
+- Modify: `playlist/src/main/java/com/pfplaybackend/api/playlist/domain/entity/data/PlaylistData.java` (`sourceSongPackId` 필드)
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/domain/entity/data/VirtualSongPackData.java`
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/domain/entity/data/VirtualSongPackTrackData.java`
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/domain/entity/data/PartyroomVirtualDjConfigData.java`
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/domain/enums/VirtualDjStatus.java`
+- Create: repositories `VirtualSongPackRepository`, `VirtualSongPackTrackRepository`, `PartyroomVirtualDjConfigRepository` (+ `*RepositoryImpl` if QueryDSL needed)
+- Test: `app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjPersistenceIT.java`
+
+- [ ] **Step 0 (verify, §9-1):** Read `PlaylistCommandPort.peekTracksFromCursor` / `advancePlaybackCursor` 구현부를 열어 **플레이리스트 끝에서 커서가 맨 앞으로 wrap 하는지** 확인. wrap 한다면 추가 작업 없음. wrap 안 하면 이 플랜에 "봇 playlist 끝→앞 wrap 보정" 태스크를 추가(별도 노트). 결과를 이 파일 상단에 한 줄 기록.
+
+- [ ] **Step 1: 마이그레이션 작성** — `V24__create_virtual_dj.sql`
+
+```sql
+-- =====================================================
+-- V24: 가상 사용자 능동 디제잉 (P2)
+-- =====================================================
+
+-- 봇 식별 플래그
+ALTER TABLE user_account
+    ADD COLUMN is_dummy TINYINT(1) NOT NULL DEFAULT 0 COMMENT '가상 사용자(봇) 여부';
+
+-- 봇 playlist 의 송팩 출처(라이브 상태 비교용)
+ALTER TABLE playlist
+    ADD COLUMN source_song_pack_id BIGINT UNSIGNED NULL COMMENT '이 playlist 가 복사된 송 팩 (봇 전용)';
+
+-- 재사용 송 팩
+CREATE TABLE virtual_song_pack (
+    id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    name        VARCHAR(100) NOT NULL,
+    description VARCHAR(255) NULL,
+    created_at  DATETIME NOT NULL,
+    updated_at  DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_virtual_song_pack_name (name)
+);
+
+CREATE TABLE virtual_song_pack_track (
+    id              BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    song_pack_id    BIGINT UNSIGNED NOT NULL,
+    order_number    INT UNSIGNED NOT NULL,
+    link_id         VARCHAR(255) NOT NULL COMMENT 'YouTube videoId',
+    name            VARCHAR(255) NOT NULL,
+    duration        VARCHAR(255) NOT NULL COMMENT 'MM:SS, playbackTimeLimit 사전검증됨',
+    thumbnail_image VARCHAR(255) NULL,
+    PRIMARY KEY (id),
+    KEY idx_vspt_song_pack_id (song_pack_id)
+);
+
+-- 방별 가상 DJ 제어 (2축: target + status)
+CREATE TABLE partyroom_virtual_dj_config (
+    partyroom_id    BIGINT UNSIGNED NOT NULL,
+    status          VARCHAR(16) NOT NULL DEFAULT 'OFF' COMMENT 'OFF/MANAGED/FROZEN',
+    target_count    INT UNSIGNED NOT NULL DEFAULT 2,
+    companion_floor INT UNSIGNED NOT NULL DEFAULT 1,
+    song_pack_id    BIGINT UNSIGNED NULL,
+    created_at      DATETIME NOT NULL,
+    updated_at      DATETIME NOT NULL,
+    PRIMARY KEY (partyroom_id)
+);
+```
+
+- [ ] **Step 2: `is_dummy` / `source_song_pack_id` 엔티티 필드 추가**
+
+`UserAccountData`에 (패턴: 기존 `mustChangePassword` 참고):
+```java
+@Column(name = "is_dummy", nullable = false, columnDefinition = "TINYINT(1)")
+private boolean isDummy;
+
+public boolean isDummy() { return isDummy; }
+```
+`PlaylistData`에 nullable `Long sourceSongPackId` + getter + `void bindSongPackSource(Long songPackId)`.
+
+- [ ] **Step 3: enum + 엔티티 작성** — `VirtualDjStatus { OFF, MANAGED, FROZEN }`. `VirtualSongPackData`/`VirtualSongPackTrackData`/`PartyroomVirtualDjConfigData`는 `TrackData` 패턴(`@Entity @DynamicInsert/Update`, protected 기본생성자, `@Builder`, 정적 팩토리 `create(...)`) 따른다. `PartyroomVirtualDjConfigData`는 `partyroom_id`가 PK이고 도메인 메서드 `applyManaged(target, floor, songPackId)`, `freeze()`, `turnOff()`, `desiredBot(humanDjCount)` 보유(산식은 Chunk 4에서 테스트, 여기선 필드/전이만).
+
+- [ ] **Step 4: 리포지토리 작성** — `JpaRepository` 상속. 필요한 파생 쿼리:
+  - `PartyroomVirtualDjConfigRepository`: `Optional<...> findByPartyroomId(Long)`, `List<...> findByStatus(VirtualDjStatus)` (안전망 reconcile용 — MANAGED 전체).
+  - `VirtualSongPackTrackRepository`: `List<...> findBySongPackIdOrderByOrderNumberAsc(Long)`.
+  - `VirtualSongPackRepository`: `boolean existsByName(String)`.
+
+- [ ] **Step 5: 통합 테스트 작성 (failing)** — `VirtualDjPersistenceIT extends AbstractIntegrationTest`
+
+```java
+@Test
+void 송팩과_트랙_저장_조회() {
+    VirtualSongPackData pack = virtualSongPackRepository.save(VirtualSongPackData.create("K-POP Hot", "케이팝"));
+    virtualSongPackTrackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 1, "POe9SOEKotk", "Shut Down", "03:01", "https://i.ytimg.com/..."));
+    List<VirtualSongPackTrackData> tracks = virtualSongPackTrackRepository.findBySongPackIdOrderByOrderNumberAsc(pack.getId());
+    assertThat(tracks).hasSize(1);
+    assertThat(tracks.get(0).getLinkId()).isEqualTo("POe9SOEKotk");
+}
+
+@Test
+void config_기본값과_전이() {
+    PartyroomVirtualDjConfigData cfg = PartyroomVirtualDjConfigData.create(1L);
+    assertThat(cfg.getStatus()).isEqualTo(VirtualDjStatus.OFF);
+    cfg.applyManaged(2, 1, 10L);
+    assertThat(cfg.getStatus()).isEqualTo(VirtualDjStatus.MANAGED);
+    partyroomVirtualDjConfigRepository.save(cfg);
+    assertThat(partyroomVirtualDjConfigRepository.findByPartyroomId(1L)).isPresent();
+}
+```
+
+- [ ] **Step 6: 마이그레이션+통합 테스트 실행 → PASS 확인**
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew integrationTest --tests "*VirtualDjPersistenceIT"`
+Expected: Flyway가 V24 적용 후 2 tests PASS.
+
+- [ ] **Step 7: 커밋** — `feat(virtual-dj): V24 스키마 + 송팩/config 엔티티·리포지토리`
+
+---
+
+## Chunk 2: 봇 정체성 임퍼소네이션 · 봇 풀 프로비저닝
+
+**책임:** (1) 봇으로서 도메인 메서드를 호출하는 `withBotIdentity` 유틸(§1.1). (2) `is_dummy` 실계정 + 그 playlist 를 생성/조회하는 봇 풀 서비스.
+
+**Files:**
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/application/identity/BotIdentityExecutor.java`
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualUserPoolService.java`
+- Test: `app/src/test/java/com/pfplaybackend/api/virtualdj/BotIdentityExecutorTest.java`, `VirtualUserPoolServiceIT.java`
+
+- [ ] **Step 0 (verify):** `ThreadLocalContext` / `AuthContext` 실제 타입을 열어 봇 AuthContext 구성에 필요한 필드(userId, authorityTier 등)와 빌더/생성자, `setContext`/`clear` 시그니처를 확인. 기존 HTTP 필터가 AuthContext 만드는 코드를 참고. (테스트는 `ThreadLocalContext.setContext(mock)`를 이미 사용 — 프로덕션 구성 경로 확인이 목적.)
+
+- [ ] **Step 1: `BotIdentityExecutorTest` 작성 (failing)** — 핵심 불변: 실행 전후 ThreadLocal 정리, 예외 시에도 정리.
+
+```java
+@Test
+void 봇_신원으로_실행하고_종료후_정리한다() {
+    UserId bot = new UserId(1000_000_001L);
+    String[] inside = new String[1];
+    executor.runAs(bot, () -> { inside[0] = ThreadLocalContext.getAuthContext().getUserId().toString(); });
+    assertThat(inside[0]).contains("1000000001");
+    assertThatThrownBy(() -> ThreadLocalContext.getAuthContext()).isInstanceOf(RuntimeException.class); // 정리됨
+}
+
+@Test
+void 예외가_나도_ThreadLocal_정리된다() {
+    assertThatThrownBy(() -> executor.runAs(new UserId(1L), () -> { throw new IllegalStateException("x"); }))
+        .isInstanceOf(IllegalStateException.class);
+    // 정리 확인
+}
+```
+
+- [ ] **Step 2: `BotIdentityExecutor` 구현** — Step 0에서 확인한 AuthContext 빌더로 구성.
+
+```java
+@Component
+@RequiredArgsConstructor
+public class BotIdentityExecutor {
+    // 봇 tier 는 실유저 일반 회원과 동일하게 구성(예: FM). Step 0 결과대로.
+    public void runAs(UserId botUserId, Runnable action) {
+        AuthContext prev = ThreadLocalContext.hasContext() ? ThreadLocalContext.getAuthContext() : null; // 헬퍼 유무는 실제 API 따름
+        try {
+            ThreadLocalContext.setContext(buildBotAuthContext(botUserId));
+            action.run();
+        } finally {
+            if (prev != null) ThreadLocalContext.setContext(prev); else ThreadLocalContext.clear();
+        }
+    }
+    private AuthContext buildBotAuthContext(UserId botUserId) { /* Step 0 결과 */ }
+}
+```
+
+- [ ] **Step 3: 테스트 실행 → PASS**
+Run: `JAVA_HOME=... ./gradlew test --tests "*BotIdentityExecutorTest"`
+
+- [ ] **Step 4: `VirtualUserPoolServiceIT` 작성 (failing)** — 봇 N명 생성: 실 `user_account`(`is_dummy=true`, provider LOCAL) + 현실적 닉네임 + 기본 아바타 프로필 + **유저당 playlist 1개** 생성. idle 봇 조회.
+
+```java
+@Test
+void 봇_N명_생성_실계정과_playlist_보유() {
+    List<UserId> bots = poolService.provision(3);
+    assertThat(bots).hasSize(3);
+    for (UserId b : bots) {
+        UserAccountData acc = userAccountRepository.findById(b).orElseThrow();
+        assertThat(acc.isDummy()).isTrue();
+        assertThat(playlistQueryPort.findByOwner(b.getUid())).isPresent(); // 봇 playlist 존재
+    }
+}
+
+@Test
+void idle_봇_조회_방에_없는_봇만() {
+    // 봇 3명 중 1명을 임의 방 crew 로 만든 뒤 findIdleBots() 가 2명 반환
+}
+```
+
+- [ ] **Step 5: `VirtualUserPoolService` 구현** — 기존 회원/프로필 생성 경로 재사용(닉네임 충돌 회피: [[pfplay-web i18n]] 무관, V15 unique 제약 주의 — UUID/시퀀스 기반 현실적 닉네임). 아바타는 기본값. playlist 생성은 기존 회원가입 시 playlist 생성 경로 재사용. `findIdleBots()` = `is_dummy=true` AND 활성 crew 없음(QueryDSL: user_account LEFT JOIN crew is_active).
+
+- [ ] **Step 6: 테스트 실행 → PASS / Step 7: 커밋** — `feat(virtual-dj): 봇 임퍼소네이션 + 풀 프로비저닝`
+
+---
+
+## Chunk 3: 송 팩 · 봇 playlist 로 복사
+
+**책임:** 어드민이 빌드한 송 팩의 트랙을 봇 playlist로 1회 복사(§5.1). duration 사전검증.
+
+**Files:**
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualSongPackService.java` (CRUD + duration 검증)
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/SongPackApplier.java` (팩→봇 playlist 복사)
+- Test: `VirtualSongPackServiceTest.java`(단위), `SongPackApplierIT.java`(통합)
+
+- [ ] **Step 0 (verify, 1회 기록):** `playbackTimeLimit`의 출처를 확정한다 — **전역 단일값인지 방별(`PartyroomData.getPlaybackTimeLimit()`)인지.** 방별이면 "빌드 시점엔 보수적 상한으로 검증, 적용(`SongPackApplier`) 시 그 방 한계로 재필터"로 확정하고, 그 보수적 상한 출처(예: 시스템 최대 또는 config 키)를 정한다. 결과를 이 Chunk 상단에 한 줄 기록 — Step 1(빌드 검증)과 Chunk 4 `addBots`(적용 재필터)가 같은 답을 재사용.
+
+- [ ] **Step 1: `VirtualSongPackServiceTest` (failing)** — 팩 생성 시 `playbackTimeLimit` 초과 트랙은 거부.
+
+```java
+@Test
+void duration_초과_트랙은_거부() {
+    // playbackTimeLimit = 10분 가정. 12:00 트랙 추가 시도 → 예외 또는 reject 목록 반환
+    AddPackTrackCommand tooLong = new AddPackTrackCommand("vid", "롱트랙", "12:00", "thumb");
+    assertThatThrownBy(() -> service.addTrack(packId, tooLong))
+        .isInstanceOf(VirtualDjException.class); // TRACK_EXCEEDS_PLAYBACK_LIMIT
+}
+```
+(전역 `playbackTimeLimit` 출처는 Step 0에서 확인 — 방별 값이면 "팩은 가장 빡빡한 한계 기준" 또는 적용 시점 검증으로 결정. 일단 전역/보수적 상한으로 빌드시 검증, 적용 시 방 한계로 재필터.)
+
+- [ ] **Step 2: `VirtualSongPackService` 구현** — create/rename/addTrack/removeTrack/delete. 삭제는 **참조 중(config.song_pack_id 또는 배치된 봇 playlist.source_song_pack_id) 차단**(§5.1). duration 파싱·검증 유틸은 기존 `DurationConverter`/`Duration` value 재사용.
+
+- [ ] **Step 3: 테스트 → PASS**
+
+- [ ] **Step 4: `SongPackApplierIT` (failing)** — 봇 playlist에 팩 트랙 복사 + `source_song_pack_id` 바인딩 + 방 `playbackTimeLimit` 초과 트랙 제외.
+
+```java
+@Test
+void 팩을_봇_playlist로_복사하고_출처기록() {
+    Long packId = /* 트랙 3개(전부 한계내) */;
+    applier.applyToBot(botUserId, packId, partyroomPlaybackTimeLimit);
+    Long botPlaylistId = playlistQueryPort.findByOwner(botUserId.getUid()).get();
+    assertThat(trackRepository.countByPlaylistId(botPlaylistId)).isEqualTo(3);
+    assertThat(playlistRepository.findById(botPlaylistId).get().getSourceSongPackId()).isEqualTo(packId);
+}
+```
+
+- [ ] **Step 5: `SongPackApplier` 구현** — 봇 playlist 비우고(기존 track 삭제) 팩 트랙을 `TrackData` 로 복사(방 `playbackTimeLimit` 초과분 제외), `playlist.bindSongPackSource(packId)`. **주의:** 여기서는 `TrackData`/`PlaylistData` 영속을 직접 다루되, 이는 봇 자신의 playlist 준비(도메인 캐스케이드 무관한 데이터 셋업)이므로 ArchUnit 규칙 대상이 아니다(규칙은 *오케스트레이터* 패키지에만 적용 — Chunk 6). Applier는 `application.service`에 두고 오케스트레이터가 호출.
+
+- [ ] **Step 6: 테스트 → PASS / Step 7: 커밋** — `feat(virtual-dj): 송팩 CRUD + 봇 playlist 복사`
+
+---
+
+## Chunk 4: 오케스트레이터 코어 — reconcileRoom
+
+**책임:** 방 하나의 desired 봇 수를 산식대로 맞춘다(§4.1). 룸 직렬락. 봇 투입/제거는 **임퍼소네이션 + public 메서드**로만.
+
+**Files:**
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/application/port/VirtualDjOrchestrator.java` (interface)
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualDjOrchestratorImpl.java`
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/domain/service/DesiredBotCalculator.java` (순수 산식)
+- Test: `DesiredBotCalculatorTest.java`(단위, 순수), `VirtualDjOrchestratorIT.java`(통합)
+
+- [ ] **Step 0 (verify):** `removeBots`의 "가장 최근 합류 봇부터 제거"(§4.1)를 위해 **`dj` 또는 `crew` row에 합류시각 컬럼이 있는지** 확인(`created_at` 등). 있으면 그걸로 정렬. 없으면 정렬 기준을 명시적으로 정한다(예: `dj.order_number` 역순 = 마지막 등록 = 가장 최근). 결과를 `readActiveDjs`의 `botsMostRecentFirst()` 정렬 기준으로 고정 — anti-flap 제거 순서가 결정적이어야 함.
+
+- [ ] **Step 1: `DesiredBotCalculatorTest` (failing)** — §4.1 산식.
+
+```java
+@ParameterizedTest
+@CsvSource({ "0,2", "1,1", "2,0", "3,0" })   // T=2, floor=1
+void desiredBot(int human, int expected) {
+    assertThat(DesiredBotCalculator.desiredBot(human, 2, 1)).isEqualTo(expected);
+}
+@Test void floor_가_T보다_클때_경계() { assertThat(DesiredBotCalculator.desiredBot(1, 2, 3)).isEqualTo(2); } // max(floor,T-1) 캡은 T
+```
+
+- [ ] **Step 2: `DesiredBotCalculator` 구현 (순수 함수)**
+
+```java
+public final class DesiredBotCalculator {
+    public static int desiredBot(int human, int target, int floor) {
+        if (human == 0) return target;
+        if (human == 1) return Math.min(target, Math.max(floor, target - 1));
+        return Math.max(0, target - human);
+    }
+}
+```
+Run → PASS.
+
+- [ ] **Step 3: `VirtualDjOrchestratorIT` (failing)** — 실제 방·봇으로 reconcile 검증(통합).
+
+```java
+@Test
+void 사람0명_MANAGED방_봇이_T까지_DJ로_채워진다() {
+    // 방 1 MANAGED(T=2,floor=1, 송팩 지정), idle 봇 ≥2
+    orchestrator.reconcileRoom(new PartyroomId(roomId));
+    assertThat(activeBotDjCount(roomId)).isEqualTo(2);
+    // 봇 crew 생성 + dj row 생성 확인
+}
+
+@Test
+void 사람1명_DJ면_봇은_floor(1)만_남는다() {
+    // 사람 DJ 1명 등록된 상태에서 reconcile
+    orchestrator.reconcileRoom(new PartyroomId(roomId));
+    assertThat(activeBotDjCount(roomId)).isEqualTo(1);
+}
+
+@Test
+void FROZEN_방은_건드리지_않는다() { /* status=FROZEN → reconcile no-op */ }
+```
+
+- [ ] **Step 4: `VirtualDjOrchestratorImpl.reconcileRoom` 구현**
+
+```java
+@Service
+@RequiredArgsConstructor
+public class VirtualDjOrchestratorImpl implements VirtualDjOrchestrator {
+    private final PartyroomVirtualDjConfigRepository configRepository;
+    private final PartyroomQueryService partyroomQueryService;   // 현재 활성 DJ 조회(읽기)
+    private final VirtualUserPoolService poolService;
+    private final SongPackApplier songPackApplier;
+    private final BotIdentityExecutor botIdentity;
+    private final PartyroomAccessCommandService accessCommandService; // tryEnter / exit (cascade)
+    private final DjCommandService djCommandService;                  // enqueueDj / dequeueDj (cascade)
+    private final DistributedLockExecutor lock;
+
+    @Override
+    public void reconcileRoom(PartyroomId partyroomId) {
+        lock.performTaskWithLock(":virtualdj:" + partyroomId.getId(), () -> { doReconcile(partyroomId); return null; });
+    }
+
+    private void doReconcile(PartyroomId partyroomId) {
+        PartyroomVirtualDjConfigData cfg = configRepository.findByPartyroomId(partyroomId.getId()).orElse(null);
+        if (cfg == null || cfg.getStatus() != VirtualDjStatus.MANAGED) return;     // OFF/FROZEN/없음 → no-op
+
+        DjSnapshot snap = readActiveDjs(partyroomId);   // 현재 *커밋된* 활성 DJ 집합 (사람/봇 분리)
+        int desired = DesiredBotCalculator.desiredBot(snap.humanCount(), cfg.getTargetCount(), cfg.getCompanionFloor());
+        int current = snap.botCount();
+
+        if (current < desired) addBots(partyroomId, cfg, desired - current);
+        else if (current > desired) removeBots(partyroomId, snap, current - desired); // anti-flap 게이팅은 Chunk5에서 래핑
+    }
+
+    private void addBots(PartyroomId pid, PartyroomVirtualDjConfigData cfg, int n) {
+        List<UserId> bots = poolService.findIdleBots(n);
+        int playbackTimeLimit = partyroomQueryService.getPartyroomById(pid).getPlaybackTimeLimit().getMinutes();
+        for (UserId bot : bots) {
+            songPackApplier.applyToBot(bot, cfg.getSongPackId(), playbackTimeLimit); // playlist 준비
+            botIdentity.runAs(bot, () -> {
+                accessCommandService.tryEnter(pid, null);               // crew (cascade + 1-room guard)
+                Long botPlaylistId = poolService.playlistIdOf(bot);
+                djCommandService.enqueueDj(pid, new PlaylistId(botPlaylistId)); // DJ (cascade)
+            });
+        }
+    }
+
+    private void removeBots(PartyroomId pid, DjSnapshot snap, int n) {
+        // 가장 최근 합류 봇부터 n명 (dwell 게이팅은 Chunk5에서 적용)
+        for (UserId bot : snap.botsMostRecentFirst().subList(0, n)) {
+            botIdentity.runAs(bot, () -> accessCommandService.exit(pid));  // dequeue+exit cascade
+        }
+    }
+}
+```
+- `readActiveDjs`/`DjSnapshot`: `partyroomQueryService.getDjs(pid)` + 각 dj 의 crew→userId→`is_dummy` 판정으로 human/bot 분리, 합류시각 정렬. (읽기 쿼리는 허용 — ArchUnit은 *쓰기* 캐스케이드 우회만 금지.)
+
+- [ ] **Step 5: 통합 테스트 → PASS** (`./gradlew integrationTest --tests "*VirtualDjOrchestratorIT"`)
+
+- [ ] **Step 6: 커밋** — `feat(virtual-dj): reconcileRoom 산식 + 임퍼소네이션 투입/제거`
+
+---
+
+## Chunk 5: 반응형 컨트롤러 — 이벤트 · anti-flap · 안전망
+
+**책임:** 도메인 이벤트를 reconcile로 잇고(§4.1), thrash 방지(디바운스/최소체류), 저빈도 안전망 + terminate 정리.
+
+**Files:**
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/event/VirtualDjEventListener.java`
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/FlapGuard.java` (디바운스/최소체류 상태)
+- Modify: `VirtualDjOrchestratorImpl.removeBots` (FlapGuard 게이팅)
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualDjReconcileScheduler.java`
+- Modify: `app/.../SystemConfigCache.java` + `ConfigKey.java` (`virtualdj.bot_yield_debounce_ms`, `virtualdj.bot_min_dwell_ms`)
+- Test: `VirtualDjEventListenerIT.java`, `FlapGuardTest.java`
+
+- [ ] **Step 1: config 키 추가** — `ConfigKey` 상수 + `SystemConfigCache.getBotYieldDebounceMs()/getBotMinDwellMs()`(fail-open 기본 5000/10000), 기존 `readInt(key, fallback)` 패턴. **추가로 D1 "구별 가능 모드" 토글 키도 여기서 pre-seed**: `ConfigKey VIRTUALDJ_DISTINGUISHABLE = new ConfigKey("virtualdj.distinguishable")` + `SystemConfigCache.isVirtualDjDistinguishable()`(fail-open 기본 false). **백엔드는 이 플래그 + `is_dummy` 노출만 책임**(예: DJ/crew DTO에 플래그 켜졌을 때만 `isBot` 필드 노출). 실제 뱃지/AI 라벨 *렌더링*은 Plan B(프론트). 이로써 여론 악화 시 코드 배포 없이 토글 가능(D1 의도). — 토글이 조용히 누락되지 않도록 여기 명시.
+
+- [ ] **Step 2: `FlapGuardTest` (failing)** — 디바운스 창 내 반복 입퇴장이 제거를 트리거하지 않음 / 최소체류 전 제거 차단. (시간은 주입된 `Clock` 으로 제어 — 기존 코드가 `Clock` DI 사용.)
+
+- [ ] **Step 3: `FlapGuard` 구현** — 룸별 "봇 제거 의도 시작시각" 기록. `shouldRemove(roomId, now)` = 의도가 디바운스 창을 넘겨 지속됐을 때만 true. `canRemoveBot(botUserId, now)` = 투입후 dwell 경과. 산식의 **제거만 게이팅**(투입은 즉시).
+
+- [ ] **Step 4: `removeBots` 게이팅 적용** — FlapGuard 통과한 봇만 exit. (Chunk4 메서드 수정 + 단위/통합 회귀.)
+
+- [ ] **Step 5: `VirtualDjEventListenerIT` (failing)** — 사람 DJ enqueue 이벤트 후 (디바운스 경과 시) 봇이 floor까지 줄고, 사람 dequeue/exit 후 봇이 T까지 복귀.
+
+```java
+@Test
+void 사람DJ_등록되면_디바운스후_봇이_floor까지_양보() { ... }
+@Test
+void 사람DJ_나가면_봇이_T까지_복귀() { ... }
+@Test
+void 사람이_enqueue했으나_silent_deactivate면_봇이_안빠진다() { // §4.1 내성
+    // 첫 트랙이 playbackTimeLimit 초과 → 사람이 활성 DJ 로 안 잡힘 → desired_bot 그대로 T
+}
+@Test
+void 방_terminate되면_config_OFF로_정리() { ... }
+```
+
+- [ ] **Step 6: `VirtualDjEventListener` 구현** — 기존 `DomainEventRedisRelay` 패턴(`@TransactionalEventListener(AFTER_COMMIT, fallbackExecution=true)` + `@Transactional(REQUIRES_NEW)`):
+
+```java
+@Component
+@RequiredArgsConstructor
+public class VirtualDjEventListener {
+    private final VirtualDjOrchestrator orchestrator;
+    private final PartyroomVirtualDjConfigRepository configRepository;
+
+    @TransactionalEventListener(phase = AFTER_COMMIT, fallbackExecution = true)
+    @Transactional(propagation = REQUIRES_NEW)
+    public void onCrewAccessed(CrewAccessedEvent e) { orchestrator.reconcileRoom(e.getPartyroomId()); }
+
+    @TransactionalEventListener(phase = AFTER_COMMIT, fallbackExecution = true)
+    @Transactional(propagation = REQUIRES_NEW)
+    public void onDjQueueChanged(DjQueueChangedEvent e) { orchestrator.reconcileRoom(e.getPartyroomId()); }
+
+    @TransactionalEventListener(phase = AFTER_COMMIT, fallbackExecution = true)
+    @Transactional(propagation = REQUIRES_NEW)
+    public void onTerminated(PartyroomTerminatedEvent e) { /* config turnOff + save */ }
+}
+```
+**무한루프 주의:** 봇 enqueue/exit 자체가 `DjQueueChangedEvent`를 발행 → 다시 onDjQueueChanged 호출. 룸락이 직렬화하나, reconcile이 "이미 desired 상태면 no-op"이므로 수렴(추가 변경 없음→이벤트 없음). 이 수렴을 **테스트로 잠근다**: 봇으로 채운 뒤 재이벤트(재reconcile) 시 **`accessCommandService`/`djCommandService`에 추가 호출이 0건**임을 spy `verify(..., never())`로 단언(단순히 최종 봇 수 동일이 아니라, 불필요한 dequeue+enqueue churn이 없음을 확인 — churn은 이벤트를 재발생시켜 무한루프 위험).
+
+- [ ] **Step 7: `VirtualDjReconcileScheduler` 구현** — `@Scheduled(fixedDelay=60_000)` 으로 `configRepository.findByStatus(MANAGED)` 전체에 `reconcileRoom` 호출(안전망, §4.1/§7). 패턴: `PartyroomPresenceService.reconcileStalePending`.
+
+- [ ] **Step 8: 통합/단위 테스트 → PASS / Step 9: 커밋** — `feat(virtual-dj): 이벤트 반응 + anti-flap + 안전망 reconcile`
+
+---
+
+## Chunk 6: 어드민 엔드포인트 · ArchUnit 가드 · 리더보드 제외
+
+**책임:** 어드민 제어 API(풀/팩/방 config/drain/freeze) + 골격 보호 ArchUnit + 봇 점수 제외.
+
+**Files:**
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/AdminVirtualDjController.java` (+ request/response payloads)
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualDjAdminService.java` (config apply/freeze/off/drain, 일괄 적용)
+- Modify: 리더보드/DJ_PNT 집계 쿼리 (is_dummy 제외)
+- Create: `app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjArchitectureTest.java` (ArchUnit)
+- Test: `AdminVirtualDjControllerIT.java`, 리더보드 제외 테스트
+
+- [ ] **Step 1: `VirtualDjArchitectureTest` (failing→PASS keystone)** — §8 키스톤.
+
+```java
+@AnalyzeClasses(packages = "com.pfplaybackend.api.virtualdj")
+class VirtualDjArchitectureTest {
+    @ArchTest static final ArchRule 오케스트레이터는_persistence_publisher_직접의존_금지 =
+        noClasses().that().resideInAPackage("..virtualdj.application.service..")
+                   .and().haveSimpleNameContaining("Orchestrator")
+        .should().dependOnClassesThat().resideInAnyPackage(
+            "..adapter.out.persistence..", "..messaging..", "..redis..")
+        .orShould().dependOnClassesThat().haveSimpleNameEndingWith("AggregatePort")
+        .orShould().dependOnClassesThat().haveSimpleNameEndingWith("Repository");
+    // 의도: 오케스트레이터는 command service + 임퍼소네이션 + query(읽기)만. 쓰기 캐스케이드 우회 차단.
+}
+```
+(패키지/이름 매처는 실제 클래스명에 맞춰 1차 실행 후 조정. **반드시 한 번 빨갛게 만든 뒤** 통과시킬 것 — 규칙이 실제로 무언가를 막는지 확인.)
+
+- [ ] **Step 2: 리더보드 is_dummy 제외 테스트 (failing)** — 봇이 트랙 완료로 DJ_PNT 가 쌓여도 리더보드 쿼리 결과에서 제외.
+
+```java
+@Test
+void 봇은_리더보드에_안나온다() {
+    // 봇 + 실유저 둘 다 DJ_PNT 보유 상태에서 리더보드 조회 → 봇 제외
+}
+```
+
+- [ ] **Step 3: 리더보드 쿼리 수정** — Step 0에서 찾은 집계 쿼리에 `JOIN user_account ua ... WHERE ua.is_dummy = false`. (Amplitude opt-out 재사용 지점은 §9-7 — P2에서 봇은 SDK 미발화이므로 클라 노출 자체가 없음. 서버 집계 제외만 P2 필수. 확인 후 불필요하면 스킵.)
+
+- [ ] **Step 4: `AdminVirtualDjControllerIT` (failing)** — 어드민 권한으로 config 적용/일괄적용/freeze/drain. 패턴: `AdminCrewPenaltyCommandController`(`@PreAuthorize("@adminAuth.isAdmin()")`, `@SecurityRequirement(name="cookieAuth")`).
+
+```java
+@Test void config_적용시_MANAGED로_전이되고_reconcile_트리거() { ... }
+@Test void drain_은_방의_모든_봇을_퇴장시킨다() { ... }
+@Test void 체크박스_일괄적용_여러방() { ... }
+@Test void 비어드민은_403() { ... }
+```
+
+- [ ] **Step 5: `AdminVirtualDjController` + `VirtualDjAdminService` 구현** — 엔드포인트(예): 
+  - `POST /api/v1/admin/virtual-dj/pool` (N명 프로비저닝)
+  - `POST/PUT/DELETE /api/v1/admin/virtual-dj/song-packs[/{id}]` + 트랙 추가/삭제(검색은 어드민 프론트가 기존 music-search 사용 → 이 API는 선택된 트랙 수신)
+  - `PUT /api/v1/admin/partyrooms/{id}/virtual-dj` (apply: target/floor/songPackId/status)
+  - `POST /api/v1/admin/partyrooms/{id}/virtual-dj/drain`, `.../freeze`
+  - `PUT /api/v1/admin/virtual-dj/bulk` (체크박스 다중 방 일괄 config)
+  - `GET /api/v1/admin/partyrooms/{id}/virtual-dj` (라이브 상태: 봇 x/T, status). 
+  config apply/drain 후 `orchestrator.reconcileRoom` 직접 호출(이벤트 외 명시적 트리거).
+
+- [ ] **Step 6: 전체 테스트 → PASS**
+Run: `JAVA_HOME=... ./gradlew test integrationTest`
+Expected: 신규 + 기존 회귀 GREEN.
+
+- [ ] **Step 7: 커밋** — `feat(virtual-dj): 어드민 API + ArchUnit 가드 + 리더보드 봇 제외`
+
+---
+
+## 마무리 체크 (구현 후, push 전)
+
+- [ ] 전체 `./gradlew test integrationTest` GREEN (JDK21).
+- [ ] §9-1 커서 wrap 확인 결과 반영(추가 보정 있었으면).
+- [ ] R4 부하: 로컬 docker compose 풀스택에서 MANAGED 방 N=20/50 — 트랙 `complete`가 duration+ε 내 발화(스케줄러 누락 없음) 확인. 초과 시 별도 follow-up 이슈.
+- [ ] presence 비간섭 회귀: 봇 crew(세션X)가 `reconcileStalePending` sweep 비대상.
+- [ ] 마이크로 커밋 → 논리단위 squash.
+- [ ] **Plan B(어드민 프론트 pfplay-admin)** 별도 작성: 풀/팩 빌더(music-search 재사용)/방 config 체크박스 일괄/라이브 상태 컬럼/drain·freeze.
+
+## 미해결·후속
+- Amplitude opt-out 재사용(§9-7): 봇이 클라 SDK를 발화할 일이 없으므로 P2 영향 적음 — Step 3에서 확인 후 결정.
+- P1(아바타 일괄 커스터마이징), P3(AI: 채팅응답·플레이리스트 자가갱신·컨셉), 크로스룸 자동 점유 reconcile(#264 통합)은 별도 단계.

--- a/docs/superpowers/specs/2026-06-01-virtual-dj-p2-design.md
+++ b/docs/superpowers/specs/2026-06-01-virtual-dj-p2-design.md
@@ -1,0 +1,326 @@
+# 가상 사용자 능동 디제잉 (P2) — 설계 문서
+
+- 작성일: 2026-06-01
+- 상태: 설계 합의 완료 (구현 전)
+- 범위: 전체 비전 3단계 중 **P2 (가상 사용자 능동 디제잉)**
+- 대상 레포: `pfplay-platform`(백엔드, 주), `pfplay-admin`(어드민 UI)
+
+---
+
+## 0. 배경과 동기
+
+파티룸 점유가 낮아 신규 유입자가 빈 방을 보고 즉시 이탈하는 문제가 빈번하다. 해법으로 여러 파티룸에
+컨셉(K-POP, 애니 OST 등)을 부여하고, 그 컨셉을 따르는 **가상 사용자**를 상주시켜 "살아있는 방"을 만든다.
+
+전체 비전은 3단계로 누적된다:
+
+| 단계 | 서브프로젝트 | 비고 |
+|---|---|---|
+| P1 | 가상 사용자 아바타 일괄/개별 셋팅 (콘솔) | 본 문서 범위 아님 |
+| **P2** | **가상 사용자 능동 디제잉 (콘솔)** | **본 문서** |
+| P3 | AI 에이전트화 (채팅 응답 + 플레이리스트 자가갱신 + 컨셉) | 본 문서 범위 아님 |
+
+P2를 먼저 설계하는 이유: 프로젝트 성패와 아키텍처 위험이 P2의 "수동 더미 → 능동 참여자" 피벗에 집중되어
+있으므로, 이를 먼저 못 박아 전체 go/no-go 확신을 확보한다.
+
+기존 더미 점유 설계(pfplay-platform 이슈 #264)는 더미를 **수동 머릿수**(채팅·디제잉·리액션 없음, presence
+비간섭)로 잠갔으나, P2는 가상 사용자를 **실제 도메인 참여자(DJ)**로 전환한다. 이는 #264의 *확장*이 아니라
+아키텍처 피벗이다.
+
+---
+
+## 1. 핵심 아키텍처 원칙 — 정직한 길 (path A)
+
+가상 사용자를 능동 참여자로 만드는 두 갈래 중 하나만 채택한다:
+
+- **(A) 정직한 길 [채택]** — 가상 유저 = **실제 계정**(진짜 userId·crew row·dj row). 실유저가 쓰는 그대로의
+  **application command service 메서드**(`tryEnter`, `enqueueDj`, `dequeueDj`, `exit`)로만 행동. → 1-room
+  불변식, crew 라이프사이클, DJ 큐, playback 스케줄러 등 **모든 기존 가드·도메인 캐스케이드가 그대로 적용**되어
+  불변식 divergence가 발생할 수 없다.
+- **(B) 게으른 길 [금지]** — `aggregatePort` / repository / `messagePublisher`를 **직접 만져 도메인
+  캐스케이드(예: `handleDjQueueOnLeave`, 이벤트 발행, atomic crew 토글)를 건너뛰는 것**. 손쉽지만 불변식 보장
+  책임이 호출자에게 전가되어 시간이 지나면 골격이 썩는다.
+
+> **주의 — "internal 메서드 = 백도어"가 아니다.** `exitInternal(partyroomId, userId)`는 *"callers MUST
+> already have authority"* 주석이 붙어 있으나, **전체 도메인 캐스케이드를 실행**하며 이미 presence grace
+> 리스너·reconcile cron이 시스템 액션으로 사용 중이다. 그 주석은 *ThreadLocal 신원 검사(본인인가)*만 호출자
+> 책임으로 위임한다는 뜻이지 불변식을 건너뛴다는 뜻이 아니다. (B)의 경계는 "public/internal"이 아니라
+> **"캐스케이드를 통과하는가"**이다.
+
+### 1.1 핵심 메커니즘 — ThreadLocal 봇 정체성 임퍼소네이션
+
+`tryEnter`·`enqueueDj`·`dequeueDj`·`exit`는 모두 행위자(userId/tier)를 `ThreadLocalContext.getAuthContext()`
+에서 읽는다(HTTP 필터가 세팅하는 것과 동일). 따라서 오케스트레이터는:
+
+```
+withBotIdentity(botUserId) {        // try: ThreadLocalContext.setContext(bot AuthContext)
+    partyroomAccessCommandService.tryEnter(partyroomId, null);
+    djCommandService.enqueueDj(partyroomId, botPlaylistId);
+}                                   // finally: ThreadLocalContext.clear()
+```
+
+- **새 guarded 진입점 추가 불필요** — 실유저가 쓰는 public 메서드를 그대로 재사용. 가장 충실한 "진짜 유저" 경로.
+- 오케스트레이터는 자기 스레드(스케줄러/이벤트 리스너 스레드)에서 실행되므로 ThreadLocal은 그 실행 범위 안에서만
+  설정·해제된다. **try/finally 정리 필수**(다른 요청으로 신원 누출 방지).
+- 봇 `AuthContext` 구성(필요 필드: userId, authorityTier 등)은 plan Chunk에서 실제 타입 확인 후 빌더 제공.
+
+> **골격 붕괴 리스크는 (B)를 택할 때만 발생한다. (A)를 규율로 못 박으면 구조적 위험은 경계가 명확하고 관리
+> 가능한 수준으로 떨어진다. 이 규율은 §8의 아키텍처 테스트(ArchUnit)로 강제한다 — 오케스트레이터 패키지는
+> application command service + 임퍼소네이션 유틸에만 의존하고, persistence 포트/repository/`messagePublisher`
+> 에는 의존하지 못한다.**
+
+### 검증된 사실 (탐색 결과)
+
+- 파티룸 멤버/DJ/아바타 목록은 **100% DB 소스**(`crew` 테이블 + `dj` 테이블 + `user_profile`),
+  presence/Redis/세션 필터 **없음**. `crew.is_active=true`이면 **WS 세션이 한 번도 없어도** 다른 유저
+  화면에 멤버·DJ·아바타로 정상 노출된다. (`findByPartyroomIdAndIsActiveTrue` → `is_active=true AND !is_banned`)
+- 입장 broadcast(`CREW_ENTERED`)는 **REST `tryEnter` AFTER_COMMIT 시점**에 발행 (WS connect 아님).
+- playback "다음 곡" 진행은 **서버 스케줄러**(`ExpirationTaskPort` → 트랙 duration 만료 → `complete()`)가
+  구동. 클라이언트 하트비트 아님 → **연결 안 된 가상 DJ라도 곡은 정상 진행**.
+- 트랙 메타데이터(videoId/title/**duration**/thumbnail)는 기존 검색 포트 `YoutubeSearchService`(구현
+  `PytubeSearchService`, 우리 `pfplay-streaming` 마이크로서비스)에서 취득. **새 YouTube Data API 불필요**.
+- 트랙 회전: PR #263에서 트랙의 위치값(`order_number`)을 고정(물리적 재정렬 제거)하고 **커서가 순환**하도록
+  변경 → **플레이리스트 소진 개념 없음, 영속 재생**.
+
+**결론: 헤드리스 가상 유저에게 WS 세션은 불필요하며, 없는 편이 낫다**(세션이 있으면 프로세스 재시작 시
+presence 상태머신이 PENDING_EXIT→OFFLINE으로 방을 비워버린다). 세션이 없으면 `pending_exit_at`이 NULL로
+남아 sweep 비대상 → 영속.
+
+---
+
+## 2. 결정 요약
+
+| # | 주제 | 결정 |
+|---|---|---|
+| D1 | 구별 가능성 | 시각적 **구별 불가(기본)** + 내부 `is_dummy` 플래그 + 리더보드/점수 제외 + Amplitude opt-out. **"구별 가능 모드"는 런타임 토글**(`system_config` 키, 기본 OFF) — 여론 악화 시 코드 배포 없이 봇 뱃지/AI 라벨을 켤 수 있게 표시 경로를 미리 심어둔다. |
+| D2 | 제어 모델 | **수동(어드민 지시형)**. 크로스룸 자동 점유 reconcile(빈 방 자동 탐지·머릿수 유지)은 #264와 합쳐 **별도 단계로 미룸**. |
+| D3 | 플레이리스트 콘텐츠 | **재사용 송 팩(템플릿)**. 어드민이 이름 붙은 팩을 빌드(기존 검색 인프라 재사용, duration 사전검증)하여 N명/방에 **일괄 적용**. |
+| D4 | 공존 정책 | **b′: 목표 DJ 수(T) + 사람 우선 + 동반자 하한(floor)**. 기본 T=2·floor=1, 방별 config. |
+| D5 | 플레이리스트 영속 | **소진 없음**(커서 순환). 추가 루프 로직 불필요. |
+| D6 | 오케스트레이터 위치 | **A안: in-process** Spring 모듈, **포트 뒤 배치**(P3에서 LLM 워커만 분리 가능하도록). |
+
+### D4 공존 정책 상세 (T=2, floor=1 예시)
+
+| 상황 | 봇 행동 | 결과 |
+|---|---|---|
+| 사람 DJ 0명 | 봇이 T까지 채움 | 봇 2명이 음악 유지 |
+| 사람 DJ 1명 | 봇 floor(1)만 남기고 나머지 빠짐 | 사람 1 + 봇 1 → 혼자 아님(부담 회피), 차례 넉넉 |
+| 사람 DJ 2명+ | 봇 전부 물러남 | 사람들끼리 활기 |
+| 사람들이 DJ 멈춤/퇴장 | 봇이 다시 T까지 복귀 | 음악 끊김 없이 유지 |
+
+설계 의도: 신규 유저가 **밀려나지도(자리 충분), 혼자 남겨지지도(곁에 봇 동반자)** 않게 한다.
+
+---
+
+## 3. 범위
+
+### 넣음 (P2)
+
+- 실제 계정 기반 가상 유저 **풀** 관리 (`is_dummy`)
+- 재사용 **송 팩** 빌드(기존 검색 인프라 재사용) + 일괄 적용
+- 방별 **가상 DJ 활성화**: T / floor / 송팩 / 상태 설정
+- in-process **오케스트레이터**: 방에 봇 배치(`tryEnter`) → DJ 등록(`enqueueDj`), 도메인 이벤트 반응으로
+  T 유지 · 사람에게 양보 · 복귀
+- **drain / FROZEN** 라이프사이클 제어
+- **`PartyroomTerminatedEvent` 리스너**: 방이 terminate되면 bulk-deactivate가 봇 crew도 비우므로, 해당 방
+  config를 OFF로 정리하고 오케스트레이터 관리에서 제외.
+
+> §9-2 검증 결과 **public `exit(PartyroomId)`가 이미 존재**하고 §1.1 임퍼소네이션으로 호출 가능하므로,
+> 새 guarded EXIT 진입점 추가는 **불필요**(범위에서 제외). path A는 기존 public 메서드의 닫힌 집합으로 성립.
+
+### 뺌 (다른 단계)
+
+- 봇 **채팅 / 리액션 / AI** → **P3** (따라서 채팅-쓰기 세션 의존 코어 추출도 P2 아님)
+- 크로스룸 **자동 점유 reconcile** → #264와 합쳐 나중
+- **풍부한 아바타 일괄 커스터마이징** → **P1** (P2는 최소 정체성: 현실적 닉네임 + 기본 아바타)
+
+---
+
+## 4. 시스템 아키텍처
+
+```
+[Admin REST] ─→ VirtualDjAdminController ─→ VirtualDjOrchestrator (port)
+                                                    │ (in-process, guarded 호출만)
+[Domain events]                                     ▼
+ CrewAccessedEvent ──listen──→            ApplicationServices (기존, 가드 내장)
+ DjQueueChangedEvent ─listen─→            tryEnter / enqueueDj / dequeue
+                                          ※ exitInternal 등 internal 메서드 직접호출 금지
+```
+
+- `VirtualDjOrchestrator`는 **새 inbound adapter**일 뿐, 새 도메인 코어가 아니다. 모든 변경은 컨트롤러가 쓰는
+  *guarded* application service를 통과한다 → 불변식 단일 강제, 우회 0.
+- **반응형 컨트롤러**: 방별 목표 상태(`target=T`, `floor`, `song_pack`, `status`)를 두고, 사람 DJ 입·퇴장
+  이벤트에 반응해 봇 DJ 수를 조정(`enqueueDj` / dequeue). 폴링 reconcile은 **저빈도 안전망**으로만 두고
+  주 동작은 이벤트 반응으로 한다.
+- 봇은 **WS 세션 없음** → 영속, presence sweep 비대상.
+- 오케스트레이터를 포트(interface) 뒤에 두어, P3에서 LLM 의사결정 워커를 out-of-process로 떼어낼 수 있게 한다.
+
+### 4.1 반응형 컨트롤러 의미론 (트리거 · 산식 · anti-flap)
+
+**구독 이벤트 → 트리거.** 컨트롤러는 다음 두 이벤트를 구독한다. 어느 쪽이 오든 **해당 방의 desired 봇 수를
+재계산**하는 단일 진입(`reconcileRoom(partyroomId)`)을 호출한다.
+
+| 이벤트 | 의미 | 반영되는 D4 상황 |
+|---|---|---|
+| `DjQueueChangedEvent` (ENQUEUE/DEQUEUE/ROTATE/DEACTIVATE) | DJ 큐 구성 변화 | 사람 DJ 등록 / 사람 DJ 멈춤(DEQUEUE) / silent deactivate |
+| `CrewAccessedEvent` (ENTER/EXIT) | 입·퇴장 (퇴장은 DJ dequeue 캐스케이드 동반) | 사람 DJ 퇴장 |
+
+**산식 (현재 *커밋된* 활성 DJ 집합 기준).** 트리거의 *행위*가 아니라 reconcile 시점의 **실제 커밋된 활성 DJ
+집합**을 읽어 계산한다. 이렇게 하면 "첫 DJ silent deactivate"(사람이 enqueue 했으나 첫 트랙이
+`playbackTimeLimit` 초과로 즉시 비활성)된 경우, 그 사람은 활성 DJ로 안 잡히므로 봇이 잘못 빠지지 않는다.
+
+```
+human = 활성 DJ 중 is_dummy=false 인 수
+bot   = 활성 DJ 중 is_dummy=true  인 수
+desired_bot =
+    if human == 0 : T
+    elif human == 1: max(floor, T - 1)     // 외톨이 사람에게 동반자 보장
+    else          : max(0,    T - human)   // 사람끼리 동반자가 됨
+```
+(T=2, floor=1 → 0명:2 / 1명:1 / 2명:0 / 3명:0 — D4 표와 일치)
+
+reconcile은 `bot`을 `desired_bot`에 맞춘다: 부족하면 idle 풀에서 봇을 `tryEnter`→`enqueueDj`(송팩 복사
+플레이리스트), 초과하면 가장 최근 합류 봇부터 guarded dequeue/exit.
+
+**anti-flap (2026-05-25 플래핑 인시던트 교훈).** 단순 이벤트 구동은 thrash(사람 입장→봇 제거→수초 후 사람
+퇴장→봇 재투입→DJ 재등록→플레이리스트 재바인딩) 위험이 있다. 따라서:
+
+- **방별 직렬화 락**: `reconcileRoom`은 룸 단위 분산락으로 직렬 실행(동시 이벤트 레이스 차단). 기존 룸락 패턴 재사용.
+- **봇 제거 디바운스(`bot_yield_debounce`, 기본 5s)**: 사람 DJ 등장으로 봇을 빼야 할 때, 그 상태가 디바운스
+  창을 넘겨 지속될 때만 실제 제거. 창 안에 사람이 사라지면 제거 취소.
+- **봇 투입 최소 체류(`bot_min_dwell`, 기본 10s)**: 투입한 봇은 최소 체류 시간 전엔 제거하지 않음.
+- 두 값은 `system_config` 키. 산식의 T/floor는 방별 config(`partyroom_virtual_dj_config`).
+- **우선순위 규칙**: 디바운스·최소체류는 **산식의 *제거* 결정을 게이팅**한다(산식이 "빼라"고 해도 dwell/debounce가
+  유지를 강제하면 유지). *투입* 결정은 게이팅하지 않는다(음악 유지가 목적이므로 부족분은 즉시 채움).
+
+**안전망 reconcile**: 위 이벤트 반응이 주 동작이고, 저빈도(예: 60s) 스케줄러가 모든 MANAGED 방에 대해
+`reconcileRoom`을 호출해 누락된 이벤트·고아 상태를 보정한다(§7 R3와 공유).
+
+---
+
+## 5. 데이터 모델
+
+- `user_account.is_dummy BOOLEAN NOT NULL DEFAULT false` — 가상 유저 식별. **`user_type` enum이 아닌
+  boolean으로 확정**(#264 잠금 설계 계승, 기존 temp 유저는 고정 ID로 식별하므로 type enum 도입은 과함, 가산적
+  최소 변경). 리더보드/점수/Amplitude 분기에 사용.
+- **`virtual_song_pack`** — 이름 붙은 재사용 팩 (id, name, 설명, 생성/수정 시각).
+- **`virtual_song_pack_track`** — 팩 내 트랙 (videoId/`link_id`, name, duration, thumbnail). duration은 빌드
+  시점에 `playbackTimeLimit` 이하로 사전검증.
+- **`partyroom_virtual_dj_config`** — `partyroom_id`, `target_count(T)`, `companion_floor`, `song_pack_id`,
+  `status(OFF / MANAGED / FROZEN)`. #264의 2축(target + enabled) + FROZEN 계승.
+- 봇의 `crew` / `dj` / `playlist` / `track` row는 **전부 기존 테이블의 진짜 row**(가상 전용 테이블 아님) →
+  조인·FK·NPE 안전(#264 PA-7 우려 해소).
+
+### 5.1 송 팩 → 봇 플레이리스트 연결 (복사 의미론)
+
+- 각 봇은 **자기 소유의 playlist + track row**를 가진다(playlist는 유저당, 커서도 playlist/DJ당 독립 →
+  봇마다 재생 위치가 따로 진행). 즉 N개 봇이 한 팩을 쓰면 **track row가 N배 복제**된다. track row는 작아
+  허용 가능.
+- **배치 시 1회 복사**: 봇이 방에 DJ로 투입될 때, 그 방 config의 `song_pack_id` 트랙을 봇 playlist로 1회
+  복사한다. 추적용으로 봇 playlist에 `source_song_pack_id`를 기록.
+- **팩 편집 비전파(기본)**: 이미 배치된 봇의 playlist는 팩 편집에 자동 갱신되지 않는다. 반영하려면 어드민이
+  **재적용**(drain 후 재배치, 또는 명시적 "refresh" 액션)한다. 라이브 상태 비교는
+  `bot.playlist.source_song_pack_id` vs `config.song_pack_id`로 판정.
+- **팩 삭제**: config 또는 배치된 봇이 참조 중인 팩은 **삭제 차단**(soft-delete 아님 — 단순·명시적). 어드민이
+  먼저 detach(config에서 분리) + drain 후 삭제.
+
+- "구별 가능 모드" 토글 = `system_config` 키 1개.
+
+마이그레이션은 Flyway 슬롯 규칙(out-of-order=false)을 따른다.
+
+---
+
+## 6. 어드민 UX (pfplay-admin)
+
+기존 어드민 인증 패턴(AdminAccessToken + XSRF double-submit + Origin allowlist) 위에 mutation 엔드포인트를 얹는다.
+(pfplay-admin은 GitHub Actions 없음 — Cloudflare/Vercel native integration.)
+
+- **가상 유저 풀 관리**: 풀 조회(idle / 배치된 방 표시), N명 생성, 최소 정체성(현실적 닉네임 자동 배정).
+  아바타는 기본값(풍부한 커스터마이징은 P1).
+- **송 팩 관리**: 목록 · 생성 · 편집 · 삭제. 생성 시 기존 `music-search` 컴포넌트 재사용(검색 또는 URL) +
+  duration 사전검증 표시.
+- **방별 가상 DJ 설정**: 파티룸 목록/상세에서 활성화 → T · floor · 송팩 · 상태 지정.
+  **체크박스 다중선택 → 일괄 적용**(#264 패턴 계승).
+- **라이브 상태 컬럼**: 방별 "봇 DJ x/T", 상태(OFF/MANAGED/FROZEN), 현재 봇.
+- **액션**: 적용 / FROZEN / **drain(방에서 봇 전부 비우기)**.
+
+---
+
+## 7. 라이프사이클 + R3 완화
+
+- **OFF**: 봇 없음, config 휴면.
+- **MANAGED**: 오케스트레이터가 T/floor를 이벤트 반응으로 능동 유지.
+- **FROZEN**: 봇 현 상태 고정, 오케스트레이터가 손대지 않음(인시던트/디버깅용).
+- **Drain**: guarded 경로로 봇 dequeue + 방 퇴장.
+- **R3 (영속 row 자가치유 X)**: 봇은 presence sweep 비대상(영속)이라 명시적 정리가 필요하다.
+  - ① 어드민 drain
+  - ② **안전망 reconcile**(config 없는 방의 봇 crew, TERMINATED 방의 봇 DJ 같은 고아 row 탐지·정리)
+  - 2026-05-25 좀비/플래핑 인시던트 교훈 반영(crew zombie flap / maintenance gate). 배포·점검 전 SQL
+    cleanup 패턴(stale crew cleanup)을 준비한다.
+- **1-room 불변식**: 봇은 정확히 한 방에만. 재배치 시 guarded autoExit 경유.
+
+---
+
+## 8. 테스트 전략 (TDD)
+
+핵심 회귀 잠금(골격 보호의 키스톤):
+
+- **🔑 "오케스트레이터는 캐스케이드만 통과"** — 오케스트레이터 패키지가 **application command service +
+  임퍼소네이션 유틸에만 의존**하고 `aggregatePort`/repository/`messagePublisher`에는 의존하지 못하도록
+  **ArchUnit(존재 확인됨: archunit-junit5)으로 강제**. (B) 백도어(캐스케이드 우회) 추락을 구조적으로 차단.
+  (`*Internal` 직접호출은 금지 대상이 아님 — §1 주의 참조. 임퍼소네이션으로 public `exit` 사용이 기본.)
+- presence 비간섭: 봇 crew(WS 세션 X)가 sweep 비대상 + **봇만 있는 방의 자동종료 상호작용** 확인(#264 PA).
+- 1-room 불변식(봇 포함).
+- **D4 공존 산식**(§4.1): human 0/1/2/3명 각각에 desired_bot = T / max(floor,T-1) / 0 / 0 (이벤트 구동
+  컨트롤러 테스트).
+- **silent-deactivate 내성**(§4.1): 사람이 enqueue 했으나 첫 트랙 초과로 즉시 비활성 → 활성 DJ로 안 잡혀
+  봇이 잘못 빠지지 않음(방이 비지 않음).
+- **anti-flap**(§4.1): 디바운스 창 내 사람 입·퇴장 반복 시 봇 add/remove thrash가 발생하지 않음 + 봇
+  최소 체류 보장.
+- **duration 필터**: 팩이 `playbackTimeLimit` 초과 트랙 거부(silent deactivate 회피).
+- 리더보드/점수 `is_dummy` 제외.
+- 반응형 컨트롤러가 실제 도메인 이벤트에 반응하는 통합 테스트.
+
+JDK 21 빌드 환경(`JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7"` prefix), 로컬 docker compose 풀스택으로 검증.
+
+---
+
+## 9. 상세 설계 단계에서 코드로 확인할 항목 (현재 단정하지 않음)
+
+1. 커서 끝→앞 **wrap** 한 줄 (영속 재생 보장). [부분 확인] `doStart`가 `rotateDjQueue` + `peekTracksFromCursor`
+   /`advancePlaybackCursor`로 진행 — 플레이리스트 끝에서 커서가 맨 앞으로 wrap 하는지 `peekTracksFromCursor`
+   구현부만 plan Chunk 1에서 눈으로 확정.
+2. ~~public guarded EXIT 존재 여부~~ → **해소.** `exit(PartyroomId)` public 존재 + §1.1 임퍼소네이션으로 호출.
+   새 메서드 불필요.
+3. ~~봇만 있는 방 자동종료~~ → **해소.** 방은 crew_count==0이어도 자동 종료 안 됨(호스트 close / admin
+   terminate만). 봇만 있는 방 유지됨. terminate 시 `PartyroomTerminatedEvent`로 config 정리(§3·§7).
+4. `enqueueDj`는 explicit `PlaylistId`를 받고 **active crew 선행 + ownership(`isOwnedBy`) + non-empty** 검증.
+   순서: 임퍼소네이션 → `tryEnter` → 봇 playlist를 팩으로 채움 → `enqueueDj(partyroomId, botPlaylistId)`.
+5. **R4 부하**: `ExpirationTaskPort` 스케줄러가 N개 동시 방에서 견디는지. **수용 기준: N=20 / N=50 동시
+   MANAGED 방에서 스케줄러 지연·누락 없음**을 로컬 풀스택에서 측정(rough target, 실측 후 조정).
+   **"누락" 관측 신호 = 트랙 완료(`complete`)가 duration+ε 보다 늦게 발화**되는 것(구체 pass/fail probe).
+6. 리더보드/점수(`user_activity` DJ_PNT) 쿼리에 `is_dummy` 제외를 넣을 지점.
+7. Amplitude opt-out 재사용 지점.
+
+---
+
+## 10. 리스크 자세
+
+| | 상태 |
+|---|---|
+| R1 presence 충돌 | **소멸** (세션 불필요 검증 완료) |
+| R2 채팅-쓰기 세션 의존 | **P2에서 제외**(P3로 이관) → P2 경량화 |
+| R3 영속 row 자가치유 X | §7 drain + 안전망 reconcile로 관리 |
+| R4 N개 상시 방 스케줄러 부하 | §9-5 plan 단계 측정 항목 (불변식 무관, 부하 이슈) |
+
+**최종 판단:** path A 규율(§1) + 아키텍처 테스트(§8) + #264 drain/FROZEN(§7)을 함께 가져가면, P2의 구조적
+위험은 "크다"가 아니라 "경계가 명확하고 관리 가능"이다. 진행 가능한 설계.
+
+---
+
+## 11. 후속 단계 (본 문서 범위 밖)
+
+- **P1**: 아바타 일괄/개별 커스터마이징 (P2가 만든 가상 계정 모델 위에).
+- **P3**: AI 에이전트화 — 채팅 응답(채팅-쓰기 세션 코어 추출 + 상용 LLM API), 디제잉 히스토리 반영
+  플레이리스트 자가갱신, 방 컨셉(K-POP/애니 OST) 추종. 오케스트레이터 포트 뒤에서 LLM 워커 분리(C안).
+- 크로스룸 **자동 점유 reconcile**: #264와 통합.

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/PlaylistRepository.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/PlaylistRepository.java
@@ -26,4 +26,6 @@ public interface PlaylistRepository extends JpaRepository<PlaylistData, Long>, P
     Optional<PlaylistData> findByIdAndOwnerIdAndType(Long playlistId, UserId userId, PlaylistType type);
 
     Optional<PlaylistData> findByIdAndOwnerId(Long playlistId, UserId userId);
+
+    boolean existsBySourceSongPackId(Long sourceSongPackId);
 }

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepository.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/TrackRepository.java
@@ -8,11 +8,18 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TrackRepository extends JpaRepository<TrackData, Long>, TrackRepositoryCustom {
 
     Optional<TrackData> findByPlaylistIdAndLinkId(PlaylistId playlistId, String linkId);
+
+    List<TrackData> findAllByPlaylistId(PlaylistId playlistId);
+
+    @Modifying
+    @Query("DELETE FROM TrackData t WHERE t.playlistId.id = :playlistId")
+    void deleteAllByPlaylistIdValue(@Param("playlistId") Long playlistId);
 
     TrackData findFirstByLinkId(String linkId);
 

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/entity/data/PlaylistData.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/entity/data/PlaylistData.java
@@ -49,6 +49,10 @@ public class PlaylistData extends BaseEntity {
     @Column(name = "last_played_track_id", columnDefinition = "bigint unsigned")
     private Long lastPlayedTrackId;
 
+    @Comment("이 playlist 가 복사된 송 팩 (봇 전용)")
+    @Column(name = "source_song_pack_id", columnDefinition = "bigint unsigned")
+    private Long sourceSongPackId;
+
     protected PlaylistData() {
     }
 
@@ -72,5 +76,9 @@ public class PlaylistData extends BaseEntity {
 
     public void rename(String name) {
         this.name = name;
+    }
+
+    public void bindSongPackSource(Long songPackId) {
+        this.sourceSongPackId = songPackId;
     }
 }

--- a/user/src/main/java/com/pfplaybackend/api/user/domain/entity/data/UserAccountData.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/domain/entity/data/UserAccountData.java
@@ -51,6 +51,10 @@ public class UserAccountData extends BaseEntity {
     @Column(name = "must_change_password", nullable = false)
     private boolean mustChangePassword;
 
+    // Same primitive-not-Boolean reasoning as mustChangePassword above.
+    @Column(name = "is_dummy", nullable = false, columnDefinition = "TINYINT(1)")
+    private boolean isDummy;
+
     @Builder(access = AccessLevel.PRIVATE)
     private UserAccountData(UserId userId, String email, ProviderType providerType,
                             String passwordHash, LocalDateTime lastLoginAt,
@@ -136,6 +140,15 @@ public class UserAccountData extends BaseEntity {
 
     public void recordLogin() {
         this.lastLoginAt = LocalDateTime.now();
+    }
+
+    /**
+     * 이 계정을 가상 사용자(봇)로 표시한다. 봇은 실제 정식 회원과 동일하게 생성되지만(LOCAL provider,
+     * 프로필·플레이리스트·activity 보유) is_dummy 플래그로 식별되어 리더보드 등 집계에서 제외된다.
+     * 가산적 표시이므로 기존 회원 생성 경로를 재사용한 뒤 호출하는 것을 전제로 한다.
+     */
+    public void markAsDummy() {
+        this.isDummy = true;
     }
 
     public void withdraw(Long byAdministratorId) {


### PR DESCRIPTION
## 개요

빈 파티룸 이탈 대응(#282). 어드민이 파티룸에 **'봇' DJ**를 배치해 음악·머릿수를 유지하고, 진짜 사람이 DJ를 하면 동반자만 남기고 양보한다. 전체 3단계 비전(P1 아바타 / **P2 능동 디제잉** / P3 AI) 중 **P2 백엔드**.

핵심 아키텍처 = **path A**: 봇 = 실제 계정(`is_dummy`)으로, 실유저가 쓰는 guarded command service(`tryEnter`/`enqueueDj`/`exit`)를 **ThreadLocal 임퍼소네이션**으로 그대로 호출 → 기존 도메인 가드·불변식 전부 그대로 적용, 우회 0(**ArchUnit**으로 강제).

## 주요 변경

- **스키마 V24**: `user_account.is_dummy`, `playlist.source_song_pack_id`, `virtual_song_pack`(+track), `partyroom_virtual_dj_config`(OFF/MANAGED/FROZEN)
- **임퍼소네이션·풀**: `BotIdentityExecutor`, `VirtualUserPoolService`, `VirtualMemberProvisionPort`(admin 결합 seam)
- **송 팩**: 재사용 CRUD + 봇 playlist 1회 복사(duration 사전검증, 참조 중 삭제 차단)
- **오케스트레이터**: `DesiredBotCalculator`(사람 우선 산식) + `reconcileRoom`(룸 분산락·idempotent·임퍼소네이션 투입/제거)
- **반응형**: `FlapGuard`(제거 디바운스/최소체류, 투입 즉시) + `AFTER_COMMIT` 이벤트 리스너 + 안전망 스케줄러 + 종료 시 정리
- **어드민 API**: 풀/송팩/방 config·bulk·drain·freeze·라이브 상태 (`@adminAuth.canManageVirtualDj`)
- **ArchUnit**: virtualdj는 `RedisMessagePublisher`·party `AggregatePort`·crew/dj/playback repo 의존 금지

## 검증된 설계 근거

- 봇은 **WS 세션 불필요**(멤버/DJ/아바타 목록은 crew DB 소스, presence 필터 없음)
- playback "다음 곡"은 **서버 스케줄러** 진행 / 커서 순환으로 **소진 없음**(영속 재생)
- 곡 검색은 기존 **PytubeSearchService 재사용**(새 YouTube API 불요)
- **리더보드 봇 제외 = N/A**: 코드베이스에 다중-유저 랭킹 read surface 부재(2회 독립 검증). `is_dummy`는 향후 랭킹 도입 시 사용

## 테스트

- 전체 `:app:test` + `:app:integrationTest` **GREEN** (BUILD SUCCESSFUL)
- 6 chunk TDD, 각 **spec 준수 + 코드 품질 2단계 리뷰** + **최종 홀리스틱 리뷰** 통과(블로커 0)
- ArchUnit 가드 RED-proven(위반 주입 시 실패 확인 후 복원)

## 후속 (비블로커)

- R4 부하 측정(stg N=20/50)
- silent-deactivate · anti-flap 타이밍 통합 테스트 보강
- drain 시 `source_song_pack_id` 해제(어드민 UX)
- 어드민 프론트 = 별도 **Plan B** (pfplay-admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
