### PR TITLE
fix(user): 프로필 없는 참조 유저로 인한 로비 NPE→500 방어 (#291)

### DIFF
--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/LobbyNullProfileGuardIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/LobbyNullProfileGuardIT.java
@@ -1,0 +1,104 @@
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.party.application.dto.dj.DjWithProfileDto;
+import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.entity.data.DjData;
+import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.domain.enums.GradeType;
+import com.pfplaybackend.api.party.domain.enums.StageType;
+import com.pfplaybackend.api.party.domain.value.CrewId;
+import com.pfplaybackend.api.party.domain.value.LinkDomain;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * 로비 쿼리가 프로필 없는 참조 유저(가상 DJ 봇 아바타 생성 실패/더미/phantom)에 대해
+ * NPE→500 로 죽지 않음을 실제 빈(Testcontainers MySQL+Redis)으로 끝까지 구동해 잠근다. (#291)
+ *
+ * <p>핵심: {@link UserProfileQueryPort} 를 MockBean 으로 가리지 않고 <b>실제</b>
+ * {@code UserProfileQueryService.getUsersProfileSetting} + 실제 repository 를 태운다.
+ * DJ 의 userId 에 대응하는 {@code user_profile} 행을 일부러 만들지 않으면,
+ * fix 이전엔 맵에서 silent drop → {@code profileSettingDto.avatarIconUri()} NPE,
+ * fix 이후엔 placeholder 로 채워져 graceful 응답한다.
+ */
+@Transactional
+class LobbyNullProfileGuardIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private PartyroomQueryService partyroomQueryService;
+
+    @AfterEach
+    void clearAuthContext() {
+        ThreadLocalContext.clearContext();
+    }
+
+    private PartyroomId persistFullActivePartyroom(UserId hostId) {
+        PartyroomData partyroom = PartyroomData.create(
+                "null-profile 가드 파티룸", "로비 NPE 방어 잠금용",
+                LinkDomain.of("null-profile-" + hostId.getUid()),
+                PlaybackTimeLimit.ofMinutes(5),
+                StageType.GENERAL, hostId);
+        entityManager.persist(partyroom);
+        entityManager.flush();
+        PartyroomId partyroomId = new PartyroomId(partyroom.getId());
+        entityManager.persist(PartyroomPlaybackData.createFor(partyroomId));
+        entityManager.persist(DjQueueData.createFor(partyroomId));
+        return partyroomId;
+    }
+
+    private CrewData persistActiveCrew(PartyroomId partyroomId, UserId userId) {
+        CrewData crew = CrewData.create(partyroomId, userId, GradeType.CLUBBER, null);
+        entityManager.persist(crew);
+        flushAndClear();
+        return crew;
+    }
+
+    private void persistDjRow(PartyroomId partyroomId, long crewId, long playlistId, int orderNumber) {
+        DjData dj = DjData.create(partyroomId, new PlaylistId(playlistId), new CrewId(crewId), orderNumber);
+        entityManager.persist(dj);
+        flushAndClear();
+    }
+
+    @Test
+    @DisplayName("getDjs — DJ 의 user_profile 이 없어도 NPE 없이 placeholder 로 응답한다 (#291)")
+    void getDjsWithProfilelessDjDoesNotThrow() {
+        // given: 호스트는 임의, DJ 의 userId(9999...)는 user_profile 행을 만들지 않음 (프로필 없는 봇/더미/phantom 모사)
+        UserId hostId = new UserId(1001L);
+        UserId profilelessDjUserId = new UserId(99990001L);
+        PartyroomId partyroomId = persistFullActivePartyroom(hostId);
+        CrewData djCrew = persistActiveCrew(partyroomId, profilelessDjUserId);
+        persistDjRow(partyroomId, djCrew.getId(), 4242L, 1);
+
+        // when / then: 로비 DJ 큐 조회가 NPE 로 죽지 않는다
+        List<DjWithProfileDto> djs = assertDoesNotThrowAndGet(partyroomId);
+
+        // and: 프로필 없는 DJ 도 결과에 포함되며 placeholder(non-null) 로 채워진다
+        assertThat(djs).hasSize(1);
+        DjWithProfileDto dj = djs.get(0);
+        assertThat(dj.crewId()).isEqualTo(djCrew.getId());
+        assertThat(dj.nickname()).isNotNull();   // placeholder "" — fix 이전엔 여기서 NPE 났음
+    }
+
+    private List<DjWithProfileDto> assertDoesNotThrowAndGet(PartyroomId partyroomId) {
+        final List<DjWithProfileDto>[] holder = new List[1];
+        assertThatCode(() -> holder[0] = partyroomQueryService.getDjs(partyroomId))
+                .doesNotThrowAnyException();
+        return holder[0];
+    }
+}

--- a/user/src/main/java/com/pfplaybackend/api/user/application/service/UserProfileQueryService.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/service/UserProfileQueryService.java
@@ -2,6 +2,7 @@ package com.pfplaybackend.api.user.application.service;
 
 import com.pfplaybackend.api.common.ThreadLocalContext;
 import com.pfplaybackend.api.common.aspect.context.AuthContext;
+import com.pfplaybackend.api.common.domain.enums.AvatarCompositionType;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.enums.AuthorityTier;
 import com.pfplaybackend.api.user.adapter.out.persistence.ActivityRepository;
@@ -21,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -88,11 +90,28 @@ public class UserProfileQueryService {
         );
     }
 
