### PR TITLE
가상 DJ(P1) 봇 아바타 변별 셋팅 콘솔 — 백엔드 (#288)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/admin/adapter/out/external/AdminMemberAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/admin/adapter/out/external/AdminMemberAdapter.java
@@ -34,6 +34,11 @@ public class AdminMemberAdapter implements AdminMemberPort {
     }
 
     @Override
+    public Optional<MemberData> findMemberByUserAccountId(Long userAccountId) {
+        return memberRepository.findByUserAccountId(userAccountId);
+    }
+
+    @Override
     public void deleteMemberById(Long id) {
         memberRepository.deleteById(id);
     }

--- a/app/src/main/java/com/pfplaybackend/api/admin/application/port/out/AdminMemberPort.java
+++ b/app/src/main/java/com/pfplaybackend/api/admin/application/port/out/AdminMemberPort.java
@@ -9,6 +9,17 @@ import java.util.Optional;
 public interface AdminMemberPort {
     MemberData saveMember(MemberData member);
     Optional<MemberData> findMemberById(Long id);
+
+    /**
+     * 사용자 계정 id(user_account_id)로 멤버를 조회한다.
+     *
+     * <p>{@link #findMemberById}는 member 테이블 PK(member_id, IDENTITY)로 조회하지만,
+     * 어드민 가상 멤버 운영은 user_account_id 로 멤버를 주소지정한다(봇 로스터·기존 어드민 가상멤버
+     * 도구 모두 user_account_id 노출). member_id ≠ user_account_id 이므로 user_account_id 주소지정에는
+     * 반드시 이 메서드를 써야 한다(코드베이스 다른 곳의 {@code findByUserAccountId} 관례와 동일).
+     */
+    Optional<MemberData> findMemberByUserAccountId(Long userAccountId);
+
     void deleteMemberById(Long id);
     Optional<MemberData> findMemberByEmail(String email);
     long countMembersByProviderType(ProviderType providerType);

--- a/app/src/main/java/com/pfplaybackend/api/admin/application/service/AdminProfileService.java
+++ b/app/src/main/java/com/pfplaybackend/api/admin/application/service/AdminProfileService.java
@@ -7,6 +7,7 @@ import com.pfplaybackend.api.avatar.application.dto.AvatarBodyDto;
 import com.pfplaybackend.api.avatar.domain.value.AvatarBodyUri;
 import com.pfplaybackend.api.avatar.domain.value.AvatarFaceUri;
 import com.pfplaybackend.api.avatar.domain.value.AvatarIconUri;
+import com.pfplaybackend.api.user.domain.entity.data.MemberData;
 import com.pfplaybackend.api.user.domain.entity.data.ProfileData;
 import com.pfplaybackend.api.user.domain.enums.FaceSourceType;
 import com.pfplaybackend.api.user.domain.value.Nickname;
@@ -55,6 +56,81 @@ public class AdminProfileService {
                 ? nickname
                 : generateRandomNickname();
 
+        // Resolve composition/icon/transform from the body+face inputs (single source of truth).
+        ResolvedAvatar resolved = resolveAvatar(avatarBodyUri, avatarFaceUri);
+
+        // Build ProfileData directly (CREATE path — a brand-new transient profile is correct here).
+        ProfileData profileData = ProfileData.builder()
+                .userId(userId)
+                .nickname(new Nickname(finalNickname))
+                .introduction("")
+                .avatarCompositionType(resolved.compositionType())
+                .faceSourceType(resolved.faceSourceType())
+                .avatarBodyUri(resolved.bodyUri())
+                .avatarFaceUri(resolved.faceUri())
+                .avatarIconUri(resolved.iconUri())
+                .combinePositionX(resolved.combinePositionX())
+                .combinePositionY(resolved.combinePositionY())
+                .offsetX(0)
+                .offsetY(0)
+                .scale(1.0)
+                .build();
+
+        return profileData;
+    }
+
+    /**
+     * Apply an avatar (body + optional face) to an <b>already-persisted</b> virtual member by
+     * MUTATING its existing {@link ProfileData} row — NOT by replacing the {@code @OneToOne}
+     * profile reference.
+     *
+     * <p>Replacing the reference (the old behaviour of the UPDATE path) made the cascade persist
+     * a SECOND transient {@code user_profile} row with the same user_id/nickname, which hits the
+     * Flyway V15 unique constraint {@code uk_user_profile_nickname} on the real {@code validate}
+     * profile (HTTP 500). The {@code create-drop} test schema lacks that constraint, so the
+     * double-insert was silent in tests — see {@code reference_ddl_auto_create_drop_hides_migration_drift}.
+     *
+     * <p>This mirrors the canonical real-member avatar path
+     * ({@code UserAvatarCommandService.setUserAvatar}): it calls the member's mutation delegates
+     * on the existing profile, keeping the SAME id (an UPDATE, not an INSERT).
+     *
+     * @param member        existing virtual member (its profile is mutated in place)
+     * @param avatarBodyUri optional body URI (default if null)
+     * @param avatarFaceUri optional face URI (empty/SINGLE_BODY if null)
+     */
+    public void applyAvatarToExistingMember(
+            MemberData member,
+            AvatarBodyUri avatarBodyUri,
+            AvatarFaceUri avatarFaceUri) {
+
+        ResolvedAvatar resolved = resolveAvatar(avatarBodyUri, avatarFaceUri);
+
+        member.updateAvatarBody(
+                resolved.bodyUri(), resolved.combinePositionX(), resolved.combinePositionY());
+
+        if (resolved.compositionType() == AvatarCompositionType.SINGLE_BODY) {
+            member.updateAvatarFace(resolved.faceUri());   // SINGLE_BODY + empty face
+        } else {
+            member.updateAvatarFace(resolved.faceUri(), resolved.faceSourceType(), 0, 0, 1.0);
+        }
+        member.updateAvatarIcon(resolved.iconUri());
+    }
+
+    /**
+     * Resolved avatar attributes (composition/face-source/icon/position) derived from a
+     * body+face pair. Shared by the CREATE path (builds a new ProfileData) and the UPDATE path
+     * (mutates an existing one) so the combinable/NFT/icon rules live in ONE place.
+     */
+    private record ResolvedAvatar(
+            AvatarCompositionType compositionType,
+            FaceSourceType faceSourceType,
+            AvatarBodyUri bodyUri,
+            AvatarFaceUri faceUri,
+            AvatarIconUri iconUri,
+            int combinePositionX,
+            int combinePositionY) {}
+
+    private ResolvedAvatar resolveAvatar(AvatarBodyUri avatarBodyUri, AvatarFaceUri avatarFaceUri) {
         // Get avatar URIs (use provided or default)
         AvatarBodyUri finalBodyUri = (avatarBodyUri != null)
                 ? avatarBodyUri
@@ -100,24 +176,9 @@ public class AdminProfileService {
             );
         }
 
-        // Build ProfileData directly
-        ProfileData profileData = ProfileData.builder()
-                .userId(userId)
-                .nickname(new Nickname(finalNickname))
-                .introduction("")
-                .avatarCompositionType(compositionType)
-                .faceSourceType(faceSourceType)
-                .avatarBodyUri(finalBodyUri)
-                .avatarFaceUri(finalFaceUri)
-                .avatarIconUri(iconUri)
-                .combinePositionX(avatarBodyDto.getCombinePositionX())
-                .combinePositionY(avatarBodyDto.getCombinePositionY())
-                .offsetX(0)
-                .offsetY(0)
-                .scale(1.0)
-                .build();
-
-        return profileData;
+        return new ResolvedAvatar(
+                compositionType, faceSourceType, finalBodyUri, finalFaceUri, iconUri,
+                avatarBodyDto.getCombinePositionX(), avatarBodyDto.getCombinePositionY());
     }
 
     /**

--- a/app/src/main/java/com/pfplaybackend/api/admin/application/service/AdminUserService.java
+++ b/app/src/main/java/com/pfplaybackend/api/admin/application/service/AdminUserService.java
@@ -201,7 +201,9 @@ public class AdminUserService {
      * @return MemberData entity
      */
     private MemberData findMemberByUserId(UserId userId) {
-        return adminMemberPort.findMemberById(userId.getUid())
+        // 가상 멤버는 user_account_id 로 주소지정된다(어드민 가상멤버 도구·봇 로스터 모두 user_account_id 노출).
+        // member_id(IDENTITY) ≠ user_account_id 이므로 user_account_id 로 조회해야 한다(코드베이스 관례 동일).
+        return adminMemberPort.findMemberByUserAccountId(userId.getUid())
                 .orElseThrow(() -> ExceptionCreator.create(AdminException.MEMBER_NOT_FOUND));
     }
 

--- a/app/src/main/java/com/pfplaybackend/api/admin/application/service/AdminUserService.java
+++ b/app/src/main/java/com/pfplaybackend/api/admin/application/service/AdminUserService.java
@@ -135,18 +135,14 @@ public class AdminUserService {
         // 2. Verify it's a virtual member (LOCAL provider type on UserAccount)
         requireLocalProviderForVirtualMemberOp(member, AdminException.NON_VIRTUAL_MEMBER_AVATAR_UPDATE);
 
-        // 3. Create new profile with updated avatar
-        ProfileData updatedProfile = adminProfileService.createProfileForVirtualMember(
-                userId,
-                member.getProfileData().getNicknameValue(),  // Keep existing nickname
-                avatarBodyUri,
-                avatarFaceUri
-        );
+        // 3. MUTATE the existing profile row (same id) — never build+swap a new ProfileData.
+        //    Replacing the @OneToOne(cascade=ALL) reference would cascade a SECOND transient
+        //    user_profile INSERT (same user_id/nickname) → V15 uk_user_profile_nickname 위반(HTTP 500).
+        //    create-drop 테스트 스키마엔 그 제약이 없어 silent 였다(reference_ddl_auto_create_drop_hides_migration_drift).
+        //    nickname 은 mutate 하지 않으므로 그대로 보존된다.
+        adminProfileService.applyAvatarToExistingMember(member, avatarBodyUri, avatarFaceUri);
 
-        // 4. Update member with new profile
-        member.initializeProfile(updatedProfile);
-
-        // 5. Save and return
+        // 4. Save and return (UPDATE on the existing row).
         MemberData savedData = adminMemberPort.saveMember(member);
 
         log.info("Virtual member avatar updated: userId={}", userId.getUid());

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/AdminVirtualDjController.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/AdminVirtualDjController.java
@@ -22,6 +22,7 @@ import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.SongPackDetailResp
 import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.SongPackListItemResponse;
 import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.VirtualDjLiveStatusResponse;
 import com.pfplaybackend.api.virtualdj.application.service.BotAvatarAdminService;
+import com.pfplaybackend.api.virtualdj.application.service.BotAvatarAssigner;
 import com.pfplaybackend.api.virtualdj.application.service.VirtualDjAdminService;
 import com.pfplaybackend.api.virtualdj.application.service.VirtualSongPackService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -259,7 +260,7 @@ public class AdminVirtualDjController {
     @PostMapping("/virtual-dj/bots/avatar/distribute")
     public ResponseEntity<ApiCommonResponse<DistributeBotAvatarResponse>> distributeBotAvatars(
             @Valid @RequestBody DistributeBotAvatarRequest req) {
-        var assigned = botAvatarAdminService.distribute(req.botIds(), req.bodyUris());
+        List<BotAvatarAssigner.Assigned> assigned = botAvatarAdminService.distribute(req.botIds(), req.bodyUris());
         return ResponseEntity.ok(ApiCommonResponse.success(DistributeBotAvatarResponse.from(assigned)));
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/AdminVirtualDjController.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/AdminVirtualDjController.java
@@ -1,20 +1,27 @@
 package com.pfplaybackend.api.virtualdj.adapter.in.web;
 
 import com.pfplaybackend.api.common.ApiCommonResponse;
+import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import com.pfplaybackend.api.playlist.adapter.in.web.payload.response.QueryMusicSearchResponse;
 import com.pfplaybackend.api.playlist.application.service.search.MusicSearchService;
 import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.AddPackTrackRequest;
 import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.ApplyVirtualDjConfigRequest;
+import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.AvatarCatalogItemResponse;
+import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.BotRosterItemResponse;
 import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.BulkApplyVirtualDjConfigRequest;
 import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.CreateSongPackRequest;
 import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.CreatedIdResponse;
+import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.DistributeBotAvatarRequest;
+import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.DistributeBotAvatarResponse;
 import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.PoolSummaryResponse;
 import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.ProvisionPoolRequest;
 import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.RenameSongPackRequest;
+import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.SetBotAvatarRequest;
 import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.SongPackDetailResponse;
 import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.SongPackListItemResponse;
 import com.pfplaybackend.api.virtualdj.adapter.in.web.payload.VirtualDjLiveStatusResponse;
+import com.pfplaybackend.api.virtualdj.application.service.BotAvatarAdminService;
 import com.pfplaybackend.api.virtualdj.application.service.VirtualDjAdminService;
 import com.pfplaybackend.api.virtualdj.application.service.VirtualSongPackService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -53,6 +60,7 @@ public class AdminVirtualDjController {
     private final VirtualDjAdminService adminService;
     private final VirtualSongPackService songPackService;
     private final MusicSearchService musicSearchService;
+    private final BotAvatarAdminService botAvatarAdminService;
 
     // ── 음악 검색 (어드민 프록시) ──
 
@@ -211,5 +219,47 @@ public class AdminVirtualDjController {
         adminService.applyBulk(req.partyroomIds(), req.status(),
                 req.targetCount(), req.companionFloor(), req.songPackId());
         return ResponseEntity.noContent().build();
+    }
+
+    // ── 봇 아바타 (P1) ──
+
+    @Operation(summary = "아바타 카탈로그 조회 (피커용)")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @GetMapping("/virtual-dj/avatar-catalog")
+    public ResponseEntity<ApiCommonResponse<List<AvatarCatalogItemResponse>>> avatarCatalog() {
+        List<AvatarCatalogItemResponse> items = botAvatarAdminService.catalog().stream()
+                .map(AvatarCatalogItemResponse::from).toList();
+        return ResponseEntity.ok(ApiCommonResponse.success(items));
+    }
+
+    @Operation(summary = "봇 로스터 조회 (신원+현재 아바타+배치룸)")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @GetMapping("/virtual-dj/bots")
+    public ResponseEntity<ApiCommonResponse<List<BotRosterItemResponse>>> bots() {
+        List<BotRosterItemResponse> items = botAvatarAdminService.roster().stream()
+                .map(BotRosterItemResponse::from).toList();
+        return ResponseEntity.ok(ApiCommonResponse.success(items));
+    }
+
+    @Operation(summary = "봇 개별 아바타 설정")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @PutMapping("/virtual-dj/bots/{userId}/avatar")
+    public ResponseEntity<Void> setBotAvatar(@PathVariable("userId") Long userId,
+                                             @Valid @RequestBody SetBotAvatarRequest req) {
+        botAvatarAdminService.setIndividual(new UserId(userId), req.avatarBodyUri());
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "봇 아바타 일괄 변별 배분", description = "선택 봇들에 셋에서 랜덤 1개씩 배분")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @PostMapping("/virtual-dj/bots/avatar/distribute")
+    public ResponseEntity<ApiCommonResponse<DistributeBotAvatarResponse>> distributeBotAvatars(
+            @Valid @RequestBody DistributeBotAvatarRequest req) {
+        var assigned = botAvatarAdminService.distribute(req.botIds(), req.bodyUris());
+        return ResponseEntity.ok(ApiCommonResponse.success(DistributeBotAvatarResponse.from(assigned)));
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/AvatarCatalogItemResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/AvatarCatalogItemResponse.java
@@ -1,0 +1,12 @@
+package com.pfplaybackend.api.virtualdj.adapter.in.web.payload;
+
+import com.pfplaybackend.api.virtualdj.application.service.BotAvatarAdminService;
+
+/** 아바타 카탈로그 1항목(피커용) 응답. */
+public record AvatarCatalogItemResponse(String bodyUri, String name, String thumbnailUri,
+                                        boolean combinable, String obtainableType) {
+    public static AvatarCatalogItemResponse from(BotAvatarAdminService.CatalogItem c) {
+        return new AvatarCatalogItemResponse(c.bodyUri(), c.name(), c.thumbnailUri(),
+                c.combinable(), c.obtainableType());
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/BotRosterItemResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/BotRosterItemResponse.java
@@ -1,0 +1,12 @@
+package com.pfplaybackend.api.virtualdj.adapter.in.web.payload;
+
+import com.pfplaybackend.api.virtualdj.application.dto.BotRosterRow;
+
+/** 봇 로스터 1행(신원+현재 아바타+배치룸) 응답. */
+public record BotRosterItemResponse(Long userId, String nickname, String avatarBodyUri, String avatarIconUri,
+                                    Long placementRoomId, String placementRoomTitle) {
+    public static BotRosterItemResponse from(BotRosterRow r) {
+        return new BotRosterItemResponse(r.userId(), r.nickname(), r.avatarBodyUri(), r.avatarIconUri(),
+                r.placementPartyroomId(), r.placementPartyroomTitle());
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/DistributeBotAvatarRequest.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/DistributeBotAvatarRequest.java
@@ -1,0 +1,10 @@
+package com.pfplaybackend.api.virtualdj.adapter.in.web.payload;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+/** 봇 아바타 일괄 변별 배분 요청 — 선택 봇들에 셋({@code bodyUris})에서 랜덤 1개씩 배분. */
+public record DistributeBotAvatarRequest(
+        @NotEmpty List<Long> botIds,
+        @NotEmpty List<String> bodyUris) {}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/DistributeBotAvatarResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/DistributeBotAvatarResponse.java
@@ -1,0 +1,15 @@
+package com.pfplaybackend.api.virtualdj.adapter.in.web.payload;
+
+import com.pfplaybackend.api.virtualdj.application.service.BotAvatarAssigner;
+
+import java.util.List;
+
+/** 봇 아바타 일괄 배분 결과 — 실제 적용된 (봇, 바디) 페어 목록. */
+public record DistributeBotAvatarResponse(List<Assigned> assigned) {
+    public record Assigned(Long userId, String avatarBodyUri) {}
+
+    public static DistributeBotAvatarResponse from(List<BotAvatarAssigner.Assigned> xs) {
+        return new DistributeBotAvatarResponse(xs.stream()
+                .map(a -> new Assigned(a.userId(), a.avatarBodyUri())).toList());
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/SetBotAvatarRequest.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/in/web/payload/SetBotAvatarRequest.java
@@ -1,0 +1,6 @@
+package com.pfplaybackend.api.virtualdj.adapter.in.web.payload;
+
+import jakarta.validation.constraints.NotBlank;
+
+/** 봇 개별 아바타 설정 요청. */
+public record SetBotAvatarRequest(@NotBlank String avatarBodyUri) {}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/BotPoolQueryRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/BotPoolQueryRepository.java
@@ -42,4 +42,13 @@ public interface BotPoolQueryRepository {
      * ACTIVE 파티룸(활성 crew 기준, 없으면 null). uid 오름차순(oldest-first).
      */
     List<BotRosterRow> findRoster();
+
+    /**
+     * 후보 userId 중 실제 봇(is_dummy=true, withdrawn_at IS NULL)인 부분집합만 반환한다.
+     *
+     * <p>일괄 배분(distribute)에서 비-봇/미존재 id 를 apply 예외로 잡아 격리하면 공유 트랜잭션이
+     * rollback-only 로 마킹돼 성공분까지 롤백되는 문제를 피하기 위해, 사전 필터로 유효 봇만 추린다.
+     * 입력이 null/빈 리스트면 빈 리스트를 반환한다.
+     */
+    List<Long> filterBotUserIds(List<Long> candidateUserIds);
 }

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/BotPoolQueryRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/BotPoolQueryRepository.java
@@ -1,6 +1,7 @@
 package com.pfplaybackend.api.virtualdj.adapter.out.persistence;
 
 import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.virtualdj.application.dto.BotRosterRow;
 import com.pfplaybackend.api.virtualdj.application.dto.PoolPlacementRow;
 
 import java.util.List;
@@ -35,4 +36,10 @@ public interface BotPoolQueryRepository {
      * 봇이 배치된 파티룸만 포함된다(botCount > 0 보장).
      */
     List<PoolPlacementRow> findPlacements();
+
+    /**
+     * 봇 전체 로스터(is_dummy=true, withdrawn_at IS NULL) — 닉네임/현재 아바타 + 현재 배치된
+     * ACTIVE 파티룸(활성 crew 기준, 없으면 null). uid 오름차순(oldest-first).
+     */
+    List<BotRosterRow> findRoster();
 }

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/impl/BotPoolQueryRepositoryImpl.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/impl/BotPoolQueryRepositoryImpl.java
@@ -58,6 +58,21 @@ public class BotPoolQueryRepositoryImpl implements BotPoolQueryRepository {
     }
 
     @Override
+    public List<Long> filterBotUserIds(List<Long> candidateUserIds) {
+        if (candidateUserIds == null || candidateUserIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return queryFactory
+                .select(userAccountData.userId.uid)
+                .from(userAccountData)
+                .where(
+                        userAccountData.userId.uid.in(candidateUserIds),
+                        userAccountData.isDummy.isTrue(),
+                        userAccountData.withdrawnAt.isNull())
+                .fetch();
+    }
+
+    @Override
     public long countBots() {
         Long count = queryFactory
                 .select(userAccountData.count())

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/impl/BotPoolQueryRepositoryImpl.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/impl/BotPoolQueryRepositoryImpl.java
@@ -2,7 +2,9 @@ package com.pfplaybackend.api.virtualdj.adapter.out.persistence.impl;
 
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.party.domain.enums.PartyroomStatus;
+import com.pfplaybackend.api.user.domain.value.Nickname;
 import com.pfplaybackend.api.virtualdj.adapter.out.persistence.BotPoolQueryRepository;
+import com.pfplaybackend.api.virtualdj.application.dto.BotRosterRow;
 import com.pfplaybackend.api.virtualdj.application.dto.PoolPlacementRow;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.JPAExpressions;
@@ -15,6 +17,7 @@ import java.util.List;
 
 import static com.pfplaybackend.api.party.domain.entity.data.QCrewData.crewData;
 import static com.pfplaybackend.api.party.domain.entity.data.QPartyroomData.partyroomData;
+import static com.pfplaybackend.api.user.domain.entity.data.QProfileData.profileData;
 import static com.pfplaybackend.api.user.domain.entity.data.QUserAccountData.userAccountData;
 
 /**
@@ -107,6 +110,42 @@ public class BotPoolQueryRepositoryImpl implements BotPoolQueryRepository {
                         t.get(partyroomData.id),
                         t.get(partyroomData.title),
                         t.get(crewData.count()) == null ? 0L : t.get(crewData.count())))
+                .toList();
+    }
+
+    @Override
+    public List<BotRosterRow> findRoster() {
+        List<Tuple> tuples = queryFactory
+                .select(
+                        userAccountData.userId.uid,
+                        profileData.bio.nickname,   // @Convert(Nickname) → tuple.get 시 Nickname 객체 반환
+                        profileData.avatarSetting.avatarBodyUri.value,
+                        profileData.avatarSetting.avatarIconUri.value,
+                        partyroomData.id,
+                        partyroomData.title)
+                .from(userAccountData)
+                .join(profileData).on(profileData.userId.uid.eq(userAccountData.userId.uid))
+                .leftJoin(crewData).on(crewData.userId.uid.eq(userAccountData.userId.uid)
+                        .and(crewData.isActive.isTrue()))
+                .leftJoin(partyroomData).on(partyroomData.id.eq(crewData.partyroomId.id)
+                        .and(partyroomData.status.eq(PartyroomStatus.ACTIVE)))
+                .where(
+                        userAccountData.isDummy.isTrue(),
+                        userAccountData.withdrawnAt.isNull())
+                .orderBy(userAccountData.userId.uid.asc())
+                .fetch();
+
+        return tuples.stream()
+                .map(t -> {
+                    Nickname nick = t.get(profileData.bio.nickname);
+                    return new BotRosterRow(
+                            t.get(userAccountData.userId.uid),
+                            nick == null ? null : nick.value(),
+                            t.get(profileData.avatarSetting.avatarBodyUri.value),
+                            t.get(profileData.avatarSetting.avatarIconUri.value),
+                            t.get(partyroomData.id),
+                            t.get(partyroomData.title));
+                })
                 .toList();
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/provision/BotAvatarApplyAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/provision/BotAvatarApplyAdapter.java
@@ -1,0 +1,28 @@
+package com.pfplaybackend.api.virtualdj.adapter.out.provision;
+
+import com.pfplaybackend.api.admin.application.service.AdminUserService;
+import com.pfplaybackend.api.avatar.domain.value.AvatarBodyUri;
+import com.pfplaybackend.api.avatar.domain.value.AvatarFaceUri;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.virtualdj.application.port.BotAvatarApplyPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link BotAvatarApplyPort} 의 유일한 구현체 — admin 레이어로 나가는 경계.
+ *
+ * <p>{@link VirtualMemberProvisionAdapter} 와 함께 virtualdj 패키지 중 {@code ..admin..} 를
+ * import 하도록 허용되는 곳이다. 합성/아이콘의 실제 결정은 admin 의 기존
+ * {@link AdminUserService#updateVirtualMemberAvatar} 로직을 그대로 재사용한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class BotAvatarApplyAdapter implements BotAvatarApplyPort {
+
+    private final AdminUserService adminUserService;
+
+    @Override
+    public void apply(UserId botUserId, AvatarBodyUri bodyUri, AvatarFaceUri faceUri) {
+        adminUserService.updateVirtualMemberAvatar(botUserId, bodyUri, faceUri);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/random/ThreadLocalRandomizer.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/random/ThreadLocalRandomizer.java
@@ -1,0 +1,15 @@
+package com.pfplaybackend.api.virtualdj.adapter.out.random;
+
+import com.pfplaybackend.api.virtualdj.application.port.Randomizer;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+@Component
+public class ThreadLocalRandomizer implements Randomizer {
+    @Override
+    public int nextIndex(int bound) {
+        if (bound <= 0) throw new IllegalArgumentException("bound must be > 0, got " + bound);
+        return ThreadLocalRandom.current().nextInt(bound);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/dto/BotRosterRow.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/dto/BotRosterRow.java
@@ -1,0 +1,11 @@
+package com.pfplaybackend.api.virtualdj.application.dto;
+
+/** 봇 로스터 1행 — 봇 신원 + 현재 아바타 + 배치 룸(없으면 null). */
+public record BotRosterRow(
+        Long userId,
+        String nickname,
+        String avatarBodyUri,
+        String avatarIconUri,
+        Long placementPartyroomId,
+        String placementPartyroomTitle
+) {}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/port/BotAvatarApplyPort.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/port/BotAvatarApplyPort.java
@@ -1,0 +1,14 @@
+package com.pfplaybackend.api.virtualdj.application.port;
+
+import com.pfplaybackend.api.avatar.domain.value.AvatarBodyUri;
+import com.pfplaybackend.api.avatar.domain.value.AvatarFaceUri;
+import com.pfplaybackend.api.common.domain.value.UserId;
+
+/**
+ * virtualdj 가 봇 멤버 아바타를 갱신하기 위해 admin BC 로 나가는 outbound port.
+ * 구현체(provision 어댑터)만 admin 레이어를 만진다 — 합성/아이콘 결정은 admin 쪽 기존 로직 재사용.
+ */
+public interface BotAvatarApplyPort {
+    /** 봇의 아바타를 (body, face) 로 갱신한다. face 빈값이면 SINGLE_BODY, 있으면 BODY_WITH_FACE 로 admin 이 합성/아이콘 결정. */
+    void apply(UserId botUserId, AvatarBodyUri bodyUri, AvatarFaceUri faceUri);
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/port/Randomizer.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/port/Randomizer.java
@@ -1,0 +1,10 @@
+package com.pfplaybackend.api.virtualdj.application.port;
+
+/**
+ * 셋→봇 랜덤 배분의 인덱스 선택을 추상화한다. 운영은 ThreadLocalRandom,
+ * 테스트는 결정적 stub 을 주입해 분배 결과를 검증 가능하게 한다.
+ */
+public interface Randomizer {
+    /** {@code [0, bound)} 범위의 인덱스를 반환한다. {@code bound <= 0} 이면 IllegalArgumentException. */
+    int nextIndex(int bound);
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/BotAvatarAdminService.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/BotAvatarAdminService.java
@@ -42,7 +42,12 @@ public class BotAvatarAdminService {
 
     @Transactional
     public List<BotAvatarAssigner.Assigned> distribute(List<Long> botIds, List<String> bodyUris) {
-        List<UserId> ids = botIds.stream().map(UserId::new).toList();
+        // 부분 성공(spec §2.3)을 트랜잭션 안전하게 처리한다. apply 단계에서 비-봇 예외를 잡아 격리하면
+        // 공유 REQUIRED 트랜잭션이 rollback-only 로 마킹돼 성공분까지 통째로 롤백(UnexpectedRollbackException)
+        // 되므로, 예외-제어흐름 대신 사전 필터로 실제 봇만 추려 넘긴다. 셋 무결성(빈 셋/빈 봇목록/미존재 bodyUri)
+        // 검증은 assigner 가 그대로 수행(→ 400).
+        List<Long> validBotIds = botPoolQueryRepository.filterBotUserIds(botIds);
+        List<UserId> ids = validBotIds.stream().map(UserId::new).toList();
         return assigner.distribute(ids, bodyUris);
     }
 

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/BotAvatarAdminService.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/BotAvatarAdminService.java
@@ -1,0 +1,53 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.avatar.application.dto.AvatarBodyDto;
+import com.pfplaybackend.api.avatar.application.port.in.AvatarCatalogQueryUseCase;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.BotPoolQueryRepository;
+import com.pfplaybackend.api.virtualdj.application.dto.BotRosterRow;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/** 봇 아바타 어드민 운영 — 카탈로그 조회 / 로스터 조회 / 개별·일괄 변별 배분. */
+@Service
+@RequiredArgsConstructor
+public class BotAvatarAdminService {
+
+    private final BotPoolQueryRepository botPoolQueryRepository;
+    private final AvatarCatalogQueryUseCase catalog;
+    private final BotAvatarAssigner assigner;
+
+    public record CatalogItem(String bodyUri, String name, String thumbnailUri,
+                              boolean combinable, String obtainableType) {}
+
+    @Transactional(readOnly = true)
+    public List<CatalogItem> catalog() {
+        return catalog.findPublishedBodies().stream()
+                .map(BotAvatarAdminService::toCatalogItem)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<BotRosterRow> roster() {
+        return botPoolQueryRepository.findRoster();
+    }
+
+    @Transactional
+    public void setIndividual(UserId botUserId, String bodyUri) {
+        assigner.assignOne(botUserId, bodyUri);
+    }
+
+    @Transactional
+    public List<BotAvatarAssigner.Assigned> distribute(List<Long> botIds, List<String> bodyUris) {
+        List<UserId> ids = botIds.stream().map(UserId::new).toList();
+        return assigner.distribute(ids, bodyUris);
+    }
+
+    private static CatalogItem toCatalogItem(AvatarBodyDto b) {
+        return new CatalogItem(b.getResourceUri(), b.getName(), b.getResourceUri(),
+                b.isCombinable(), b.getObtainableType() == null ? null : b.getObtainableType().name());
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/BotAvatarAssigner.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/BotAvatarAssigner.java
@@ -67,18 +67,14 @@ public class BotAvatarAssigner {
                 throw ExceptionCreator.create(VirtualDjException.INVALID_AVATAR_SET);
             }
         }
-        // 부분 성공(spec §2.3): 비-봇/미존재 userId 는 apply 단계에서 예외가 나도 배치 전체를 중단하지 않고
-        // 해당 봇만 건너뛴다. 셋 무결성(위 검증)은 강제하되, 대상 목록의 오염은 격리한다.
+        // 부분 성공(spec §2.3)의 "비-봇/미존재 격리"는 호출자(BotAvatarAdminService)가 사전 필터로 처리한다.
+        // 여기서는 넘어온 봇이 모두 유효하다고 보고 전수 적용한다. apply 가 예외를 던지면(진짜 버그/인프라 장애)
+        // 공유 트랜잭션이 어차피 rollback-only 가 되므로 삼키지 않고 그대로 전파해 배치를 실패시킨다.
         List<Assigned> assigned = new ArrayList<>();
         for (UserId botId : botIds) {
             String chosen = bodyUris.get(randomizer.nextIndex(bodyUris.size()));
-            try {
-                assignOne(botId, chosen);
-                assigned.add(new Assigned(botId.getUid(), chosen));
-            } catch (RuntimeException e) {
-                log.warn("[BotAvatarAssigner.distribute] 봇 적용 실패로 건너뜀 userId={} bodyUri={} cause={}",
-                        botId.getUid(), chosen, e.toString());
-            }
+            assignOne(botId, chosen);
+            assigned.add(new Assigned(botId.getUid(), chosen));
         }
         log.info("[BotAvatarAssigner.distribute] bots={} setSize={} applied={}",
                 botIds.size(), bodyUris.size(), assigned.size());

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/BotAvatarAssigner.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/BotAvatarAssigner.java
@@ -67,13 +67,21 @@ public class BotAvatarAssigner {
                 throw ExceptionCreator.create(VirtualDjException.INVALID_AVATAR_SET);
             }
         }
+        // 부분 성공(spec §2.3): 비-봇/미존재 userId 는 apply 단계에서 예외가 나도 배치 전체를 중단하지 않고
+        // 해당 봇만 건너뛴다. 셋 무결성(위 검증)은 강제하되, 대상 목록의 오염은 격리한다.
         List<Assigned> assigned = new ArrayList<>();
         for (UserId botId : botIds) {
             String chosen = bodyUris.get(randomizer.nextIndex(bodyUris.size()));
-            assignOne(botId, chosen);
-            assigned.add(new Assigned(botId.getUid(), chosen));
+            try {
+                assignOne(botId, chosen);
+                assigned.add(new Assigned(botId.getUid(), chosen));
+            } catch (RuntimeException e) {
+                log.warn("[BotAvatarAssigner.distribute] 봇 적용 실패로 건너뜀 userId={} bodyUri={} cause={}",
+                        botId.getUid(), chosen, e.toString());
+            }
         }
-        log.info("[BotAvatarAssigner.distribute] bots={} setSize={}", botIds.size(), bodyUris.size());
+        log.info("[BotAvatarAssigner.distribute] bots={} setSize={} applied={}",
+                botIds.size(), bodyUris.size(), assigned.size());
         return assigned;
     }
 

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/BotAvatarAssigner.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/BotAvatarAssigner.java
@@ -1,0 +1,87 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.avatar.application.dto.AvatarBodyDto;
+import com.pfplaybackend.api.avatar.application.dto.AvatarFaceDto;
+import com.pfplaybackend.api.avatar.application.port.in.AvatarCatalogQueryUseCase;
+import com.pfplaybackend.api.avatar.domain.value.AvatarBodyUri;
+import com.pfplaybackend.api.avatar.domain.value.AvatarFaceUri;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.exception.ExceptionCreator;
+import com.pfplaybackend.api.virtualdj.application.port.BotAvatarApplyPort;
+import com.pfplaybackend.api.virtualdj.application.port.Randomizer;
+import com.pfplaybackend.api.virtualdj.domain.exception.VirtualDjException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 봇 아바타 변별 배분의 단일 소스 — 합성 규칙(combinable→공통 face / standalone→자체 아이콘)을
+ * 여기 한 곳에만 두고, 개별 적용 / 셋 랜덤 배분 / provision 자동부여가 모두 이 헬퍼를 거친다.
+ *
+ * <p>합성 규칙(spec §1.2/§1.3): combinable 바디는 icon_uri 가 NULL 이라 face 없이는 아이콘이 깨진다.
+ * 따라서 기본 basic face 를 합성해 BODY_WITH_FACE(face 페어 아이콘)로 만들고, standalone 바디는
+ * face="" 로 SINGLE_BODY(자체 아이콘)로 둔다. 합성/아이콘의 실제 결정은 admin 쪽 update 로직이 수행.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BotAvatarAssigner {
+
+    private final AvatarCatalogQueryUseCase catalog;
+    private final BotAvatarApplyPort applyPort;
+    private final Randomizer randomizer;
+
+    public record Assigned(Long userId, String avatarBodyUri) {}
+
+    /** 전체 published 카탈로그에서 랜덤 1개를 골라 적용(provision 자동부여 + 단발 변별용). */
+    public void assignRandomFromCatalog(UserId botUserId) {
+        List<AvatarBodyDto> bodies = catalog.findPublishedBodies();
+        if (bodies.isEmpty()) {
+            throw ExceptionCreator.create(VirtualDjException.INVALID_AVATAR_SET);
+        }
+        String bodyUri = bodies.get(randomizer.nextIndex(bodies.size())).getResourceUri();
+        assignOne(botUserId, bodyUri);
+    }
+
+    /** 단일 봇에 지정 바디 적용(개별 셋팅). 합성 규칙 적용. */
+    public void assignOne(UserId botUserId, String bodyUri) {
+        AvatarBodyDto body = catalog.findBodyByUri(bodyUri)
+                .orElseThrow(() -> ExceptionCreator.create(VirtualDjException.INVALID_AVATAR_SET));
+        AvatarFaceUri faceUri = body.isCombinable()
+                ? new AvatarFaceUri(defaultFaceUri())
+                : new AvatarFaceUri();   // 빈 face = SINGLE_BODY
+        applyPort.apply(botUserId, new AvatarBodyUri(bodyUri), faceUri);
+    }
+
+    /** 셋({@code bodyUris})에서 봇별 랜덤 1개를 배분(일괄). */
+    public List<Assigned> distribute(List<UserId> botIds, List<String> bodyUris) {
+        if (bodyUris == null || bodyUris.isEmpty() || botIds == null || botIds.isEmpty()) {
+            throw ExceptionCreator.create(VirtualDjException.INVALID_AVATAR_SET);
+        }
+        // 셋 무결성: 모든 bodyUri 가 카탈로그에 존재해야 한다.
+        for (String uri : bodyUris) {
+            if (catalog.findBodyByUri(uri).isEmpty()) {
+                throw ExceptionCreator.create(VirtualDjException.INVALID_AVATAR_SET);
+            }
+        }
+        List<Assigned> assigned = new ArrayList<>();
+        for (UserId botId : botIds) {
+            String chosen = bodyUris.get(randomizer.nextIndex(bodyUris.size()));
+            assignOne(botId, chosen);
+            assigned.add(new Assigned(botId.getUid(), chosen));
+        }
+        log.info("[BotAvatarAssigner.distribute] bots={} setSize={}", botIds.size(), bodyUris.size());
+        return assigned;
+    }
+
+    private String defaultFaceUri() {
+        List<AvatarFaceDto> faces = catalog.findPublishedFaces();
+        if (faces.isEmpty()) {
+            throw ExceptionCreator.create(VirtualDjException.INVALID_AVATAR_SET);
+        }
+        return faces.get(0).resourceUri();   // 단일 basic face (AvatarFaceDto 접근자에 맞춰 조정)
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualUserPoolService.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualUserPoolService.java
@@ -37,6 +37,7 @@ public class VirtualUserPoolService {
     private final UserAccountRepository userAccountRepository;
     private final PlaylistRepository playlistRepository;
     private final BotPoolQueryRepository botPoolQueryRepository;
+    private final BotAvatarAssigner botAvatarAssigner;
 
     /**
      * 봇 {@code n} 명을 생성한다. 각 봇은 실 {@code user_account}(is_dummy=true, LOCAL),
@@ -58,6 +59,11 @@ public class VirtualUserPoolService {
             // 3) DJ 가 enqueue 할 PLAYLIST 타입 playlist 1개 생성 (송팩 복사 대상).
             playlistRepository.save(
                     PlaylistData.create(1, BOT_PLAYLIST_NAME, PlaylistType.PLAYLIST, botUserId));
+
+            // 4) P1-D5: 생성 즉시 카탈로그에서 랜덤 변별 아바타를 부여한다. createVirtualMember 의
+            //    디폴트 바디(ava_basic_001, combinable·icon NULL)는 채팅 아이콘이 깨지므로 합성 규칙
+            //    (combinable→공통 face / standalone→자체 아이콘)으로 non-blank 아이콘을 보장한다.
+            botAvatarAssigner.assignRandomFromCatalog(botUserId);
 
             created.add(botUserId);
         }

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/domain/exception/VirtualDjException.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/domain/exception/VirtualDjException.java
@@ -13,7 +13,8 @@ public enum VirtualDjException implements DomainException {
     TRACK_EXCEEDS_PLAYBACK_LIMIT("VDJ-004", "트랙의 재생 시간이 playbackTimeLimit을 초과합니다", ErrorType.BAD_REQUEST),
     PACK_TRACK_NOT_FOUND("VDJ-005", "송 팩 트랙을 찾을 수 없습니다", ErrorType.NOT_FOUND),
     CONFIG_NOT_FOUND("VDJ-006", "해당 룸의 가상 DJ 설정을 찾을 수 없습니다", ErrorType.NOT_FOUND),
-    INVALID_CONFIG("VDJ-007", "MANAGED 전환에는 targetCount/companionFloor 가 필요합니다", ErrorType.BAD_REQUEST);
+    INVALID_CONFIG("VDJ-007", "MANAGED 전환에는 targetCount/companionFloor 가 필요합니다", ErrorType.BAD_REQUEST),
+    INVALID_AVATAR_SET("VDJ-008", "유효하지 않은 아바타 셋입니다 (빈 셋·빈 봇목록·미존재 바디 URI)", ErrorType.BAD_REQUEST);
 
     private final String errorCode;
     private final String message;

--- a/app/src/test/java/com/pfplaybackend/api/admin/application/service/AdminUserServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/admin/application/service/AdminUserServiceTest.java
@@ -127,23 +127,23 @@ class AdminUserServiceTest {
         UserId userId = new UserId(200L);
         MemberData virtualMember = createMemberFor(userId.getUid());
         UserAccountData localAccount = createLocalAccount(userId);
+        ProfileData existingProfile = virtualMember.getProfileData();   // 교체되면 안 되는 기존 row
 
         AvatarBodyUri newBodyUri = new AvatarBodyUri("new_body.png");
         AvatarFaceUri newFaceUri = new AvatarFaceUri("new_face.png");
-        ProfileData updatedProfile = createDummyProfile(userId);
 
         when(adminMemberPort.findMemberByUserAccountId(userId.getUid())).thenReturn(Optional.of(virtualMember));
         when(userAccountRepository.findById(userId)).thenReturn(Optional.of(localAccount));
-        when(adminProfileService.createProfileForVirtualMember(
-                userId, "Virtual_AABBCC", newBodyUri, newFaceUri))
-                .thenReturn(updatedProfile);
         when(adminMemberPort.saveMember(any(MemberData.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // when
         MemberData result = adminUserService.updateVirtualMemberAvatar(userId, newBodyUri, newFaceUri);
 
-        // then
-        assertThat(result.getProfileData()).isEqualTo(updatedProfile);
+        // then: 기존 profile row 를 MUTATE 해야 한다 — 교체(createProfileForVirtualMember) 금지.
+        verify(adminProfileService).applyAvatarToExistingMember(virtualMember, newBodyUri, newFaceUri);
+        verify(adminProfileService, never()).createProfileForVirtualMember(any(), any(), any(), any());
+        // 동일 ProfileData 참조가 유지돼야(swap 아님) → 같은 user_profile id 가 UPDATE 된다.
+        assertThat(result.getProfileData()).isSameAs(existingProfile);
         verify(adminMemberPort).saveMember(virtualMember);
     }
 

--- a/app/src/test/java/com/pfplaybackend/api/admin/application/service/AdminUserServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/admin/application/service/AdminUserServiceTest.java
@@ -132,7 +132,7 @@ class AdminUserServiceTest {
         AvatarFaceUri newFaceUri = new AvatarFaceUri("new_face.png");
         ProfileData updatedProfile = createDummyProfile(userId);
 
-        when(adminMemberPort.findMemberById(userId.getUid())).thenReturn(Optional.of(virtualMember));
+        when(adminMemberPort.findMemberByUserAccountId(userId.getUid())).thenReturn(Optional.of(virtualMember));
         when(userAccountRepository.findById(userId)).thenReturn(Optional.of(localAccount));
         when(adminProfileService.createProfileForVirtualMember(
                 userId, "Virtual_AABBCC", newBodyUri, newFaceUri))
@@ -157,7 +157,7 @@ class AdminUserServiceTest {
         AvatarBodyUri bodyUri = new AvatarBodyUri("body.png");
         AvatarFaceUri faceUri = new AvatarFaceUri("face.png");
 
-        when(adminMemberPort.findMemberById(userId.getUid())).thenReturn(Optional.of(googleMember));
+        when(adminMemberPort.findMemberByUserAccountId(userId.getUid())).thenReturn(Optional.of(googleMember));
         when(userAccountRepository.findById(userId)).thenReturn(Optional.of(googleAccount));
 
         // when & then
@@ -173,7 +173,7 @@ class AdminUserServiceTest {
         MemberData virtualMember = createMemberFor(userId.getUid());
         UserAccountData localAccount = createLocalAccount(userId);
 
-        when(adminMemberPort.findMemberById(userId.getUid())).thenReturn(Optional.of(virtualMember));
+        when(adminMemberPort.findMemberByUserAccountId(userId.getUid())).thenReturn(Optional.of(virtualMember));
         when(userAccountRepository.findById(userId)).thenReturn(Optional.of(localAccount));
 
         // when
@@ -191,7 +191,7 @@ class AdminUserServiceTest {
         MemberData googleMember = createMemberFor(userId.getUid());
         UserAccountData googleAccount = createGoogleAccount(userId);
 
-        when(adminMemberPort.findMemberById(userId.getUid())).thenReturn(Optional.of(googleMember));
+        when(adminMemberPort.findMemberByUserAccountId(userId.getUid())).thenReturn(Optional.of(googleMember));
         when(userAccountRepository.findById(userId)).thenReturn(Optional.of(googleAccount));
 
         // when & then
@@ -205,7 +205,7 @@ class AdminUserServiceTest {
         // given
         UserId userId = new UserId(999L);
 
-        when(adminMemberPort.findMemberById(userId.getUid())).thenReturn(Optional.empty());
+        when(adminMemberPort.findMemberByUserAccountId(userId.getUid())).thenReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> adminUserService.getVirtualMember(userId))

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/AdminVirtualDjControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/AdminVirtualDjControllerTest.java
@@ -5,12 +5,16 @@ import com.pfplaybackend.api.common.config.security.jwt.AdminCookieWriter;
 import com.pfplaybackend.api.common.config.security.jwt.JwtService;
 import com.pfplaybackend.api.common.config.security.jwt.SharedSessionCookieWriter;
 import com.pfplaybackend.api.common.config.security.jwt.properties.JwtProperties;
+import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import com.pfplaybackend.api.playlist.application.dto.search.SearchResultDto;
 import com.pfplaybackend.api.playlist.application.dto.search.SearchResultRawDto;
 import com.pfplaybackend.api.playlist.application.service.search.MusicSearchService;
 import com.pfplaybackend.api.virtualdj.adapter.in.web.AdminVirtualDjController;
+import com.pfplaybackend.api.virtualdj.application.dto.BotRosterRow;
+import com.pfplaybackend.api.virtualdj.application.service.BotAvatarAdminService;
+import com.pfplaybackend.api.virtualdj.application.service.BotAvatarAssigner;
 import com.pfplaybackend.api.virtualdj.application.service.VirtualDjAdminService;
 import com.pfplaybackend.api.virtualdj.application.service.VirtualSongPackService;
 import com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus;
@@ -77,6 +81,7 @@ class AdminVirtualDjControllerTest {
     @MockBean private VirtualDjAdminService adminService;
     @MockBean private VirtualSongPackService songPackService;
     @MockBean private MusicSearchService musicSearchService;
+    @MockBean private BotAvatarAdminService botAvatarAdminService;
 
     // SecurityConfig autoconfig deps — @MockBean shims so the slice context loads.
     @MockBean private JwtDecoder jwtDecoder;
@@ -468,6 +473,130 @@ class AdminVirtualDjControllerTest {
     @WithMockUser(roles = "ADMIN")
     void drain_missingCsrf_returns403() throws Exception {
         mockMvc.perform(post("/api/v1/admin/partyrooms/7/virtual-dj/drain"))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── 봇 아바타 (P1) ──
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void avatarCatalog_admin_returns200WithBody() throws Exception {
+        given(botAvatarAdminService.catalog())
+                .willReturn(List.of(new BotAvatarAdminService.CatalogItem(
+                        "https://cdn/body.png", "바디", "https://cdn/body.png", true, "BASIC")));
+        mockMvc.perform(get("/api/v1/admin/virtual-dj/avatar-catalog"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].bodyUri").value("https://cdn/body.png"))
+                .andExpect(jsonPath("$.data[0].name").value("바디"))
+                .andExpect(jsonPath("$.data[0].thumbnailUri").value("https://cdn/body.png"))
+                .andExpect(jsonPath("$.data[0].combinable").value(true))
+                .andExpect(jsonPath("$.data[0].obtainableType").value("BASIC"));
+        verify(botAvatarAdminService).catalog();
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    void avatarCatalog_member_returns403() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/virtual-dj/avatar-catalog"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void bots_admin_returns200WithBody() throws Exception {
+        given(botAvatarAdminService.roster())
+                .willReturn(List.of(new BotRosterRow(
+                        1L, "봇", "https://cdn/body.png", "https://cdn/icon.png", 7L, "룸")));
+        mockMvc.perform(get("/api/v1/admin/virtual-dj/bots"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].userId").value(1))
+                .andExpect(jsonPath("$.data[0].nickname").value("봇"))
+                .andExpect(jsonPath("$.data[0].avatarBodyUri").value("https://cdn/body.png"))
+                .andExpect(jsonPath("$.data[0].avatarIconUri").value("https://cdn/icon.png"))
+                .andExpect(jsonPath("$.data[0].placementRoomId").value(7))
+                .andExpect(jsonPath("$.data[0].placementRoomTitle").value("룸"));
+        verify(botAvatarAdminService).roster();
+    }
+
+    @Test
+    @WithAnonymousUser
+    void bots_anonymous_returns401() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/virtual-dj/bots"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void setBotAvatar_admin_returns204() throws Exception {
+        mockMvc.perform(put("/api/v1/admin/virtual-dj/bots/42/avatar")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"avatarBodyUri":"https://cdn/body.png"}
+                                """))
+                .andExpect(status().isNoContent());
+        verify(botAvatarAdminService).setIndividual(new UserId(42L), "https://cdn/body.png");
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void setBotAvatar_blankBodyUri_returns400() throws Exception {
+        mockMvc.perform(put("/api/v1/admin/virtual-dj/bots/42/avatar")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"avatarBodyUri":""}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void distribute_admin_returns200WithBody() throws Exception {
+        given(botAvatarAdminService.distribute(List.of(1L, 2L), List.of("https://cdn/a.png", "https://cdn/b.png")))
+                .willReturn(List.of(
+                        new BotAvatarAssigner.Assigned(1L, "https://cdn/a.png"),
+                        new BotAvatarAssigner.Assigned(2L, "https://cdn/b.png")));
+        mockMvc.perform(post("/api/v1/admin/virtual-dj/bots/avatar/distribute")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"botIds":[1,2],"bodyUris":["https://cdn/a.png","https://cdn/b.png"]}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.assigned[0].userId").value(1))
+                .andExpect(jsonPath("$.data.assigned[0].avatarBodyUri").value("https://cdn/a.png"))
+                .andExpect(jsonPath("$.data.assigned[1].userId").value(2));
+        verify(botAvatarAdminService).distribute(List.of(1L, 2L), List.of("https://cdn/a.png", "https://cdn/b.png"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void distribute_emptyBotIds_returns400() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/virtual-dj/bots/avatar/distribute")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"botIds":[],"bodyUris":["https://cdn/a.png"]}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    void distribute_member_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/virtual-dj/bots/avatar/distribute")
+                        .with(csrf()).contentType(APPLICATION_JSON)
+                        .content("""
+                                {"botIds":[1],"bodyUris":["https://cdn/a.png"]}
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void distribute_missingCsrf_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/virtual-dj/bots/avatar/distribute")
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {"botIds":[1],"bodyUris":["https://cdn/a.png"]}
+                                """))
                 .andExpect(status().isForbidden());
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAdminServiceIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAdminServiceIT.java
@@ -129,6 +129,22 @@ class BotAvatarAdminServiceIT extends AbstractIntegrationTest {
                 .getProfileData().getAvatarSetting().getAvatarIconUriValue();
     }
 
+    /**
+     * 봇 user_id 에 매달린 user_profile row 개수(네이티브 카운트).
+     *
+     * <p>이 가드가 replace-vs-mutate 더블 인서트를 직접 잡는다: test 프로파일은 create-drop 이라
+     * uk_user_profile_nickname 제약이 없어(=Flyway V15 부재) 더블 인서트가 SQL 에러 없이 통과해버린다.
+     * 따라서 제약에 의존하지 않고 row 개수를 세어 회귀를 막는다
+     * (reference_ddl_auto_create_drop_hides_migration_drift).
+     */
+    private long profileRowCount(UserId botId) {
+        Number count = (Number) entityManager.createNativeQuery(
+                        "SELECT COUNT(*) FROM user_profile WHERE user_id = :uid")
+                .setParameter("uid", botId.getUid())
+                .getSingleResult();
+        return count.longValue();
+    }
+
     @Test
     @DisplayName("C1: distribute([validBot, nonBot]) — 유효 봇 아바타가 실제로 커밋, 비-봇 격리, 결과 1건, 롤백 없음")
     void distribute_validBotCommitted_nonBotSkipped_noRollback() {
@@ -159,6 +175,28 @@ class BotAvatarAdminServiceIT extends AbstractIntegrationTest {
 
         assertThat(currentBodyUri(bot)).isEqualTo(COMBINABLE_BODY_URI);
         // combinable → 기본 face 합성 → face-pair 아이콘이 채워져 non-blank.
+        assertThat(currentIconUri(bot)).isNotBlank();
+        // 회귀 가드: update 는 기존 row 를 mutate 해야 한다. profile 교체(=cascade 더블 인서트)면 2가 된다.
+        assertThat(profileRowCount(bot))
+                .as("setIndividual 후 봇 %s 의 user_profile row 는 정확히 1개여야(교체 아님 mutate)", bot.getUid())
+                .isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("회귀 가드: provision→update 반복해도 user_profile row 는 봇당 정확히 1개 (replace-vs-mutate 더블 인서트 차단)")
+    void repeatedUpdate_keepsExactlyOneProfileRow() {
+        UserId bot = seedBot(STANDALONE_BODY_URI);
+        assertThat(profileRowCount(bot)).isEqualTo(1L);   // 생성 직후 1개
+
+        // 여러 번 갱신해도(교체였다면 매번 +1) row 는 1개로 유지돼야 한다.
+        botAvatarAdminService.setIndividual(bot, COMBINABLE_BODY_URI);
+        botAvatarAdminService.setIndividual(bot, STANDALONE_BODY_URI);
+        botAvatarAdminService.setIndividual(bot, COMBINABLE_BODY_URI);
+
+        assertThat(profileRowCount(bot))
+                .as("update 3회 후 봇 %s 의 user_profile row 는 여전히 1개여야", bot.getUid())
+                .isEqualTo(1L);
+        assertThat(currentBodyUri(bot)).isEqualTo(COMBINABLE_BODY_URI);
         assertThat(currentIconUri(bot)).isNotBlank();
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAdminServiceIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAdminServiceIT.java
@@ -1,0 +1,164 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.admin.application.service.AdminUserService;
+import com.pfplaybackend.api.avatar.adapter.out.persistence.AvatarBodyResourceRepository;
+import com.pfplaybackend.api.avatar.adapter.out.persistence.AvatarFaceResourceRepository;
+import com.pfplaybackend.api.avatar.domain.entity.data.AvatarBodyResourceData;
+import com.pfplaybackend.api.avatar.domain.entity.data.AvatarFaceResourceData;
+import com.pfplaybackend.api.avatar.domain.enums.ObtainmentType;
+import com.pfplaybackend.api.avatar.domain.value.AvatarBodyUri;
+import com.pfplaybackend.api.avatar.domain.value.AvatarFaceUri;
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.domain.entity.data.MemberData;
+import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
+import com.pfplaybackend.api.virtualdj.application.service.BotAvatarAdminService;
+import com.pfplaybackend.api.virtualdj.application.service.BotAvatarAssigner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * BotAvatarAdminService 통합 테스트 — 실 트랜잭션 매니저 + Testcontainer DB.
+ *
+ * <p><b>비-@Transactional 이다(의도적).</b> 클래스에 @Transactional 을 걸면 distribute 의 @Transactional
+ * 이 테스트 트랜잭션에 join 만 하고 실제 커밋 경계가 테스트 종료 시점으로 미뤄져, rollback-only 마킹이
+ * 던지는 {@link org.springframework.transaction.UnexpectedRollbackException} 이 distribute 호출 시점에
+ * 드러나지 않는다(=버그를 못 잡음). 비-Tx 로 두어 distribute 자신의 @Transactional 을 실제 커밋 경계로
+ * 만들고, 재조회로 "커밋됐는가"를 확인한다.
+ *
+ * <p>C1(핵심): 사전필터 도입 전이면 distribute 안에서 비-봇 apply 가 공유 tx 를 rollback-only 로 마킹 →
+ * distribute 커밋 시 UnexpectedRollbackException + 성공분까지 롤백. 도입 후엔 유효 봇만 넘어가 정상 커밋.
+ *
+ * <p>I2(combinable 아이콘): combinable 바디는 icon_uri 가 NULL 이라, assignOne 이 기본 face 를 합성
+ * (BODY_WITH_FACE)해 face-pair 아이콘으로 채워야 최종 avatarIconUri 가 non-blank 가 된다.
+ *
+ * <p>test 프로파일은 create-drop + Flyway 비활성(시드 없음)이라 카탈로그를 직접 시드한다(다른 IT 동일).
+ */
+class BotAvatarAdminServiceIT extends AbstractIntegrationTest {
+
+    private static final String COMBINABLE_BODY_URI = "https://cdn.test/ava_body_basic_001.png";
+    private static final String STANDALONE_BODY_URI = "https://cdn.test/ava_body_basic_002.png";
+    private static final String FACE_URI = "https://cdn.test/ava_face_basic_001.png";
+    private static final String FACE_ICON_URI = "https://cdn.test/ava_icon_face_basic_001.png";
+    private static final String STANDALONE_ICON_URI = "https://cdn.test/ava_icon_body_basic_002.png";
+
+    private static final long NON_BOT_MISSING_UID = 7_999_001L;
+
+    @Autowired private BotAvatarAdminService botAvatarAdminService;
+    @Autowired private AdminUserService adminUserService;
+    @Autowired private UserAccountRepository userAccountRepository;
+    @Autowired private AvatarBodyResourceRepository avatarBodyResourceRepository;
+    @Autowired private AvatarFaceResourceRepository avatarFaceResourceRepository;
+
+    // 비-Tx IT 라 생성한 봇이 커밋돼 같은 컨테이너를 공유하는 다른 IT(BotPoolQueryRepositoryImplIT 등)를
+    // 오염시킨다. @AfterEach 에서 withdraw 처리해 봇 조회(is_dummy + withdrawn_at IS NULL)에서 제외한다.
+    private final List<UserId> createdBots = new ArrayList<>();
+
+    @BeforeEach
+    void seedCatalog() {
+        // combinable 바디: icon_uri NULL → face 합성이 강제됨.
+        seedBody("ava_body_basic_001", COMBINABLE_BODY_URI, null, true, true, 60, 41);
+        // standalone 바디: 자체 icon_uri 보유.
+        seedBody("ava_body_basic_002", STANDALONE_BODY_URI, STANDALONE_ICON_URI, false, false, 0, 0);
+        // 기본 face: face-pair 아이콘 보유.
+        seedFace("ava_face_basic_001", FACE_URI, FACE_ICON_URI);
+    }
+
+    private void seedBody(String name, String uri, String iconUri, boolean combinable,
+                          boolean defaultSetting, int px, int py) {
+        if (avatarBodyResourceRepository.findOneAvatarResourceByResourceUri(uri) != null) {
+            return;
+        }
+        AvatarBodyResourceData body = AvatarBodyResourceData.draft(
+                name, uri, iconUri, ObtainmentType.BASIC, 0, combinable, defaultSetting, px, py, null);
+        body.publish(null);   // PUBLISHED 여야 findPublishedBodies/Faces 에 노출
+        avatarBodyResourceRepository.save(body);
+    }
+
+    private void seedFace(String name, String uri, String iconUri) {
+        if (avatarFaceResourceRepository.findOneAvatarResourceByResourceUri(uri) != null) {
+            return;
+        }
+        AvatarFaceResourceData face = AvatarFaceResourceData.draft(name, uri, iconUri, null);
+        face.publish(null);
+        avatarFaceResourceRepository.save(face);
+    }
+
+    /**
+     * 실제 봇(LOCAL 가상 멤버 + is_dummy)을 1명 만든다. createVirtualMember 와 markAsDummy 는
+     * 각자 자기 트랜잭션에서 커밋된다(테스트가 비-Tx 이므로).
+     */
+    private UserId seedBot(String initialBodyUri) {
+        MemberData member = adminUserService.createVirtualMember(
+                null, new AvatarBodyUri(initialBodyUri), new AvatarFaceUri(""));
+        UserId botId = new UserId(member.getUserAccountId());
+        UserAccountData account = userAccountRepository.findById(botId).orElseThrow();
+        account.markAsDummy();
+        userAccountRepository.saveAndFlush(account);
+        createdBots.add(botId);
+        return botId;
+    }
+
+    @AfterEach
+    void withdrawCreatedBots() {
+        for (UserId botId : createdBots) {
+            userAccountRepository.findById(botId).ifPresent(account -> {
+                account.withdraw(null);
+                userAccountRepository.saveAndFlush(account);
+            });
+        }
+        createdBots.clear();
+    }
+
+    private String currentBodyUri(UserId botId) {
+        return adminUserService.getVirtualMember(botId)
+                .getProfileData().getAvatarSetting().getAvatarBodyUriValue();
+    }
+
+    private String currentIconUri(UserId botId) {
+        return adminUserService.getVirtualMember(botId)
+                .getProfileData().getAvatarSetting().getAvatarIconUriValue();
+    }
+
+    @Test
+    @DisplayName("C1: distribute([validBot, nonBot]) — 유효 봇 아바타가 실제로 커밋, 비-봇 격리, 결과 1건, 롤백 없음")
+    void distribute_validBotCommitted_nonBotSkipped_noRollback() {
+        UserId validBot = seedBot(STANDALONE_BODY_URI);
+        assertThat(currentBodyUri(validBot)).isEqualTo(STANDALONE_BODY_URI);
+
+        // 비-봇/미존재 id 를 섞는다. 사전필터 전이면 apply 예외 → 공유 tx rollback-only →
+        // distribute 커밋 시 UnexpectedRollbackException + 유효 봇 변경까지 롤백.
+        List<BotAvatarAssigner.Assigned> assigned = botAvatarAdminService.distribute(
+                List.of(validBot.getUid(), NON_BOT_MISSING_UID),
+                List.of(COMBINABLE_BODY_URI));
+
+        // 비-봇은 격리 → 결과는 유효 봇 1건.
+        assertThat(assigned).hasSize(1);
+        assertThat(assigned.get(0).userId()).isEqualTo(validBot.getUid());
+        assertThat(assigned.get(0).avatarBodyUri()).isEqualTo(COMBINABLE_BODY_URI);
+
+        // 핵심: 유효 봇의 아바타 변경이 실제로 커밋됐다(롤백되지 않음). 재조회로 증명.
+        assertThat(currentBodyUri(validBot)).isEqualTo(COMBINABLE_BODY_URI);
+    }
+
+    @Test
+    @DisplayName("I2: setIndividual(combinable body) — face 합성으로 최종 채팅 아이콘(avatarIconUri)이 non-blank")
+    void setIndividual_combinableBody_yieldsNonBlankIcon() {
+        UserId bot = seedBot(STANDALONE_BODY_URI);
+
+        botAvatarAdminService.setIndividual(bot, COMBINABLE_BODY_URI);
+
+        assertThat(currentBodyUri(bot)).isEqualTo(COMBINABLE_BODY_URI);
+        // combinable → 기본 face 합성 → face-pair 아이콘이 채워져 non-blank.
+        assertThat(currentIconUri(bot)).isNotBlank();
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAdminServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAdminServiceTest.java
@@ -1,0 +1,107 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.avatar.application.dto.AvatarBodyDto;
+import com.pfplaybackend.api.avatar.application.port.in.AvatarCatalogQueryUseCase;
+import com.pfplaybackend.api.avatar.domain.enums.ObtainmentType;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.BotPoolQueryRepository;
+import com.pfplaybackend.api.virtualdj.application.dto.BotRosterRow;
+import com.pfplaybackend.api.virtualdj.application.service.BotAvatarAdminService;
+import com.pfplaybackend.api.virtualdj.application.service.BotAvatarAssigner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * BotAvatarAdminService 단위 테스트 — 카탈로그 매핑 / 로스터·개별·일괄 위임 검증(mock).
+ */
+class BotAvatarAdminServiceTest {
+
+    private BotPoolQueryRepository botPoolQueryRepository;
+    private AvatarCatalogQueryUseCase catalog;
+    private BotAvatarAssigner assigner;
+    private BotAvatarAdminService service;
+
+    @BeforeEach
+    void setUp() {
+        botPoolQueryRepository = mock(BotPoolQueryRepository.class);
+        catalog = mock(AvatarCatalogQueryUseCase.class);
+        assigner = mock(BotAvatarAssigner.class);
+        service = new BotAvatarAdminService(botPoolQueryRepository, catalog, assigner);
+    }
+
+    @Test
+    void catalog_은_published_바디를_CatalogItem_으로_매핑한다() {
+        given(catalog.findPublishedBodies()).willReturn(List.of(
+                AvatarBodyDto.builder()
+                        .name("바디A").resourceUri("https://cdn/a.png").iconUri(null)
+                        .combinable(true).obtainableType(ObtainmentType.BASIC).build(),
+                AvatarBodyDto.builder()
+                        .name("바디B").resourceUri("https://cdn/b.png").iconUri("https://cdn/b.icon.png")
+                        .combinable(false).obtainableType(ObtainmentType.DJ_PNT).build()));
+
+        List<BotAvatarAdminService.CatalogItem> items = service.catalog();
+
+        assertThat(items).hasSize(2);
+        assertThat(items.get(0).bodyUri()).isEqualTo("https://cdn/a.png");
+        assertThat(items.get(0).name()).isEqualTo("바디A");
+        assertThat(items.get(0).thumbnailUri()).isEqualTo("https://cdn/a.png");
+        assertThat(items.get(0).combinable()).isTrue();
+        assertThat(items.get(0).obtainableType()).isEqualTo("BASIC");
+        assertThat(items.get(1).combinable()).isFalse();
+        assertThat(items.get(1).obtainableType()).isEqualTo("DJ_PNT");
+    }
+
+    @Test
+    void catalog_은_obtainableType_null_을_null_로_매핑한다() {
+        given(catalog.findPublishedBodies()).willReturn(List.of(
+                AvatarBodyDto.builder()
+                        .name("바디").resourceUri("https://cdn/a.png").iconUri(null)
+                        .combinable(true).obtainableType(null).build()));
+
+        assertThat(service.catalog().get(0).obtainableType()).isNull();
+    }
+
+    @Test
+    void roster_는_repository_findRoster_에_위임한다() {
+        List<BotRosterRow> rows = List.of(
+                new BotRosterRow(1L, "봇", "https://cdn/body.png", "https://cdn/icon.png", 7L, "룸"));
+        given(botPoolQueryRepository.findRoster()).willReturn(rows);
+
+        assertThat(service.roster()).isEqualTo(rows);
+        verify(botPoolQueryRepository).findRoster();
+    }
+
+    @Test
+    void setIndividual_은_assigner_assignOne_에_위임한다() {
+        service.setIndividual(new UserId(5L), "https://cdn/body.png");
+        verify(assigner).assignOne(eq(new UserId(5L)), eq("https://cdn/body.png"));
+    }
+
+    @Test
+    void distribute_는_Long_id_를_UserId_로_변환해_assigner_에_위임하고_결과를_반환한다() {
+        List<BotAvatarAssigner.Assigned> result = List.of(
+                new BotAvatarAssigner.Assigned(1L, "https://cdn/body1.png"),
+                new BotAvatarAssigner.Assigned(2L, "https://cdn/body2.png"));
+        given(assigner.distribute(
+                List.of(new UserId(1L), new UserId(2L)),
+                List.of("https://cdn/body1.png", "https://cdn/body2.png")))
+                .willReturn(result);
+
+        List<BotAvatarAssigner.Assigned> out = service.distribute(
+                List.of(1L, 2L),
+                List.of("https://cdn/body1.png", "https://cdn/body2.png"));
+
+        assertThat(out).isEqualTo(result);
+        verify(assigner).distribute(
+                List.of(new UserId(1L), new UserId(2L)),
+                List.of("https://cdn/body1.png", "https://cdn/body2.png"));
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAdminServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAdminServiceTest.java
@@ -86,7 +86,10 @@ class BotAvatarAdminServiceTest {
     }
 
     @Test
-    void distribute_는_Long_id_를_UserId_로_변환해_assigner_에_위임하고_결과를_반환한다() {
+    void distribute_는_실제_봇만_사전필터한_뒤_UserId_로_변환해_assigner_에_위임하고_결과를_반환한다() {
+        // 후보 [1,2,3] 중 사전필터가 [1,2] 만 봇으로 추린다(3 은 비-봇/미존재 → 격리).
+        given(botPoolQueryRepository.filterBotUserIds(List.of(1L, 2L, 3L)))
+                .willReturn(List.of(1L, 2L));
         List<BotAvatarAssigner.Assigned> result = List.of(
                 new BotAvatarAssigner.Assigned(1L, "https://cdn/body1.png"),
                 new BotAvatarAssigner.Assigned(2L, "https://cdn/body2.png"));
@@ -96,10 +99,11 @@ class BotAvatarAdminServiceTest {
                 .willReturn(result);
 
         List<BotAvatarAssigner.Assigned> out = service.distribute(
-                List.of(1L, 2L),
+                List.of(1L, 2L, 3L),
                 List.of("https://cdn/body1.png", "https://cdn/body2.png"));
 
         assertThat(out).isEqualTo(result);
+        verify(botPoolQueryRepository).filterBotUserIds(List.of(1L, 2L, 3L));
         verify(assigner).distribute(
                 List.of(new UserId(1L), new UserId(2L)),
                 List.of("https://cdn/body1.png", "https://cdn/body2.png"));

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAssignerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAssignerTest.java
@@ -83,6 +83,22 @@ class BotAvatarAssignerTest {
     }
 
     @Test
+    void distribute_는_적용_실패한_봇은_건너뛰고_성공분만_반환한다() {
+        // 봇 2명, 셋 [standalone]. 1번 봇은 apply 시 예외(비-봇/미존재 모사) → 건너뛰고 2번만 성공.
+        given(randomizer.nextIndex(1)).willReturn(0);
+        org.mockito.BDDMockito.willThrow(new RuntimeException("non-bot"))
+                .given(applyPort).apply(eq(new UserId(1L)), any(), any());
+
+        var assigned = assigner.distribute(
+                List.of(new UserId(1L), new UserId(2L)),
+                List.of(STANDALONE_BODY));
+
+        assertThat(assigned).hasSize(1);
+        assertThat(assigned.get(0).userId()).isEqualTo(2L);
+        verify(applyPort).apply(eq(new UserId(2L)), bodyUri(STANDALONE_BODY), any());
+    }
+
+    @Test
     void distribute_빈_셋이면_INVALID() {
         assertThatThrownBy(() -> assigner.distribute(List.of(new UserId(1L)), List.of()))
                 .isInstanceOf(RuntimeException.class);

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAssignerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAssignerTest.java
@@ -1,0 +1,132 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.avatar.application.dto.AvatarBodyDto;
+import com.pfplaybackend.api.avatar.application.dto.AvatarFaceDto;
+import com.pfplaybackend.api.avatar.application.port.in.AvatarCatalogQueryUseCase;
+import com.pfplaybackend.api.avatar.domain.value.AvatarBodyUri;
+import com.pfplaybackend.api.avatar.domain.value.AvatarFaceUri;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.virtualdj.application.port.BotAvatarApplyPort;
+import com.pfplaybackend.api.virtualdj.application.port.Randomizer;
+import com.pfplaybackend.api.virtualdj.application.service.BotAvatarAssigner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class BotAvatarAssignerTest {
+
+    private AvatarCatalogQueryUseCase catalog;
+    private BotAvatarApplyPort applyPort;
+    private Randomizer randomizer;
+    private BotAvatarAssigner assigner;
+
+    private static final String FACE_URI = "https://cdn/ava_face_basic_001.png";
+    private static final String COMBINABLE_BODY = "https://cdn/ava_body_basic_001.png";
+    private static final String STANDALONE_BODY = "https://cdn/ava_body_basic_002.png";
+
+    @BeforeEach
+    void setUp() {
+        catalog = mock(AvatarCatalogQueryUseCase.class);
+        applyPort = mock(BotAvatarApplyPort.class);
+        randomizer = mock(Randomizer.class);
+        assigner = new BotAvatarAssigner(catalog, applyPort, randomizer);
+
+        // 기본 face = 단일 basic face
+        given(catalog.findPublishedFaces())
+                .willReturn(List.of(face(FACE_URI)));
+        given(catalog.findBodyByUri(COMBINABLE_BODY)).willReturn(Optional.of(body(COMBINABLE_BODY, true)));
+        given(catalog.findBodyByUri(STANDALONE_BODY)).willReturn(Optional.of(body(STANDALONE_BODY, false)));
+    }
+
+    @Test
+    void combinable_바디는_기본_face_를_합성해_적용한다() {
+        assigner.assignOne(new UserId(1L), COMBINABLE_BODY);
+
+        ArgumentCaptor<AvatarFaceUri> faceCap = ArgumentCaptor.forClass(AvatarFaceUri.class);
+        verify(applyPort).apply(eq(new UserId(1L)), bodyUri(COMBINABLE_BODY), faceCap.capture());
+        assertThat(faceCap.getValue().getValue()).isEqualTo(FACE_URI);  // non-empty = BODY_WITH_FACE
+    }
+
+    @Test
+    void standalone_바디는_빈_face_로_적용한다() {
+        assigner.assignOne(new UserId(2L), STANDALONE_BODY);
+
+        ArgumentCaptor<AvatarFaceUri> faceCap = ArgumentCaptor.forClass(AvatarFaceUri.class);
+        verify(applyPort).apply(eq(new UserId(2L)), bodyUri(STANDALONE_BODY), faceCap.capture());
+        assertThat(faceCap.getValue().getValue()).isEmpty();  // empty = SINGLE_BODY
+    }
+
+    @Test
+    void distribute_는_셋에서_Randomizer_인덱스로_봇별_배분한다() {
+        // 봇 2명, 셋 [standalone, combinable]; randomizer 가 0,1 반환 → 각각 배분
+        given(randomizer.nextIndex(2)).willReturn(0, 1);
+
+        var assigned = assigner.distribute(
+                List.of(new UserId(1L), new UserId(2L)),
+                List.of(STANDALONE_BODY, COMBINABLE_BODY));
+
+        assertThat(assigned).hasSize(2);
+        verify(applyPort).apply(eq(new UserId(1L)), bodyUri(STANDALONE_BODY), any());
+        verify(applyPort).apply(eq(new UserId(2L)), bodyUri(COMBINABLE_BODY), any());
+    }
+
+    @Test
+    void distribute_빈_셋이면_INVALID() {
+        assertThatThrownBy(() -> assigner.distribute(List.of(new UserId(1L)), List.of()))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void distribute_빈_봇목록이면_INVALID() {
+        assertThatThrownBy(() -> assigner.distribute(List.of(), List.of(STANDALONE_BODY)))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void 카탈로그에_없는_bodyUri_는_INVALID() {
+        given(catalog.findBodyByUri("https://cdn/unknown.png")).willReturn(Optional.empty());
+        assertThatThrownBy(() -> assigner.assignOne(new UserId(1L), "https://cdn/unknown.png"))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void assignRandomFromCatalog_는_published_바디에서_랜덤_1개를_적용한다() {
+        given(catalog.findPublishedBodies())
+                .willReturn(List.of(body(STANDALONE_BODY, false), body(COMBINABLE_BODY, true)));
+        given(randomizer.nextIndex(2)).willReturn(1);
+
+        assigner.assignRandomFromCatalog(new UserId(9L));
+
+        verify(applyPort).apply(eq(new UserId(9L)), bodyUri(COMBINABLE_BODY), any());
+    }
+
+    /**
+     * AvatarBodyUri 는 value object 이지만 equals 미구현(avatar BC 소관, Chunk 1 범위 외)이라
+     * {@code eq(new AvatarBodyUri(...))} 가 동작하지 않는다. value 기준으로 매칭한다.
+     */
+    private static AvatarBodyUri bodyUri(String expected) {
+        return argThat(u -> u != null && expected.equals(u.getValue()));
+    }
+
+    private static AvatarBodyDto body(String uri, boolean combinable) {
+        return AvatarBodyDto.builder().name("b").resourceUri(uri).iconUri(combinable ? null : uri + ".icon")
+                .combinable(combinable).build();
+    }
+
+    private static AvatarFaceDto face(String uri) {
+        // AvatarFaceDto = 4-arg record (long id, String name, String resourceUri, boolean available)
+        return new AvatarFaceDto(1L, "ava_face_basic_001", uri, true);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAssignerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAssignerTest.java
@@ -83,19 +83,30 @@ class BotAvatarAssignerTest {
     }
 
     @Test
-    void distribute_는_적용_실패한_봇은_건너뛰고_성공분만_반환한다() {
-        // 봇 2명, 셋 [standalone]. 1번 봇은 apply 시 예외(비-봇/미존재 모사) → 건너뛰고 2번만 성공.
+    void distribute_는_넘어온_모든_봇에_전수_적용한다() {
+        // 비-봇 격리는 호출자(서비스)가 사전 필터로 처리하므로, assigner 는 받은 봇 전부에 적용한다.
         given(randomizer.nextIndex(1)).willReturn(0);
-        org.mockito.BDDMockito.willThrow(new RuntimeException("non-bot"))
-                .given(applyPort).apply(eq(new UserId(1L)), any(), any());
 
         var assigned = assigner.distribute(
                 List.of(new UserId(1L), new UserId(2L)),
                 List.of(STANDALONE_BODY));
 
-        assertThat(assigned).hasSize(1);
-        assertThat(assigned.get(0).userId()).isEqualTo(2L);
+        assertThat(assigned).hasSize(2);
+        verify(applyPort).apply(eq(new UserId(1L)), bodyUri(STANDALONE_BODY), any());
         verify(applyPort).apply(eq(new UserId(2L)), bodyUri(STANDALONE_BODY), any());
+    }
+
+    @Test
+    void distribute_는_apply_예외를_삼키지_않고_전파한다() {
+        // 사전 필터를 통과했는데도 apply 가 예외를 던지면(진짜 버그/인프라 장애) 배치를 실패시킨다.
+        given(randomizer.nextIndex(1)).willReturn(0);
+        org.mockito.BDDMockito.willThrow(new RuntimeException("genuine failure"))
+                .given(applyPort).apply(eq(new UserId(1L)), any(), any());
+
+        assertThatThrownBy(() -> assigner.distribute(
+                List.of(new UserId(1L), new UserId(2L)),
+                List.of(STANDALONE_BODY)))
+                .isInstanceOf(RuntimeException.class);
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/BotPoolQueryRepositoryImplIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/BotPoolQueryRepositoryImplIT.java
@@ -12,9 +12,15 @@ import com.pfplaybackend.api.party.domain.enums.StageType;
 import com.pfplaybackend.api.party.domain.value.LinkDomain;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.avatar.domain.value.AvatarBodyUri;
+import com.pfplaybackend.api.avatar.domain.value.AvatarFaceUri;
+import com.pfplaybackend.api.avatar.domain.value.AvatarIconUri;
 import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserProfileRepository;
+import com.pfplaybackend.api.user.domain.entity.data.ProfileData;
 import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
 import com.pfplaybackend.api.virtualdj.adapter.out.persistence.BotPoolQueryRepository;
+import com.pfplaybackend.api.virtualdj.application.dto.BotRosterRow;
 import com.pfplaybackend.api.virtualdj.application.dto.PoolPlacementRow;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -41,6 +47,7 @@ class BotPoolQueryRepositoryImplIT extends AbstractIntegrationTest {
 
     @Autowired private BotPoolQueryRepository botPoolQueryRepository;
     @Autowired private UserAccountRepository userAccountRepository;
+    @Autowired private UserProfileRepository userProfileRepository;
     @Autowired private CrewRepository crewRepository;
     @Autowired private PartyroomRepository partyroomRepository;
 
@@ -97,6 +104,17 @@ class BotPoolQueryRepositoryImplIT extends AbstractIntegrationTest {
             account.markAsDummy();
         }
         userAccountRepository.saveAndFlush(account);
+    }
+
+    private void seedProfile(long uid, String nickname, String bodyUri, String iconUri) {
+        ProfileData profile = ProfileData.builder()
+                .userId(new UserId(uid))
+                .nickname(new com.pfplaybackend.api.user.domain.value.Nickname(nickname))
+                .avatarBodyUri(new AvatarBodyUri(bodyUri))
+                .avatarFaceUri(new AvatarFaceUri(""))
+                .avatarIconUri(new AvatarIconUri(iconUri))
+                .build();
+        userProfileRepository.saveAndFlush(profile);
     }
 
     @Test
@@ -172,6 +190,39 @@ class BotPoolQueryRepositoryImplIT extends AbstractIntegrationTest {
         assertThat(placements).hasSize(1);
         assertThat(placements.get(0).partyroomId()).isEqualTo(partyroomId);
         assertThat(placements.get(0).botCount()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("findRoster() — 봇의 닉네임/아바타/배치룸 반환, idle 봇은 placementPartyroomId null")
+    void findRoster_returns_bot_identity_avatar_and_placement() {
+        // 봇 프로필 시드: BOT1(배치됨), BOT2(idle). HUMAN(비봇)도 프로필 시드해 is_dummy 게이트로 제외됨을 검증.
+        seedProfile(BOT1_UID, "봇하나", "https://cdn/body1.png", "https://cdn/icon1.png");
+        seedProfile(BOT2_UID, "봇둘", "https://cdn/body2.png", "https://cdn/icon2.png");
+        seedProfile(HUMAN_UID, "사람", "https://cdn/bodyH.png", "https://cdn/iconH.png");
+
+        List<BotRosterRow> roster = botPoolQueryRepository.findRoster();
+
+        // BOT1·BOT2 만 (프로필 없는 BOT3 는 inner join 으로 빠짐, HUMAN 은 비봇).
+        assertThat(roster).hasSize(2);
+        assertThat(roster).allSatisfy(r -> {
+            assertThat(r.nickname()).isNotBlank();
+            assertThat(r.avatarBodyUri()).isNotNull();
+        });
+
+        // 비봇(사람)이 로스터에 섞이지 않는다.
+        assertThat(roster).noneSatisfy(r -> assertThat(r.userId()).isEqualTo(HUMAN_UID));
+
+        // uid 오름차순 → BOT1 먼저(배치됨), BOT2 다음(idle).
+        BotRosterRow placed = roster.get(0);
+        assertThat(placed.userId()).isEqualTo(BOT1_UID);
+        assertThat(placed.placementPartyroomId()).isEqualTo(partyroomId);
+        assertThat(placed.placementPartyroomTitle()).isEqualTo("테스트 파티룸");
+        assertThat(placed.avatarBodyUri()).isEqualTo("https://cdn/body1.png");
+
+        BotRosterRow idle = roster.get(1);
+        assertThat(idle.userId()).isEqualTo(BOT2_UID);
+        assertThat(idle.placementPartyroomId()).isNull();
+        assertThat(idle.placementPartyroomTitle()).isNull();
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/SongPackApplierIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/SongPackApplierIT.java
@@ -46,10 +46,13 @@ class SongPackApplierIT extends AbstractIntegrationTest {
         if (avatarBodyResourceRepository.findOneAvatarResourceByResourceUri(DEFAULT_BODY_URI) != null) {
             return;
         }
+        // Chunk 3: provision 이 생성 즉시 assignRandomFromCatalog 로 변별 아바타를 부여하므로
+        // 이 바디가 published 후보로 노출돼야 한다(standalone, 자체 아이콘 → face 의존 없음).
         AvatarBodyResourceData body = AvatarBodyResourceData.draft(
                 "ava_body_basic_001", DEFAULT_BODY_URI,
                 "https://example.test/icon_basic_001.png",
                 ObtainmentType.BASIC, 0, false, true, 60, 41, null);
+        body.publish(null);
         avatarBodyResourceRepository.save(body);
     }
 

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjAdminServiceIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjAdminServiceIT.java
@@ -75,11 +75,15 @@ class VirtualDjAdminServiceIT extends AbstractIntegrationTest {
                     }
                     return result;
                 });
+        // Chunk 3: provision 이 생성 즉시 assignRandomFromCatalog 로 변별 아바타를 부여하므로
+        // 이 바디가 published 후보로 노출돼야 한다(standalone, 자체 아이콘 → face 의존 없음).
         if (avatarBodyResourceRepository.findOneAvatarResourceByResourceUri(DEFAULT_BODY_URI) == null) {
-            avatarBodyResourceRepository.save(AvatarBodyResourceData.draft(
+            AvatarBodyResourceData body = AvatarBodyResourceData.draft(
                     "ava_body_basic_001", DEFAULT_BODY_URI,
                     "https://example.test/icon_basic_001.png",
-                    ObtainmentType.BASIC, 0, false, true, 60, 41, null));
+                    ObtainmentType.BASIC, 0, false, true, 60, 41, null);
+            body.publish(null);
+            avatarBodyResourceRepository.save(body);
         }
     }
 

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjEventListenerIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjEventListenerIT.java
@@ -101,11 +101,15 @@ class VirtualDjEventListenerIT extends AbstractIntegrationTest {
                     }
                     return result;
                 });
+        // Chunk 3: provision 이 생성 즉시 assignRandomFromCatalog 로 변별 아바타를 부여하므로
+        // 이 바디가 published 후보로 노출돼야 한다(standalone, 자체 아이콘 → face 의존 없음).
         if (avatarBodyResourceRepository.findOneAvatarResourceByResourceUri(DEFAULT_BODY_URI) == null) {
-            avatarBodyResourceRepository.save(AvatarBodyResourceData.draft(
+            AvatarBodyResourceData body = AvatarBodyResourceData.draft(
                     "ava_body_basic_001", DEFAULT_BODY_URI,
                     "https://example.test/icon_basic_001.png",
-                    ObtainmentType.BASIC, 0, false, true, 60, 41, null));
+                    ObtainmentType.BASIC, 0, false, true, 60, 41, null);
+            body.publish(null);
+            avatarBodyResourceRepository.save(body);
         }
 
         transactionTemplate.executeWithoutResult(status -> {

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjOrchestratorIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjOrchestratorIT.java
@@ -98,11 +98,15 @@ class VirtualDjOrchestratorIT extends AbstractIntegrationTest {
                     return result;
                 });
         // 봇 프로비저닝이 쓰는 기본 아바타 바디 시드 (test 프로파일은 Flyway 비활성).
+        // Chunk 3: provision 이 생성 즉시 assignRandomFromCatalog 로 변별 아바타를 부여하므로
+        // 이 바디가 published 후보로 노출돼야 한다(standalone, 자체 아이콘 → face 의존 없음).
         if (avatarBodyResourceRepository.findOneAvatarResourceByResourceUri(DEFAULT_BODY_URI) == null) {
-            avatarBodyResourceRepository.save(AvatarBodyResourceData.draft(
+            AvatarBodyResourceData body = AvatarBodyResourceData.draft(
                     "ava_body_basic_001", DEFAULT_BODY_URI,
                     "https://example.test/icon_basic_001.png",
-                    ObtainmentType.BASIC, 0, false, true, 60, 41, null));
+                    ObtainmentType.BASIC, 0, false, true, 60, 41, null);
+            body.publish(null);
+            avatarBodyResourceRepository.save(body);
         }
     }
 

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualUserPoolServiceIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualUserPoolServiceIT.java
@@ -1,7 +1,10 @@
 package com.pfplaybackend.api.virtualdj;
 
+import com.pfplaybackend.api.admin.application.service.AdminUserService;
 import com.pfplaybackend.api.avatar.adapter.out.persistence.AvatarBodyResourceRepository;
+import com.pfplaybackend.api.avatar.adapter.out.persistence.AvatarFaceResourceRepository;
 import com.pfplaybackend.api.avatar.domain.entity.data.AvatarBodyResourceData;
+import com.pfplaybackend.api.avatar.domain.entity.data.AvatarFaceResourceData;
 import com.pfplaybackend.api.avatar.domain.enums.ObtainmentType;
 import com.pfplaybackend.api.common.AbstractIntegrationTest;
 import com.pfplaybackend.api.common.domain.value.UserId;
@@ -30,22 +33,58 @@ class VirtualUserPoolServiceIT extends AbstractIntegrationTest {
     private static final String DEFAULT_BODY_URI =
             "https://firebasestorage.googleapis.com/v0/b/pfplay-firebase.appspot.com/o/ava_basic%2Fava_basic_001.png?alt=media";
 
+    // assignRandomFromCatalog 가 고를 published 카탈로그(combinable + standalone + 기본 face).
+    private static final String COMBINABLE_BODY_URI = "https://cdn.test/ava_body_basic_001.png";
+    private static final String STANDALONE_BODY_URI = "https://cdn.test/ava_body_basic_002.png";
+    private static final String STANDALONE_ICON_URI = "https://cdn.test/ava_icon_body_basic_002.png";
+    private static final String FACE_URI = "https://cdn.test/ava_face_basic_001.png";
+    private static final String FACE_ICON_URI = "https://cdn.test/ava_icon_face_basic_001.png";
+
     @Autowired private VirtualUserPoolService poolService;
     @Autowired private UserAccountRepository userAccountRepository;
     @Autowired private CrewRepository crewRepository;
+    @Autowired private AdminUserService adminUserService;
     @Autowired private AvatarBodyResourceRepository avatarBodyResourceRepository;
+    @Autowired private AvatarFaceResourceRepository avatarFaceResourceRepository;
 
     @BeforeEach
-    void seedDefaultAvatarBody() {
-        if (avatarBodyResourceRepository.findOneAvatarResourceByResourceUri(DEFAULT_BODY_URI) != null) {
+    void seedCatalog() {
+        // createVirtualMember 의 디폴트 바디 — prod 의 깨진 디폴트(ava_basic_001)를 그대로 재현한다:
+        // combinable=true + icon_uri NULL. provision 이 디폴트 그대로 두면 SINGLE_BODY 아이콘(=body iconUri)
+        // 이 NULL 이라 채팅 아이콘이 blank 가 된다(=P1 이 고치려는 그 갭). 이게 회귀 가드의 red 전제.
+        if (avatarBodyResourceRepository.findOneAvatarResourceByResourceUri(DEFAULT_BODY_URI) == null) {
+            AvatarBodyResourceData body = AvatarBodyResourceData.draft(
+                    "ava_body_basic_001", DEFAULT_BODY_URI,
+                    null,
+                    ObtainmentType.BASIC, 0, true, true, 60, 41, null);
+            avatarBodyResourceRepository.save(body);
+        }
+        // assignRandomFromCatalog 가 고를 published 후보들.
+        // combinable 바디: icon_uri NULL → face 합성이 강제됨(BODY_WITH_FACE).
+        seedPublishedBody("ava_body_basic_001_pub", COMBINABLE_BODY_URI, null, true, 60, 41);
+        // standalone 바디: 자체 icon_uri 보유(SINGLE_BODY).
+        seedPublishedBody("ava_body_basic_002_pub", STANDALONE_BODY_URI, STANDALONE_ICON_URI, false, 0, 0);
+        // 기본 face: combinable 합성 시 face-pair 아이콘 제공.
+        seedPublishedFace("ava_face_basic_001_pub", FACE_URI, FACE_ICON_URI);
+    }
+
+    private void seedPublishedBody(String name, String uri, String iconUri, boolean combinable, int px, int py) {
+        if (avatarBodyResourceRepository.findOneAvatarResourceByResourceUri(uri) != null) {
             return;
         }
-        // SINGLE_BODY 경로(face 비움)만 타도록 combinable=false + icon_uri 보유.
         AvatarBodyResourceData body = AvatarBodyResourceData.draft(
-                "ava_body_basic_001", DEFAULT_BODY_URI,
-                "https://example.test/icon_basic_001.png",
-                ObtainmentType.BASIC, 0, false, true, 60, 41, null);
+                name, uri, iconUri, ObtainmentType.BASIC, 0, combinable, false, px, py, null);
+        body.publish(null);   // PUBLISHED 여야 findPublishedBodies 에 노출
         avatarBodyResourceRepository.save(body);
+    }
+
+    private void seedPublishedFace(String name, String uri, String iconUri) {
+        if (avatarFaceResourceRepository.findOneAvatarResourceByResourceUri(uri) != null) {
+            return;
+        }
+        AvatarFaceResourceData face = AvatarFaceResourceData.draft(name, uri, iconUri, null);
+        face.publish(null);
+        avatarFaceResourceRepository.save(face);
     }
 
     @Test
@@ -97,5 +136,22 @@ class VirtualUserPoolServiceIT extends AbstractIntegrationTest {
 
         List<UserId> idle = poolService.findIdleBots(10);
         assertThat(idle).contains(bot);
+    }
+
+    @Test
+    @DisplayName("provision 후 모든 봇은 유효한 채팅 아이콘을 가진다 (null-icon 갭 제거, spec §0/§4-3)")
+    void provision_후_모든_봇은_유효한_채팅_아이콘을_가진다() {
+        // when: 생성 즉시 카탈로그 랜덤 변별 아바타가 부여돼야 한다.
+        List<UserId> bots = poolService.provision(5);
+
+        flushAndClear();
+
+        // then: 각 봇의 user_profile.avatar_icon_uri 가 non-blank.
+        // (현 디폴트 basic_001 combinable 의 NULL 아이콘 깨짐이 사라졌는지 = P1-D5 핵심 회귀 가드)
+        for (UserId id : bots) {
+            String iconUri = adminUserService.getVirtualMember(id)
+                    .getProfileData().getAvatarSetting().getAvatarIconUriValue();
+            assertThat(iconUri).as("bot %s avatar icon", id.getUid()).isNotBlank();
+        }
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualUserPoolServiceIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualUserPoolServiceIT.java
@@ -152,6 +152,18 @@ class VirtualUserPoolServiceIT extends AbstractIntegrationTest {
             String iconUri = adminUserService.getVirtualMember(id)
                     .getProfileData().getAvatarSetting().getAvatarIconUriValue();
             assertThat(iconUri).as("bot %s avatar icon", id.getUid()).isNotBlank();
+
+            // 회귀 가드(replace-vs-mutate): provision = createVirtualMember(1 row) + 자동 변별 update.
+            // update 가 profile 을 교체하면 cascade 더블 인서트로 2 row 가 된다. create-drop 엔
+            // uk_user_profile_nickname 제약이 없어 SQL 에러 없이 통과하므로 row 개수로 직접 막는다
+            // (reference_ddl_auto_create_drop_hides_migration_drift).
+            long profileRows = ((Number) entityManager.createNativeQuery(
+                            "SELECT COUNT(*) FROM user_profile WHERE user_id = :uid")
+                    .setParameter("uid", id.getUid())
+                    .getSingleResult()).longValue();
+            assertThat(profileRows)
+                    .as("bot %s user_profile row count (provision 후 정확히 1개)", id.getUid())
+                    .isEqualTo(1L);
         }
     }
 }

--- a/docs/superpowers/plans/2026-06-02-virtual-dj-p1-avatar.md
+++ b/docs/superpowers/plans/2026-06-02-virtual-dj-p1-avatar.md
@@ -1,0 +1,938 @@
+# 가상 DJ(P1) 봇 아바타 변별 셋팅 콘솔 — 구현 플랜
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 어드민이 봇(가상 DJ) 계정에 카탈로그의 다양한 아바타를 일괄(셋 랜덤 분배)·개별로 입혀 방을 시각적으로 살아있게 보이게 하고, 봇 생성 시점부터 null-icon 갭을 원천 제거한다.
+
+**Architecture:** 합성 규칙(combinable→공통 face 합성 / standalone→자체 아이콘)을 `BotAvatarAssigner`(virtualdj 모듈) 단일 소스에 두고, 랜덤 배분·개별 적용·provision 자동부여가 모두 이 헬퍼를 거친다. 카탈로그는 `AvatarCatalogQueryUseCase`(avatar BC)에서 읽고, 봇 멤버 아바타 적용은 `BotAvatarApplyPort`(→ `AdminUserService.updateVirtualMemberAvatar`)로 나간다. 어드민 엔드포인트는 P2 `AdminVirtualDjController`에 합류(`canManageVirtualDj` 게이트). 어드민 프론트는 풀 페이지에 봇 로스터 + 아바타 피커 + 일괄/개별 다이얼로그를 P2 패턴 계승해 추가.
+
+**Tech Stack:** Spring Boot(JDK 21, Gradle multi-module: `app`/`avatar`/`user`), QueryDSL, JUnit5 + Mockito + `@WebMvcTest` + IT(`@SpringBootTest`), ArchUnit. 프론트: React + TypeScript(Vite) + react-query + zod + vitest + MSW.
+
+> **빌드 prefix 필수:** Gradle 호출 시 `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7"` ([[reference_pfplay_platform_jdk]]).
+> **마이그레이션 없음:** P1은 `user_profile` 기존 컬럼만 갱신 → 신규 Flyway 없음(부팅 drift 리스크 낮음, 단 e2e 게이트는 유지).
+> **브랜치:** `feature/virtual-dj-p1-avatar`(이미 origin/develop 분기, spec 커밋됨). 백엔드 PR 먼저, 프론트 PR(pfplay-admin) 별도.
+> **spec:** `docs/superpowers/specs/2026-06-02-virtual-dj-p1-avatar-design.md`
+
+---
+
+## Chunk 1: 백엔드 — 합성 규칙 코어 (`BotAvatarAssigner` + 포트)
+
+> 모듈 `app`, 패키지 `com.pfplaybackend.api.virtualdj`. 이 chunk는 순수 로직 + 시임만; 엔드포인트/쿼리는 Chunk 2.
+> 합성 규칙 근거(spec §1.2/§1.3): combinable 바디(`is_combinable=1`, `icon_uri` NULL)는 face 없이는 아이콘이 NULL이 된다 → **반드시 기본 face 합성**. standalone 바디(`icon_uri` 보유)는 face="" → 자체 아이콘.
+
+### Task 1.1: `Randomizer` 포트 + 어댑터 (테스트 결정성)
+
+**Files:**
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/application/port/Randomizer.java`
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/random/ThreadLocalRandomizer.java`
+
+- [ ] **Step 1: 포트 인터페이스 작성**
+
+```java
+package com.pfplaybackend.api.virtualdj.application.port;
+
+/**
+ * 셋→봇 랜덤 배분의 인덱스 선택을 추상화한다. 운영은 ThreadLocalRandom,
+ * 테스트는 결정적 stub 을 주입해 분배 결과를 검증 가능하게 한다.
+ */
+public interface Randomizer {
+    /** {@code [0, bound)} 범위의 인덱스를 반환한다. {@code bound <= 0} 이면 IllegalArgumentException. */
+    int nextIndex(int bound);
+}
+```
+
+- [ ] **Step 2: 어댑터 작성**
+
+```java
+package com.pfplaybackend.api.virtualdj.adapter.out.random;
+
+import com.pfplaybackend.api.virtualdj.application.port.Randomizer;
+import org.springframework.stereotype.Component;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Component
+public class ThreadLocalRandomizer implements Randomizer {
+    @Override
+    public int nextIndex(int bound) {
+        if (bound <= 0) throw new IllegalArgumentException("bound must be > 0, got " + bound);
+        return ThreadLocalRandom.current().nextInt(bound);
+    }
+}
+```
+
+- [ ] **Step 3: 컴파일 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:compileJava -q`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/virtualdj/application/port/Randomizer.java \
+        app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/random/ThreadLocalRandomizer.java
+git commit -m "feat(가상DJ P1): Randomizer 포트+ThreadLocalRandom 어댑터 (#288)"
+```
+
+### Task 1.2: `BotAvatarApplyPort` + 어댑터 (admin 시임)
+
+> `VirtualMemberProvisionPort`/`VirtualMemberProvisionAdapter` 패턴 미러. virtualdj 중 `..admin..` import 허용은 `adapter.out.provision` 패키지뿐(ArchUnit 호환).
+
+**Files:**
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/application/port/BotAvatarApplyPort.java`
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/provision/BotAvatarApplyAdapter.java`
+
+- [ ] **Step 1: 포트 작성**
+
+```java
+package com.pfplaybackend.api.virtualdj.application.port;
+
+import com.pfplaybackend.api.avatar.domain.value.AvatarBodyUri;
+import com.pfplaybackend.api.avatar.domain.value.AvatarFaceUri;
+import com.pfplaybackend.api.common.domain.value.UserId;
+
+/**
+ * virtualdj 가 봇 멤버 아바타를 갱신하기 위해 admin BC 로 나가는 outbound port.
+ * 구현체(provision 어댑터)만 admin 레이어를 만진다 — 합성/아이콘 결정은 admin 쪽 기존 로직 재사용.
+ */
+public interface BotAvatarApplyPort {
+    /** 봇의 아바타를 (body, face) 로 갱신한다. face 빈값이면 SINGLE_BODY, 있으면 BODY_WITH_FACE 로 admin 이 합성/아이콘 결정. */
+    void apply(UserId botUserId, AvatarBodyUri bodyUri, AvatarFaceUri faceUri);
+}
+```
+
+- [ ] **Step 2: 어댑터 작성** (기존 `AdminUserService.updateVirtualMemberAvatar(UserId, AvatarBodyUri, AvatarFaceUri)` 위임)
+
+```java
+package com.pfplaybackend.api.virtualdj.adapter.out.provision;
+
+import com.pfplaybackend.api.admin.application.service.AdminUserService;
+import com.pfplaybackend.api.avatar.domain.value.AvatarBodyUri;
+import com.pfplaybackend.api.avatar.domain.value.AvatarFaceUri;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.virtualdj.application.port.BotAvatarApplyPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BotAvatarApplyAdapter implements BotAvatarApplyPort {
+
+    private final AdminUserService adminUserService;
+
+    @Override
+    public void apply(UserId botUserId, AvatarBodyUri bodyUri, AvatarFaceUri faceUri) {
+        adminUserService.updateVirtualMemberAvatar(botUserId, bodyUri, faceUri);
+    }
+}
+```
+
+- [ ] **Step 3: 컴파일 확인** — `:app:compileJava -q` → SUCCESSFUL
+- [ ] **Step 4: 커밋** — `feat(가상DJ P1): BotAvatarApplyPort + admin 시임 어댑터 (#288)`
+
+### Task 1.3: `BotAvatarAssigner` 합성 규칙 — 실패 테스트 먼저
+
+> 합성 규칙은 순수 로직: 주어진 bodyUri를 카탈로그에서 조회 → combinable 이면 기본 face 합성(non-empty faceUri), 아니면 face="". 카탈로그/적용/랜덤은 mock. **icon non-null 종단 단언은 Chunk 2/3 IT 책임**(여기선 "combinable→face 전달" 규칙만).
+
+**Files:**
+- Create: `app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAssignerTest.java`
+- (다음 Task에서) Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/BotAvatarAssigner.java`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```java
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.avatar.application.dto.AvatarBodyDto;
+import com.pfplaybackend.api.avatar.application.dto.AvatarFaceDto;
+import com.pfplaybackend.api.avatar.application.port.in.AvatarCatalogQueryUseCase;
+import com.pfplaybackend.api.avatar.domain.value.AvatarBodyUri;
+import com.pfplaybackend.api.avatar.domain.value.AvatarFaceUri;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.virtualdj.application.port.BotAvatarApplyPort;
+import com.pfplaybackend.api.virtualdj.application.port.Randomizer;
+import com.pfplaybackend.api.virtualdj.application.service.BotAvatarAssigner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class BotAvatarAssignerTest {
+
+    private AvatarCatalogQueryUseCase catalog;
+    private BotAvatarApplyPort applyPort;
+    private Randomizer randomizer;
+    private BotAvatarAssigner assigner;
+
+    private static final String FACE_URI = "https://cdn/ava_face_basic_001.png";
+    private static final String COMBINABLE_BODY = "https://cdn/ava_body_basic_001.png";
+    private static final String STANDALONE_BODY = "https://cdn/ava_body_basic_002.png";
+
+    @BeforeEach
+    void setUp() {
+        catalog = mock(AvatarCatalogQueryUseCase.class);
+        applyPort = mock(BotAvatarApplyPort.class);
+        randomizer = mock(Randomizer.class);
+        assigner = new BotAvatarAssigner(catalog, applyPort, randomizer);
+
+        // 기본 face = 단일 basic face
+        given(catalog.findPublishedFaces())
+                .willReturn(List.of(face(FACE_URI)));
+        given(catalog.findBodyByUri(COMBINABLE_BODY)).willReturn(Optional.of(body(COMBINABLE_BODY, true)));
+        given(catalog.findBodyByUri(STANDALONE_BODY)).willReturn(Optional.of(body(STANDALONE_BODY, false)));
+    }
+
+    @Test
+    void combinable_바디는_기본_face_를_합성해_적용한다() {
+        assigner.assignOne(new UserId(1L), COMBINABLE_BODY);
+
+        ArgumentCaptor<AvatarFaceUri> faceCap = ArgumentCaptor.forClass(AvatarFaceUri.class);
+        verify(applyPort).apply(eq(new UserId(1L)), eq(new AvatarBodyUri(COMBINABLE_BODY)), faceCap.capture());
+        assertThat(faceCap.getValue().getValue()).isEqualTo(FACE_URI);  // non-empty = BODY_WITH_FACE
+    }
+
+    @Test
+    void standalone_바디는_빈_face_로_적용한다() {
+        assigner.assignOne(new UserId(2L), STANDALONE_BODY);
+
+        ArgumentCaptor<AvatarFaceUri> faceCap = ArgumentCaptor.forClass(AvatarFaceUri.class);
+        verify(applyPort).apply(eq(new UserId(2L)), eq(new AvatarBodyUri(STANDALONE_BODY)), faceCap.capture());
+        assertThat(faceCap.getValue().getValue()).isEmpty();  // empty = SINGLE_BODY
+    }
+
+    @Test
+    void distribute_는_셋에서_Randomizer_인덱스로_봇별_배분한다() {
+        // 봇 2명, 셋 [standalone, combinable]; randomizer 가 0,1 반환 → 각각 배분
+        given(randomizer.nextIndex(2)).willReturn(0, 1);
+
+        var assigned = assigner.distribute(
+                List.of(new UserId(1L), new UserId(2L)),
+                List.of(STANDALONE_BODY, COMBINABLE_BODY));
+
+        assertThat(assigned).hasSize(2);
+        verify(applyPort).apply(eq(new UserId(1L)), eq(new AvatarBodyUri(STANDALONE_BODY)), any());
+        verify(applyPort).apply(eq(new UserId(2L)), eq(new AvatarBodyUri(COMBINABLE_BODY)), any());
+    }
+
+    @Test
+    void distribute_빈_셋이면_INVALID() {
+        assertThatThrownBy(() -> assigner.distribute(List.of(new UserId(1L)), List.of()))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void distribute_빈_봇목록이면_INVALID() {
+        assertThatThrownBy(() -> assigner.distribute(List.of(), List.of(STANDALONE_BODY)))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void 카탈로그에_없는_bodyUri_는_INVALID() {
+        given(catalog.findBodyByUri("https://cdn/unknown.png")).willReturn(Optional.empty());
+        assertThatThrownBy(() -> assigner.assignOne(new UserId(1L), "https://cdn/unknown.png"))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void assignRandomFromCatalog_는_published_바디에서_랜덤_1개를_적용한다() {
+        given(catalog.findPublishedBodies())
+                .willReturn(List.of(body(STANDALONE_BODY, false), body(COMBINABLE_BODY, true)));
+        given(randomizer.nextIndex(2)).willReturn(1);
+
+        assigner.assignRandomFromCatalog(new UserId(9L));
+
+        verify(applyPort).apply(eq(new UserId(9L)), eq(new AvatarBodyUri(COMBINABLE_BODY)), any());
+    }
+
+    private static AvatarBodyDto body(String uri, boolean combinable) {
+        return AvatarBodyDto.builder().name("b").resourceUri(uri).iconUri(combinable ? null : uri + ".icon")
+                .combinable(combinable).build();
+    }
+
+    private static AvatarFaceDto face(String uri) {
+        // AvatarFaceDto = 4-arg record (long id, String name, String resourceUri, boolean available)
+        return new AvatarFaceDto(1L, "ava_face_basic_001", uri, true);
+    }
+}
+```
+
+> **NOTE (executor):** `AvatarFaceDto`는 4-component record `(long id, String name, String resourceUri, boolean available)` (검증됨). `.resourceUri()` 접근자로 읽는다. 목적은 `resourceUri==FACE_URI` 인 face 1건 반환.
+
+- [ ] **Step 2: 컴파일/실행 → 실패 확인** (`BotAvatarAssigner` 미존재)
+
+Run: `JAVA_HOME=... ./gradlew :app:test --tests "*BotAvatarAssignerTest" -q`
+Expected: 컴파일 에러(심볼 없음) 또는 FAIL
+
+### Task 1.4: `BotAvatarAssigner` 구현 → 테스트 GREEN
+
+**Files:**
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/BotAvatarAssigner.java`
+
+- [ ] **Step 1: 구현 작성**
+
+```java
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.avatar.application.dto.AvatarBodyDto;
+import com.pfplaybackend.api.avatar.application.dto.AvatarFaceDto;
+import com.pfplaybackend.api.avatar.application.port.in.AvatarCatalogQueryUseCase;
+import com.pfplaybackend.api.avatar.domain.value.AvatarBodyUri;
+import com.pfplaybackend.api.avatar.domain.value.AvatarFaceUri;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.exception.ExceptionCreator;
+import com.pfplaybackend.api.virtualdj.application.port.BotAvatarApplyPort;
+import com.pfplaybackend.api.virtualdj.application.port.Randomizer;
+import com.pfplaybackend.api.virtualdj.domain.exception.VirtualDjException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 봇 아바타 변별 배분의 단일 소스 — 합성 규칙(combinable→공통 face / standalone→자체 아이콘)을
+ * 여기 한 곳에만 두고, 개별 적용 / 셋 랜덤 배분 / provision 자동부여가 모두 이 헬퍼를 거친다.
+ *
+ * <p>합성 규칙(spec §1.2/§1.3): combinable 바디는 icon_uri 가 NULL 이라 face 없이는 아이콘이 깨진다.
+ * 따라서 기본 basic face 를 합성해 BODY_WITH_FACE(face 페어 아이콘)로 만들고, standalone 바디는
+ * face="" 로 SINGLE_BODY(자체 아이콘)로 둔다. 합성/아이콘의 실제 결정은 admin 쪽 update 로직이 수행.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BotAvatarAssigner {
+
+    private final AvatarCatalogQueryUseCase catalog;
+    private final BotAvatarApplyPort applyPort;
+    private final Randomizer randomizer;
+
+    public record Assigned(Long userId, String avatarBodyUri) {}
+
+    /** 전체 published 카탈로그에서 랜덤 1개를 골라 적용(provision 자동부여 + 단발 변별용). */
+    public void assignRandomFromCatalog(UserId botUserId) {
+        List<AvatarBodyDto> bodies = catalog.findPublishedBodies();
+        if (bodies.isEmpty()) {
+            throw ExceptionCreator.create(VirtualDjException.INVALID_AVATAR_SET);
+        }
+        String bodyUri = bodies.get(randomizer.nextIndex(bodies.size())).getResourceUri();
+        assignOne(botUserId, bodyUri);
+    }
+
+    /** 단일 봇에 지정 바디 적용(개별 셋팅). 합성 규칙 적용. */
+    public void assignOne(UserId botUserId, String bodyUri) {
+        AvatarBodyDto body = catalog.findBodyByUri(bodyUri)
+                .orElseThrow(() -> ExceptionCreator.create(VirtualDjException.INVALID_AVATAR_SET));
+        AvatarFaceUri faceUri = body.isCombinable()
+                ? new AvatarFaceUri(defaultFaceUri())
+                : new AvatarFaceUri();   // 빈 face = SINGLE_BODY
+        applyPort.apply(botUserId, new AvatarBodyUri(bodyUri), faceUri);
+    }
+
+    /** 셋({@code bodyUris})에서 봇별 랜덤 1개를 배분(일괄). */
+    public List<Assigned> distribute(List<UserId> botIds, List<String> bodyUris) {
+        if (bodyUris == null || bodyUris.isEmpty() || botIds == null || botIds.isEmpty()) {
+            throw ExceptionCreator.create(VirtualDjException.INVALID_AVATAR_SET);
+        }
+        // 셋 무결성: 모든 bodyUri 가 카탈로그에 존재해야 한다.
+        for (String uri : bodyUris) {
+            if (catalog.findBodyByUri(uri).isEmpty()) {
+                throw ExceptionCreator.create(VirtualDjException.INVALID_AVATAR_SET);
+            }
+        }
+        List<Assigned> assigned = new ArrayList<>();
+        for (UserId botId : botIds) {
+            String chosen = bodyUris.get(randomizer.nextIndex(bodyUris.size()));
+            assignOne(botId, chosen);
+            assigned.add(new Assigned(botId.getUid(), chosen));
+        }
+        log.info("[BotAvatarAssigner.distribute] bots={} setSize={}", botIds.size(), bodyUris.size());
+        return assigned;
+    }
+
+    private String defaultFaceUri() {
+        List<AvatarFaceDto> faces = catalog.findPublishedFaces();
+        if (faces.isEmpty()) {
+            throw ExceptionCreator.create(VirtualDjException.INVALID_AVATAR_SET);
+        }
+        return faces.get(0).resourceUri();   // 단일 basic face (AvatarFaceDto 접근자에 맞춰 조정)
+    }
+}
+```
+
+> **NOTE (executor):** (1) **`VirtualDjException`에 신규 상수 `INVALID_AVATAR_SET`(코드 예: `VDJ-008`, `ErrorType.BAD_REQUEST`=400) 추가** 후 사용 — 기존 `INVALID_CONFIG` 메시지는 "MANAGED 전환에 targetCount/floor 필요"로 빈 셋/미존재 URI 에는 오해를 준다([[feedback_elegant_no_code_dirtying]]). 기존 enum 패턴(코드/메시지/ErrorType) 그대로 따른다. (2) `AvatarFaceDto.resourceUri()` = record accessor(검증됨). (3) `UserId.getUid()` = Long, `new UserId(Long)` 생성자 존재(검증됨).
+
+- [ ] **Step 2: 테스트 GREEN 확인**
+
+Run: `JAVA_HOME=... ./gradlew :app:test --tests "*BotAvatarAssignerTest" -q`
+Expected: PASS (7 tests)
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/BotAvatarAssigner.java \
+        app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAssignerTest.java
+git commit -m "feat(가상DJ P1): BotAvatarAssigner 합성 규칙 단일 소스 (#288)"
+```
+
+---
+
+## Chunk 2: 백엔드 — 로스터 쿼리 + 카탈로그 + 엔드포인트
+
+### Task 2.1: 봇 로스터 쿼리 (`findRoster`) + IT
+
+**Files:**
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/application/dto/BotRosterRow.java`
+- Modify: `app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/BotPoolQueryRepository.java` (메서드 추가)
+- Modify: `app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/impl/BotPoolQueryRepositoryImpl.java`
+- Modify: `app/src/test/java/com/pfplaybackend/api/virtualdj/BotPoolQueryRepositoryImplIT.java`
+
+- [ ] **Step 1: DTO 작성**
+
+```java
+package com.pfplaybackend.api.virtualdj.application.dto;
+
+/** 봇 로스터 1행 — 봇 신원 + 현재 아바타 + 배치 룸(없으면 null). */
+public record BotRosterRow(
+        Long userId,
+        String nickname,
+        String avatarBodyUri,
+        String avatarIconUri,
+        Long placementPartyroomId,
+        String placementPartyroomTitle
+) {}
+```
+
+- [ ] **Step 2: 인터페이스에 메서드 추가**
+
+```java
+    /**
+     * 봇 전체 로스터(is_dummy=true, withdrawn_at IS NULL) — 닉네임/현재 아바타 + 현재 배치된
+     * ACTIVE 파티룸(활성 crew 기준, 없으면 null). uid 오름차순(oldest-first).
+     */
+    List<BotRosterRow> findRoster();
+```
+(import `com.pfplaybackend.api.virtualdj.application.dto.BotRosterRow;` 추가)
+
+- [ ] **Step 3: impl 작성** (profile 조인 + crew→partyroom left join)
+
+```java
+    @Override
+    public List<BotRosterRow> findRoster() {
+        List<Tuple> tuples = queryFactory
+                .select(
+                        userAccountData.userId.uid,
+                        profileData.bio.nickname,   // @Convert(Nickname) → tuple.get 시 Nickname 객체 반환
+                        profileData.avatarSetting.avatarBodyUri.value,
+                        profileData.avatarSetting.avatarIconUri.value,
+                        partyroomData.id,
+                        partyroomData.title)
+                .from(userAccountData)
+                .join(profileData).on(profileData.userId.uid.eq(userAccountData.userId.uid))
+                .leftJoin(crewData).on(crewData.userId.uid.eq(userAccountData.userId.uid)
+                        .and(crewData.isActive.isTrue()))
+                .leftJoin(partyroomData).on(partyroomData.id.eq(crewData.partyroomId.id)
+                        .and(partyroomData.status.eq(PartyroomStatus.ACTIVE)))
+                .where(
+                        userAccountData.isDummy.isTrue(),
+                        userAccountData.withdrawnAt.isNull())
+                .orderBy(userAccountData.userId.uid.asc())
+                .fetch();
+
+        return tuples.stream()
+                .map(t -> {
+                    Nickname nick = t.get(profileData.bio.nickname);
+                    return new BotRosterRow(
+                        t.get(userAccountData.userId.uid),
+                        nick == null ? null : nick.value(),
+                        t.get(profileData.avatarSetting.avatarBodyUri.value),
+                        t.get(profileData.avatarSetting.avatarIconUri.value),
+                        t.get(partyroomData.id),
+                        t.get(partyroomData.title));
+                })
+                .toList();
+    }
+```
+
+> **검증된 Q-경로 (executor):** `QProfileData.profileData` (import `static ...QProfileData.profileData`). 아바타는 `@Embeddable`+`@Column value` 중첩이라 `avatarSetting.avatarBodyUri.value` / `...avatarIconUri.value` 가 맞다(검증됨). **nickname 은 `bio.nickname`** — `Bio.nickname` 이 `@Convert(NicknameConverter)` 단일 컬럼이라 `profileData.bio.nickname` 은 `SimplePath<Nickname>` 이고 tuple.get 시 `Nickname` 객체를 돌려준다. `.value()` (record accessor) 로 String 추출. import `com.pfplaybackend.api.user.domain.value.Nickname`. 봇은 한 번에 1방만 활성 crew(invariant)라 left join row 중복 없음.
+
+- [ ] **Step 4: IT 추가** (`BotPoolQueryRepositoryImplIT`에 테스트 메서드 추가)
+
+```java
+    @Test
+    void findRoster_는_봇의_닉네임_아바타_배치룸을_반환한다() {
+        // given: 봇 2명 시드(기존 헬퍼 재사용), 1명은 ACTIVE 방에 활성 crew 배치, 1명은 idle
+        // when
+        List<BotRosterRow> roster = repository.findRoster();
+        // then: 2행, idle 봇은 placementPartyroomId == null, 배치 봇은 != null,
+        //       avatarBodyUri/nickname non-null
+        assertThat(roster).hasSize(2);
+        assertThat(roster).allSatisfy(r -> {
+            assertThat(r.nickname()).isNotBlank();
+            assertThat(r.avatarBodyUri()).isNotNull();
+        });
+    }
+```
+
+> **NOTE (executor):** `BotPoolQueryRepositoryImplIT`의 기존 봇/crew/partyroom 시드 헬퍼를 재사용. 비-봇(실유저)이 로스터에 안 섞이는지도 1건 단언 추가.
+
+- [ ] **Step 5: IT 실행** — `./gradlew :app:integrationTest --tests "*BotPoolQueryRepositoryImplIT" -q` → PASS
+- [ ] **Step 6: 커밋** — `feat(가상DJ P1): 봇 로스터 쿼리 findRoster (#288)`
+
+### Task 2.2: `BotAvatarAdminService` (로스터/카탈로그/개별/일괄)
+
+**Files:**
+- Create: `app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/BotAvatarAdminService.java`
+- Create: `app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAdminServiceTest.java`
+
+- [ ] **Step 1: 실패 테스트 작성** (mock 기반 위임 검증)
+
+```java
+package com.pfplaybackend.api.virtualdj;
+// ... imports: mockito, AvatarCatalogQueryUseCase, BotPoolQueryRepository, BotAvatarAssigner, BotAvatarAdminService
+
+class BotAvatarAdminServiceTest {
+    // catalog() → findPublishedBodies 매핑(bodyUri/name/thumbnailUri/combinable/obtainableType)
+    // roster() → repository.findRoster 위임
+    // setIndividual(id, uri) → assigner.assignOne 위임
+    // distribute(ids, uris) → assigner.distribute 위임 + 결과 반환
+}
+```
+
+- [ ] **Step 2: 구현 작성**
+
+```java
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.avatar.application.dto.AvatarBodyDto;
+import com.pfplaybackend.api.avatar.application.port.in.AvatarCatalogQueryUseCase;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.BotPoolQueryRepository;
+import com.pfplaybackend.api.virtualdj.application.dto.BotRosterRow;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/** 봇 아바타 어드민 운영 — 카탈로그 조회 / 로스터 조회 / 개별·일괄 변별 배분. */
+@Service
+@RequiredArgsConstructor
+public class BotAvatarAdminService {
+
+    private final BotPoolQueryRepository botPoolQueryRepository;
+    private final AvatarCatalogQueryUseCase catalog;
+    private final BotAvatarAssigner assigner;
+
+    public record CatalogItem(String bodyUri, String name, String thumbnailUri,
+                              boolean combinable, String obtainableType) {}
+
+    @Transactional(readOnly = true)
+    public List<CatalogItem> catalog() {
+        return catalog.findPublishedBodies().stream()
+                .map(BotAvatarAdminService::toCatalogItem)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<BotRosterRow> roster() {
+        return botPoolQueryRepository.findRoster();
+    }
+
+    @Transactional
+    public void setIndividual(UserId botUserId, String bodyUri) {
+        assigner.assignOne(botUserId, bodyUri);
+    }
+
+    @Transactional
+    public List<BotAvatarAssigner.Assigned> distribute(List<Long> botIds, List<String> bodyUris) {
+        List<UserId> ids = botIds.stream().map(UserId::new).toList();
+        return assigner.distribute(ids, bodyUris);
+    }
+
+    private static CatalogItem toCatalogItem(AvatarBodyDto b) {
+        return new CatalogItem(b.getResourceUri(), b.getName(), b.getResourceUri(),
+                b.isCombinable(), b.getObtainableType() == null ? null : b.getObtainableType().name());
+    }
+}
+```
+
+> **NOTE (executor):** distribute 가 비-봇 userId 를 받으면 — `assignOne`→`updateVirtualMemberAvatar` 가 비-봇/미존재에 대해 던지는 예외를 확인. spec §2.3 "비-봇 무시(부분성공)" 의미를 살리려면 distribute 루프에서 per-bot try/catch 로 격리하고 성공분만 `assigned`에 담는 방식으로 보강(또는 단순화: 미존재 봇은 404로 묶지 말고 무시). 결정은 executor 가 `updateVirtualMemberAvatar` 의 미존재 동작 확인 후 택1, 테스트로 잠금.
+
+- [ ] **Step 3: 테스트 GREEN** — `./gradlew :app:test --tests "*BotAvatarAdminServiceTest" -q` → PASS
+- [ ] **Step 4: 커밋** — `feat(가상DJ P1): BotAvatarAdminService (카탈로그/로스터/배분) (#288)`
+
+### Task 2.3: 페이로드 + 컨트롤러 엔드포인트 4종
+
+**Files:**
+- Create: `.../adapter/in/web/payload/AvatarCatalogItemResponse.java`
+- Create: `.../adapter/in/web/payload/BotRosterItemResponse.java`
+- Create: `.../adapter/in/web/payload/SetBotAvatarRequest.java`
+- Create: `.../adapter/in/web/payload/DistributeBotAvatarRequest.java`
+- Create: `.../adapter/in/web/payload/DistributeBotAvatarResponse.java`
+- Modify: `.../adapter/in/web/AdminVirtualDjController.java`
+- Modify: `app/src/test/java/com/pfplaybackend/api/virtualdj/AdminVirtualDjControllerTest.java`
+
+- [ ] **Step 1: 페이로드 작성** (P2 payload 스타일: record + static `from`)
+
+```java
+// AvatarCatalogItemResponse
+public record AvatarCatalogItemResponse(String bodyUri, String name, String thumbnailUri,
+                                        boolean combinable, String obtainableType) {
+    public static AvatarCatalogItemResponse from(BotAvatarAdminService.CatalogItem c) {
+        return new AvatarCatalogItemResponse(c.bodyUri(), c.name(), c.thumbnailUri(), c.combinable(), c.obtainableType());
+    }
+}
+// BotRosterItemResponse
+public record BotRosterItemResponse(Long userId, String nickname, String avatarBodyUri, String avatarIconUri,
+                                    Long placementRoomId, String placementRoomTitle) {
+    public static BotRosterItemResponse from(BotRosterRow r) {
+        return new BotRosterItemResponse(r.userId(), r.nickname(), r.avatarBodyUri(), r.avatarIconUri(),
+                r.placementPartyroomId(), r.placementPartyroomTitle());
+    }
+}
+// SetBotAvatarRequest
+public record SetBotAvatarRequest(@jakarta.validation.constraints.NotBlank String avatarBodyUri) {}
+// DistributeBotAvatarRequest
+public record DistributeBotAvatarRequest(
+        @jakarta.validation.constraints.NotEmpty List<Long> botIds,
+        @jakarta.validation.constraints.NotEmpty List<String> bodyUris) {}
+// DistributeBotAvatarResponse
+public record DistributeBotAvatarResponse(List<Assigned> assigned) {
+    public record Assigned(Long userId, String avatarBodyUri) {}
+    public static DistributeBotAvatarResponse from(List<BotAvatarAssigner.Assigned> xs) {
+        return new DistributeBotAvatarResponse(xs.stream()
+                .map(a -> new Assigned(a.userId(), a.avatarBodyUri())).toList());
+    }
+}
+```
+
+- [ ] **Step 2: 컨트롤러에 4 엔드포인트 추가** (AdminVirtualDjController, `BotAvatarAdminService` 주입 추가)
+
+```java
+    private final BotAvatarAdminService botAvatarAdminService;
+
+    // ── 봇 아바타 (P1) ──
+
+    @Operation(summary = "아바타 카탈로그 조회 (피커용)")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @GetMapping("/virtual-dj/avatar-catalog")
+    public ResponseEntity<ApiCommonResponse<List<AvatarCatalogItemResponse>>> avatarCatalog() {
+        List<AvatarCatalogItemResponse> items = botAvatarAdminService.catalog().stream()
+                .map(AvatarCatalogItemResponse::from).toList();
+        return ResponseEntity.ok(ApiCommonResponse.success(items));
+    }
+
+    @Operation(summary = "봇 로스터 조회 (신원+현재 아바타+배치룸)")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @GetMapping("/virtual-dj/bots")
+    public ResponseEntity<ApiCommonResponse<List<BotRosterItemResponse>>> bots() {
+        List<BotRosterItemResponse> items = botAvatarAdminService.roster().stream()
+                .map(BotRosterItemResponse::from).toList();
+        return ResponseEntity.ok(ApiCommonResponse.success(items));
+    }
+
+    @Operation(summary = "봇 개별 아바타 설정")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @PutMapping("/virtual-dj/bots/{userId}/avatar")
+    public ResponseEntity<Void> setBotAvatar(@PathVariable("userId") Long userId,
+                                             @Valid @RequestBody SetBotAvatarRequest req) {
+        botAvatarAdminService.setIndividual(new UserId(userId), req.avatarBodyUri());
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "봇 아바타 일괄 변별 배분", description = "선택 봇들에 셋에서 랜덤 1개씩 배분")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualDj()")
+    @PostMapping("/virtual-dj/bots/avatar/distribute")
+    public ResponseEntity<ApiCommonResponse<DistributeBotAvatarResponse>> distributeBotAvatars(
+            @Valid @RequestBody DistributeBotAvatarRequest req) {
+        var assigned = botAvatarAdminService.distribute(req.botIds(), req.bodyUris());
+        return ResponseEntity.ok(ApiCommonResponse.success(DistributeBotAvatarResponse.from(assigned)));
+    }
+```
+(import: `UserId`, 신규 payload들, `BotAvatarAdminService`)
+
+> **NOTE (executor):** `userId` path는 `AdminUserController`가 `UserId.fromString(String)`을 쓴다. 봇 userId가 Long 인지 UUID-문자열인지 확인 — `UserId`의 실제 표현(snowflake Long 으로 보임, `userId.uid` Long)에 맞춰 `@PathVariable Long` 또는 `String`+`UserId.fromString` 택1. 로스터가 Long userId 를 반환하므로 Long 일관 가정.
+
+- [ ] **Step 3: 컨트롤러 슬라이스 테스트 추가** (`AdminVirtualDjControllerTest`, `BotAvatarAdminService` @MockBean 추가)
+
+```java
+    @Test @WithMockUser(roles = "ADMIN")
+    void avatarCatalog_ADMIN_200() throws Exception { /* given service returns 1 item; GET → 200 jsonPath */ }
+
+    @Test @WithMockUser(roles = "ADMIN")
+    void bots_ADMIN_200() throws Exception { /* GET /virtual-dj/bots → 200 */ }
+
+    @Test @WithMockUser(roles = "ADMIN")
+    void setBotAvatar_ADMIN_204() throws Exception { /* PUT with body → 204, verify service */ }
+
+    @Test @WithMockUser(roles = "ADMIN")
+    void distribute_빈_botIds_400() throws Exception { /* POST {botIds:[],bodyUris:["x"]} → 400 (validation) */ }
+
+    @Test @WithMockUser(roles = "MEMBER")
+    void distribute_비어드민_403() throws Exception { /* → 403 */ }
+
+    @Test @WithAnonymousUser
+    void bots_익명_401() throws Exception { /* → 401 */ }
+
+    @Test @WithMockUser(roles = "ADMIN")
+    void distribute_CSRF_누락_403() throws Exception { /* csrf() 없이 POST → 403 */ }
+```
+
+> **NOTE (executor):** 기존 테스트의 `@MockBean` 목록과 `csrf()` post-processor 사용 패턴을 그대로 따른다. `BotAvatarAdminService`를 `@MockBean`으로 추가.
+
+- [ ] **Step 4: 전체 슬라이스 테스트 GREEN** — `./gradlew :app:test --tests "*AdminVirtualDjControllerTest" -q` → PASS
+- [ ] **Step 5: 커밋** — `feat(가상DJ P1): 봇 아바타 어드민 엔드포인트 4종 (카탈로그/로스터/개별/일괄) (#288)`
+
+---
+
+## Chunk 3: 백엔드 — provision 자동부여 + 전체 GREEN
+
+### Task 3.1: provision 시 랜덤 변별 자동부여
+
+**Files:**
+- Modify: `app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualUserPoolService.java`
+- Modify: `app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualUserPoolServiceIT.java`
+
+- [ ] **Step 1: IT 실패 테스트 추가** (provision 후 전원 icon non-null)
+
+```java
+    @Test
+    void provision_후_모든_봇은_유효한_채팅_아이콘을_가진다() {
+        // when
+        List<UserId> bots = poolService.provision(5);
+        // then: 각 봇의 user_profile.avatar_icon_uri 가 non-null·non-blank (null-icon 갭 제거)
+        for (UserId id : bots) {
+            ProfileData p = profileRepository.findByUserId(id).orElseThrow(); // 실제 조회 경로에 맞춰 조정
+            assertThat(p.getAvatarSetting().getAvatarIconUriValue()).isNotBlank();
+        }
+    }
+```
+
+> **NOTE (executor):** 봇 프로필 조회 경로(`MemberRepository`/`ProfileRepository`/`AdminUserService.getVirtualMember`)는 IT 컨텍스트에 이미 있는 빈을 재사용. 핵심 단언 = `getAvatarIconUriValue()` non-blank. 이게 spec §0/§4-3 의 핵심 회귀 가드(combinable basic_001 디폴트의 null-icon 깨짐이 사라졌는지).
+
+- [ ] **Step 2: 실패 확인** — 현재 provision 은 basic_001(combinable)+빈face → icon NULL → FAIL 예상
+
+Run: `./gradlew :app:integrationTest --tests "*VirtualUserPoolServiceIT" -q`
+Expected: 신규 테스트 FAIL (icon blank)
+
+- [ ] **Step 3: provision 수정** (BotAvatarAssigner 주입 + 봇별 호출)
+
+```java
+    private final BotAvatarAssigner botAvatarAssigner;   // 생성자 주입 추가
+
+    @Transactional
+    public List<UserId> provision(int n) {
+        List<UserId> created = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            MemberData member = virtualMemberProvisionPort.createVirtualMember(generateBotNickname());
+            UserId botUserId = new UserId(member.getUserAccountId());
+
+            UserAccountData account = userAccountRepository.findById(botUserId).orElseThrow();
+            account.markAsDummy();
+
+            playlistRepository.save(
+                    PlaylistData.create(1, BOT_PLAYLIST_NAME, PlaylistType.PLAYLIST, botUserId));
+
+            // P1: 생성 즉시 카탈로그 랜덤 변별 아바타 부여 (기존 깨진 basic_001 디폴트 대체).
+            botAvatarAssigner.assignRandomFromCatalog(botUserId);
+
+            created.add(botUserId);
+        }
+        return created;
+    }
+```
+
+> **NOTE (executor):** 같은 `@Transactional` 안에서 `assignRandomFromCatalog`→`updateVirtualMemberAvatar`가 같은 영속 컨텍스트에 join 되는지(spec §6-C4). updateVirtualMemberAvatar 가 self-flush/이벤트 발행으로 부수효과 내면 IT 로 노출됨 — 그 경우 createVirtualMember 직후 같은 멤버를 다시 로드해 적용하거나, 순서를 markAsDummy 전/후로 조정. IT GREEN 이 기준.
+
+- [ ] **Step 4: IT GREEN** — `./gradlew :app:integrationTest --tests "*VirtualUserPoolServiceIT" -q` → PASS
+- [ ] **Step 5: 커밋** — `feat(가상DJ P1): provision 시 랜덤 변별 아바타 자동부여 — null-icon 갭 제거 (#288)`
+
+### Task 3.2: ArchUnit + 전체 백엔드 GREEN
+
+**Files:**
+- Check: `app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjArchitectureTest.java` (있으면)
+
+- [ ] **Step 1: ArchUnit 통과 확인** — 신규 코드가 path A 규칙 위반 없는지(virtualdj→admin 직접 import 는 `adapter.out.provision`만). `BotAvatarApplyAdapter`가 그 패키지에 있으므로 OK. `BotAvatarAssigner`는 admin import 없음(catalog=avatar, apply=port). 위반 시 규칙 범위 재확인.
+
+Run: `./gradlew :app:test --tests "*VirtualDjArchitectureTest" -q`
+Expected: PASS
+
+- [ ] **Step 2: 전체 백엔드 테스트 GREEN**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test :app:integrationTest :user:test -q`
+Expected: BUILD SUCCESSFUL (전부 GREEN)
+
+- [ ] **Step 3: 커밋(있으면 사소 보정)** — `test(가상DJ P1): ArchUnit + 전체 GREEN 확인 (#288)`
+
+> **백엔드 PR 게이트:** 여기까지 GREEN 이면 PR(base develop) 가능. 단 **dev 머지는 Chunk 6(로컬 e2e) 통과 후**. 프론트(Chunk 4–5)는 백엔드 develop 머지 전이라면 MSW 로 독립 진행 가능.
+
+---
+
+## Chunk 4: 프론트(pfplay-admin) — 타입 + API + 카탈로그/로스터 + 피커
+
+> 레포 `pfplay-admin`. 기존 `features/virtual-dj-pool` 확장. 패턴 출처: `features/virtual-dj-song-packs`(api/hook), `features/music-search`(boundary 매퍼), `features/partyrooms`(bulk 다이얼로그/체크박스). 테스트 vitest+MSW.
+> **NOTE (executor):** 정확한 파일 경로/엔트리는 `pfplay-admin` 탐색 후 확정(spec §1.6). 아래는 의도와 계약.
+
+### Task 4.1: 엔티티 타입 + API 클라이언트
+
+**Files:**
+- Modify: `src/entities/virtual-dj/model/types.ts` (타입 추가)
+- Create: `src/features/virtual-dj-pool/api/avatar-catalog-api.ts` + `use-avatar-catalog.ts`
+- Create: `src/features/virtual-dj-pool/api/bots-api.ts` + `use-bots.ts` / `use-set-bot-avatar.ts` / `use-distribute-avatars.ts`
+
+- [ ] **Step 1: 타입 추가**
+
+```ts
+export interface AvatarCatalogItem {
+  bodyUri: string; name: string; thumbnailUri: string; combinable: boolean; obtainableType: string | null;
+}
+export interface BotRosterItem {
+  userId: number; nickname: string; avatarBodyUri: string; avatarIconUri: string;
+  placementRoomId: number | null; placementRoomTitle: string | null;
+}
+```
+
+> **NOTE (executor):** `src/entities/virtual-dj/index.ts` barrel 이 각 타입을 명시 re-export 한다(형제 api 파일이 `@/entities/virtual-dj` 에서 import). **새 두 타입을 barrel 에도 추가**해야 import 가 깨지지 않는다.
+
+- [ ] **Step 2: API 함수** (기존 `song-packs-api.ts` 헤더 그대로 미러 — `http<ApiCommonResponse<T>>` 2단계 + `unwrap`)
+
+> **검증된 시그니처:** `http<T = unknown>(path, opts?): Promise<T>` 는 파싱된 바디를 직접 반환(204면 undefined), body 자동 JSON.stringify + CSRF echo 자동. `unwrap<T>(res: ApiCommonResponse<T>): T` 는 **`@/shared/api/page`** 에서 import(http 가 아님). 따라서 `http` 호출에 `<ApiCommonResponse<T>>` 제네릭 필수.
+
+```ts
+import { http } from "@/shared/api/http";
+import { unwrap, type ApiCommonResponse } from "@/shared/api/page"; // 실제 export 경로/이름 확인(song-packs-api.ts 헤더 복사)
+import type { AvatarCatalogItem, BotRosterItem } from "@/entities/virtual-dj";
+
+// avatar-catalog-api.ts
+export async function getAvatarCatalog(): Promise<AvatarCatalogItem[]> {
+  const res = await http<ApiCommonResponse<AvatarCatalogItem[]>>("/api/v1/admin/virtual-dj/avatar-catalog");
+  return unwrap(res);
+}
+// bots-api.ts
+export async function getBots(): Promise<BotRosterItem[]> {
+  const res = await http<ApiCommonResponse<BotRosterItem[]>>("/api/v1/admin/virtual-dj/bots");
+  return unwrap(res);
+}
+export async function setBotAvatar(userId: number, avatarBodyUri: string): Promise<void> {
+  await http<void>(`/api/v1/admin/virtual-dj/bots/${userId}/avatar`, { method: "PUT", body: { avatarBodyUri } });
+}
+type DistributeResult = { assigned: { userId: number; avatarBodyUri: string }[] };
+export async function distributeAvatars(botIds: number[], bodyUris: string[]): Promise<DistributeResult> {
+  const res = await http<ApiCommonResponse<DistributeResult>>(
+    "/api/v1/admin/virtual-dj/bots/avatar/distribute", { method: "POST", body: { botIds, bodyUris } });
+  return unwrap(res);
+}
+```
+
+- [ ] **Step 3: react-query 훅** — `useAvatarCatalog`(staleTime 길게, 정적), `useBots`(`["virtual-dj","bots"]`), `useSetBotAvatar`/`useDistributeAvatars`(성공 시 `["virtual-dj","bots"]` invalidate). 기존 `use-provision-pool.ts` 패턴 미러.
+- [ ] **Step 4: 단위 테스트(MSW)** — 각 api 함수 요청 형태/언랩. → `yarn vitest run <paths>` PASS
+- [ ] **Step 5: 커밋** — `feat(가상DJ P1): 봇 아바타 카탈로그/로스터/배분 API 클라이언트 (#<admin-issue>)`
+  > **NOTE (executor):** 프론트 작업 시작 시 **pfplay-admin 레포에 한글 GitHub 이슈 먼저 등록**([[feedback_korean_issue_commit_pr]]) 후 그 번호를 커밋에 사용. pfplay-admin 은 GHA 없음([[reference_pfplay_admin_no_gha]]).
+
+### Task 4.2: boundary 매퍼 + 아바타 피커 컴포넌트
+
+**Files:**
+- Create: `src/features/virtual-dj-pool/model/to-avatar-option.ts` + 테스트
+- Create: `src/features/virtual-dj-pool/ui/avatar-picker.tsx` + 테스트
+
+- [ ] **Step 1: 매퍼 실패 테스트** (`to-pack-track.test.ts` 패턴 — 명시 매핑·빈값 없음·source 어휘 누수 가드)
+
+```ts
+it("각 필드 매핑 + source 어휘 누수 없음", () => {
+  const out = toAvatarOption({ bodyUri:"u", name:"n", thumbnailUri:"t", combinable:true, obtainableType:"BASIC" });
+  expect(out.value).toBe("u"); expect(out.label).toBe("n"); expect(out.thumbnail).toBe("t");
+  expect((out as any).bodyUri).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: 매퍼 구현**
+
+```ts
+export interface AvatarOption { value: string; label: string; thumbnail: string; combinable: boolean; tier: string | null; }
+export function toAvatarOption(c: AvatarCatalogItem): AvatarOption {
+  return { value: c.bodyUri, label: c.name, thumbnail: c.thumbnailUri, combinable: c.combinable, tier: c.obtainableType };
+}
+```
+
+- [ ] **Step 3: 피커 컴포넌트** — 썸네일 그리드. props: `mode: "single"|"multi"`, `value`, `onChange`. multi=체크 토글(셋), single=라디오. combinable/standalone 배지(선택). `useAvatarCatalog()` 사용.
+- [ ] **Step 4: 피커 테스트(MSW)** — 카탈로그 렌더, multi 다중선택 토글, single 단일선택. PASS
+- [ ] **Step 5: 커밋** — `feat(가상DJ P1): 아바타 피커 + boundary 매퍼`
+
+---
+
+## Chunk 5: 프론트(pfplay-admin) — 로스터 UI + 일괄/개별 다이얼로그
+
+### Task 5.1: 봇 로스터 섹션 (풀 페이지)
+
+**Files:**
+- Create: `src/features/virtual-dj-pool/ui/bot-roster.tsx` + 테스트
+- Modify: `src/features/virtual-dj-pool/ui/pool-page-content.tsx` (로스터 섹션 추가)
+
+- [ ] **Step 1: 로스터 테스트(MSW)** — `getBots` mock → 행마다 바디 썸네일(`avatarBodyUri`)·닉네임·배치룸·체크박스·"아바타 변경" 버튼 렌더. 아이콘 non-null 썸네일 표시.
+- [ ] **Step 2: 로스터 구현** — 체크박스 다중선택 state(`selectedBotIds`), 선택>0 시 툴바("아바타 일괄 변경"). 기존 `bulk-action-toolbar` 스타일 계승.
+- [ ] **Step 3: 풀 페이지 통합** — 요약 카드 아래 `<BotRoster/>` 추가(기존 테스트 회귀 없게 추가만).
+- [ ] **Step 4: 테스트 GREEN** → 커밋 `feat(가상DJ P1): 봇 로스터 섹션 (풀 페이지)`
+
+### Task 5.2: 일괄 배분 다이얼로그
+
+**Files:**
+- Create: `src/features/virtual-dj-pool/ui/distribute-avatars-dialog.tsx` + 테스트
+- Create: `src/features/virtual-dj-pool/model/distribute-schema.ts`
+
+- [ ] **Step 1: zod 스키마** — `botIds` non-empty, `bodyUris`(셋) non-empty.
+- [ ] **Step 2: 다이얼로그 테스트(MSW)** — 선택 봇 N + 피커(multi)로 셋 선택 → 제출 시 `POST distribute {botIds, bodyUris}` 바디 정확 + 빈 셋 차단(제출 비활성/에러). 성공 시 `["virtual-dj","bots"]` invalidate.
+- [ ] **Step 3: 다이얼로그 구현** — `AvatarPicker mode="multi"` + `useDistributeAvatars`. P2 `virtual-dj-bulk-dialog` UX(닫기 reset, pending 비활성, 결과 요약) 계승.
+- [ ] **Step 4: 테스트 GREEN** → 커밋 `feat(가상DJ P1): 아바타 일괄 배분 다이얼로그`
+
+### Task 5.3: 개별 편집 다이얼로그 + 전체 GREEN
+
+**Files:**
+- Create: `src/features/virtual-dj-pool/ui/set-bot-avatar-dialog.tsx` + 테스트
+
+- [ ] **Step 1: 다이얼로그 테스트(MSW)** — 행 "아바타 변경" → 피커(single) → `PUT bots/{userId}/avatar {avatarBodyUri}` 정확. 성공 invalidate.
+- [ ] **Step 2: 구현** — `AvatarPicker mode="single"` + `useSetBotAvatar`.
+- [ ] **Step 3: 전체 프론트 검증**
+
+Run: `yarn vitest run` / `yarn tsc --noEmit` / `yarn lint`
+Expected: 전부 GREEN/clean (기존 582+ 테스트 + 신규)
+
+- [ ] **Step 4: 커밋** — `feat(가상DJ P1): 봇 개별 아바타 편집 다이얼로그 + 전체 GREEN`
+
+---
+
+## Chunk 6: 로컬 docker-compose 풀스택 e2e 게이트 (dev 머지 전 필수)
+
+> [[feedback_local_e2e_before_dev_merge]] — 단위/통합 GREEN ≠ 배포안전. **둘 다(백엔드+프론트) 로컬 기동 후 실 HTTP 흐름 검증.** [[reference_local_docker_compose]] / [[reference_pfplay_web_local_dev_http_webpack]]/admin 로컬 절차.
+
+- [ ] **Step 1: 백엔드 기동** — `docker-compose.local.yml` + `.env.local`(`local` profile, 8080). **validate 부팅 확인**(P1은 마이그레이션 없으나 엔티티 정합·부팅 회귀 확인). app 로그 `Started ... Application` + 에러 없음.
+- [ ] **Step 2: 어드민 기동** — pfplay-admin 로컬 dev 서버. admin seed 로그인(`admin@pfplay.local`).
+- [ ] **Step 3: 카탈로그** — `GET /api/v1/admin/virtual-dj/avatar-catalog` (UI 피커 또는 curl) → published 바디 15종 반환 확인.
+- [ ] **Step 4: provision 검증(핵심)** — 봇 풀 N명 생성 → `GET /virtual-dj/bots` 로스터 **전원 `avatarIconUri` non-null** 확인(P1-D5/null-icon 갭 제거 종단 증명).
+- [ ] **Step 5: 일괄 배분** — 봇 다중선택 → 셋(예: standalone 4 + DJ_PNT 몇) 선택 → distribute → 로스터 아바타가 봇별로 달라졌는지 확인.
+- [ ] **Step 6: 개별 변경** — 1봇 개별 변경 반영 확인.
+- [ ] **Step 7: (가능 시) 룸 렌더** — MANAGED 방 배치 → pfplay-web 또는 API(`activeDjSnapshot`)에서 봇 아바타 변별 확인. 불가 시 API 레벨로 대체.
+- [ ] **Step 8: 무NPE/무500 확인** — app 로그에 P1 경로 예외 없음.
+- [ ] **Step 9: 결과 사용자 보고** — e2e 결과 요약. **GREEN 후에만** 백엔드 PR dev 머지 + 프론트 PR dev 머지 진행(승격은 P1+P3 후 일괄, 메모리 정책).
+
+---
+
+## 완료 기준 (Definition of Done)
+
+1. 백엔드: `BotAvatarAssigner`(합성 규칙 단일 소스) + Randomizer/ApplyPort + 로스터 쿼리 + 어드민 4 엔드포인트 + provision 자동부여. `:app:test`+`:app:integrationTest`+`:user:test` GREEN. ArchUnit GREEN. 마이그레이션 없음.
+2. 프론트: 로스터 + 피커 + 일괄/개별 다이얼로그. `vitest`+`tsc`+`lint` GREEN.
+3. **로컬 docker-compose 풀스택 e2e GREEN** (provision 후 icon non-null + 배분 반영 + 무NPE).
+4. 두 PR 한글 커밋/이슈(#288), dev 머지(사용자 게이트 아님 — e2e GREEN 후 자율). **release/main 승격은 보류**(P1+P3 후 #283~ 묶음 일괄).

--- a/docs/superpowers/specs/2026-06-02-virtual-dj-p1-avatar-design.md
+++ b/docs/superpowers/specs/2026-06-02-virtual-dj-p1-avatar-design.md
@@ -87,7 +87,7 @@ P1의 목적은 운영자가 어드민 콘솔에서 **봇들에 카탈로그의 
 ### 2.3 신규 엔드포인트
 | Method | Path | 요청 | 응답 |
 |---|---|---|---|
-| GET | `/api/v1/admin/virtual-dj/avatar-catalog` | — | `[ { bodyUri, name, thumbnailUri, isCombinable, obtainableType } ]` |
+| GET | `/api/v1/admin/virtual-dj/avatar-catalog` | — | `[ { bodyUri, name, thumbnailUri, combinable, obtainableType } ]` |
 | GET | `/api/v1/admin/virtual-dj/bots` | — | `[ { userId, nickname, avatarBodyUri, avatarIconUri, placementRoomId?, placementRoomTitle? } ]` |
 | PUT | `/api/v1/admin/virtual-dj/bots/{userId}/avatar` | `{ avatarBodyUri }` | 200 `{ ...bot }` |
 | POST | `/api/v1/admin/virtual-dj/bots/avatar/distribute` | `{ botIds[], bodyUris[] }` | 200 `{ assigned: [ { userId, avatarBodyUri } ] }` |

--- a/docs/superpowers/specs/2026-06-02-virtual-dj-p1-avatar-design.md
+++ b/docs/superpowers/specs/2026-06-02-virtual-dj-p1-avatar-design.md
@@ -1,0 +1,186 @@
+# 가상 DJ(P1) 봇 아바타 변별 셋팅 콘솔 — 설계
+
+- 작성일: 2026-06-02
+- 대상 레포: `pfplay-platform`(백엔드, 주), `pfplay-admin`(어드민 UI)
+- 선행: P2 = `develop` 라이브(봇 풀 / 송팩 / 룸별 config / reconcile / drain·freeze / 어드민 콘솔 Plan B). PR #283·#285·#287 + admin #17.
+- 위치: 3단계 누적 비전(**P1 아바타 콘솔** / P2 능동 디제잉 / P3 AI 에이전트화) 중 P1. P2의 봇 계정 모델 + Plan B 콘솔 위에 증분.
+
+---
+
+## 0. 배경과 목적
+
+P2로 봇(가상 DJ)이 빈 방에 상주하지만, **봇이 전부 같은 기본 아바타로 보인다**. 정확히는 봇이 생성 시 받는 기본 바디 `ava_body_basic_001`은 **combinable 바디**(face 합성 전제)라 자체 채팅 아이콘이 없다(`avatar_icon_uri` NULL). 그 결과:
+
+1. 한 방에 봇이 여러 명이면 **시각적으로 변별 불가** — "여러 사람이 있는 방"이 아니라 "복제된 더미"로 보임.
+2. 채팅 아이콘 NULL = P2에서 방어적 null-가드는 넣었으나(PR #287 버그 B), **시각적으로는 빈/깨진 아이콘** 상태.
+
+P1의 목적은 운영자가 어드민 콘솔에서 **봇들에 카탈로그의 다양한 아바타를 입혀(일괄·개별) 방을 "살아있게" 보이게** 하고, **null-icon 갭을 원천 제거**하는 것이다.
+
+### 핵심 결정 (brainstorming 잠금, 2026-06-02)
+| ID | 결정 | 근거 |
+|---|---|---|
+| P1-D1 | 목적 = **시각적 다양성(변별)**, 컨셉/송팩 결속 아님 | 봇들이 똑같이 안 보이게. 카탈로그에서 다양한 바디를 봇별/그룹별로 입힘 |
+| P1-D2 | "일괄" = **셋에서 랜덤 분배** (관리자가 아바타 셋 선택 → 선택 봇들에 랜덤 1개씩 배분), 개별 셋팅 별도 제공 | "전부 같은 값"은 다양성 목적과 모순 |
+| P1-D3 | 셋 범위 = **전체 카탈로그**(BASIC 4 + DJ_PNT 12, 점수 게이트 없음) | 봇=구별불가(P2 D1)라 실유저에 봇티 안 남, 현재 과금 미개시=희소성 판매 전 |
+| P1-D4 | combinable 바디(11종) = **셋에 포함, 공통 face 합성** | 룸 실루엣 풀 다양성 확보. 단 face 카탈로그 1종이라 combinable 11종은 얼굴/채팅아이콘 동일 공유(수용) |
+| P1-D5 | provision = **생성 즉시 카탈로그 랜덤 변별 자동 부여** | 깨진 null-icon 디폴트를 원천 제거. distribute와 동일 헬퍼 |
+
+---
+
+## 1. 확인된 사실 (탐색 결과, 코드 근거)
+
+### 1.1 아바타 모델
+- `AvatarSetting`(embeddable, `user/.../domain/value/AvatarSetting.java`): `avatarBodyUri` / `avatarFaceUri` / `avatarIconUri` + `avatarCompositionType`(`SINGLE_BODY`|`BODY_WITH_FACE`) + `faceSourceType`(`INTERNAL_IMAGE`|`NFT_URI`) + face 변환 좌표. null-safe 접근자 `getAvatarBodyUriValue()`/`...FaceUriValue()`/`...IconUriValue()`(PR #287)는 null→`""`.
+- 저장: `user_profile` 테이블의 위 컬럼들(기존). **P1은 신규 스키마 없음**(아래 §2.6).
+
+### 1.2 카탈로그 ground truth (V3 seed + V12 재구조화)
+바디 15종(`avatar_body_resource`), face 1종(`avatar_face_resource`), V12가 icon을 부모 row의 `icon_uri`로 이관(이름-prefix 매칭) 후 `avatar_icon_resource` DROP.
+
+| 구분 | 바디 | `is_combinable` | `icon_uri` | 채팅 아이콘 변별 |
+|---|---|---|---|---|
+| standalone 4 | `ava_body_basic_002`, `_003`, `ava_body_djing_001`, `_002` | 0 | 있음(body 페어) | **4종 distinct** |
+| combinable 11 | `ava_body_basic_001` + `ava_body_djing_003`~`012` | 1 | **NULL** | face 합성 필요 → face 1종이라 **11종 동일** |
+
+- face `ava_face_basic_001`은 `icon_uri` 보유(`ava_icon_face_basic_001`).
+- **결론**: 룸 내 바디 실루엣은 15종 다양, 채팅 distinct 아이콘은 사실상 5종(body 4 + face 1). P1-D4에서 이 제약을 수용.
+
+### 1.3 합성/아이콘 결정 로직 (재사용 대상)
+`AdminProfileService`(app 모듈) — 주어진 (bodyUri, faceUri)로 composition/icon 자동 결정:
+- faceUri 비어있음 → `SINGLE_BODY` + `findAvatarIconPairWithSingleBody(body)` = `body.iconUri`.
+- faceUri 있음(non-NFT) → `BODY_WITH_FACE` + `findPairAvatarIconByFaceUri(face)`.
+- `AdminAvatarResourceAdapter`(`AdminAvatarResourcePort` 구현): `findAllAvatarBodyResources()`, `findAvatarBodyByUri()`, 아이콘 페어링 제공.
+- **함의**: combinable 바디에 face=""를 주면 `icon_uri`가 NULL이라 다시 깨진다. 따라서 **combinable → 반드시 기본 face 합성**해야 유효 아이콘이 나온다(P1 합성 규칙의 근거).
+
+### 1.4 봇 계정 모델 (P2)
+- `VirtualUserPoolService.provision(n)`(`virtualdj` 모듈): `VirtualMemberProvisionPort.createVirtualMember(nickname)` → 실회원 경로(LOCAL+프로필+activity+GRABLIST+FM) → `markAsDummy()` → PLAYLIST 1개. 현재 아바타는 포트 내부 디폴트(`basic_001`, combinable=깨짐).
+- 봇 식별 = `user_account.is_dummy=true`.
+
+### 1.5 기존 아바타 update 표면
+`AdminUserController`(`/api/v1/admin/users/virtual/...`, `@Hidden`, `@adminAuth.canChangeMemberTier()` 게이트) = **P2 이전 데모용 가상멤버 도구**. `PUT /virtual/{userId}/avatar {avatarBodyUri, avatarFaceUri}` 존재(내부 `AdminUserService.updateVirtualMemberAvatar` → composition 자동). **게이트(`canChangeMemberTier`)·경로가 P2 콘솔(`canManageVirtualDj`, `/admin/virtual-dj`)과 불일치** → P1은 콘솔 계약에 맞춰 신설하되 내부 update 로직은 재사용(§2.2).
+
+### 1.6 어드민 콘솔 (pfplay-admin, P2 Plan B)
+- nav "가상 DJ"(운영 관리 그룹, role 무제한) → `/virtual-dj/:resourceType`(`pool`|`song-packs`).
+- `features/virtual-dj-pool/{api,model,ui}`: `pool-summary-cards`는 방별 `botCount`만, **개별 봇 신원(userId/nickname/아바타) 미노출** = P1이 채울 갭.
+- `features/music-search`: pfplay-web 포팅 + **boundary 매퍼**(`to-pack-track.ts`, `videoTitle→name`) — 아바타 피커의 매퍼 패턴 모델.
+- `features/partyrooms`: 체크박스 다중선택 + `bulk-action-toolbar`/`virtual-dj-bulk-dialog` 인프라 — 일괄 배분 다이얼로그 모델.
+- 호출: `shared/api/http.ts`(AdminAccessToken 쿠키 + XSRF double-submit + Origin). 테스트 vitest + MSW(`server.use`).
+
+---
+
+## 2. 백엔드 (pfplay-platform)
+
+모두 `@adminAuth.canManageVirtualDj()` 게이팅, `ApiCommonResponse` 봉투, 기존 query/port 패턴 준수. 엔드포인트는 P2 콘솔 표면(`AdminVirtualDjController`, app 모듈 `virtualdj`)에 합류.
+
+### 2.1 합성 규칙 — `BotAvatarAssigner` (도메인 헬퍼, 단일 소스)
+주어진 `bodyUri`에 대해:
+- 카탈로그에서 바디 조회 → `isCombinable=true` → faceUri = 기본 face(`ava_face_basic_001`) → `BODY_WITH_FACE` → face 페어 아이콘.
+- `false` → faceUri = `""` → `SINGLE_BODY` → body 페어 아이콘(`body.iconUri`).
+내부적으로 기존 (bodyUri, faceUri) → composition 결정 로직(§1.3)에 위임. **불변식: 결과 `avatarIconUri`는 절대 NULL/`""`이 아니다**(단위 테스트로 전수 단언).
+
+랜덤 배분/단건 적용/provision 자동부여가 **모두 이 헬퍼 1곳**을 거친다(divergence 불가).
+
+- **모듈 경계(plan 코드확인 §6-C1)**: `BotAvatarAssigner`는 `virtualdj` 모듈. 두 out-port 필요 — (a) 카탈로그 published 바디 목록/조회(avatar BC), (b) 봇 멤버에 (body,face) 적용(admin/user BC, `updateVirtualMemberAvatar` 래핑). 기존 `AdminAvatarResourcePort`/`AdminUserService` 재사용 가능성 우선 확인, 불가 시 얇은 신규 포트.
+
+### 2.2 랜덤성 — `Randomizer` 포트 (테스트 결정성)
+`BotAvatarAssigner`의 셋→봇 매핑은 시드 가능한 `Randomizer`(예: `int nextIndex(int bound)`) 주입. 운영=`SecureRandom`/`ThreadLocalRandom` 어댑터, 테스트=결정적 stub. 분배 결과를 단위/통합에서 검증 가능하게.
+
+### 2.3 신규 엔드포인트
+| Method | Path | 요청 | 응답 |
+|---|---|---|---|
+| GET | `/api/v1/admin/virtual-dj/avatar-catalog` | — | `[ { bodyUri, name, thumbnailUri, isCombinable, obtainableType } ]` |
+| GET | `/api/v1/admin/virtual-dj/bots` | — | `[ { userId, nickname, avatarBodyUri, avatarIconUri, placementRoomId?, placementRoomTitle? } ]` |
+| PUT | `/api/v1/admin/virtual-dj/bots/{userId}/avatar` | `{ avatarBodyUri }` | 200 `{ ...bot }` |
+| POST | `/api/v1/admin/virtual-dj/bots/avatar/distribute` | `{ botIds[], bodyUris[] }` | 200 `{ assigned: [ { userId, avatarBodyUri } ] }` |
+
+- **avatar-catalog**: `published`(`lifecycle_status='PUBLISHED'`) 바디만. `thumbnailUri`=`resource_uri`. obtainableType 표시는 운영자 참고용(게이트 아님). face=1종이라 face 선택 UI 없음(combinable은 서버가 자동 합성).
+- **bots(로스터)**: is_dummy 봇 목록 + 현재 아바타(바디/아이콘) + 배치된 방(있으면). 데이터원 `BotPoolQueryRepository` 확장(idle 판정 패턴 재사용, crew→partyroom 조인). 정렬은 nickname 또는 생성순.
+- **개별 PUT**: `{avatarBodyUri}`만 받고 face는 §2.1 규칙으로 서버 결정(요청에 face 없음). 미존재/비-봇 userId → 404.
+- **distribute**: `bodyUris[]`(셋, 비어있으면 400) + `botIds[]`(비어있으면 400). 각 봇에 셋에서 `Randomizer`로 1개 뽑아 §2.1 적용, 한 트랜잭션. 비-봇 id 포함 시 정책 = **무시하고 유효 봇만 적용**(응답 `assigned`에 실제 적용분만; 부분성공). bodyUris 중 카탈로그 비존재 URI → 400(셋 무결성).
+
+### 2.4 provision 변경 (P1-D5)
+`VirtualUserPoolService.provision`: 봇 생성·markAsDummy·playlist 후 각 봇에 `BotAvatarAssigner.assignRandomFromCatalog(botUserId)` 호출(전체 published 카탈로그에서 랜덤 1개). 기존 깨진 `basic_001` 디폴트 경로 제거. 동일 헬퍼라 합성/아이콘 불변식 동일 보장.
+
+### 2.5 에러/예외
+- 신규 도메인 예외 최소화: 빈 셋/빈 봇목록/미존재 바디 URI = 400(`INVALID_*`, 기존 `GlobalExceptionHandler` 매핑 패턴). 미존재 봇 = 404. 권한 = `canManageVirtualDj` 게이트(403).
+
+### 2.6 마이그레이션 없음 (긍정 신호)
+P1은 `user_profile`의 **기존 컬럼만** 갱신. 셋은 요청 본문 transient. provision 자동부여는 코드. **신규 Flyway 마이그레이션 불필요** → V24 같은 마이그레이션↔엔티티 drift / `validate` 부팅 실패 리스크 없음([[reference_ddl_auto_create_drop_hides_migration_drift]] 클래스 회피). e2e 부팅 게이트는 여전히 수행하되, 부팅 실패 표면적이 작다.
+
+### 2.7 테스트 (백엔드)
+- `BotAvatarAssigner` 단위: **15종 바디 전수** — combinable→`BODY_WITH_FACE`+face아이콘, standalone→`SINGLE_BODY`+body아이콘, **모든 경우 `avatarIconUri` non-null·non-blank 단언**.
+- distribute: `Randomizer` stub으로 결정적 분배 검증 + 빈 셋/빈 봇 400 + 비-봇 무시(부분성공) + 미존재 URI 400.
+- 개별 PUT: 성공·404·권한(403).
+- provision 통합: n명 생성 후 전원 `avatarIconUri` non-null + 바디가 카탈로그 소속.
+- 권한 게이팅(`canManageVirtualDj`) 슬라이스. `:app:test` + `:app:integrationTest` GREEN.
+
+---
+
+## 3. 어드민 프론트 (pfplay-admin)
+
+### 3.1 봇 로스터 (풀 페이지 확장)
+`/virtual-dj/pool` 페이지에 **봇 로스터 섹션** 추가(기존 요약 카드 아래):
+- 행: 바디 썸네일(`avatarBodyUri`) + 닉네임 + 배치룸(있으면 링크) + 행 체크박스 + "아바타 변경" 버튼.
+- 데이터 = `GET /virtual-dj/bots`(§2.3). react-query 키 `["virtual-dj","bots"]`.
+- feature: 기존 `features/virtual-dj-pool` 확장(`ui/bot-roster.tsx` 등).
+- 봇 수가 많을 수 있으나(N=20~50급) 단순 목록 + 클라 필터로 충분(페이지네이션=비블로커 후속).
+
+### 3.2 아바타 피커 (신규 공용 컴포넌트)
+- 카탈로그 썸네일 그리드. 데이터 = `GET /virtual-dj/avatar-catalog`(정적 → staleTime 길게).
+- **boundary 매퍼**(`to-avatar-option.ts`): 서버 `{bodyUri, name, thumbnailUri, isCombinable, obtainableType}` → UI 옵션. 어휘 정리 + spread 금지(music-search 매퍼 패턴, [[reference_dto_vocabulary_zero_content_hidden]]).
+- 모드: **다중선택(셋, 일괄용)** / **단일선택(개별용)**. combinable/standalone 시각 구분 배지(선택).
+
+### 3.3 일괄 배분 다이얼로그
+- 로스터에서 봇 다중선택(체크박스) → 툴바 "아바타 일괄 변경" → 피커(다중선택, 셋) → `POST /virtual-dj/bots/avatar/distribute {botIds[], bodyUris[]}`.
+- 빈 셋/빈 선택 zod 차단. 성공 시 결과 요약(몇 명에 배분) + `["virtual-dj","bots"]` invalidate. P2 `virtual-dj-bulk-dialog`/`bulk-action-toolbar` 패턴 계승.
+
+### 3.4 개별 편집 다이얼로그
+- 로스터 행 "아바타 변경" → 피커(단일선택) → `PUT /virtual-dj/bots/{userId}/avatar {avatarBodyUri}`. 성공 시 invalidate.
+
+### 3.5 데이터 흐름 & 에러
+- 기존 `http` 클라이언트(쿠키+XSRF+Origin). 조회 `useQuery` / 변경 `useMutation`+invalidate. 에러는 admin 패턴(toast + 인라인), 400/404/403 코드별 메시지.
+
+### 3.6 테스트 (프론트, vitest + MSW)
+- `to-avatar-option` 매퍼 단위(필드 매핑·빈값 없음·source 어휘 누수 가드).
+- 로스터 렌더(아이콘 non-null 썸네일), 피커 다중/단일 선택, 일괄 distribute 요청 바디 매핑, 개별 PUT.
+- 회귀: 기존 pool 페이지 테스트 보존(로스터 추가가 요약 카드/생성 폼 안 깨뜨림).
+
+---
+
+## 4. dev 머지 전 로컬 풀스택 e2e 게이트 (필수)
+
+[[feedback_local_e2e_before_dev_merge]] — 단위/통합 GREEN ≠ 배포안전. docker-compose 풀스택(backend :8080 validate 부팅 + admin) 기동 후:
+1. **부팅 검증**: `ddl-auto=validate` 프로파일 정상 부팅(마이그레이션 없어도 엔티티 정합 확인).
+2. 어드민 로그인 → `GET /virtual-dj/avatar-catalog` published 바디 반환 확인.
+3. **풀 생성(provision)** → `GET /virtual-dj/bots` 로스터 전원 **`avatarIconUri` non-null** 확인(P1-D5 검증).
+4. **일괄 배분**: 봇 다중선택 → 셋 배분 → 로스터 아바타 변경 반영 확인.
+5. **개별 변경** 1건 확인.
+6. (가능 시) MANAGED 방 배치 → pfplay-web/렌더 경로에서 봇 아바타가 변별되어 보이는지 확인(없으면 API 레벨 검증으로 대체).
+무NPE·무500 확인. 그 후에만 dev 머지.
+
+---
+
+## 5. 범위 밖 (YAGNI)
+
+- 아바타 리소스 CRUD 콘솔(바디/face 추가·편집·retire) — 별도 미래 콘솔. P1은 카탈로그 **소비만**.
+- face 카탈로그 확장(데이터/디자인) — combinable 동일 얼굴 제약은 본 단계 수용(P1-D4).
+- 컨셉/송팩 결속 아바타(P1-D1 기각).
+- 구별가능 모드 뱃지(P2 deferred).
+- 봇 닉네임 관리 / 봇 개별 삭제 UI.
+- 로스터 페이지네이션·고급 필터(비블로커 후속).
+
+---
+
+## 6. plan 단계 코드확인 항목
+
+- **C1 (모듈 경계)**: `BotAvatarAssigner`(virtualdj)가 카탈로그 조회 + 봇 아바타 적용을 위해 기존 `AdminAvatarResourcePort`/`AdminUserService.updateVirtualMemberAvatar`를 재사용 가능한지(가시성·트랜잭션). 불가 시 얇은 out-port 신설.
+- **C2 (로스터 쿼리)**: `BotPoolQueryRepositoryImpl`의 idle 판정(NOT EXISTS active crew) 패턴 위에 "봇+현재 아바타+배치룸" 조인 추가(QueryDSL tuple). placement는 crew→partyroom.
+- **C3 (avatar-catalog 노출)**: published 필터 + `resource_uri`를 thumbnail로. avatar BC에 어드민 조회 useCase 존재 여부(`AvatarCatalogQueryUseCase`) 확인 후 재사용.
+- **C4 (provision 자동부여 트랜잭션)**: provision 트랜잭션 안에서 아바타 적용이 같은 영속 컨텍스트로 안전한지(멤버 update 경로가 self-flush/이벤트 발행 시 부수효과 없는지).
+
+---
+
+## 7. 산출물 요약
+
+- **pfplay-platform**: `BotAvatarAssigner`(합성 규칙 단일 소스) + `Randomizer` 포트 + GET 2종(avatar-catalog·bots 로스터) + 개별 PUT + distribute POST + provision 자동부여 변경 + 테스트. **마이그레이션 없음.**
+- **pfplay-admin**: 봇 로스터(풀 페이지 확장) + 아바타 피커(공용, boundary 매퍼) + 일괄 배분 다이얼로그 + 개별 편집 + 테스트.
+- **게이트**: 두 레포 단위/통합 GREEN → 로컬 docker-compose 풀스택 e2e(§4) → dev 머지. **prod 승격은 P1+P3 후 #283~ 묶음 일괄**(메모리 정책 유지).


### PR DESCRIPTION
## 개요
봇(가상 DJ)이 전부 같은 기본 아바타(`ava_body_basic_001`=combinable→채팅 아이콘 NULL)로 보이는 문제 해소. 카탈로그의 다양한 아바타를 일괄(셋 랜덤 분배)·개별로 입히고, 봇 생성 시점부터 null-icon 갭을 원천 제거한다. closes #288

## 변경
- **`BotAvatarAssigner`** — 합성 규칙 단일 소스(combinable→공통 face 합성 / standalone→자체 아이콘). 랜덤 배분·개별·provision 자동부여가 모두 경유.
- **`Randomizer` 포트** + ThreadLocalRandom 어댑터(테스트 결정성).
- **`BotAvatarApplyPort`** — admin BC 시임(`VirtualMemberProvisionPort` 패턴, virtualdj→admin import는 adapter.out.provision만).
- **봇 로스터 쿼리 `findRoster`** — is_dummy 봇 + 현재 아바타 + 배치룸.
- **어드민 엔드포인트 4종** (`canManageVirtualDj`): `GET /virtual-dj/avatar-catalog`, `GET /virtual-dj/bots`, `PUT /virtual-dj/bots/{userId}/avatar`, `POST /virtual-dj/bots/avatar/distribute`.
- **provision 자동부여** — 생성 즉시 카탈로그 랜덤 변별 아바타(깨진 디폴트 제거).
- **마이그레이션 없음** (user_profile 기존 컬럼만).

## 로컬 e2e가 잡은 deploy-blocking 버그 2건 (fix→재실증)
- distribute per-bot try/catch가 REQUIRED 전파 rollback-only에 무력화 → 비-봇 사전필터로 교정 + non-@Tx IT 잠금.
- `updateVirtualMemberAvatar`가 @OneToOne 프로필 통째 교체 → cascade 2번째 user_profile INSERT → `uk_user_profile_nickname` 중복 500. 교체→기존 row mutate로 교정(`resolveAvatar` DRY). 테스트 갭(uk 제약이 V15에만·엔티티 무) → row count==1 IT 가드로 폐쇄.
- (부수) `findMemberByUserId`가 account_id를 member PK로 오인 → `findMemberByUserAccountId` 교정.

## 검증
- `:app:test` 1111 / `:app:integrationTest` 252 / `:user:test` 145 GREEN, ArchUnit GREEN.
- **로컬 docker-compose 풀스택 e2e GREEN**: 부팅(Flyway V24+validate) → provision 봇 5명 전원 `avatarIconUri` non-empty → distribute → 개별 변경 → 중복 user_profile row 없음(5↔5) → 무 NPE/500.

## 후속(비블로커)
- IT 카탈로그 seed 6중복 → `AbstractIntegrationTest` 추출.
- 동일 클래스 `deleteVirtualMember` PK 오삭제 → #289.

## 승격
prod 승격은 P1+P3 완성 후 #283~#287+P1+P3 묶음 일괄(현 정책). 본 PR은 dev/stg 축적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)