### PR TITLE
test(voc): BugReport 게스트 허용 회귀 잠금 (#250)

### DIFF
--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/web/AbstractVocCommandWebMvcTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/web/AbstractVocCommandWebMvcTest.java
@@ -46,14 +46,26 @@ abstract class AbstractVocCommandWebMvcTest {
      * post-processor 는 principal 이 Jwt 라 @AuthenticationPrincipal UserId 가 null — 실제 토큰 형태 미러)
      */
     protected static RequestPostProcessor authedUser(long userId) {
+        return authedPrincipal(userId, "ROLE_MEMBER", AuthorityTier.AM);
+    }
+
+    /**
+     * 게스트 인증 주체(ROLE_GUEST + {@link AuthorityTier#GT}). VOC 버그 신고는 게스트도 허용이
+     * 의도된 동작이라, 그 계약을 회귀 잠금하기 위한 헬퍼.
+     */
+    protected static RequestPostProcessor authedGuest(long userId) {
+        return authedPrincipal(userId, "ROLE_GUEST", AuthorityTier.GT);
+    }
+
+    private static RequestPostProcessor authedPrincipal(long userId, String role, AuthorityTier tier) {
         Jwt jwt = Jwt.withTokenValue("test-token").header("alg", "none")
                 .claim("sub", String.valueOf(userId)).build();
         CustomJwtAuthenticationToken token = new CustomJwtAuthenticationToken(
                 jwt,
-                List.of(new SimpleGrantedAuthority("ROLE_MEMBER")),
+                List.of(new SimpleGrantedAuthority(role)),
                 new UserId(userId),
                 "tester@pfplay.local",
-                AuthorityTier.AM);
+                tier);
         return authentication(token);
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/web/BugReportCommandControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/web/BugReportCommandControllerTest.java
@@ -95,6 +95,25 @@ class BugReportCommandControllerTest extends AbstractVocCommandWebMvcTest {
     }
 
     @Test
+    @DisplayName("submit — 게스트(ROLE_GUEST)도 201 (게스트 허용 회귀 잠금)")
+    void submitAsGuestReturns201() throws Exception {
+        // VOC 버그 신고는 게스트+AM+FM 모두 허용이 의도된 동작. 누군가 실수로 'MEMBER 만'
+        // 가드를 넣으면 게스트가 막히는데, 기존 통과 케이스가 전부 ROLE_MEMBER 라 CI 가 못 잡았다.
+        // 이 케이스가 게스트 허용 계약을 잠근다 (회귀 시 403 으로 실패).
+        when(bugReportCommandService.submit(any(), any(), any(), any(), any())).thenReturn(42L);
+
+        mockMvc.perform(post("/api/v1/voc/bug-reports")
+                        .with(authedGuest(100L))
+                        .with(csrf())
+                        .header("Referer", "https://pfplay.xyz/parties/7")
+                        .header("User-Agent", "Mozilla/5.0")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"재생이 안 됩니다\",\"partyroomId\":7}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.bugReportId").value(42));
+    }
+
+    @Test
     @DisplayName("submit — rate-limit 시 429 + BUG-001")
     void submitRateLimitReturns429() throws Exception {
         doThrow(ExceptionCreator.create(BugReportException.RATE_LIMIT_EXCEEDED))


### PR DESCRIPTION
## 요약
quick-win — VOC 버그 신고(`POST /api/v1/voc/bug-reports`)의 **게스트 허용 회귀 잠금** 추가. 이슈 #250.

## 배경
버그 신고는 **게스트+AM+FM 모두 허용**이 의도된 동작(헤더 🐛 버튼, 로그인 안 한 사용자도 제보 가능). 그러나 기존 통과 케이스가 전부 `ROLE_MEMBER` 라 **게스트 회귀 가드가 부재** — 누군가 실수로 'MEMBER 만' 가드를 넣어 게스트를 막아도 CI 가 못 잡는 갭.

## 변경 (테스트 전용, 프로덕션 코드 무변경)
- `AbstractVocCommandWebMvcTest`: `authedGuest(ROLE_GUEST + AuthorityTier.GT)` 헬퍼 추가 (`authedUser`/`authedGuest` 가 공용 `authedPrincipal` 위임).
- `submitAsGuestReturns201`: 게스트 제출 201 계약 잠금.

## 검증
- `:app:test --tests BugReportCommandControllerTest` 8 GREEN.
- **teeth(뮤테이션) 검증**: 컨트롤러를 `@PreAuthorize("hasRole('MEMBER')")` 로 임시 변경 시 `submitAsGuestReturns201` **만** 단독 FAILED(8중 1) → 원복. 회귀를 정확히 포착함을 입증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)