+    /**
+     * 프로필이 없는 참조 유저(가상 DJ 봇 아바타 생성 실패/더미 점유/이상 데이터)에 대한 방어용 placeholder.
+     *
+     * <p>{@link #getUsersProfileSetting}이 요청된 모든 userId에 대해 non-null을 보장하도록,
+     * 프로필 행이 없는 userId는 본 값으로 채운다. 소비처(로비 메인스테이지/크루 아이콘 등 7+)가
+     * {@code map.get(userId).avatarIconUri()}를 null 가드 없이 역참조하던 NPE→500(로비 전체 다운)을
+     * 원천 차단한다(defense-in-depth, #291). 아바타 URI는 null로 두어 프런트의 기본 아바타로 graceful 표시.
+     */
+    private static final ProfileSettingDto PLACEHOLDER_PROFILE = new ProfileSettingDto(
+            "", AvatarCompositionType.SINGLE_BODY, null, null, null, 0, 0, 0.0, 0.0, 1.0);
+
     // 다수 사용자에 대한 프로필 설정 정보 조회
+    // 프로필 없는 userId도 placeholder로 채워 silent drop(소비처 NPE 원인)을 방지한다. (#291)
     @Transactional(readOnly = true)
     public Map<UserId, ProfileSettingDto> getUsersProfileSetting(List<UserId> userIds) {
-        return userProfileRepository.findAllByUserIdIn(userIds).stream()
-                .collect(Collectors.toMap(ProfileData::getUserId, this::toProfileSettingDto));
+        Map<UserId, ProfileSettingDto> profileMap = new HashMap<>(
+                userProfileRepository.findAllByUserIdIn(userIds).stream()
+                        .collect(Collectors.toMap(ProfileData::getUserId, this::toProfileSettingDto)));
+        for (UserId id : userIds) {
+            profileMap.putIfAbsent(id, PLACEHOLDER_PROFILE);
+        }
+        return profileMap;
     }
 
     // 특정 사용자에 대한 프로필 설정 정보 조회

--- a/user/src/test/java/com/pfplaybackend/api/user/application/service/UserProfileQueryServiceTest.java
+++ b/user/src/test/java/com/pfplaybackend/api/user/application/service/UserProfileQueryServiceTest.java
@@ -113,6 +113,28 @@ class UserProfileQueryServiceTest {
         assertThat(result).isEmpty();
     }
 
+    @Test
+    @DisplayName("getUsersProfileSetting — 프로필 없는 userId 도 placeholder 로 채워 맵에서 누락되지 않는다 (로비 NPE 방어, #291)")
+    void getUsersProfileSettingFillsMissingWithPlaceholder() {
+        // given: user2 는 프로필 행이 없음 (봇 아바타 생성 실패 / 더미 / phantom 데이터)
+        UserId user2 = new UserId(2L);
+        ProfileData profile1 = createProfileData(userId, "User1");
+        when(userProfileRepository.findAllByUserIdIn(List.of(userId, user2)))
+                .thenReturn(List.of(profile1)); // user2 는 silent drop 되던 케이스
+
+        // when
+        Map<UserId, ProfileSettingDto> result = userProfileQueryService.getUsersProfileSetting(List.of(userId, user2));
+
+        // then: 요청한 모든 userId 가 맵에 존재해야 한다 (silent drop 금지)
+        assertThat(result).containsKeys(userId, user2);
+        // 누락 유저는 non-null placeholder → 소비처의 .avatarIconUri()/.nickname() NPE 원천 차단
+        assertThat(result.get(user2)).isNotNull();
+        assertThat(result.get(user2).nickname()).isNotNull();
+        assertThat(result.get(user2).avatarCompositionType()).isNotNull();
+        // 정상 유저는 그대로
+        assertThat(result.get(userId).nickname()).isEqualTo("User1");
+    }
+
     // ========== getMyProfileSummary ==========
 
     @Test


### PR DESCRIPTION
## 무엇을 / 왜

`UserProfileQueryService.getUsersProfileSetting(userIds)` 가 **프로필 행이 있는 userId 만** 맵에 담아 반환(`findAllByUserIdIn` → `toMap`). 프로필 없는 userId 는 **silent drop**.

소비처(로비 메인스테이지 `QueryPartyroomSummaryResponse`, 크루 아이콘 `QueryPartyroomListResponse`, `PartyroomQueryService.getDjs/getSummaryInfo` 등 7+)가 `map.get(userId)` 후 **null 가드 없이** `.nickname()`/`.avatarIconUri()` 역참조 →

```
Cannot invoke "...ProfileSettingDto.avatarIconUri()" because "profileSettingDto" is null
```

→ NPE → 500 → **로비가 모든 사용자에게 다운**(한 행의 프로필 누락이 전체 로비를 죽임). closes #291

## 트리거 (prod 리스크)

- 가상 DJ **봇 아바타 생성 실패**(P1 `updateVirtualMemberAvatar`/distribute 롤백 이력 계열)
- 더미 점유(#264) 더미 유저
- 로컬 모바일 e2e 에서 phantom host 9999/crew 7777 로 실증(로비/룸 e2e 6건 동시 다운)

## 변경

`getUsersProfileSetting` 단일 지점에서 **요청된 모든 userId 에 non-null 보장** — 누락 userId 는 `PLACEHOLDER_PROFILE`(빈 닉네임 + null 아바타 URI, SINGLE_BODY)로 채움. 소비처 7+ 를 한 번에 방어(defense-in-depth). 아바타 URI null → 프런트 기본 아바타로 graceful 표시. 정상 happy-path 동작 불변(누락 없으면 placeholder 미추가).

## 검증

- TDD: 실패 테스트(프로필 없는 userId 가 맵에서 누락) → fix → green
- `:user:test` 전체 GREEN, 소비처 단위 테스트(PartyroomQueryService·GetDjs·PartyroomSetup·Playback·CrewPenalty·CrewBlock) GREEN, `:app` 컴파일 OK
- 마이그레이션·부팅경로·스키마·API 계약 변경 없음 = crash-loop/deploy-blocking 위험 없는 순수 additive 로직

## 범위
develop 독립 버그픽스(가상 DJ prod 승격 전 하드닝). 핵심 NPE 사이트는 develop 일반 코드라 parked P3 에 묶지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
