### PR TITLE
[가상 DJ P3-B] 플레이리스트 반응 적응 자가갱신 (백엔드, stacked on P3-A)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/operations/domain/value/ConfigKey.java
+++ b/app/src/main/java/com/pfplaybackend/api/operations/domain/value/ConfigKey.java
@@ -53,4 +53,14 @@ public record ConfigKey(String value) {
 
     // 가상 DJ P3-B 플레이리스트 자가갱신 forward-gate (구현 전 기본 잠금)
     public static final ConfigKey VDJ_PLAYLIST_SELF_UPDATE_ENABLED = new ConfigKey("vdj.playlist.self_update.enabled");
+
+    // 가상 DJ P3-B 자가갱신 튜닝 키
+    public static final ConfigKey VDJ_SELF_UPDATE_COOLDOWN_SECONDS = new ConfigKey("vdj.playlist.self_update.cooldown_seconds");
+    public static final ConfigKey VDJ_SELF_UPDATE_MIN_REACTIONS = new ConfigKey("vdj.playlist.self_update.min_reactions");
+    public static final ConfigKey VDJ_SELF_UPDATE_TARGET_SIZE = new ConfigKey("vdj.playlist.self_update.target_size");
+    public static final ConfigKey VDJ_SELF_UPDATE_REPLACE_PER_CYCLE = new ConfigKey("vdj.playlist.self_update.replace_per_cycle");
+    public static final ConfigKey VDJ_SELF_UPDATE_RECOMMEND_COUNT = new ConfigKey("vdj.playlist.self_update.recommend_count");
+    public static final ConfigKey VDJ_SELF_UPDATE_WEIGHT_REACTION = new ConfigKey("vdj.playlist.self_update.weight.reaction");
+    public static final ConfigKey VDJ_SELF_UPDATE_WEIGHT_GRAB = new ConfigKey("vdj.playlist.self_update.weight.grab");
+    public static final ConfigKey VDJ_SELF_UPDATE_PRUNED_COOLDOWN_SECONDS = new ConfigKey("vdj.playlist.self_update.pruned_cooldown_seconds");
 }

--- a/app/src/main/java/com/pfplaybackend/api/operations/domain/value/ConfigKey.java
+++ b/app/src/main/java/com/pfplaybackend/api/operations/domain/value/ConfigKey.java
@@ -57,7 +57,6 @@ public record ConfigKey(String value) {
     // 가상 DJ P3-B 자가갱신 튜닝 키
     public static final ConfigKey VDJ_SELF_UPDATE_COOLDOWN_SECONDS = new ConfigKey("vdj.playlist.self_update.cooldown_seconds");
     public static final ConfigKey VDJ_SELF_UPDATE_MIN_REACTIONS = new ConfigKey("vdj.playlist.self_update.min_reactions");
-    public static final ConfigKey VDJ_SELF_UPDATE_TARGET_SIZE = new ConfigKey("vdj.playlist.self_update.target_size");
     public static final ConfigKey VDJ_SELF_UPDATE_REPLACE_PER_CYCLE = new ConfigKey("vdj.playlist.self_update.replace_per_cycle");
     public static final ConfigKey VDJ_SELF_UPDATE_RECOMMEND_COUNT = new ConfigKey("vdj.playlist.self_update.recommend_count");
     public static final ConfigKey VDJ_SELF_UPDATE_WEIGHT_REACTION = new ConfigKey("vdj.playlist.self_update.weight.reaction");

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomQueryService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomQueryService.java
@@ -156,6 +156,19 @@ public class PartyroomQueryService {
         return playbackQueryService.getPlaybackById(playbackState.getCurrentPlaybackId()).getName();
     }
 
+    /**
+     * 현재 재생 중인 곡의 linkId 를 반환한다. 재생 비활성/곡 없음이면 {@code null}.
+     * P3-B 자가갱신의 현재곡 prune 보호(INV-3)용. AggregatePort 는 party BC 안에 가두고 String 만 노출.
+     */
+    @Transactional(readOnly = true)
+    public String getCurrentPlaybackLinkId(PartyroomId partyroomId) {
+        PartyroomPlaybackData playbackState = aggregatePort.findPlaybackState(partyroomId);
+        if (!playbackState.isActivated() || playbackState.getCurrentPlaybackId() == null) {
+            return null;
+        }
+        return playbackQueryService.getPlaybackById(playbackState.getCurrentPlaybackId()).getLinkId();
+    }
+
     @Transactional(readOnly = true)
     public Optional<CrewData> getCrewByUserId(PartyroomId partyroomId, UserId userId) {
         return aggregatePort.findCrew(partyroomId, userId);

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/llm/OpenAiChatProvider.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/llm/OpenAiChatProvider.java
@@ -22,26 +22,25 @@ import java.net.http.HttpClient;
 import java.time.Duration;
 
 /**
- * Anthropic Messages API({@code POST /v1/messages})를 호출하는 {@link LlmChatProvider} 구현.
+ * OpenAI Chat Completions API({@code POST /v1/chat/completions})를 호출하는 {@link LlmChatProvider} 구현.
+ *
+ * <h2>프로바이더 선택</h2>
+ * {@code service-api.llm.provider} 가 {@code openai}(미설정 시 기본)일 때만 빈으로 등록된다. {@code anthropic}
+ * 이면 대신 {@link AnthropicChatProvider} 가 등록된다 — 두 어댑터는 같은 포트의 상호배타 구현이다.
  *
  * <h2>best-effort 계약</h2>
  * {@link #complete} 는 절대 예외를 던지지 않는다. API 키 미설정 → 즉시 {@code ""}(호출 자체를 하지 않음).
- * HTTP 4xx/5xx, 타임아웃, 파싱 실패 → catch 후 {@code log.warn} + {@code ""}. 성공 시 첫 text 블록 텍스트
- * (없으면 {@code ""}).
+ * HTTP 4xx/5xx, 타임아웃, 파싱 실패 → catch 후 {@code log.warn} + {@code ""}. 성공 시 첫 choice 의
+ * {@code message.content}(문자열이 아니면 {@code ""}).
  *
- * <h2>system 프롬프트 / prompt caching</h2>
- * system 은 평문 문자열로 보낸다. 채팅용 system(고정 규칙 + 페르소나 + 방 컨텍스트)은 짧아(수백 토큰)
- * Haiku 4.5 의 최소 캐시 prefix(4096 토큰) 미만이라 prompt caching 이 어차피 걸리지 않는다
- * (cache_control 을 붙여도 silent no-op). 따라서 불필요한 블록 배열/cache_control 을 두지 않는다.
- * 향후 system 이 4096 토큰을 넘기게 설계되면 그때 {@code [{type:text,…,cache_control:{type:ephemeral}}]}
- * 배열 형태 + cache_control 로 캐싱을 도입한다.
+ * <h2>system/user 매핑</h2>
+ * Anthropic 의 별도 {@code system} 필드와 달리 OpenAI 는 {@code messages} 배열의 {@code role:"system"}
+ * 메시지로 system 프롬프트를 전달한다. 따라서 systemPrompt→messages[0](system), userContent→messages[1](user).
  */
 @Slf4j
 @Component
-@ConditionalOnProperty(name = "service-api.llm.provider", havingValue = "anthropic")
-public class AnthropicChatProvider implements LlmChatProvider {
-
-    private static final String ANTHROPIC_VERSION = "2023-06-01";
+@ConditionalOnProperty(name = "service-api.llm.provider", havingValue = "openai", matchIfMissing = true)
+public class OpenAiChatProvider implements LlmChatProvider {
 
     private final String apiKey;
     private final String baseUri;
@@ -49,11 +48,11 @@ public class AnthropicChatProvider implements LlmChatProvider {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final RestTemplate restTemplate;
 
-    public AnthropicChatProvider(
-            @Value("${service-api.anthropic.api-key:}") String apiKey,
-            @Value("${service-api.anthropic.base-uri:https://api.anthropic.com}") String baseUri,
-            @Value("${service-api.anthropic.model:claude-haiku-4-5}") String model,
-            @Value("${service-api.anthropic.timeout-ms:12000}") long timeoutMs) {
+    public OpenAiChatProvider(
+            @Value("${service-api.openai.api-key:}") String apiKey,
+            @Value("${service-api.openai.base-uri:https://api.openai.com}") String baseUri,
+            @Value("${service-api.openai.model:gpt-4o-mini}") String model,
+            @Value("${service-api.openai.timeout-ms:12000}") long timeoutMs) {
         this.apiKey = apiKey;
         this.baseUri = baseUri;
         this.model = model;
@@ -61,10 +60,10 @@ public class AnthropicChatProvider implements LlmChatProvider {
 
         // 키 부재는 정상 상태다(프로세스 다운 아님) — 가시성을 위해 기동 시 한 번 알린다.
         if (apiKey == null || apiKey.isBlank()) {
-            log.info("ANTHROPIC_API_KEY 미설정 — 봇 채팅 LLM 응답은 no-op(빈 응답→드롭). 프로세스 정상 기동. "
-                    + "키 설정 후 자동 동작(전역 토글 vdj.chat.enabled 과는 별개 레이어).");
+            log.info("OPENAI_API_KEY 미설정 — 봇 채팅/선곡 LLM 응답은 no-op(빈 응답→드롭). 프로세스 정상 기동. "
+                    + "키 설정 후 자동 동작(전역 토글 vdj.chat.enabled / vdj.playlist.self_update.enabled 과는 별개 레이어).");
         } else {
-            log.info("AnthropicChatProvider 준비 완료 — model={}", model);
+            log.info("OpenAiChatProvider 준비 완료 — model={}", model);
         }
     }
 
@@ -89,16 +88,15 @@ public class AnthropicChatProvider implements LlmChatProvider {
     @Override
     public String complete(String systemPrompt, String userContent, int maxTokens) {
         if (apiKey == null || apiKey.isBlank()) {
-            log.debug("no anthropic key, skipping bot chat completion");
+            log.debug("no openai key, skipping completion");
             return "";
         }
 
         try {
-            URI uri = URI.create(baseUri + "/v1/messages");
+            URI uri = URI.create(baseUri + "/v1/chat/completions");
 
             HttpHeaders headers = new HttpHeaders();
-            headers.set("x-api-key", apiKey);
-            headers.set("anthropic-version", ANTHROPIC_VERSION);
+            headers.setBearerAuth(apiKey);
             headers.setContentType(MediaType.APPLICATION_JSON);
 
             String body = buildRequestBody(systemPrompt, userContent, maxTokens);
@@ -107,9 +105,9 @@ public class AnthropicChatProvider implements LlmChatProvider {
             ResponseEntity<String> response =
                     restTemplate.exchange(uri, HttpMethod.POST, entity, String.class);
 
-            return extractFirstText(response.getBody());
+            return extractFirstContent(response.getBody());
         } catch (Exception e) {
-            log.warn("anthropic chat completion failed: {}", e.toString());
+            log.warn("openai chat completion failed: {}", e.toString());
             return "";
         }
     }
@@ -120,11 +118,11 @@ public class AnthropicChatProvider implements LlmChatProvider {
         root.put("model", model);
         root.put("max_tokens", maxTokens);
 
-        // system: 평문 문자열(짧은 채팅 프롬프트 → 캐싱 임계 미만, 블록배열/cache_control 불필요)
-        root.put("system", systemPrompt);
-
-        // messages: [{ role:user, content:… }]
+        // messages: [{ role:system, content:… }, { role:user, content:… }]
         ArrayNode messagesArr = root.putArray("messages");
+        ObjectNode systemMsg = messagesArr.addObject();
+        systemMsg.put("role", "system");
+        systemMsg.put("content", systemPrompt);
         ObjectNode userMsg = messagesArr.addObject();
         userMsg.put("role", "user");
         userMsg.put("content", userContent);
@@ -132,18 +130,17 @@ public class AnthropicChatProvider implements LlmChatProvider {
         return objectMapper.writeValueAsString(root);
     }
 
-    /** content 배열에서 첫 {@code type=="text"} 블록의 text 를 반환. 없으면 "". */
-    private String extractFirstText(String responseBody) throws Exception {
+    /** {@code choices[0].message.content} 가 문자열이면 그 텍스트, 아니면(null/누락/빈 choices) "". */
+    private String extractFirstContent(String responseBody) throws Exception {
         if (responseBody == null || responseBody.isBlank()) {
             return "";
         }
         JsonNode root = objectMapper.readTree(responseBody);
-        JsonNode content = root.path("content");
-        if (content.isArray()) {
-            for (JsonNode block : content) {
-                if ("text".equals(block.path("type").asText())) {
-                    return block.path("text").asText("");
-                }
+        JsonNode choices = root.path("choices");
+        if (choices.isArray() && !choices.isEmpty()) {
+            JsonNode content = choices.get(0).path("message").path("content");
+            if (content.isTextual()) {
+                return content.asText();
             }
         }
         return "";

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/ReactionScoreQueryRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/ReactionScoreQueryRepository.java
@@ -1,0 +1,19 @@
+package com.pfplaybackend.api.virtualdj.adapter.out.persistence;
+
+import com.pfplaybackend.api.virtualdj.application.dto.LinkReactionScore;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * P3-B 자가갱신용 cross-BC 반응 읽기 — playback / playback_aggregation / playback_reaction_history 를
+ * 가로질러 봇 자기 plays 의 반응을 집계한다. ActiveDjSnapshotQueryRepository 와 동일한 virtualdj-adapter
+ * cross-BC 패턴. ArchUnit: "Orchestrator" 미포함 + party *AggregatePort/*MessagePublisher 미의존(QueryDSL 엔티티 조회만)이라 통과.
+ */
+public interface ReactionScoreQueryRepository {
+
+    /** watermark 이후 봇 plays 에 달린 반응 row 수(비용 게이트). botUserIds 비면 0. since==null 이면 전체 기간. */
+    long countReactionsSince(List<Long> botUserIds, long partyroomId, LocalDateTime since);
+
+    /** 한 봇의 plays 를 link_id 로 group 한 반응 집계(score 입력). */
+    List<LinkReactionScore> aggregateByLink(long botUserId, long partyroomId);
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/impl/ReactionScoreQueryRepositoryImpl.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/impl/ReactionScoreQueryRepositoryImpl.java
@@ -1,0 +1,108 @@
+package com.pfplaybackend.api.virtualdj.adapter.out.persistence.impl;
+
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.ReactionScoreQueryRepository;
+import com.pfplaybackend.api.virtualdj.application.dto.LinkReactionScore;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.pfplaybackend.api.party.domain.entity.data.QPlaybackAggregationData.playbackAggregationData;
+import static com.pfplaybackend.api.party.domain.entity.data.QPlaybackData.playbackData;
+import static com.pfplaybackend.api.party.domain.entity.data.history.QPlaybackReactionHistoryData.playbackReactionHistoryData;
+
+/**
+ * P3-B cross-BC 반응 집계 QueryDSL 구현체.
+ *
+ * <p>ActiveDjSnapshotQueryRepositoryImpl 과 동일한 virtualdj-adapter cross-BC 패턴.
+ * ArchUnit 통과 조건: "Orchestrator" 미포함 + party *AggregatePort/*MessagePublisher 미의존.
+ */
+@Repository
+@RequiredArgsConstructor
+public class ReactionScoreQueryRepositoryImpl implements ReactionScoreQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public long countReactionsSince(List<Long> botUserIds, long partyroomId, LocalDateTime since) {
+        if (botUserIds.isEmpty()) {
+            return 0L;
+        }
+
+        var subquery = JPAExpressions
+                .select(playbackData.id)
+                .from(playbackData)
+                .where(
+                        playbackData.userId.uid.in(botUserIds),
+                        playbackData.partyroomId.id.eq(partyroomId));
+
+        var sincePredicate = since == null ? null
+                : playbackReactionHistoryData.createdAt.gt(since);
+
+        Long count = queryFactory
+                .select(playbackReactionHistoryData.count())
+                .from(playbackReactionHistoryData)
+                .where(
+                        playbackReactionHistoryData.playbackId.id.in(subquery),
+                        sincePredicate)
+                .fetchOne();
+
+        return count == null ? 0L : count;
+    }
+
+    @Override
+    public List<LinkReactionScore> aggregateByLink(long botUserId, long partyroomId) {
+        // (1) 봇의 plays: playbackId → linkId
+        List<Tuple> plays = queryFactory
+                .select(playbackData.id, playbackData.linkId)
+                .from(playbackData)
+                .where(
+                        playbackData.userId.uid.eq(botUserId),
+                        playbackData.partyroomId.id.eq(partyroomId))
+                .fetch();
+
+        if (plays.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, String> linkIdByPlaybackId = new HashMap<>();
+        for (Tuple t : plays) {
+            Long pid = t.get(playbackData.id);
+            String linkId = t.get(playbackData.linkId);
+            if (pid != null && linkId != null) {
+                linkIdByPlaybackId.put(pid, linkId);
+            }
+        }
+
+        // (2) 해당 plays 의 aggregation rows
+        List<Long> playbackIds = new ArrayList<>(linkIdByPlaybackId.keySet());
+        var aggregations = queryFactory
+                .selectFrom(playbackAggregationData)
+                .where(playbackAggregationData.playbackId.id.in(playbackIds))
+                .fetch();
+
+        // (3) linkId 별 합산: long[3] = {likeSum, dislikeSum, grabSum}
+        Map<String, long[]> sums = new HashMap<>();
+        for (var agg : aggregations) {
+            Long pid = agg.getPlaybackId().getId();
+            String linkId = linkIdByPlaybackId.get(pid);
+            if (linkId == null) continue;
+            long[] s = sums.computeIfAbsent(linkId, k -> new long[3]);
+            s[0] += agg.getLikeCount();
+            s[1] += agg.getDislikeCount();
+            s[2] += agg.getGrabCount();
+        }
+
+        // (4) LinkReactionScore 목록 생성
+        return sums.entrySet().stream()
+                .map(e -> new LinkReactionScore(e.getKey(), e.getValue()[0], e.getValue()[1], e.getValue()[2]))
+                .toList();
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/dto/LinkReactionScore.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/dto/LinkReactionScore.java
@@ -1,0 +1,11 @@
+package com.pfplaybackend.api.virtualdj.application.dto;
+
+/**
+ * 봇 자기 plays 를 link_id 로 group 한 반응 집계 (P3-B score 입력).
+ *
+ * @param linkId        곡 링크 식별자
+ * @param likeSum       Σ like_count
+ * @param dislikeSum    Σ dislike_count
+ * @param grabSum       Σ grab_count
+ */
+public record LinkReactionScore(String linkId, long likeSum, long dislikeSum, long grabSum) {}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/dto/NewTrack.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/dto/NewTrack.java
@@ -1,0 +1,6 @@
+package com.pfplaybackend.api.virtualdj.application.dto;
+
+import com.pfplaybackend.api.common.domain.value.Duration;
+
+/** 봇 playlist 에 새로 추가할 곡(해소 결과·송팩 폴백의 공용 입력). */
+public record NewTrack(String name, String linkId, Duration duration, String thumbnailImage) {}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/port/SongRecommendationProvider.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/port/SongRecommendationProvider.java
@@ -1,0 +1,15 @@
+package com.pfplaybackend.api.virtualdj.application.port;
+
+import com.pfplaybackend.api.virtualdj.application.port.RoomContextReader.RoomContext;
+import java.util.List;
+
+/** 고반응 우승 곡 + 방 컨셉 → 추천 곡명(검색 쿼리) 리스트. best-effort: 실패 시 빈 리스트. */
+public interface SongRecommendationProvider {
+    /**
+     * @param roomContext  방 제목/소개/현재곡(컨셉)
+     * @param winnerTitles 고반응 우승 곡 제목들(LLM 의 취향 단서)
+     * @param count        원하는 추천 수 N
+     * @return 추천 곡명 리스트(0~count). 실패 시 빈 리스트(예외 없음).
+     */
+    List<String> recommend(RoomContext roomContext, List<String> winnerTitles, int count);
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/BotPlaylistEditor.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/BotPlaylistEditor.java
@@ -1,0 +1,79 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.TrackRepository;
+import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
+import com.pfplaybackend.api.virtualdj.application.dto.NewTrack;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * 봇 playlist 의 트랙을 원자적으로 교체(prune + add-to-head + 순서 재정규화)하는 서비스.
+ *
+ * <p>P3-B 자가갱신 파이프라인에서 호출한다. {@code n = min(addTracks.size, pruneTrackIds.size)}
+ * 개 트랙을 삭제하고 동일 개수의 신규 트랙을 헤드(1..n)에 추가한다. 기존 생존 트랙은
+ * {@code n+1..n+m} 으로 순서가 재정규화되어 총 트랙 수(크기 불변)가 유지된다.
+ *
+ * <p>ArchUnit: {@code *Orchestrator*} 클래스가 아니므로 persistence 직접 접근 허용.
+ */
+@Service
+@RequiredArgsConstructor
+public class BotPlaylistEditor {
+
+    private final TrackRepository trackRepository;
+
+    /**
+     * 봇 playlist 의 트랙을 원자적으로 교체한다.
+     *
+     * @param playlistId     봇 playlist id
+     * @param pruneTrackIds  제거 후보 트랙 id 목록 (앞에서 n 개만 실제 삭제)
+     * @param addTracks      추가할 신규 트랙 목록 (앞에서 n 개만 실제 추가)
+     * @return 실제 교체된 트랙 수 n (0이면 변경 없음)
+     */
+    @Transactional
+    public int swap(Long playlistId, List<Long> pruneTrackIds, List<NewTrack> addTracks) {
+        int n = Math.min(addTracks.size(), pruneTrackIds.size());
+        if (n == 0) {
+            return 0;
+        }
+
+        // 1. 앞 n 개 트랙 삭제
+        trackRepository.deleteAllById(pruneTrackIds.subList(0, n));
+
+        // 2. 남은 트랙 로드 → 현재 orderNumber 오름차순 정렬
+        List<TrackData> survivors = trackRepository.findAllByPlaylistId(new PlaylistId(playlistId))
+                .stream()
+                .sorted(Comparator.comparingInt(TrackData::getOrderNumber))
+                .collect(java.util.stream.Collectors.toCollection(ArrayList::new));
+
+        // 3. 생존 트랙 순서를 n+1..n+m 으로 재정규화 (add-to-head: 신곡이 1..n 점유)
+        int survivorOrder = n + 1;
+        for (TrackData survivor : survivors) {
+            survivor.reorder(survivorOrder++);
+        }
+        trackRepository.saveAll(survivors);
+
+        // 4. 신규 트랙 n 개를 헤드(1..n)에 추가
+        PlaylistId pid = new PlaylistId(playlistId);
+        List<TrackData> newTracks = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            NewTrack nt = addTracks.get(i);
+            newTracks.add(TrackData.builder()
+                    .playlistId(pid)
+                    .orderNumber(i + 1)
+                    .name(nt.name())
+                    .linkId(nt.linkId())
+                    .duration(nt.duration())
+                    .thumbnailImage(nt.thumbnailImage())
+                    .build());
+        }
+        trackRepository.saveAll(newTracks);
+
+        return n;
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/LlmSongRecommendationProvider.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/LlmSongRecommendationProvider.java
@@ -1,0 +1,86 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.virtualdj.application.port.LlmChatProvider;
+import com.pfplaybackend.api.virtualdj.application.port.RoomContextReader.RoomContext;
+import com.pfplaybackend.api.virtualdj.application.port.SongRecommendationProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * LLM 을 이용해 방 컨셉 + 고반응 우승 곡 기반으로 신규 곡명을 추천한다.
+ *
+ * <p>best-effort: LLM 호출 실패·파싱 실패 모두 빈 리스트 반환(예외 없음).
+ */
+@Service
+@RequiredArgsConstructor
+public class LlmSongRecommendationProvider implements SongRecommendationProvider {
+
+    /** 추천 프롬프트용 최대 응답 토큰 수. */
+    static final int RECOMMEND_MAX_TOKENS = 256;
+
+    /** 줄 맨 앞 번호/불릿 접두사 제거 패턴 (예: "1. ", "2) ", "- ", "* "). */
+    private static final Pattern PREFIX_PATTERN = Pattern.compile("^\\s*(\\d+[.)]|[-*])\\s*");
+
+    private final LlmChatProvider llm;
+
+    @Override
+    public List<String> recommend(RoomContext roomContext, List<String> winnerTitles, int count) {
+        if (count <= 0) {
+            return List.of();
+        }
+        try {
+            String systemPrompt = buildSystemPrompt(roomContext);
+            String userContent = buildUserContent(winnerTitles);
+            String raw = llm.complete(systemPrompt, userContent, RECOMMEND_MAX_TOKENS);
+            if (raw == null || raw.isBlank()) {
+                return List.of();
+            }
+            return parseLines(raw, count);
+        } catch (Exception e) {
+            return List.of();
+        }
+    }
+
+    // ─── private helpers ──────────────────────────────────────────────────────
+
+    private String buildSystemPrompt(RoomContext ctx) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("당신은 음악 큐레이터입니다. 방의 컨셉과 인기 곡을 참고하여 잘 어울리는 신규 곡을 추천해야 합니다.\n");
+        sb.append("응답 규칙:\n");
+        sb.append("- 한 줄에 곡 이름 하나만 출력하세요.\n");
+        sb.append("- 번호, 불릿, 설명, 부가 텍스트 없이 곡 이름(아티스트 - 곡명 형식 권장)만 출력하세요.\n");
+        sb.append("- 빈 줄 없이 연속해서 출력하세요.\n\n");
+        sb.append("방 정보:\n");
+        sb.append("제목: ").append(ctx.title()).append("\n");
+        if (ctx.introduction() != null && !ctx.introduction().isBlank()) {
+            sb.append("소개: ").append(ctx.introduction()).append("\n");
+        }
+        if (ctx.nowPlayingTitle() != null && !ctx.nowPlayingTitle().isBlank()) {
+            sb.append("현재 재생 중: ").append(ctx.nowPlayingTitle()).append("\n");
+        }
+        return sb.toString();
+    }
+
+    private String buildUserContent(List<String> winnerTitles) {
+        if (winnerTitles == null || winnerTitles.isEmpty()) {
+            return "아직 인기 곡 데이터가 없습니다. 방 컨셉에 어울리는 곡을 자유롭게 추천해주세요.";
+        }
+        return "다음 인기 곡들과 비슷한 분위기의 새로운 곡을 추천해주세요:\n"
+                + String.join("\n", winnerTitles);
+    }
+
+    private List<String> parseLines(String raw, int count) {
+        return Arrays.stream(raw.split("\n"))
+                .map(line -> PREFIX_PATTERN.matcher(line).replaceFirst(""))
+                .map(String::trim)
+                .filter(line -> !line.isBlank())
+                .distinct()
+                .limit(count)
+                .collect(Collectors.toList());
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/PlaylistSelfUpdateService.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/PlaylistSelfUpdateService.java
@@ -1,0 +1,242 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.common.domain.value.Duration;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.application.service.PartyroomQueryService;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.PlaylistRepository;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.TrackRepository;
+import com.pfplaybackend.api.playlist.application.dto.search.SearchResultDto;
+import com.pfplaybackend.api.playlist.application.dto.search.SearchResultRawDto;
+import com.pfplaybackend.api.playlist.application.service.search.PytubeSearchService;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
+import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.PartyroomVirtualDjConfigRepository;
+import com.pfplaybackend.api.virtualdj.application.dto.NewTrack;
+import com.pfplaybackend.api.virtualdj.application.port.RoomContextReader;
+import com.pfplaybackend.api.virtualdj.application.port.RoomContextReader.RoomContext;
+import com.pfplaybackend.api.virtualdj.application.port.SongRecommendationProvider;
+import com.pfplaybackend.api.virtualdj.application.service.ActiveDjSnapshotService.ActiveDjSnapshot;
+import com.pfplaybackend.api.virtualdj.application.service.ReactionScoreReader.ScoredLink;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.PartyroomVirtualDjConfigData;
+import com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 가상 DJ P3-B 플레이리스트 자가갱신 사이클 조립기(assembler).
+ *
+ * <p>룸 레벨 게이트(MANAGED · 쿨다운 · 신규 반응 ≥ K)를 통과하면 룸의 각 봇마다 한 사이클씩
+ * 실행한다: 점수 정렬 → 보호곡 산정 → LLM 리필 → Pytube 해소 → 송팩 폴백 → 원자적 swap →
+ * prune 기록. 모든 봇 처리 후 룸 watermark 를 한 번 전진시킨다.
+ *
+ * <p><b>INV-2 (비용 게이트):</b> 신규 반응 수 < K 이면 어떤 LLM 호출도 하기 전에 즉시 반환한다.
+ * 조용한/빈 룸은 LLM 비용 0 으로 빠져나간다.
+ *
+ * <p>ArchUnit: 클래스명에 {@code Orchestrator} 를 포함하지 않으므로 application service /
+ * playlist·track repo 직접 접근이 허용된다(가상 DJ 가드 규칙 A 비대상).
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class PlaylistSelfUpdateService {
+
+    private final PartyroomVirtualDjConfigRepository configRepository;
+    private final SelfUpdateConfig selfUpdateConfig;
+    private final ActiveDjSnapshotService activeDjSnapshotService;
+    private final ReactionScoreReader reactionScoreReader;
+    private final RoomContextReader roomContextReader;
+    private final PartyroomQueryService partyroomQueryService;
+    private final VirtualUserPoolService virtualUserPoolService;
+    private final TrackRepository trackRepository;
+    private final PlaylistRepository playlistRepository;
+    private final SongRecommendationProvider songRecommendationProvider;
+    private final PytubeSearchService pytubeSearchService;
+    private final SongPackReservoir songPackReservoir;
+    private final RecentlyPrunedStore recentlyPrunedStore;
+    private final BotPlaylistEditor botPlaylistEditor;
+    private final Clock clock;
+
+    /**
+     * 한 룸의 자가갱신 사이클을 시도한다(게이트 통과 시에만 실제 갱신).
+     */
+    public void tryUpdateRoom(PartyroomId roomId) {
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        PartyroomVirtualDjConfigData config = configRepository.findByPartyroomId(roomId.getId()).orElse(null);
+        if (config == null || config.getStatus() != VirtualDjStatus.MANAGED) {
+            return;
+        }
+
+        // 쿨다운 — watermark null(첫 사이클)은 통과.
+        LocalDateTime watermark = config.getLastSelfUpdateAt();
+        if (watermark != null
+                && java.time.Duration.between(watermark, now).getSeconds() < selfUpdateConfig.cooldownSeconds()) {
+            return;
+        }
+
+        ActiveDjSnapshot snapshot = activeDjSnapshotService.snapshot(roomId);
+        List<UserId> bots = snapshot.botUserIdsByJoinedDesc();
+        if (bots.isEmpty()) {
+            return;
+        }
+
+        // ⭐ INV-2: 비용 게이트 — 어떤 LLM 호출보다 먼저 신규 반응 수를 확인한다.
+        List<Long> botIdLongs = bots.stream().map(UserId::getUid).toList();
+        if (reactionScoreReader.countNewReactions(botIdLongs, roomId.getId(), watermark)
+                < selfUpdateConfig.minReactions()) {
+            return;
+        }
+
+        RoomContext roomCtx = roomContextReader.read(roomId);
+        String nowPlayingLinkId = partyroomQueryService.getCurrentPlaybackLinkId(roomId); // nullable
+        int limitMin = partyroomQueryService.getPartyroomById(roomId).getPlaybackTimeLimit().getMinutes();
+
+        for (UserId botUserId : bots) {
+            try {
+                updateBot(botUserId, roomId, roomCtx, nowPlayingLinkId, limitMin, config.getSongPackId());
+            } catch (Exception e) {
+                log.warn("[vdj-selfupdate] bot {} failed: {}", botUserId.getUid(), e.getMessage());
+            }
+        }
+
+        config.markSelfUpdated(now);
+        configRepository.save(config);
+    }
+
+    private void updateBot(UserId botUserId, PartyroomId roomId, RoomContext roomCtx,
+                           String nowPlayingLinkId, int limitMin, Long songPackId) {
+        int replacePerCycle = selfUpdateConfig.replacePerCycle();
+
+        List<ScoredLink> scoredAsc = reactionScoreReader.scoredAscending(botUserId, roomId); // 오름차순(낮은 점수 먼저)
+        Long playlistId = virtualUserPoolService.playlistIdOf(botUserId);
+        List<TrackData> tracks = trackRepository.findAllByPlaylistId(new PlaylistId(playlistId));
+
+        Set<String> trackLinkIds = tracks.stream().map(TrackData::getLinkId).collect(Collectors.toSet());
+        Map<String, Long> trackIdByLink = tracks.stream()
+                .collect(Collectors.toMap(TrackData::getLinkId, TrackData::getId, (a, b) -> a));
+        Map<String, String> nameByLink = tracks.stream()
+                .collect(Collectors.toMap(TrackData::getLinkId, TrackData::getName, (a, b) -> a));
+
+        // 보호곡 — 현재곡(INV-3) + 커서/다음곡(임박 재생 보호) + 최근 prune(INV-6 진동 방지).
+        Set<String> protectedLinks = new HashSet<>();
+        if (nowPlayingLinkId != null) {
+            protectedLinks.add(nowPlayingLinkId);
+        }
+        protectedLinks.addAll(cursorAndNextLinkIds(playlistId, tracks));
+        protectedLinks.addAll(recentlyPrunedStore.recentlyPruned(botUserId));
+
+        // prune 후보 — playlist 안에 있고 보호되지 않은, 점수 낮은 곡 최대 P 개.
+        List<ScoredLink> pruneCandidates = scoredAsc.stream()
+                .filter(s -> trackLinkIds.contains(s.linkId()) && !protectedLinks.contains(s.linkId()))
+                .limit(replacePerCycle)
+                .toList();
+        if (pruneCandidates.isEmpty()) {
+            return; // 교체할 가치가 있는 곡 없음
+        }
+        List<Long> pruneTrackIds = pruneCandidates.stream()
+                .map(s -> trackIdByLink.get(s.linkId()))
+                .toList();
+        List<String> prunedLinkOrder = pruneCandidates.stream()
+                .map(ScoredLink::linkId)
+                .toList();
+
+        // 우승 곡명(LLM 취향 단서) — 점수 높은 순.
+        List<String> winnerTitles = scoredAsc.stream()
+                .sorted((a, b) -> Double.compare(b.score(), a.score()))
+                .limit(replacePerCycle)
+                .map(s -> nameByLink.get(s.linkId()))
+                .filter(Objects::nonNull)
+                .toList();
+
+        // LLM 리필 (best-effort).
+        List<String> recommended = songRecommendationProvider.recommend(
+                roomCtx, winnerTitles, selfUpdateConfig.recommendCount());
+
+        List<NewTrack> resolved = new ArrayList<>();
+        Set<String> seen = new HashSet<>(trackLinkIds);
+        seen.addAll(protectedLinks);
+        PlaybackTimeLimit timeLimit = PlaybackTimeLimit.ofMinutes(limitMin);
+
+        for (String query : recommended) {
+            if (resolved.size() >= pruneTrackIds.size()) {
+                break;
+            }
+            SearchResultDto searchResult = pytubeSearchService.searchByWord(query, 1);
+            if (searchResult == null || searchResult.data() == null || searchResult.data().isEmpty()) {
+                continue;
+            }
+            SearchResultRawDto raw = searchResult.data().get(0);
+            Duration duration = Duration.fromString(raw.running_time());
+            if (timeLimit.exceedsDuration(duration)) {
+                continue;
+            }
+            if (!seen.add(raw.video_id())) {
+                continue; // 이미 playlist/보호/직전 해소에 있음
+            }
+            resolved.add(new NewTrack(raw.video_title(), raw.video_id(), duration, raw.thumbnail_url()));
+        }
+
+        // 부족하면 송팩 폴백.
+        if (resolved.size() < pruneTrackIds.size()) {
+            int need = pruneTrackIds.size() - resolved.size();
+            List<NewTrack> fill = songPackReservoir.untried(songPackId, seen, limitMin, need);
+            for (NewTrack track : fill) {
+                if (seen.add(track.linkId())) {
+                    resolved.add(track);
+                }
+            }
+        }
+
+        int swapped = botPlaylistEditor.swap(playlistId, pruneTrackIds, resolved); // editor 가 n=min 적용
+        if (swapped > 0) {
+            recentlyPrunedStore.markPruned(botUserId, prunedLinkOrder.subList(0, swapped));
+        }
+    }
+
+    /**
+     * 커서(마지막 재생 곡)와 그 다음(order_number 더 큰 첫 곡)의 linkId 를 임박 재생 보호용으로 반환한다.
+     * 커서가 없거나 트랙을 못 찾으면 빈 set. 절대 throw 하지 않는다(방어적).
+     */
+    private Set<String> cursorAndNextLinkIds(Long playlistId, List<TrackData> tracks) {
+        Set<String> result = new HashSet<>();
+        try {
+            Optional<PlaylistData> playlist = playlistRepository.findById(playlistId);
+            if (playlist.isEmpty() || playlist.get().getLastPlayedTrackId() == null) {
+                return result;
+            }
+            Long cursorId = playlist.get().getLastPlayedTrackId();
+            TrackData cursorTrack = tracks.stream()
+                    .filter(t -> Objects.equals(t.getId(), cursorId))
+                    .findFirst()
+                    .orElse(null);
+            if (cursorTrack == null) {
+                return result;
+            }
+            result.add(cursorTrack.getLinkId());
+
+            int cursorOrder = cursorTrack.getOrderNumber();
+            tracks.stream()
+                    .filter(t -> t.getOrderNumber() != null && t.getOrderNumber() > cursorOrder)
+                    .min((a, b) -> Integer.compare(a.getOrderNumber(), b.getOrderNumber()))
+                    .ifPresent(next -> result.add(next.getLinkId()));
+        } catch (Exception e) {
+            log.warn("[vdj-selfupdate] cursor protection skipped for playlist {}: {}", playlistId, e.getMessage());
+        }
+        return result;
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/ReactionScoreReader.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/ReactionScoreReader.java
@@ -1,0 +1,66 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.ReactionScoreQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * P3-B 자가갱신용 반응 점수 읽기 서비스.
+ *
+ * <p>{@link ReactionScoreQueryRepository} 결과에 weight 를 적용해 오름차순 정렬한 {@link ScoredLink} 목록을
+ * 반환한다. 가장 점수가 낮은(반응이 좋지 않은) 곡이 먼저 오므로 교체 우선순위 그대로 쓸 수 있다.
+ *
+ * <p>ActiveDjSnapshotService 와 동일한 "thin wrapper" 패턴.
+ */
+@Service
+@RequiredArgsConstructor
+public class ReactionScoreReader {
+
+    private final ReactionScoreQueryRepository repo;
+    private final SelfUpdateConfig config;
+
+    /**
+     * @param linkId 곡 링크 식별자
+     * @param score  가중 반응 점수 ({@code w_react*(like-dislike) + w_grab*grab})
+     */
+    public record ScoredLink(String linkId, double score) {}
+
+    /**
+     * watermark 이후 봇 plays 에 달린 반응 row 수(비용 게이트용).
+     *
+     * @param botUserIds 봇 userId 목록 (비면 즉시 0)
+     * @param partyroomId 파티룸 ID
+     * @param since watermark (null 이면 전체 기간)
+     */
+    public long countNewReactions(List<Long> botUserIds, long partyroomId, LocalDateTime since) {
+        return repo.countReactionsSince(botUserIds, partyroomId, since);
+    }
+
+    /**
+     * 봇의 plays 를 link_id 로 집계한 후 weighted score 기준 오름차순 정렬해 반환한다.
+     *
+     * <p>score = {@code w_react*(likeSum - dislikeSum) + w_grab*grabSum}
+     * 낮은 점수(반응 나쁜 곡)가 앞에 오므로 교체 후보 선정에 바로 활용 가능.
+     */
+    @Transactional(readOnly = true)
+    public List<ScoredLink> scoredAscending(UserId botUserId, PartyroomId partyroomId) {
+        double wReact = config.weightReaction();
+        double wGrab  = config.weightGrab();
+
+        return repo.aggregateByLink(botUserId.getUid(), partyroomId.getId())
+                .stream()
+                .map(lrs -> {
+                    double score = wReact * (lrs.likeSum() - lrs.dislikeSum()) + wGrab * lrs.grabSum();
+                    return new ScoredLink(lrs.linkId(), score);
+                })
+                .sorted(Comparator.comparingDouble(ScoredLink::score))
+                .toList();
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/RecentlyPrunedStore.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/RecentlyPrunedStore.java
@@ -1,0 +1,58 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 최근 prune 된 linkId 를 봇별 Redis TTL set 으로 보관한다(진동 방지).
+ *
+ * <p>TTL({@link SelfUpdateConfig#prunedCooldownSeconds()}) 이 지나면 자동으로 set 이 삭제되어
+ * 해당 곡이 다시 신규 후보로 고려될 수 있다.
+ */
+@Service
+@RequiredArgsConstructor
+public class RecentlyPrunedStore {
+
+    public static final String KEY_PREFIX = "vdj:pruned:";
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final SelfUpdateConfig config;
+
+    private static String keyOf(UserId botUserId) {
+        return KEY_PREFIX + botUserId.getUid();
+    }
+
+    /**
+     * 주어진 linkId 들을 최근 prune 목록에 추가하고 TTL 을 갱신한다.
+     * linkIds 가 비어있으면 아무 것도 하지 않는다.
+     */
+    public void markPruned(UserId botUserId, Collection<String> linkIds) {
+        if (linkIds == null || linkIds.isEmpty()) {
+            return;
+        }
+        String key = keyOf(botUserId);
+        redisTemplate.opsForSet().add(key, linkIds.toArray());
+        redisTemplate.expire(key, Duration.ofSeconds(config.prunedCooldownSeconds()));
+    }
+
+    /**
+     * 봇의 최근 prune set 을 반환한다.
+     * 키가 없거나 만료됐으면 빈 set.
+     */
+    public Set<String> recentlyPruned(UserId botUserId) {
+        Set<Object> members = redisTemplate.opsForSet().members(keyOf(botUserId));
+        if (members == null || members.isEmpty()) {
+            return Set.of();
+        }
+        return members.stream()
+                .map(String::valueOf)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/SelfUpdateConfig.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/SelfUpdateConfig.java
@@ -19,7 +19,6 @@ public class SelfUpdateConfig {
     static final boolean DEFAULT_ENABLED = false;          // fail-closed
     static final int DEFAULT_COOLDOWN_SECONDS = 1800;      // 30분
     static final int DEFAULT_MIN_REACTIONS = 5;            // K
-    static final int DEFAULT_TARGET_SIZE = 20;             // T
     static final int DEFAULT_REPLACE_PER_CYCLE = 3;        // P
     static final int DEFAULT_RECOMMEND_COUNT = 6;          // N
     static final int DEFAULT_PRUNED_COOLDOWN_SECONDS = 3600;
@@ -38,10 +37,6 @@ public class SelfUpdateConfig {
 
     public int minReactions() {
         return cache.readInt(ConfigKey.VDJ_SELF_UPDATE_MIN_REACTIONS, DEFAULT_MIN_REACTIONS);
-    }
-
-    public int targetSize() {
-        return cache.readInt(ConfigKey.VDJ_SELF_UPDATE_TARGET_SIZE, DEFAULT_TARGET_SIZE);
     }
 
     public int replacePerCycle() {

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/SelfUpdateConfig.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/SelfUpdateConfig.java
@@ -1,0 +1,66 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.operations.application.service.SystemConfigCache;
+import com.pfplaybackend.api.operations.domain.value.ConfigKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 가상 DJ P3-B 플레이리스트 자가갱신 런타임 설정 읽기 래퍼.
+ *
+ * <p>{@link SystemConfigCache} fail-open readInt(양수만)/readBoolean 에 위임. {@link #isEnabled()} 는
+ * 전역 kill switch 이며 <b>기본 잠금(false)</b>(fail-closed) — 행 부재/오타/캐시 실패 시 자가갱신은 켜지지
+ * 않는다(V28 시드 참조). weight 는 readDouble 부재로 정수 퍼밀(‰)로 저장하고 1000 으로 나눠 double 로 쓴다.
+ */
+@Component
+@RequiredArgsConstructor
+public class SelfUpdateConfig {
+
+    static final boolean DEFAULT_ENABLED = false;          // fail-closed
+    static final int DEFAULT_COOLDOWN_SECONDS = 1800;      // 30분
+    static final int DEFAULT_MIN_REACTIONS = 5;            // K
+    static final int DEFAULT_TARGET_SIZE = 20;             // T
+    static final int DEFAULT_REPLACE_PER_CYCLE = 3;        // P
+    static final int DEFAULT_RECOMMEND_COUNT = 6;          // N
+    static final int DEFAULT_PRUNED_COOLDOWN_SECONDS = 3600;
+    static final int DEFAULT_WEIGHT_REACTION_PERMILLE = 1000;   // 1.0
+    static final int DEFAULT_WEIGHT_GRAB_PERMILLE = 2000;       // 2.0
+
+    private final SystemConfigCache cache;
+
+    public boolean isEnabled() {
+        return cache.readBoolean(ConfigKey.VDJ_PLAYLIST_SELF_UPDATE_ENABLED, DEFAULT_ENABLED);
+    }
+
+    public int cooldownSeconds() {
+        return cache.readInt(ConfigKey.VDJ_SELF_UPDATE_COOLDOWN_SECONDS, DEFAULT_COOLDOWN_SECONDS);
+    }
+
+    public int minReactions() {
+        return cache.readInt(ConfigKey.VDJ_SELF_UPDATE_MIN_REACTIONS, DEFAULT_MIN_REACTIONS);
+    }
+
+    public int targetSize() {
+        return cache.readInt(ConfigKey.VDJ_SELF_UPDATE_TARGET_SIZE, DEFAULT_TARGET_SIZE);
+    }
+
+    public int replacePerCycle() {
+        return cache.readInt(ConfigKey.VDJ_SELF_UPDATE_REPLACE_PER_CYCLE, DEFAULT_REPLACE_PER_CYCLE);
+    }
+
+    public int recommendCount() {
+        return cache.readInt(ConfigKey.VDJ_SELF_UPDATE_RECOMMEND_COUNT, DEFAULT_RECOMMEND_COUNT);
+    }
+
+    public int prunedCooldownSeconds() {
+        return cache.readInt(ConfigKey.VDJ_SELF_UPDATE_PRUNED_COOLDOWN_SECONDS, DEFAULT_PRUNED_COOLDOWN_SECONDS);
+    }
+
+    public double weightReaction() {
+        return cache.readInt(ConfigKey.VDJ_SELF_UPDATE_WEIGHT_REACTION, DEFAULT_WEIGHT_REACTION_PERMILLE) / 1000.0;
+    }
+
+    public double weightGrab() {
+        return cache.readInt(ConfigKey.VDJ_SELF_UPDATE_WEIGHT_GRAB, DEFAULT_WEIGHT_GRAB_PERMILLE) / 1000.0;
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/SongPackReservoir.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/SongPackReservoir.java
@@ -1,0 +1,58 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.common.domain.value.Duration;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackTrackRepository;
+import com.pfplaybackend.api.virtualdj.application.dto.NewTrack;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackTrackData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 송 팩에서 아직 시도되지 않은(미시도) 곡 목록을 조회하는 폴백 소스.
+ *
+ * <p>excludeLinkIds 에 포함된 곡과 playbackTimeLimit 을 초과하는 곡을 제외하고,
+ * order_number 순서대로 최대 limit 개 반환한다.
+ *
+ * <p>SongPackApplier 는 건드리지 않는다 — 동일 레포를 재사용만 한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class SongPackReservoir {
+
+    private final VirtualSongPackTrackRepository songPackTrackRepository;
+
+    /**
+     * 미시도 곡 목록을 order_number 순으로 반환한다.
+     *
+     * @param songPackId        대상 송 팩 id
+     * @param excludeLinkIds    이미 playlist 에 있거나 최근에 사용된 linkId 세트
+     * @param timeLimitMinutes  재생 시간 제한(분). 0 이하 = unlimited
+     * @param limit             최대 반환 수
+     * @return in-limit 미시도 곡 리스트 (빈 리스트 가능)
+     */
+    public List<NewTrack> untried(Long songPackId, Set<String> excludeLinkIds,
+                                  int timeLimitMinutes, int limit) {
+        List<VirtualSongPackTrackData> packTracks =
+                songPackTrackRepository.findBySongPackIdOrderByOrderNumberAsc(songPackId);
+
+        PlaybackTimeLimit timeLimit = PlaybackTimeLimit.ofMinutes(timeLimitMinutes);
+
+        return packTracks.stream()
+                .filter(t -> !excludeLinkIds.contains(t.getLinkId()))
+                .filter(t -> {
+                    Duration dur = Duration.fromString(t.getDuration());
+                    return !timeLimit.exceedsDuration(dur);
+                })
+                .limit(limit)
+                .map(t -> new NewTrack(
+                        t.getName(),
+                        t.getLinkId(),
+                        Duration.fromString(t.getDuration()),
+                        t.getThumbnailImage()))
+                .toList();
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualDjReconcileScheduler.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/application/service/VirtualDjReconcileScheduler.java
@@ -29,6 +29,8 @@ public class VirtualDjReconcileScheduler {
 
     private final PartyroomVirtualDjConfigRepository configRepository;
     private final VirtualDjOrchestrator orchestrator;
+    private final SelfUpdateConfig selfUpdateConfig;
+    private final PlaylistSelfUpdateService playlistSelfUpdateService;
 
     @Scheduled(fixedDelay = 60_000)
     public void reconcileManagedRooms() {
@@ -43,6 +45,17 @@ public class VirtualDjReconcileScheduler {
             } catch (Exception e) {
                 log.warn("[vdj-cron] reconcile failed for partyroomId={} : {}",
                         cfg.getPartyroomId(), e.getMessage());
+            }
+        }
+
+        if (selfUpdateConfig.isEnabled()) {
+            for (PartyroomVirtualDjConfigData cfg : managed) {
+                try {
+                    playlistSelfUpdateService.tryUpdateRoom(new PartyroomId(cfg.getPartyroomId()));
+                } catch (Exception e) {
+                    log.warn("[vdj-cron] self-update failed for partyroomId={} : {}",
+                            cfg.getPartyroomId(), e.getMessage());
+                }
             }
         }
     }

--- a/app/src/main/java/com/pfplaybackend/api/virtualdj/domain/entity/data/PartyroomVirtualDjConfigData.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualdj/domain/entity/data/PartyroomVirtualDjConfigData.java
@@ -37,6 +37,10 @@ public class PartyroomVirtualDjConfigData extends BaseEntity {
     @Column(name = "song_pack_id", columnDefinition = "bigint unsigned")
     private Long songPackId;
 
+    @Comment("마지막 자가갱신 시각(P3-B watermark 겸 쿨다운 기준). null=미실행")
+    @Column(name = "last_self_update_at")
+    private java.time.LocalDateTime lastSelfUpdateAt;
+
     protected PartyroomVirtualDjConfigData() {
     }
 
@@ -89,6 +93,11 @@ public class PartyroomVirtualDjConfigData extends BaseEntity {
      */
     public void turnOff() {
         this.status = VirtualDjStatus.OFF;
+    }
+
+    /** P3-B 자가갱신 사이클 완료 표시(watermark 전진). */
+    public void markSelfUpdated(java.time.LocalDateTime now) {
+        this.lastSelfUpdateAt = now;
     }
 
 }

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -92,6 +92,14 @@ service-api:
     uri: ${PYTUBE_URI:http://localhost:9000}
     api-key: ${PYTUBE_API_KEY:pfplay_streaming}
     api-secret: ${PYTUBE_API_SECRET}
+  # 가상 DJ LLM 프로바이더 선택 — openai(기본) | anthropic. 두 어댑터는 같은 포트의 상호배타 구현.
+  llm:
+    provider: ${LLM_PROVIDER:openai}
+  openai:
+    api-key: ${OPENAI_API_KEY:}               # blank allowed — 미설정 시 봇 채팅/선곡 LLM 응답 skip
+    base-uri: ${OPENAI_BASE_URI:https://api.openai.com}
+    model: ${OPENAI_MODEL:gpt-4o-mini}        # 고볼륨 ambient 채팅/큐레이션용 비용 효율 기본값
+    timeout-ms: ${OPENAI_TIMEOUT_MS:12000}
   anthropic:
     api-key: ${ANTHROPIC_API_KEY:}            # blank allowed — 미설정 시 봇 채팅 응답 skip
     base-uri: ${ANTHROPIC_BASE_URI:https://api.anthropic.com}

--- a/app/src/main/resources/db/migration/V29__add_self_update_watermark_and_tuning.sql
+++ b/app/src/main/resources/db/migration/V29__add_self_update_watermark_and_tuning.sql
@@ -1,0 +1,16 @@
+-- 가상 DJ P3-B 플레이리스트 자가갱신: watermark 컬럼 + 튜닝 키 시드.
+-- ⚠️ V28 은 전역 enabled 게이트(기본 false)만 시드했다. 본 마이그레이션은 사이클 동작에 필요한
+--    watermark 컬럼과 튜닝 system_config 행을 추가한다. enabled 는 여전히 false(구현 후 명시 활성화).
+
+ALTER TABLE partyroom_virtual_dj_config
+    ADD COLUMN last_self_update_at DATETIME NULL COMMENT 'P3-B 자가갱신 watermark(쿨다운 기준)';
+
+INSERT INTO system_config (config_key, config_value, description) VALUES
+    ('vdj.playlist.self_update.cooldown_seconds', '1800', 'P3-B 자가갱신 룸별 최소 간격(초)'),
+    ('vdj.playlist.self_update.min_reactions', '5', 'P3-B 갱신 트리거 새 반응 임계 K(미만이면 LLM 미호출)'),
+    ('vdj.playlist.self_update.target_size', '20', 'P3-B 봇 playlist 목표 크기 T'),
+    ('vdj.playlist.self_update.replace_per_cycle', '3', 'P3-B 사이클당 최대 교체 수 P'),
+    ('vdj.playlist.self_update.recommend_count', '6', 'P3-B LLM 곡명 추천 수 N'),
+    ('vdj.playlist.self_update.weight.reaction', '1000', 'P3-B score 순반응 가중치(퍼밀 ‰, 1000=1.0)'),
+    ('vdj.playlist.self_update.weight.grab', '2000', 'P3-B score grab 가중치(퍼밀 ‰)'),
+    ('vdj.playlist.self_update.pruned_cooldown_seconds', '3600', 'P3-B prune 곡 재추가 차단 기간(초)');

--- a/app/src/main/resources/db/migration/V29__add_self_update_watermark_and_tuning.sql
+++ b/app/src/main/resources/db/migration/V29__add_self_update_watermark_and_tuning.sql
@@ -8,7 +8,6 @@ ALTER TABLE partyroom_virtual_dj_config
 INSERT INTO system_config (config_key, config_value, description) VALUES
     ('vdj.playlist.self_update.cooldown_seconds', '1800', 'P3-B 자가갱신 룸별 최소 간격(초)'),
     ('vdj.playlist.self_update.min_reactions', '5', 'P3-B 갱신 트리거 새 반응 임계 K(미만이면 LLM 미호출)'),
-    ('vdj.playlist.self_update.target_size', '20', 'P3-B 봇 playlist 목표 크기 T'),
     ('vdj.playlist.self_update.replace_per_cycle', '3', 'P3-B 사이클당 최대 교체 수 P'),
     ('vdj.playlist.self_update.recommend_count', '6', 'P3-B LLM 곡명 추천 수 N'),
     ('vdj.playlist.self_update.weight.reaction', '1000', 'P3-B score 순반응 가중치(퍼밀 ‰, 1000=1.0)'),

--- a/app/src/test/java/com/pfplaybackend/api/operations/domain/value/ConfigKeyTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/operations/domain/value/ConfigKeyTest.java
@@ -58,7 +58,6 @@ class ConfigKeyTest {
     void selfUpdateTuningKeys_haveExpectedValues() {
         assertThat(ConfigKey.VDJ_SELF_UPDATE_COOLDOWN_SECONDS.value()).isEqualTo("vdj.playlist.self_update.cooldown_seconds");
         assertThat(ConfigKey.VDJ_SELF_UPDATE_MIN_REACTIONS.value()).isEqualTo("vdj.playlist.self_update.min_reactions");
-        assertThat(ConfigKey.VDJ_SELF_UPDATE_TARGET_SIZE.value()).isEqualTo("vdj.playlist.self_update.target_size");
         assertThat(ConfigKey.VDJ_SELF_UPDATE_REPLACE_PER_CYCLE.value()).isEqualTo("vdj.playlist.self_update.replace_per_cycle");
         assertThat(ConfigKey.VDJ_SELF_UPDATE_RECOMMEND_COUNT.value()).isEqualTo("vdj.playlist.self_update.recommend_count");
         assertThat(ConfigKey.VDJ_SELF_UPDATE_WEIGHT_REACTION.value()).isEqualTo("vdj.playlist.self_update.weight.reaction");

--- a/app/src/test/java/com/pfplaybackend/api/operations/domain/value/ConfigKeyTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/operations/domain/value/ConfigKeyTest.java
@@ -53,4 +53,16 @@ class ConfigKeyTest {
         assertThat(ConfigKey.PRESENCE_DJ_GRACE_SECONDS.value()).isEqualTo("presence.dj_grace_seconds");
         assertThat(ConfigKey.PRESENCE_LISTENER_GRACE_SECONDS.value()).isEqualTo("presence.listener_grace_seconds");
     }
+
+    @Test
+    void selfUpdateTuningKeys_haveExpectedValues() {
+        assertThat(ConfigKey.VDJ_SELF_UPDATE_COOLDOWN_SECONDS.value()).isEqualTo("vdj.playlist.self_update.cooldown_seconds");
+        assertThat(ConfigKey.VDJ_SELF_UPDATE_MIN_REACTIONS.value()).isEqualTo("vdj.playlist.self_update.min_reactions");
+        assertThat(ConfigKey.VDJ_SELF_UPDATE_TARGET_SIZE.value()).isEqualTo("vdj.playlist.self_update.target_size");
+        assertThat(ConfigKey.VDJ_SELF_UPDATE_REPLACE_PER_CYCLE.value()).isEqualTo("vdj.playlist.self_update.replace_per_cycle");
+        assertThat(ConfigKey.VDJ_SELF_UPDATE_RECOMMEND_COUNT.value()).isEqualTo("vdj.playlist.self_update.recommend_count");
+        assertThat(ConfigKey.VDJ_SELF_UPDATE_WEIGHT_REACTION.value()).isEqualTo("vdj.playlist.self_update.weight.reaction");
+        assertThat(ConfigKey.VDJ_SELF_UPDATE_WEIGHT_GRAB.value()).isEqualTo("vdj.playlist.self_update.weight.grab");
+        assertThat(ConfigKey.VDJ_SELF_UPDATE_PRUNED_COOLDOWN_SECONDS.value()).isEqualTo("vdj.playlist.self_update.pruned_cooldown_seconds");
+    }
 }

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomQueryServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomQueryServiceTest.java
@@ -544,4 +544,43 @@ class PartyroomQueryServiceTest {
         // then
         assertThat(result.getId()).isEqualTo(1L);
     }
+
+    // ── getCurrentPlaybackLinkId ──
+
+    @Test
+    @DisplayName("getCurrentPlaybackLinkId — 재생 활성 시 현재 곡의 linkId 를 반환한다")
+    void getCurrentPlaybackLinkId_활성_시_linkId_반환() {
+        // given
+        PlaybackId playbackId = new PlaybackId(200L);
+        PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+        playbackState.activate(playbackId, new CrewId(1L));
+
+        PlaybackData playback = mock(PlaybackData.class);
+        when(playback.getLinkId()).thenReturn("youtube_abc123");
+
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+        when(playbackQueryService.getPlaybackById(playbackId)).thenReturn(playback);
+
+        // when
+        String result = partyroomQueryService.getCurrentPlaybackLinkId(partyroomId);
+
+        // then
+        assertThat(result).isEqualTo("youtube_abc123");
+    }
+
+    @Test
+    @DisplayName("getCurrentPlaybackLinkId — 재생 비활성 시 null 을 반환한다")
+    void getCurrentPlaybackLinkId_비활성_시_null_반환() {
+        // given
+        PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+        // 활성화 안 함 → isActivated() == false
+
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+
+        // when
+        String result = partyroomQueryService.getCurrentPlaybackLinkId(partyroomId);
+
+        // then
+        assertThat(result).isNull();
+    }
 }

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/BotPlaylistEditorIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/BotPlaylistEditorIT.java
@@ -1,0 +1,142 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.Duration;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.PlaylistRepository;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.TrackRepository;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
+import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
+import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
+import com.pfplaybackend.api.virtualdj.application.dto.NewTrack;
+import com.pfplaybackend.api.virtualdj.application.service.BotPlaylistEditor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+class BotPlaylistEditorIT extends AbstractIntegrationTest {
+
+    @Autowired private BotPlaylistEditor editor;
+    @Autowired private TrackRepository trackRepository;
+    @Autowired private PlaylistRepository playlistRepository;
+
+    // ── 헬퍼 ──
+
+    private PlaylistData seedPlaylist() {
+        return playlistRepository.save(
+                PlaylistData.create(1, "봇_플리", PlaylistType.PLAYLIST, new UserId(9999L)));
+    }
+
+    private List<TrackData> seedTracks(Long playlistId, int count) {
+        List<TrackData> tracks = IntStream.rangeClosed(1, count)
+                .mapToObj(i -> TrackData.builder()
+                        .playlistId(new PlaylistId(playlistId))
+                        .orderNumber(i)
+                        .name("Old Song " + i)
+                        .linkId("old" + i)
+                        .duration(Duration.fromString("3:00"))
+                        .thumbnailImage("thumb" + i)
+                        .build())
+                .collect(Collectors.toList());
+        return trackRepository.saveAll(tracks);
+    }
+
+    // ── 케이스 1: n=2 swap ──
+
+    @Test
+    @DisplayName("swap — n=2 교체 시 크기 불변·헤드 정렬·prune 제거 확인")
+    void swap_n2_교체_크기불변_헤드정렬() {
+        // given
+        PlaylistData playlist = seedPlaylist();
+        Long playlistId = playlist.getId();
+        List<TrackData> saved = seedTracks(playlistId, 5);
+        entityManager.flush();
+        entityManager.clear();
+
+        // old4, old5 를 prune 대상으로 선택 (orderNumber 4, 5)
+        List<TrackData> reloaded = trackRepository.findAllByPlaylistId(new PlaylistId(playlistId))
+                .stream().sorted(Comparator.comparingInt(TrackData::getOrderNumber)).toList();
+        Long old4Id = reloaded.get(3).getId(); // orderNumber=4 → old4
+        Long old5Id = reloaded.get(4).getId(); // orderNumber=5 → old5
+
+        List<Long> pruneIds = List.of(old4Id, old5Id);
+        List<NewTrack> addTracks = List.of(
+                new NewTrack("X", "newX", Duration.fromString("3:00"), "t"),
+                new NewTrack("Y", "newY", Duration.fromString("3:10"), "t")
+        );
+
+        // when
+        int swapped = editor.swap(playlistId, pruneIds, addTracks);
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        assertThat(swapped).isEqualTo(2);
+
+        List<TrackData> after = trackRepository.findAllByPlaylistId(new PlaylistId(playlistId))
+                .stream().sorted(Comparator.comparingInt(TrackData::getOrderNumber)).toList();
+
+        // 크기 불변: 5 - 2 + 2 = 5
+        assertThat(after).hasSize(5);
+
+        // prune 된 linkId 가 없어야 함
+        Set<String> linkIds = after.stream().map(TrackData::getLinkId).collect(Collectors.toSet());
+        assertThat(linkIds).doesNotContain("old4", "old5");
+
+        // 신규 트랙 추가됨
+        assertThat(linkIds).contains("newX", "newY");
+
+        // orderNumber 가 1..5 연속 유일
+        List<Integer> orders = after.stream().map(TrackData::getOrderNumber).sorted().toList();
+        assertThat(orders).containsExactly(1, 2, 3, 4, 5);
+
+        // 신규 트랙이 헤드(1 또는 2) 에 위치
+        Set<Integer> newOrders = after.stream()
+                .filter(t -> t.getLinkId().equals("newX") || t.getLinkId().equals("newY"))
+                .map(TrackData::getOrderNumber)
+                .collect(Collectors.toSet());
+        assertThat(newOrders).allMatch(o -> o == 1 || o == 2);
+    }
+
+    // ── 케이스 2: addTracks 비어 있으면 n=0, 변경 없음 ──
+
+    @Test
+    @DisplayName("swap — addTracks 가 비어 있으면 0 반환, 플리 불변")
+    void swap_addTracks_비어있으면_0반환() {
+        // given
+        PlaylistData playlist = seedPlaylist();
+        Long playlistId = playlist.getId();
+        List<TrackData> saved = seedTracks(playlistId, 5);
+        entityManager.flush();
+        entityManager.clear();
+
+        List<TrackData> reloaded = trackRepository.findAllByPlaylistId(new PlaylistId(playlistId));
+        Long someId = reloaded.get(0).getId();
+
+        // when
+        int swapped = editor.swap(playlistId, List.of(someId), List.of());
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        assertThat(swapped).isEqualTo(0);
+
+        List<TrackData> after = trackRepository.findAllByPlaylistId(new PlaylistId(playlistId));
+        assertThat(after).hasSize(5);
+
+        // someId 의 트랙이 여전히 존재
+        Set<Long> ids = after.stream().map(TrackData::getId).collect(Collectors.toSet());
+        assertThat(ids).contains(someId);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/OpenAiChatProviderTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/OpenAiChatProviderTest.java
@@ -1,0 +1,107 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.virtualdj.adapter.out.llm.OpenAiChatProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.test.web.client.ExpectedCount.never;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.anything;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+/**
+ * {@link OpenAiChatProvider} 단위 테스트. {@link AnthropicChatProviderTest} 와 동일하게 신규 의존성 없이
+ * Spring {@link MockRestServiceServer} 를 provider 전용 RestTemplate 에 바인딩해 OpenAI
+ * Chat Completions({@code POST /v1/chat/completions}) 호출 형태를 검증한다.
+ */
+@DisplayName("OpenAiChatProvider — Chat Completions best-effort 호출")
+class OpenAiChatProviderTest {
+
+    private static final String BASE_URI = "http://openai.test";
+
+    private OpenAiChatProvider newProvider(String apiKey) {
+        return new OpenAiChatProvider(apiKey, BASE_URI, "gpt-4o-mini", 12000L);
+    }
+
+    private MockRestServiceServer bindServer(OpenAiChatProvider provider) {
+        RestTemplate rt = (RestTemplate) ReflectionTestUtils.getField(provider, "restTemplate");
+        return MockRestServiceServer.createServer(rt);
+    }
+
+    @Test
+    @DisplayName("200 + message content → 텍스트를 반환하고 요청 형태(Bearer/messages)를 검증한다")
+    void returnsTextAndSendsCorrectRequest() {
+        OpenAiChatProvider provider = newProvider("sk-test");
+        MockRestServiceServer server = bindServer(provider);
+
+        server.expect(requestTo(BASE_URI + "/v1/chat/completions"))
+                .andExpect(method(POST))
+                .andExpect(header("Authorization", "Bearer sk-test"))
+                .andExpect(jsonPath("$.model").value("gpt-4o-mini"))
+                .andExpect(jsonPath("$.max_tokens").value(64))
+                .andExpect(jsonPath("$.messages[0].role").value("system"))
+                .andExpect(jsonPath("$.messages[0].content").value("system-prompt"))
+                .andExpect(jsonPath("$.messages[1].role").value("user"))
+                .andExpect(jsonPath("$.messages[1].content").value("user-content"))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"안녕!\"}}]}"));
+
+        String result = provider.complete("system-prompt", "user-content", 64);
+
+        assertThat(result).isEqualTo("안녕!");
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("content 가 null/누락 → 예외 없이 빈 문자열을 반환한다")
+    void returnsEmptyWhenContentMissing() {
+        OpenAiChatProvider provider = newProvider("sk-test");
+        MockRestServiceServer server = bindServer(provider);
+
+        server.expect(requestTo(BASE_URI + "/v1/chat/completions"))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":null}}]}"));
+
+        assertThat(provider.complete("s", "u", 64)).isEqualTo("");
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("500 응답 → 예외 없이 빈 문자열을 반환한다")
+    void returnsEmptyOnServerError() {
+        OpenAiChatProvider provider = newProvider("sk-test");
+        MockRestServiceServer server = bindServer(provider);
+
+        server.expect(requestTo(BASE_URI + "/v1/chat/completions"))
+                .andRespond(withServerError());
+
+        assertThat(provider.complete("s", "u", 64)).isEqualTo("");
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("api-key 가 blank → 호출 없이 빈 문자열을 반환한다")
+    void returnsEmptyWithoutCallWhenKeyBlank() {
+        OpenAiChatProvider provider = newProvider("");
+        MockRestServiceServer server = bindServer(provider);
+
+        // 어떤 요청도 발생하지 않아야 한다.
+        server.expect(never(), anything());
+
+        assertThat(provider.complete("s", "u", 64)).isEqualTo("");
+        server.verify();
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/PlaylistSelfUpdateIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/PlaylistSelfUpdateIT.java
@@ -1,0 +1,411 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.avatar.adapter.out.persistence.AvatarBodyResourceRepository;
+import com.pfplaybackend.api.avatar.domain.entity.data.AvatarBodyResourceData;
+import com.pfplaybackend.api.avatar.domain.enums.ObtainmentType;
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomPlaybackRepository;
+import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomRepository;
+import com.pfplaybackend.api.party.adapter.out.persistence.PlaybackAggregationRepository;
+import com.pfplaybackend.api.party.adapter.out.persistence.PlaybackReactionHistoryRepository;
+import com.pfplaybackend.api.party.adapter.out.persistence.PlaybackRepository;
+import com.pfplaybackend.api.party.application.port.out.UserProfileQueryPort;
+import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
+import com.pfplaybackend.api.party.domain.entity.data.PlaybackAggregationData;
+import com.pfplaybackend.api.party.domain.entity.data.PlaybackData;
+import com.pfplaybackend.api.party.domain.entity.data.history.PlaybackReactionHistoryData;
+import com.pfplaybackend.api.party.domain.enums.StageType;
+import com.pfplaybackend.api.party.domain.value.CrewId;
+import com.pfplaybackend.api.party.domain.value.LinkDomain;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackId;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.TrackRepository;
+import com.pfplaybackend.api.playlist.application.dto.search.SearchResultDto;
+import com.pfplaybackend.api.playlist.application.dto.search.SearchResultRawDto;
+import com.pfplaybackend.api.playlist.application.service.search.PytubeSearchService;
+import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
+import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.PartyroomVirtualDjConfigRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackTrackRepository;
+import com.pfplaybackend.api.virtualdj.application.port.SongRecommendationProvider;
+import com.pfplaybackend.api.virtualdj.application.port.VirtualDjOrchestrator;
+import com.pfplaybackend.api.virtualdj.application.service.PlaylistSelfUpdateService;
+import com.pfplaybackend.api.virtualdj.application.service.VirtualUserPoolService;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.PartyroomVirtualDjConfigData;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackData;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackTrackData;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Task 13 — {@link PlaylistSelfUpdateService#tryUpdateRoom} 풀 DB 통합 테스트(Testcontainers).
+ *
+ * <p>배포 차단(bean wiring / V29·DDL drift / 실 쿼리 정확성 / 트랜잭션)을 잡는 게이트.
+ * LLM({@link SongRecommendationProvider})·Pytube({@link PytubeSearchService})만 @MockBean 으로
+ * 시나리오별 제어하고, 그 외 게이트/점수/스왑/송팩 폴백/watermark 는 전부 실 빈 + 실 DB 로 검증한다.
+ *
+ * <p>봇을 <b>활성 봇 DJ</b> 로 만드는 셋업은 {@link VirtualDjOrchestratorIT} 와 동일하게
+ * 오케스트레이터({@code reconcileRoom}) 경로를 그대로 재사용한다 — provision → MANAGED config(+송팩) →
+ * reconcile → 봇이 crew + DJ 로 등록되고 playlist 가 송팩 A 트랙으로 채워진다. 그 후 점수/반응을
+ * 직접 시드하고 self-update 용 송팩 B 로 config 를 갱신한다.
+ *
+ * <p>격리: {@link UserProfileQueryPort} 는 race/orchestrator IT 와 동일한 lenient mock 으로
+ * assertHasProfile 게이트만 통과시킨다(실 ProfileData 구성이 fragile 하기 때문). 기본 아바타 바디도 시드한다.
+ */
+@Transactional
+class PlaylistSelfUpdateIT extends AbstractIntegrationTest {
+
+    private static final String DEFAULT_BODY_URI =
+            "https://firebasestorage.googleapis.com/v0/b/pfplay-firebase.appspot.com/o/ava_basic%2Fava_basic_001.png?alt=media";
+
+    // 봇 playlist 에 들어갈 송팩 A 트랙 linkId
+    private static final String LINK_LOW = "vidLow";   // 높은 dislike → 최저점수 → prune 후보
+    private static final String LINK_HIGH = "vidHigh"; // 높은 like → 보존
+    // 송팩 B(self-update 폴백) 전용 미시도 트랙 linkId
+    private static final String LINK_PACK_FALLBACK = "vidPackFallback";
+    // LLM/Pytube 가 해소하는 신규 트랙 linkId
+    private static final String LINK_NEW = "vidNew";
+
+    @Autowired private PlaylistSelfUpdateService selfUpdateService;
+    @Autowired private VirtualDjOrchestrator orchestrator;
+    @Autowired private VirtualUserPoolService poolService;
+    @Autowired private PartyroomRepository partyroomRepository;
+    @Autowired private PartyroomVirtualDjConfigRepository configRepository;
+    @Autowired private VirtualSongPackRepository packRepository;
+    @Autowired private VirtualSongPackTrackRepository packTrackRepository;
+    @Autowired private TrackRepository trackRepository;
+    @Autowired private PlaybackRepository playbackRepository;
+    @Autowired private PlaybackAggregationRepository playbackAggregationRepository;
+    @Autowired private PlaybackReactionHistoryRepository playbackReactionHistoryRepository;
+    @Autowired private PartyroomPlaybackRepository partyroomPlaybackRepository;
+    @Autowired private AvatarBodyResourceRepository avatarBodyResourceRepository;
+
+    @MockBean private SongRecommendationProvider songRecommendationProvider;
+    @MockBean private PytubeSearchService pytubeSearchService;
+    @MockBean private UserProfileQueryPort userProfileQueryPort;
+
+    @BeforeEach
+    void seedGatesAndAvatar() {
+        lenient().when(userProfileQueryPort.getUsersProfileSetting(any()))
+                .thenAnswer(inv -> {
+                    List<UserId> ids = inv.getArgument(0);
+                    Map<UserId, ProfileSettingDto> result = new HashMap<>();
+                    for (UserId id : ids) {
+                        result.put(id, mock(ProfileSettingDto.class));
+                    }
+                    return result;
+                });
+        if (avatarBodyResourceRepository.findOneAvatarResourceByResourceUri(DEFAULT_BODY_URI) == null) {
+            AvatarBodyResourceData body = AvatarBodyResourceData.draft(
+                    "ava_body_basic_001", DEFAULT_BODY_URI,
+                    "https://example.test/icon_basic_001.png",
+                    ObtainmentType.BASIC, 0, false, true, 60, 41, null);
+            body.publish(null);
+            avatarBodyResourceRepository.save(body);
+        }
+    }
+
+    @AfterEach
+    void clearContext() {
+        ThreadLocalContext.clearContext();
+    }
+
+    // ───────────────────────────── 시나리오 1 ─────────────────────────────
+
+    @Test
+    @DisplayName("1. 빈 룸(반응 < K) → LLM 미호출 + playlist 불변 + watermark 미전진 (INV-2)")
+    void emptyRoom_noLlm_noChange() {
+        Fixture fx = seedActiveBotDjRoom();
+        // 반응 history 0건(K=5 미만) — playback/aggregation 은 점수용으로 시드하되 반응은 안 단다.
+        seedBotPlays(fx, /*lowDislike*/3, /*highLike*/3, /*reactions*/0);
+        flushAndClear();
+
+        List<String> before = playlistLinkIds(fx.botPlaylistId);
+
+        selfUpdateService.tryUpdateRoom(new PartyroomId(fx.roomId));
+        flushAndClear();
+
+        verifyNoInteractions(songRecommendationProvider);
+        assertThat(playlistLinkIds(fx.botPlaylistId))
+                .containsExactlyInAnyOrderElementsOf(before);
+        assertThat(reloadConfig(fx.roomId).getLastSelfUpdateAt()).isNull();
+    }
+
+    // ───────────────────────────── 시나리오 2 ─────────────────────────────
+
+    @Test
+    @DisplayName("2. 반응 ≥ K → 1회 갱신(저점수곡 교체·크기불변·watermark 전진), 재호출은 쿨다운 차단")
+    void reactionsAboveK_oneUpdate_thenCooldownBlocks() {
+        Fixture fx = seedActiveBotDjRoom();
+        seedBotPlays(fx, /*lowDislike*/5, /*highLike*/5, /*reactions*/5);
+        flushAndClear();
+
+        int sizeBefore = playlistLinkIds(fx.botPlaylistId).size();
+
+        when(songRecommendationProvider.recommend(any(), anyList(), anyInt()))
+                .thenReturn(List.of("new song A"));
+        when(pytubeSearchService.searchByWord(eq("new song A"), anyInt()))
+                .thenReturn(pytubeHit(LINK_NEW, "New Song A", "3:30"));
+
+        selfUpdateService.tryUpdateRoom(new PartyroomId(fx.roomId));
+        flushAndClear();
+
+        Set<String> after = Set.copyOf(playlistLinkIds(fx.botPlaylistId));
+        // INV-1: 크기 불변
+        assertThat(after).hasSize(sizeBefore);
+        // 저점수곡 교체, 신규 트랙 진입
+        assertThat(after).doesNotContain(LINK_LOW);
+        assertThat(after).contains(LINK_NEW);
+        // 고점수곡 보존
+        assertThat(after).contains(LINK_HIGH);
+        // watermark 전진
+        assertThat(reloadConfig(fx.roomId).getLastSelfUpdateAt()).isNotNull();
+
+        // ── 재호출: 쿨다운 미경과로 차단 — recommend 2번째 미호출, playlist 무변 ──
+        selfUpdateService.tryUpdateRoom(new PartyroomId(fx.roomId));
+        flushAndClear();
+
+        verify(songRecommendationProvider, times(1)).recommend(any(), anyList(), anyInt());
+        assertThat(Set.copyOf(playlistLinkIds(fx.botPlaylistId)))
+                .containsExactlyInAnyOrderElementsOf(after);
+    }
+
+    // ───────────────────────────── 시나리오 3 ─────────────────────────────
+
+    @Test
+    @DisplayName("3. LLM 빈 결과 → 송팩 폴백으로 교체, 크기 불변 (INV-1)")
+    void llmEmpty_songPackFallback_sizeInvariant() {
+        Fixture fx = seedActiveBotDjRoom();
+        seedBotPlays(fx, /*lowDislike*/5, /*highLike*/5, /*reactions*/5);
+        flushAndClear();
+
+        int sizeBefore = playlistLinkIds(fx.botPlaylistId).size();
+
+        when(songRecommendationProvider.recommend(any(), anyList(), anyInt()))
+                .thenReturn(List.of()); // LLM 빈 결과
+
+        selfUpdateService.tryUpdateRoom(new PartyroomId(fx.roomId));
+        flushAndClear();
+
+        Set<String> after = Set.copyOf(playlistLinkIds(fx.botPlaylistId));
+        // INV-1: 크기 불변
+        assertThat(after).hasSize(sizeBefore);
+        // 저점수곡이 송팩 B 의 미시도 트랙으로 교체됨
+        assertThat(after).doesNotContain(LINK_LOW);
+        assertThat(after).contains(LINK_PACK_FALLBACK);
+        // LLM 이 빈 결과였으므로 Pytube 해소는 호출되지 않는다.
+        verify(pytubeSearchService, never()).searchByWord(any(), anyInt());
+    }
+
+    // ───────────────────────────── 시나리오 4 ─────────────────────────────
+
+    @Test
+    @DisplayName("4. 현재곡 보호 (INV-3): 최저점수곡이 현재 재생곡이면 prune 되지 않는다")
+    void currentTrackProtected_notPruned() {
+        Fixture fx = seedActiveBotDjRoom();
+        seedBotPlays(fx, /*lowDislike*/5, /*highLike*/5, /*reactions*/5);
+        // 최저점수곡(LINK_LOW)을 "현재 재생곡" 으로 만든다:
+        // 봇 playback row(linkId=LINK_LOW) 를 만들고 partyroom_playback 을 그걸로 activate.
+        PlaybackData nowPlaying = playbackRepository.saveAndFlush(
+                PlaybackData.builder()
+                        .partyroomId(new PartyroomId(fx.roomId))
+                        .userId(new UserId(fx.botUid))
+                        .linkId(LINK_LOW)
+                        .name("Now Playing Low")
+                        .build());
+        PartyroomPlaybackData pp = partyroomPlaybackRepository.findById(new PartyroomId(fx.roomId)).orElseThrow();
+        pp.activate(new PlaybackId(nowPlaying.getId()), new CrewId(1L));
+        partyroomPlaybackRepository.saveAndFlush(pp);
+        flushAndClear();
+
+        when(songRecommendationProvider.recommend(any(), anyList(), anyInt()))
+                .thenReturn(List.of("new song A"));
+        when(pytubeSearchService.searchByWord(any(), anyInt()))
+                .thenReturn(pytubeHit(LINK_NEW, "New Song A", "3:30"));
+
+        selfUpdateService.tryUpdateRoom(new PartyroomId(fx.roomId));
+        flushAndClear();
+
+        // INV-3: 현재 재생 중인 LINK_LOW 는 최저점수임에도 여전히 playlist 에 남아 있어야 한다.
+        assertThat(playlistLinkIds(fx.botPlaylistId)).contains(LINK_LOW);
+    }
+
+    // ───────────────────────────── fixtures ─────────────────────────────
+
+    private record Fixture(long roomId, long botUid, long botPlaylistId, long fallbackPackId) {}
+
+    /**
+     * 활성 봇 DJ 1명이 있는 MANAGED 룸을 만든다(오케스트레이터 경로 재사용).
+     * <ul>
+     *   <li>송팩 A(vidLow/vidHigh) 적용 후 reconcile → 봇 playlist = {vidLow, vidHigh}</li>
+     *   <li>self-update 폴백용 송팩 B(vidLow/vidHigh/vidPackFallback) 로 config 갱신
+     *       — vidPackFallback 은 playlist 밖 미시도 트랙</li>
+     * </ul>
+     * watermark(lastSelfUpdateAt)는 reconcile 이 건드리지 않으므로 첫 호출 때 null(쿨다운 통과).
+     */
+    private Fixture seedActiveBotDjRoom() {
+        long roomId = seedRoom(10);
+        // 송팩 A — order 1=vidHigh(재생 시작 → 커서), 2~5=filler(점수 없음=0),
+        // 6=vidLow(최저점수). vidLow 를 tail 에 두어 커서/다음곡 임박-재생 보호(INV-6)에서 벗어나게 한다.
+        long packA = seedSongPack("Pack A",
+                List.of(track(LINK_HIGH, "High Song", "3:00"),
+                        track("vidF1", "Filler 1", "3:00"),
+                        track("vidF2", "Filler 2", "3:00"),
+                        track("vidF3", "Filler 3", "3:00"),
+                        track("vidF4", "Filler 4", "3:00"),
+                        track(LINK_LOW, "Low Song", "3:00")));
+
+        seedManagedConfig(roomId, /*target*/1, /*floor*/0, packA);
+        poolService.provision(1);
+        flushAndClear();
+
+        orchestrator.reconcileRoom(new PartyroomId(roomId));
+        flushAndClear();
+
+        // 활성 봇 DJ userId + 그 playlist id 조회.
+        long botUid = activeBotDjUserId(roomId);
+        long botPlaylistId = poolService.playlistIdOf(new UserId(botUid));
+
+        // 폴백용 송팩 B — vidPackFallback 만 playlist 밖 미시도 트랙(나머지는 이미 playlist 에 있음).
+        long packB = seedSongPack("Pack B",
+                List.of(track(LINK_HIGH, "High Song", "3:00"),
+                        track("vidF1", "Filler 1", "3:00"),
+                        track("vidF2", "Filler 2", "3:00"),
+                        track("vidF3", "Filler 3", "3:00"),
+                        track("vidF4", "Filler 4", "3:00"),
+                        track(LINK_LOW, "Low Song", "3:00"),
+                        track(LINK_PACK_FALLBACK, "Fallback Song", "2:30")));
+
+        // config 를 packB 로 갱신(MANAGED 유지). reconcile 이후 봇 1명 = target 충족이라
+        // self-update 내부 게이트엔 영향 없음.
+        PartyroomVirtualDjConfigData cfg = reloadConfig(roomId);
+        cfg.applyManaged(1, 0, packB);
+        configRepository.saveAndFlush(cfg);
+
+        return new Fixture(roomId, botUid, botPlaylistId, packB);
+    }
+
+    /**
+     * 봇의 plays 를 시드한다 — LINK_LOW(dislike 다수 → 최저점수), LINK_HIGH(like 다수).
+     * 반응 history 는 LINK_LOW play 에 {@code reactions} 개 달아 비용 게이트(K)를 제어한다.
+     */
+    private void seedBotPlays(Fixture fx, int lowDislike, int highLike, int reactions) {
+        PartyroomId pid = new PartyroomId(fx.roomId);
+        UserId bot = new UserId(fx.botUid);
+
+        PlaybackData lowPlay = playbackRepository.saveAndFlush(
+                PlaybackData.builder().partyroomId(pid).userId(bot)
+                        .linkId(LINK_LOW).name("Low Song").build());
+        PlaybackData highPlay = playbackRepository.saveAndFlush(
+                PlaybackData.builder().partyroomId(pid).userId(bot)
+                        .linkId(LINK_HIGH).name("High Song").build());
+
+        playbackAggregationRepository.saveAndFlush(PlaybackAggregationData.createFor(new PlaybackId(lowPlay.getId())));
+        playbackAggregationRepository.applyAggregationDelta(new PlaybackId(lowPlay.getId()), 0, lowDislike, 0);
+
+        playbackAggregationRepository.saveAndFlush(PlaybackAggregationData.createFor(new PlaybackId(highPlay.getId())));
+        playbackAggregationRepository.applyAggregationDelta(new PlaybackId(highPlay.getId()), highLike, 0, 0);
+
+        for (int i = 0; i < reactions; i++) {
+            playbackReactionHistoryRepository.saveAndFlush(
+                    new PlaybackReactionHistoryData(new UserId(2000L + i), new PlaybackId(lowPlay.getId())));
+        }
+    }
+
+    private long seedRoom(int playbackTimeLimitMinutes) {
+        PartyroomData p = PartyroomData.create(
+                "vdj-selfupdate", "intro", LinkDomain.of("link-vdj-su-" + System.nanoTime()),
+                PlaybackTimeLimit.ofMinutes(playbackTimeLimitMinutes), StageType.GENERAL,
+                new UserId(8000L));
+        long id = partyroomRepository.saveAndFlush(p).getId();
+        PartyroomId pid = new PartyroomId(id);
+        entityManager.persist(PartyroomPlaybackData.createFor(pid));
+        entityManager.persist(DjQueueData.createFor(pid));
+        entityManager.flush();
+        return id;
+    }
+
+    private void seedManagedConfig(long roomId, int target, int floor, Long songPackId) {
+        configRepository.save(PartyroomVirtualDjConfigData.builder()
+                .partyroomId(roomId)
+                .status(com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus.MANAGED)
+                .targetCount(target).companionFloor(floor).songPackId(songPackId).build());
+    }
+
+    private record SeedTrack(String linkId, String name, String duration) {}
+
+    private SeedTrack track(String linkId, String name, String duration) {
+        return new SeedTrack(linkId, name, duration);
+    }
+
+    private long seedSongPack(String name, List<SeedTrack> tracks) {
+        VirtualSongPackData pack = packRepository.save(VirtualSongPackData.create(name, "IT"));
+        int order = 1;
+        for (SeedTrack t : tracks) {
+            packTrackRepository.save(VirtualSongPackTrackData.create(
+                    pack.getId(), order++, t.linkId(), t.name(), t.duration(), null));
+        }
+        return pack.getId();
+    }
+
+    private SearchResultDto pytubeHit(String videoId, String title, String runningTime) {
+        return new SearchResultDto("ok",
+                List.of(new SearchResultRawDto(videoId, title, "watch", runningTime, "thumb")));
+    }
+
+    // ───────────────────────────── helpers ─────────────────────────────
+
+    private PartyroomVirtualDjConfigData reloadConfig(long roomId) {
+        return configRepository.findByPartyroomId(roomId).orElseThrow();
+    }
+
+    private List<String> playlistLinkIds(long playlistId) {
+        return trackRepository.findAllByPlaylistId(new PlaylistId(playlistId)).stream()
+                .map(TrackData::getLinkId)
+                .collect(Collectors.toList());
+    }
+
+    /** 룸의 활성 봇(is_dummy=1) DJ 의 user_id 를 반환한다. */
+    private long activeBotDjUserId(long roomId) {
+        Number n = (Number) entityManager.createNativeQuery(
+                        "SELECT c.user_id FROM dj d " +
+                        "JOIN crew c ON c.crew_id = d.crew_id " +
+                        "JOIN user_account u ON u.user_id = c.user_id " +
+                        "WHERE d.partyroom_id = :rid AND c.is_active = 1 AND u.is_dummy = 1 " +
+                        "LIMIT 1")
+                .setParameter("rid", roomId)
+                .getSingleResult();
+        return n.longValue();
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/RecentlyPrunedStoreIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/RecentlyPrunedStoreIT.java
@@ -1,0 +1,66 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.virtualdj.application.service.RecentlyPrunedStore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecentlyPrunedStoreIT extends AbstractIntegrationTest {
+
+    @Autowired private RecentlyPrunedStore store;
+    @Autowired private RedisTemplate<String, Object> redisTemplate;
+
+    @Test
+    @DisplayName("markPruned 후 recentlyPruned 에서 추가한 linkId 조회 가능, 없는 것은 미포함")
+    void markPruned_후_조회() {
+        UserId bot = new UserId(7L);
+
+        store.markPruned(bot, List.of("x", "y"));
+
+        Set<String> pruned = store.recentlyPruned(bot);
+        assertThat(pruned).contains("x", "y");
+        assertThat(pruned).doesNotContain("z");
+    }
+
+    @Test
+    @DisplayName("markPruned 후 TTL 이 양수로 설정된다")
+    void markPruned_TTL_양수() {
+        UserId bot = new UserId(8L);
+        store.markPruned(bot, List.of("a"));
+
+        String key = RecentlyPrunedStore.KEY_PREFIX + bot.getUid();
+        Long ttl = redisTemplate.getExpire(key);
+        assertThat(ttl).isNotNull().isGreaterThan(0L);
+    }
+
+    @Test
+    @DisplayName("빈 linkIds 로 markPruned 하면 아무 것도 저장되지 않는다")
+    void markPruned_빈_컬렉션_noop() {
+        UserId bot = new UserId(9L);
+        store.markPruned(bot, List.of());
+
+        Set<String> pruned = store.recentlyPruned(bot);
+        assertThat(pruned).isEmpty();
+    }
+
+    @Test
+    @DisplayName("서로 다른 봇의 set 은 독립적이다")
+    void 다른봇_set_독립() {
+        UserId botA = new UserId(10L);
+        UserId botB = new UserId(11L);
+
+        store.markPruned(botA, List.of("shared", "only-a"));
+        store.markPruned(botB, List.of("shared", "only-b"));
+
+        assertThat(store.recentlyPruned(botA)).contains("only-a").doesNotContain("only-b");
+        assertThat(store.recentlyPruned(botB)).contains("only-b").doesNotContain("only-a");
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/SongPackReservoirIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/SongPackReservoirIT.java
@@ -1,0 +1,109 @@
+package com.pfplaybackend.api.virtualdj;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.Duration;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackRepository;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.VirtualSongPackTrackRepository;
+import com.pfplaybackend.api.virtualdj.application.dto.NewTrack;
+import com.pfplaybackend.api.virtualdj.application.service.SongPackReservoir;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackData;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.VirtualSongPackTrackData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+class SongPackReservoirIT extends AbstractIntegrationTest {
+
+    @Autowired private SongPackReservoir reservoir;
+    @Autowired private VirtualSongPackRepository packRepository;
+    @Autowired private VirtualSongPackTrackRepository trackRepository;
+
+    @Test
+    @DisplayName("excludeLinkIds + timeLimitMinutes 필터 후 order_number 순 반환")
+    void untried_필터_및_순서_검증() {
+        // 송 팩 생성
+        VirtualSongPackData pack = packRepository.save(VirtualSongPackData.create("테스트 팩", "IT 검증용"));
+        Long packId = pack.getId();
+
+        // 5개 트랙: order 1=2분/id1, 2=3분/id2, 3=2분/id3, 4=4분/id4, 5=6분/id5(초과)
+        trackRepository.save(VirtualSongPackTrackData.create(packId, 1, "id1", "Song 1", "2:00", null));
+        trackRepository.save(VirtualSongPackTrackData.create(packId, 2, "id2", "Song 2", "3:00", null));
+        trackRepository.save(VirtualSongPackTrackData.create(packId, 3, "id3", "Song 3", "2:00", null));
+        trackRepository.save(VirtualSongPackTrackData.create(packId, 4, "id4", "Song 4", "4:00", null));
+        trackRepository.save(VirtualSongPackTrackData.create(packId, 5, "id5", "Song 5", "6:00", null));
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // 제외: id2(order2), id4(order4) / 시간 제한: 5분 → id5(6분) 초과
+        // 남는 것: id1(order1,2분), id3(order3,2분)
+        List<NewTrack> result = reservoir.untried(packId, Set.of("id2", "id4"), 5, 10);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).linkId()).isEqualTo("id1");
+        assertThat(result.get(0).name()).isEqualTo("Song 1");
+        assertThat(result.get(0).duration()).isEqualTo(Duration.fromString("2:00"));
+        assertThat(result.get(1).linkId()).isEqualTo("id3");
+        assertThat(result.get(1).name()).isEqualTo("Song 3");
+    }
+
+    @Test
+    @DisplayName("limit 로 반환 수 제한")
+    void untried_limit_적용() {
+        VirtualSongPackData pack = packRepository.save(VirtualSongPackData.create("리밋 팩", "limit 테스트"));
+        Long packId = pack.getId();
+
+        trackRepository.save(VirtualSongPackTrackData.create(packId, 1, "lim1", "L1", "1:00", null));
+        trackRepository.save(VirtualSongPackTrackData.create(packId, 2, "lim2", "L2", "1:00", null));
+        trackRepository.save(VirtualSongPackTrackData.create(packId, 3, "lim3", "L3", "1:00", null));
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<NewTrack> result = reservoir.untried(packId, Set.of(), 0, 2);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).linkId()).isEqualTo("lim1");
+        assertThat(result.get(1).linkId()).isEqualTo("lim2");
+    }
+
+    @Test
+    @DisplayName("unlimited(timeLimitMinutes=0) 이면 긴 곡도 포함")
+    void untried_unlimited_긴곡_포함() {
+        VirtualSongPackData pack = packRepository.save(VirtualSongPackData.create("무제한 팩", "unlimited 테스트"));
+        Long packId = pack.getId();
+
+        trackRepository.save(VirtualSongPackTrackData.create(packId, 1, "long1", "Long Song", "60:00", null));
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<NewTrack> result = reservoir.untried(packId, Set.of(), 0, 10);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).linkId()).isEqualTo("long1");
+    }
+
+    @Test
+    @DisplayName("모두 제외되면 빈 리스트 반환")
+    void untried_모두제외_빈리스트() {
+        VirtualSongPackData pack = packRepository.save(VirtualSongPackData.create("빈 팩", "empty 테스트"));
+        Long packId = pack.getId();
+
+        trackRepository.save(VirtualSongPackTrackData.create(packId, 1, "ex1", "Excluded", "2:00", null));
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<NewTrack> result = reservoir.untried(packId, Set.of("ex1"), 5, 10);
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/ReactionScoreQueryRepositoryIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/adapter/out/persistence/ReactionScoreQueryRepositoryIT.java
@@ -1,0 +1,196 @@
+package com.pfplaybackend.api.virtualdj.adapter.out.persistence;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.adapter.out.persistence.PlaybackAggregationRepository;
+import com.pfplaybackend.api.party.adapter.out.persistence.PlaybackReactionHistoryRepository;
+import com.pfplaybackend.api.party.adapter.out.persistence.PlaybackRepository;
+import com.pfplaybackend.api.party.domain.entity.data.PlaybackAggregationData;
+import com.pfplaybackend.api.party.domain.entity.data.PlaybackData;
+import com.pfplaybackend.api.party.domain.entity.data.history.PlaybackReactionHistoryData;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackId;
+import com.pfplaybackend.api.virtualdj.application.dto.LinkReactionScore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * ReactionScoreQueryRepositoryImpl 통합 테스트.
+ *
+ * <p>픽스처: bot=7L, room=99L plays (linkA×2, linkB×1),
+ * 데코이 play: 다른 user(8L)/같은 방 + 같은 bot(7L)/다른 방(100L).
+ */
+@Transactional
+class ReactionScoreQueryRepositoryIT extends AbstractIntegrationTest {
+
+    @Autowired private ReactionScoreQueryRepository reactionScoreQueryRepository;
+    @Autowired private PlaybackRepository playbackRepository;
+    @Autowired private PlaybackAggregationRepository playbackAggregationRepository;
+    @Autowired private PlaybackReactionHistoryRepository playbackReactionHistoryRepository;
+
+    private static final long BOT_UID   = 7L;
+    private static final long DECOY_UID = 8L;
+    private static final long ROOM_ID   = 99L;
+    private static final long OTHER_ROOM_ID = 100L;
+
+    // linkA: 2 plays → like총3, dislike총1, grab총1
+    private long playA1Id;
+    private long playA2Id;
+    // linkB: 1 play → dislike총2
+    private long playB1Id;
+    // 데코이 playback ids
+    private long decoyUserPlayId;
+    private long decoyRoomPlayId;
+
+    // reaction_history row 수 (bot7/room99 한정)
+    private int historyRowCount;
+
+    @BeforeEach
+    void setUp() {
+        // ── bot 7, room 99 ──────────────────────────────────────────────
+        // linkA play #1
+        PlaybackData a1 = playbackRepository.saveAndFlush(
+                PlaybackData.builder()
+                        .partyroomId(new PartyroomId(ROOM_ID))
+                        .userId(new UserId(BOT_UID))
+                        .linkId("linkA")
+                        .name("Song A1")
+                        .build());
+        playA1Id = a1.getId();
+
+        // linkA play #2
+        PlaybackData a2 = playbackRepository.saveAndFlush(
+                PlaybackData.builder()
+                        .partyroomId(new PartyroomId(ROOM_ID))
+                        .userId(new UserId(BOT_UID))
+                        .linkId("linkA")
+                        .name("Song A2")
+                        .build());
+        playA2Id = a2.getId();
+
+        // linkB play #1
+        PlaybackData b1 = playbackRepository.saveAndFlush(
+                PlaybackData.builder()
+                        .partyroomId(new PartyroomId(ROOM_ID))
+                        .userId(new UserId(BOT_UID))
+                        .linkId("linkB")
+                        .name("Song B1")
+                        .build());
+        playB1Id = b1.getId();
+
+        // ── 데코이: 다른 user, 같은 방 ──────────────────────────────────
+        PlaybackData decoyUser = playbackRepository.saveAndFlush(
+                PlaybackData.builder()
+                        .partyroomId(new PartyroomId(ROOM_ID))
+                        .userId(new UserId(DECOY_UID))
+                        .linkId("linkDecoy")
+                        .name("Decoy User Song")
+                        .build());
+        decoyUserPlayId = decoyUser.getId();
+
+        // ── 데코이: 같은 bot, 다른 방 ───────────────────────────────────
+        PlaybackData decoyRoom = playbackRepository.saveAndFlush(
+                PlaybackData.builder()
+                        .partyroomId(new PartyroomId(OTHER_ROOM_ID))
+                        .userId(new UserId(BOT_UID))
+                        .linkId("linkOtherRoom")
+                        .name("Other Room Song")
+                        .build());
+        decoyRoomPlayId = decoyRoom.getId();
+
+        // ── aggregation rows ─────────────────────────────────────────────
+        // linkA play1: like2, dislike1, grab1
+        playbackAggregationRepository.saveAndFlush(PlaybackAggregationData.createFor(new PlaybackId(playA1Id)));
+        playbackAggregationRepository.applyAggregationDelta(new PlaybackId(playA1Id), 2, 1, 1);
+
+        // linkA play2: like1, dislike0, grab0
+        playbackAggregationRepository.saveAndFlush(PlaybackAggregationData.createFor(new PlaybackId(playA2Id)));
+        playbackAggregationRepository.applyAggregationDelta(new PlaybackId(playA2Id), 1, 0, 0);
+
+        // linkB play1: like0, dislike2, grab0
+        playbackAggregationRepository.saveAndFlush(PlaybackAggregationData.createFor(new PlaybackId(playB1Id)));
+        playbackAggregationRepository.applyAggregationDelta(new PlaybackId(playB1Id), 0, 2, 0);
+
+        // 데코이 aggregation (이것들은 aggregateByLink 결과에 나오면 안 됨)
+        playbackAggregationRepository.saveAndFlush(PlaybackAggregationData.createFor(new PlaybackId(decoyUserPlayId)));
+        playbackAggregationRepository.applyAggregationDelta(new PlaybackId(decoyUserPlayId), 10, 0, 0);
+
+        playbackAggregationRepository.saveAndFlush(PlaybackAggregationData.createFor(new PlaybackId(decoyRoomPlayId)));
+        playbackAggregationRepository.applyAggregationDelta(new PlaybackId(decoyRoomPlayId), 10, 0, 0);
+
+        // ── reaction_history rows (bot7/room99 plays 에 달린 반응) ───────
+        // play A1 에 user1, user2 반응
+        playbackReactionHistoryRepository.saveAndFlush(
+                new PlaybackReactionHistoryData(new UserId(1001L), new PlaybackId(playA1Id)));
+        playbackReactionHistoryRepository.saveAndFlush(
+                new PlaybackReactionHistoryData(new UserId(1002L), new PlaybackId(playA1Id)));
+        // play B1 에 user3 반응
+        playbackReactionHistoryRepository.saveAndFlush(
+                new PlaybackReactionHistoryData(new UserId(1003L), new PlaybackId(playB1Id)));
+
+        historyRowCount = 3;
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    @DisplayName("countReactionsSince — 과거 watermark: bot7/room99 의 history row 모두 포함")
+    void countReactionsSince_pastWatermark_returnsAll() {
+        long count = reactionScoreQueryRepository.countReactionsSince(
+                List.of(BOT_UID), ROOM_ID, LocalDateTime.now().minusHours(1));
+        assertThat(count).isEqualTo(historyRowCount);
+    }
+
+    @Test
+    @DisplayName("countReactionsSince — 미래 watermark: 아무것도 포함 안 됨")
+    void countReactionsSince_futureWatermark_returnsZero() {
+        long count = reactionScoreQueryRepository.countReactionsSince(
+                List.of(BOT_UID), ROOM_ID, LocalDateTime.now().plusHours(1));
+        assertThat(count).isZero();
+    }
+
+    @Test
+    @DisplayName("countReactionsSince — 빈 botUserIds: 즉시 0 반환")
+    void countReactionsSince_emptyBots_returnsZero() {
+        long count = reactionScoreQueryRepository.countReactionsSince(
+                List.of(), ROOM_ID, null);
+        assertThat(count).isZero();
+    }
+
+    @Test
+    @DisplayName("aggregateByLink — linkA(like3/dislike1/grab1), linkB(like0/dislike2/grab0), 데코이 제외")
+    void aggregateByLink_correctSumsAndNoDecoy() {
+        List<LinkReactionScore> scores = reactionScoreQueryRepository.aggregateByLink(BOT_UID, ROOM_ID);
+
+        assertThat(scores).extracting(LinkReactionScore::linkId)
+                .containsExactlyInAnyOrder("linkA", "linkB");
+
+        Map<String, LinkReactionScore> byLink = scores.stream()
+                .collect(Collectors.toMap(LinkReactionScore::linkId, s -> s));
+
+        LinkReactionScore a = byLink.get("linkA");
+        assertThat(a.likeSum()).isEqualTo(3L);
+        assertThat(a.dislikeSum()).isEqualTo(1L);
+        assertThat(a.grabSum()).isEqualTo(1L);
+
+        LinkReactionScore b = byLink.get("linkB");
+        assertThat(b.likeSum()).isEqualTo(0L);
+        assertThat(b.dislikeSum()).isEqualTo(2L);
+        assertThat(b.grabSum()).isEqualTo(0L);
+
+        // 데코이 linkId 가 결과에 없어야 함
+        assertThat(byLink).doesNotContainKey("linkDecoy");
+        assertThat(byLink).doesNotContainKey("linkOtherRoom");
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/application/service/LlmSongRecommendationProviderTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/application/service/LlmSongRecommendationProviderTest.java
@@ -1,0 +1,75 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.virtualdj.application.port.LlmChatProvider;
+import com.pfplaybackend.api.virtualdj.application.port.RoomContextReader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LlmSongRecommendationProviderTest {
+
+    @Mock
+    private LlmChatProvider llm;
+
+    @InjectMocks
+    private LlmSongRecommendationProvider provider;
+
+    private RoomContextReader.RoomContext ctx;
+
+    @BeforeEach
+    void setUp() {
+        ctx = new RoomContextReader.RoomContext("90s 시티팝", "집중용", null);
+    }
+
+    @Test
+    @DisplayName("LLM 빈 응답 → 빈 리스트 반환")
+    void empty_llm_response_returns_empty_list() {
+        when(llm.complete(anyString(), anyString(), anyInt())).thenReturn("");
+        assertThat(provider.recommend(ctx, List.of("Song A"), 6)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("번호/불릿/공백 줄 제거 후 순서 보존")
+    void parse_strips_numbering_bullets_blank_lines_preserves_order() {
+        when(llm.complete(anyString(), anyString(), anyInt()))
+                .thenReturn("1. Daft Punk - Around the World\n- Justice - Genesis\n\n  M83 - Midnight City  \n");
+        assertThat(provider.recommend(ctx, List.of("Song A"), 6))
+                .containsExactly("Daft Punk - Around the World", "Justice - Genesis", "M83 - Midnight City");
+    }
+
+    @Test
+    @DisplayName("count 로 결과 수 잘림")
+    void truncate_to_count() {
+        when(llm.complete(anyString(), anyString(), anyInt())).thenReturn("a\nb\nc\nd");
+        assertThat(provider.recommend(ctx, List.of(), 2)).containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("count=0 이면 바로 빈 리스트")
+    void count_zero_returns_empty() {
+        assertThat(provider.recommend(ctx, List.of("Song A"), 0)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("nowPlayingTitle non-null 일 때도 정상 동작")
+    void with_now_playing_title() {
+        RoomContextReader.RoomContext ctxWithNowPlaying =
+                new RoomContextReader.RoomContext("Lo-Fi 방", null, "Nujabes - Feather");
+        when(llm.complete(anyString(), anyString(), anyInt()))
+                .thenReturn("* Bonobo - Kiara\n* Nujabes - Aruarian Dance");
+        assertThat(provider.recommend(ctxWithNowPlaying, List.of(), 5))
+                .containsExactly("Bonobo - Kiara", "Nujabes - Aruarian Dance");
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/application/service/PlaylistSelfUpdateServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/application/service/PlaylistSelfUpdateServiceTest.java
@@ -1,0 +1,275 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.common.domain.value.Duration;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.application.service.PartyroomQueryService;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.PlaylistRepository;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.TrackRepository;
+import com.pfplaybackend.api.playlist.application.dto.search.SearchResultDto;
+import com.pfplaybackend.api.playlist.application.dto.search.SearchResultRawDto;
+import com.pfplaybackend.api.playlist.application.service.search.PytubeSearchService;
+import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.PartyroomVirtualDjConfigRepository;
+import com.pfplaybackend.api.virtualdj.application.dto.NewTrack;
+import com.pfplaybackend.api.virtualdj.application.port.RoomContextReader;
+import com.pfplaybackend.api.virtualdj.application.port.RoomContextReader.RoomContext;
+import com.pfplaybackend.api.virtualdj.application.port.SongRecommendationProvider;
+import com.pfplaybackend.api.virtualdj.application.service.ActiveDjSnapshotService.ActiveDjSnapshot;
+import com.pfplaybackend.api.virtualdj.application.service.ReactionScoreReader.ScoredLink;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.PartyroomVirtualDjConfigData;
+import com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class PlaylistSelfUpdateServiceTest {
+
+    private static final long ROOM = 99L;
+    private static final long BOT = 7L;
+    private static final long PLAYLIST_ID = 500L;
+    private static final long SONG_PACK_ID = 42L;
+    private static final int COOLDOWN = 1800;
+    private static final int K = 5;     // minReactions
+    private static final int P = 3;     // replacePerCycle
+    private static final int N = 6;     // recommendCount
+    private static final int LIMIT_MIN = 10;
+
+    private final PartyroomVirtualDjConfigRepository configRepository = mock(PartyroomVirtualDjConfigRepository.class);
+    private final SelfUpdateConfig selfUpdateConfig = mock(SelfUpdateConfig.class);
+    private final ActiveDjSnapshotService activeDjSnapshotService = mock(ActiveDjSnapshotService.class);
+    private final ReactionScoreReader reactionScoreReader = mock(ReactionScoreReader.class);
+    private final RoomContextReader roomContextReader = mock(RoomContextReader.class);
+    private final PartyroomQueryService partyroomQueryService = mock(PartyroomQueryService.class);
+    private final VirtualUserPoolService virtualUserPoolService = mock(VirtualUserPoolService.class);
+    private final TrackRepository trackRepository = mock(TrackRepository.class);
+    private final PlaylistRepository playlistRepository = mock(PlaylistRepository.class);
+    private final SongRecommendationProvider songRecommendationProvider = mock(SongRecommendationProvider.class);
+    private final PytubeSearchService pytubeSearchService = mock(PytubeSearchService.class);
+    private final SongPackReservoir songPackReservoir = mock(SongPackReservoir.class);
+    private final RecentlyPrunedStore recentlyPrunedStore = mock(RecentlyPrunedStore.class);
+    private final BotPlaylistEditor botPlaylistEditor = mock(BotPlaylistEditor.class);
+
+    private final Clock clock = Clock.fixed(Instant.parse("2026-06-03T12:00:00Z"), ZoneId.of("UTC"));
+    private final LocalDateTime now = LocalDateTime.now(clock);
+
+    private final PartyroomId roomId = new PartyroomId(ROOM);
+    private final UserId botUserId = new UserId(BOT);
+
+    private PlaylistSelfUpdateService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PlaylistSelfUpdateService(
+                configRepository, selfUpdateConfig, activeDjSnapshotService, reactionScoreReader,
+                roomContextReader, partyroomQueryService, virtualUserPoolService, trackRepository,
+                playlistRepository, songRecommendationProvider, pytubeSearchService, songPackReservoir,
+                recentlyPrunedStore, botPlaylistEditor, clock);
+
+        when(selfUpdateConfig.cooldownSeconds()).thenReturn(COOLDOWN);
+        when(selfUpdateConfig.minReactions()).thenReturn(K);
+        when(selfUpdateConfig.replacePerCycle()).thenReturn(P);
+        when(selfUpdateConfig.recommendCount()).thenReturn(N);
+    }
+
+    // ── fixtures ──
+
+    /** MANAGED config with the given watermark (null = first cycle). */
+    private PartyroomVirtualDjConfigData managedConfig(LocalDateTime watermark) {
+        PartyroomVirtualDjConfigData config = PartyroomVirtualDjConfigData.create(ROOM);
+        config.applyManaged(2, 1, SONG_PACK_ID);
+        if (watermark != null) {
+            config.markSelfUpdated(watermark);
+        }
+        return config;
+    }
+
+    private TrackData track(long id, String linkId, String name, int orderNumber) {
+        TrackData t = TrackData.builder()
+                .playlistId(new com.pfplaybackend.api.common.domain.value.PlaylistId(PLAYLIST_ID))
+                .orderNumber(orderNumber)
+                .name(name)
+                .linkId(linkId)
+                .duration(Duration.fromString("3:00"))
+                .thumbnailImage("thumb")
+                .build();
+        // id is generated; set via reflection for the test
+        try {
+            java.lang.reflect.Field f = TrackData.class.getDeclaredField("id");
+            f.setAccessible(true);
+            f.set(t, id);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+        return t;
+    }
+
+    private SearchResultDto pytubeHit(String videoId, String title, String runningTime) {
+        return new SearchResultDto("ok",
+                List.of(new SearchResultRawDto(videoId, title, "watch", runningTime, "thumb")));
+    }
+
+    /** Wire the happy-path collaborators: one bot, low-score track lowLink in playlist + a higher-score track. */
+    private void wireHappyPath(String lowLink, String highLink, String nowPlayingLinkId) {
+        when(configRepository.findByPartyroomId(ROOM)).thenReturn(Optional.of(managedConfig(null)));
+        when(activeDjSnapshotService.snapshot(roomId)).thenReturn(new ActiveDjSnapshot(1, List.of(botUserId)));
+        when(reactionScoreReader.countNewReactions(eq(List.of(BOT)), eq(ROOM), any())).thenReturn((long) K);
+        when(roomContextReader.read(roomId)).thenReturn(new RoomContext("title", "intro", "np"));
+        when(partyroomQueryService.getCurrentPlaybackLinkId(roomId)).thenReturn(nowPlayingLinkId);
+
+        PartyroomData partyroom = mock(PartyroomData.class, RETURNS_DEEP_STUBS);
+        when(partyroom.getPlaybackTimeLimit()).thenReturn(PlaybackTimeLimit.ofMinutes(LIMIT_MIN));
+        when(partyroomQueryService.getPartyroomById(roomId)).thenReturn(partyroom);
+
+        when(virtualUserPoolService.playlistIdOf(botUserId)).thenReturn(PLAYLIST_ID);
+        List<TrackData> tracks = List.of(
+                track(101L, lowLink, "Low Song", 1),
+                track(102L, highLink, "High Song", 2));
+        when(trackRepository.findAllByPlaylistId(any())).thenReturn(tracks);
+        // ascending: low score first
+        when(reactionScoreReader.scoredAscending(botUserId, roomId)).thenReturn(List.of(
+                new ScoredLink(lowLink, -3.0),
+                new ScoredLink(highLink, 5.0)));
+        when(playlistRepository.findById(PLAYLIST_ID)).thenReturn(Optional.empty());
+        when(recentlyPrunedStore.recentlyPruned(botUserId)).thenReturn(Set.of());
+    }
+
+    // ── cases ──
+
+    @Test
+    @DisplayName("1. count < K → no-op (INV-2): LLM·swap 미호출 + watermark 미전진")
+    void countBelowK_noOp() {
+        when(configRepository.findByPartyroomId(ROOM)).thenReturn(Optional.of(managedConfig(null)));
+        when(activeDjSnapshotService.snapshot(roomId)).thenReturn(new ActiveDjSnapshot(1, List.of(botUserId)));
+        when(reactionScoreReader.countNewReactions(eq(List.of(BOT)), eq(ROOM), any())).thenReturn((long) (K - 1));
+
+        service.tryUpdateRoom(roomId);
+
+        verifyNoInteractions(songRecommendationProvider);
+        verifyNoInteractions(botPlaylistEditor);
+        verify(configRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("2. 쿨다운 미경과 → 즉시 no-op (snapshot/count/LLM/swap 미호출)")
+    void cooldownNotElapsed_noOp() {
+        when(configRepository.findByPartyroomId(ROOM)).thenReturn(Optional.of(managedConfig(now.minusSeconds(10))));
+
+        service.tryUpdateRoom(roomId);
+
+        verifyNoInteractions(activeDjSnapshotService);
+        verifyNoInteractions(reactionScoreReader);
+        verifyNoInteractions(songRecommendationProvider);
+        verifyNoInteractions(botPlaylistEditor);
+        verify(configRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("3. config 부재 → no-op")
+    void configAbsent_noOp() {
+        when(configRepository.findByPartyroomId(ROOM)).thenReturn(Optional.empty());
+
+        service.tryUpdateRoom(roomId);
+
+        verifyNoInteractions(activeDjSnapshotService);
+        verifyNoInteractions(botPlaylistEditor);
+        verify(configRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("3b. config MANAGED 아님 → no-op")
+    void configNotManaged_noOp() {
+        PartyroomVirtualDjConfigData off = PartyroomVirtualDjConfigData.create(ROOM); // status=OFF
+        when(configRepository.findByPartyroomId(ROOM)).thenReturn(Optional.of(off));
+
+        service.tryUpdateRoom(roomId);
+
+        verifyNoInteractions(activeDjSnapshotService);
+        verifyNoInteractions(botPlaylistEditor);
+        verify(configRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("4. count≥K & 쿨다운 경과 & happy path → swap 호출 + watermark 전진")
+    void happyPath_swapAndWatermark() {
+        wireHappyPath("low", "high", null);
+        when(songRecommendationProvider.recommend(any(), anyList(), eq(N)))
+                .thenReturn(List.of("new song A"));
+        when(pytubeSearchService.searchByWord(eq("new song A"), eq(1)))
+                .thenReturn(pytubeHit("vidA", "New Song A", "3:30"));
+        when(botPlaylistEditor.swap(eq(PLAYLIST_ID), anyList(), anyList())).thenReturn(1);
+
+        service.tryUpdateRoom(roomId);
+
+        verify(botPlaylistEditor).swap(eq(PLAYLIST_ID), anyList(), anyList());
+        ArgumentCaptor<PartyroomVirtualDjConfigData> captor = ArgumentCaptor.forClass(PartyroomVirtualDjConfigData.class);
+        verify(configRepository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getLastSelfUpdateAt()).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("5. LLM 빈 결과 → 송팩 폴백으로 swap")
+    void llmEmpty_songPackFallback() {
+        wireHappyPath("low", "high", null);
+        when(songRecommendationProvider.recommend(any(), anyList(), eq(N))).thenReturn(List.of());
+        List<NewTrack> fill = List.of(new NewTrack("Pack Song", "packVid", Duration.fromString("2:30"), "thumb"));
+        when(songPackReservoir.untried(eq(SONG_PACK_ID), anySet(), eq(LIMIT_MIN), anyInt())).thenReturn(fill);
+
+        ArgumentCaptor<List<NewTrack>> addCaptor = ArgumentCaptor.forClass(List.class);
+        when(botPlaylistEditor.swap(eq(PLAYLIST_ID), anyList(), addCaptor.capture())).thenReturn(1);
+
+        service.tryUpdateRoom(roomId);
+
+        verify(pytubeSearchService, never()).searchByWord(any(), anyInt());
+        verify(botPlaylistEditor).swap(eq(PLAYLIST_ID), anyList(), anyList());
+        assertThat(addCaptor.getValue()).extracting(NewTrack::linkId).contains("packVid");
+    }
+
+    @Test
+    @DisplayName("6. 현재곡 보호 (INV-3): nowPlayingLinkId == 최저점수 곡 → prune 목록에서 제외")
+    void currentTrackProtected() {
+        // lowLink is both lowest-score AND the now-playing track → must be protected
+        wireHappyPath("low", "high", "low");
+        when(songRecommendationProvider.recommend(any(), anyList(), eq(N)))
+                .thenReturn(List.of("new song A"));
+        when(pytubeSearchService.searchByWord(any(), eq(1)))
+                .thenReturn(pytubeHit("vidA", "New Song A", "3:30"));
+
+        ArgumentCaptor<List<Long>> pruneCaptor = ArgumentCaptor.forClass(List.class);
+        when(botPlaylistEditor.swap(eq(PLAYLIST_ID), pruneCaptor.capture(), anyList())).thenReturn(1);
+
+        service.tryUpdateRoom(roomId);
+
+        // 101 = trackId of "low" (now-playing) → must NOT be in prune list.
+        // "high"(102) is the only non-protected in-playlist track → it is the prune candidate.
+        verify(botPlaylistEditor).swap(eq(PLAYLIST_ID), anyList(), anyList());
+        assertThat(pruneCaptor.getValue()).doesNotContain(101L);
+        assertThat(pruneCaptor.getValue()).containsExactly(102L);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/application/service/ReactionScoreReaderTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/application/service/ReactionScoreReaderTest.java
@@ -1,0 +1,56 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.ReactionScoreQueryRepository;
+import com.pfplaybackend.api.virtualdj.application.dto.LinkReactionScore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.Mockito.*;
+
+class ReactionScoreReaderTest {
+
+    private final ReactionScoreQueryRepository repo = mock(ReactionScoreQueryRepository.class);
+    private final SelfUpdateConfig config = mock(SelfUpdateConfig.class);
+    private ReactionScoreReader reader;
+
+    @BeforeEach
+    void setUp() {
+        reader = new ReactionScoreReader(repo, config);
+    }
+
+    @Test
+    @DisplayName("scoredAscending — w_react=1.0, w_grab=2.0 → linkB(-2.0) < linkA(4.0) 오름차순")
+    void scoredAscending_weightsAndSortAscending() {
+        // w_react=1.0, w_grab=2.0 ; linkA(3,1,1)→4.0 ; linkB(0,2,0)→-2.0 ; ascending=[linkB,linkA]
+        when(config.weightReaction()).thenReturn(1.0);
+        when(config.weightGrab()).thenReturn(2.0);
+        when(repo.aggregateByLink(7L, 99L)).thenReturn(List.of(
+                new LinkReactionScore("linkA", 3, 1, 1),
+                new LinkReactionScore("linkB", 0, 2, 0)));
+
+        List<ReactionScoreReader.ScoredLink> result = reader.scoredAscending(new UserId(7L), new PartyroomId(99L));
+
+        assertThat(result).extracting(ReactionScoreReader.ScoredLink::linkId)
+                .containsExactly("linkB", "linkA");
+        assertThat(result.get(0).score()).isCloseTo(-2.0, within(1e-9));
+        assertThat(result.get(1).score()).isCloseTo(4.0, within(1e-9));
+    }
+
+    @Test
+    @DisplayName("countNewReactions — repo 에 위임")
+    void countNewReactions_delegates() {
+        when(repo.countReactionsSince(List.of(7L), 99L, null)).thenReturn(5L);
+
+        long count = reader.countNewReactions(List.of(7L), 99L, null);
+
+        assertThat(count).isEqualTo(5L);
+        verify(repo).countReactionsSince(List.of(7L), 99L, null);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/application/service/SelfUpdateConfigTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/application/service/SelfUpdateConfigTest.java
@@ -26,7 +26,6 @@ class SelfUpdateConfigTest {
         when(cache.readInt(any(), anyInt())).thenAnswer(inv -> inv.getArgument(1));
         assertThat(config.cooldownSeconds()).isEqualTo(1800);
         assertThat(config.minReactions()).isEqualTo(5);
-        assertThat(config.targetSize()).isEqualTo(20);
         assertThat(config.replacePerCycle()).isEqualTo(3);
         assertThat(config.recommendCount()).isEqualTo(6);
         assertThat(config.prunedCooldownSeconds()).isEqualTo(3600);

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/application/service/SelfUpdateConfigTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/application/service/SelfUpdateConfigTest.java
@@ -1,0 +1,36 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.operations.application.service.SystemConfigCache;
+import com.pfplaybackend.api.operations.domain.value.ConfigKey;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class SelfUpdateConfigTest {
+
+    private final SystemConfigCache cache = mock(SystemConfigCache.class);
+    private final SelfUpdateConfig config = new SelfUpdateConfig(cache);
+
+    @Test
+    void isEnabled_defaultsFalse_failClosed() {
+        when(cache.readBoolean(eq(ConfigKey.VDJ_PLAYLIST_SELF_UPDATE_ENABLED), anyBoolean()))
+                .thenAnswer(inv -> inv.getArgument(1));
+        assertThat(config.isEnabled()).isFalse();
+        verify(cache).readBoolean(ConfigKey.VDJ_PLAYLIST_SELF_UPDATE_ENABLED, false);
+    }
+
+    @Test
+    void tuningGetters_delegateWithDefaults() {
+        when(cache.readInt(any(), anyInt())).thenAnswer(inv -> inv.getArgument(1));
+        assertThat(config.cooldownSeconds()).isEqualTo(1800);
+        assertThat(config.minReactions()).isEqualTo(5);
+        assertThat(config.targetSize()).isEqualTo(20);
+        assertThat(config.replacePerCycle()).isEqualTo(3);
+        assertThat(config.recommendCount()).isEqualTo(6);
+        assertThat(config.prunedCooldownSeconds()).isEqualTo(3600);
+        assertThat(config.weightReaction()).isEqualTo(1.0);   // 1000‰
+        assertThat(config.weightGrab()).isEqualTo(2.0);       // 2000‰
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/application/service/VirtualDjReconcileSchedulerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/application/service/VirtualDjReconcileSchedulerTest.java
@@ -1,0 +1,120 @@
+package com.pfplaybackend.api.virtualdj.application.service;
+
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.virtualdj.adapter.out.persistence.PartyroomVirtualDjConfigRepository;
+import com.pfplaybackend.api.virtualdj.application.port.VirtualDjOrchestrator;
+import com.pfplaybackend.api.virtualdj.domain.entity.data.PartyroomVirtualDjConfigData;
+import com.pfplaybackend.api.virtualdj.domain.enums.VirtualDjStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * {@link VirtualDjReconcileScheduler} 단위 테스트.
+ *
+ * <p>협력자 4개 모두 mock — 스케줄러 로직만 검증한다.
+ */
+class VirtualDjReconcileSchedulerTest {
+
+    private PartyroomVirtualDjConfigRepository configRepository;
+    private VirtualDjOrchestrator orchestrator;
+    private SelfUpdateConfig selfUpdateConfig;
+    private PlaylistSelfUpdateService playlistSelfUpdateService;
+
+    private VirtualDjReconcileScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        configRepository = mock(PartyroomVirtualDjConfigRepository.class);
+        orchestrator = mock(VirtualDjOrchestrator.class);
+        selfUpdateConfig = mock(SelfUpdateConfig.class);
+        playlistSelfUpdateService = mock(PlaylistSelfUpdateService.class);
+
+        scheduler = new VirtualDjReconcileScheduler(
+                configRepository, orchestrator, selfUpdateConfig, playlistSelfUpdateService);
+    }
+
+    // ── 헬퍼 ───────────────────────────────────────────────────────────────────────────
+
+    private PartyroomVirtualDjConfigData mockCfg(long partyroomId) {
+        PartyroomVirtualDjConfigData cfg = mock(PartyroomVirtualDjConfigData.class);
+        when(cfg.getPartyroomId()).thenReturn(partyroomId);
+        return cfg;
+    }
+
+    // ── 테스트 케이스 ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("enabled=false → 자가갱신 패스 전체 건너뜀, reconcile 은 정상 실행")
+    void disabled_selfUpdateNeverCalled() {
+        // given
+        PartyroomVirtualDjConfigData cfg1 = mockCfg(1L);
+        PartyroomVirtualDjConfigData cfg2 = mockCfg(2L);
+        when(configRepository.findByStatus(VirtualDjStatus.MANAGED)).thenReturn(List.of(cfg1, cfg2));
+        when(selfUpdateConfig.isEnabled()).thenReturn(false);
+
+        // when
+        scheduler.reconcileManagedRooms();
+
+        // then — reconcile 은 2회 실행
+        verify(orchestrator, times(2)).reconcileRoom(any());
+        // then — 자가갱신 호출 없음
+        verify(playlistSelfUpdateService, never()).tryUpdateRoom(any());
+    }
+
+    @Test
+    @DisplayName("enabled=true → MANAGED 룸 수만큼 tryUpdateRoom 호출")
+    void enabled_tryUpdateRoomCalledPerRoom() {
+        // given
+        PartyroomVirtualDjConfigData cfg1 = mockCfg(10L);
+        PartyroomVirtualDjConfigData cfg2 = mockCfg(20L);
+        when(configRepository.findByStatus(VirtualDjStatus.MANAGED)).thenReturn(List.of(cfg1, cfg2));
+        when(selfUpdateConfig.isEnabled()).thenReturn(true);
+
+        // when
+        scheduler.reconcileManagedRooms();
+
+        // then
+        verify(playlistSelfUpdateService, times(2)).tryUpdateRoom(any(PartyroomId.class));
+    }
+
+    @Test
+    @DisplayName("첫 번째 룸에서 self-update 예외 발생 → 두 번째 룸도 호출됨, 메서드 밖으로 전파 안 됨")
+    void selfUpdateExceptionIsolated() {
+        // given
+        PartyroomVirtualDjConfigData cfg1 = mockCfg(100L);
+        PartyroomVirtualDjConfigData cfg2 = mockCfg(200L);
+        when(configRepository.findByStatus(VirtualDjStatus.MANAGED)).thenReturn(List.of(cfg1, cfg2));
+        when(selfUpdateConfig.isEnabled()).thenReturn(true);
+        doThrow(new RuntimeException("LLM 타임아웃"))
+                .when(playlistSelfUpdateService).tryUpdateRoom(new PartyroomId(100L));
+
+        // when — 예외가 바깥으로 나오면 안 됨
+        assertDoesNotThrow(() -> scheduler.reconcileManagedRooms());
+
+        // then — 두 번째 룸도 호출됨
+        verify(playlistSelfUpdateService, times(2)).tryUpdateRoom(any(PartyroomId.class));
+    }
+
+    @Test
+    @DisplayName("MANAGED 룸 없음 → early return, orchestrator 와 self-update 모두 미호출")
+    void emptyManagedList_earlyReturn() {
+        // given
+        when(configRepository.findByStatus(VirtualDjStatus.MANAGED)).thenReturn(List.of());
+
+        // when
+        scheduler.reconcileManagedRooms();
+
+        // then
+        verify(orchestrator, never()).reconcileRoom(any());
+        verify(playlistSelfUpdateService, never()).tryUpdateRoom(any());
+        // early return 이므로 isEnabled 체크조차 발생하지 않음
+        verify(selfUpdateConfig, never()).isEnabled();
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/domain/entity/data/PartyroomVirtualDjConfigDataTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/domain/entity/data/PartyroomVirtualDjConfigDataTest.java
@@ -1,0 +1,16 @@
+package com.pfplaybackend.api.virtualdj.domain.entity.data;
+
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PartyroomVirtualDjConfigDataTest {
+    @Test
+    void markSelfUpdated_setsWatermark() {
+        PartyroomVirtualDjConfigData cfg = PartyroomVirtualDjConfigData.create(1L);
+        assertThat(cfg.getLastSelfUpdateAt()).isNull();
+        LocalDateTime t = LocalDateTime.of(2026, 6, 3, 12, 0);
+        cfg.markSelfUpdated(t);
+        assertThat(cfg.getLastSelfUpdateAt()).isEqualTo(t);
+    }
+}

--- a/docs/superpowers/plans/2026-06-03-virtual-dj-p3-playlist-self-update.md
+++ b/docs/superpowers/plans/2026-06-03-virtual-dj-p3-playlist-self-update.md
@@ -57,7 +57,6 @@
 void selfUpdateTuningKeys_haveExpectedValues() {
     assertThat(ConfigKey.VDJ_SELF_UPDATE_COOLDOWN_SECONDS.value()).isEqualTo("vdj.playlist.self_update.cooldown_seconds");
     assertThat(ConfigKey.VDJ_SELF_UPDATE_MIN_REACTIONS.value()).isEqualTo("vdj.playlist.self_update.min_reactions");
-    assertThat(ConfigKey.VDJ_SELF_UPDATE_TARGET_SIZE.value()).isEqualTo("vdj.playlist.self_update.target_size");
     assertThat(ConfigKey.VDJ_SELF_UPDATE_REPLACE_PER_CYCLE.value()).isEqualTo("vdj.playlist.self_update.replace_per_cycle");
     assertThat(ConfigKey.VDJ_SELF_UPDATE_RECOMMEND_COUNT.value()).isEqualTo("vdj.playlist.self_update.recommend_count");
     assertThat(ConfigKey.VDJ_SELF_UPDATE_WEIGHT_REACTION.value()).isEqualTo("vdj.playlist.self_update.weight.reaction");
@@ -75,7 +74,6 @@ void selfUpdateTuningKeys_haveExpectedValues() {
 ```java
     public static final ConfigKey VDJ_SELF_UPDATE_COOLDOWN_SECONDS = new ConfigKey("vdj.playlist.self_update.cooldown_seconds");
     public static final ConfigKey VDJ_SELF_UPDATE_MIN_REACTIONS = new ConfigKey("vdj.playlist.self_update.min_reactions");
-    public static final ConfigKey VDJ_SELF_UPDATE_TARGET_SIZE = new ConfigKey("vdj.playlist.self_update.target_size");
     public static final ConfigKey VDJ_SELF_UPDATE_REPLACE_PER_CYCLE = new ConfigKey("vdj.playlist.self_update.replace_per_cycle");
     public static final ConfigKey VDJ_SELF_UPDATE_RECOMMEND_COUNT = new ConfigKey("vdj.playlist.self_update.recommend_count");
     public static final ConfigKey VDJ_SELF_UPDATE_WEIGHT_REACTION = new ConfigKey("vdj.playlist.self_update.weight.reaction");
@@ -133,7 +131,6 @@ class SelfUpdateConfigTest {
         when(cache.readInt(any(), anyInt())).thenAnswer(inv -> inv.getArgument(1));
         assertThat(config.cooldownSeconds()).isEqualTo(1800);
         assertThat(config.minReactions()).isEqualTo(5);
-        assertThat(config.targetSize()).isEqualTo(20);
         assertThat(config.replacePerCycle()).isEqualTo(3);
         assertThat(config.recommendCount()).isEqualTo(6);
         assertThat(config.prunedCooldownSeconds()).isEqualTo(3600);
@@ -170,7 +167,6 @@ public class SelfUpdateConfig {
     static final boolean DEFAULT_ENABLED = false;          // fail-closed
     static final int DEFAULT_COOLDOWN_SECONDS = 1800;      // 30분
     static final int DEFAULT_MIN_REACTIONS = 5;            // K
-    static final int DEFAULT_TARGET_SIZE = 20;             // T
     static final int DEFAULT_REPLACE_PER_CYCLE = 3;        // P
     static final int DEFAULT_RECOMMEND_COUNT = 6;          // N
     static final int DEFAULT_PRUNED_COOLDOWN_SECONDS = 3600;
@@ -189,10 +185,6 @@ public class SelfUpdateConfig {
 
     public int minReactions() {
         return cache.readInt(ConfigKey.VDJ_SELF_UPDATE_MIN_REACTIONS, DEFAULT_MIN_REACTIONS);
-    }
-
-    public int targetSize() {
-        return cache.readInt(ConfigKey.VDJ_SELF_UPDATE_TARGET_SIZE, DEFAULT_TARGET_SIZE);
     }
 
     public int replacePerCycle() {
@@ -281,7 +273,6 @@ ALTER TABLE partyroom_virtual_dj_config
 INSERT INTO system_config (config_key, config_value, description) VALUES
     ('vdj.playlist.self_update.cooldown_seconds', '1800', 'P3-B 자가갱신 룸별 최소 간격(초)'),
     ('vdj.playlist.self_update.min_reactions', '5', 'P3-B 갱신 트리거 새 반응 임계 K(미만이면 LLM 미호출)'),
-    ('vdj.playlist.self_update.target_size', '20', 'P3-B 봇 playlist 목표 크기 T'),
     ('vdj.playlist.self_update.replace_per_cycle', '3', 'P3-B 사이클당 최대 교체 수 P'),
     ('vdj.playlist.self_update.recommend_count', '6', 'P3-B LLM 곡명 추천 수 N'),
     ('vdj.playlist.self_update.weight.reaction', '1000', 'P3-B score 순반응 가중치(퍼밀 ‰, 1000=1.0)'),

--- a/docs/superpowers/specs/2026-06-03-virtual-dj-p3-playlist-self-update-design.md
+++ b/docs/superpowers/specs/2026-06-03-virtual-dj-p3-playlist-self-update-design.md
@@ -124,7 +124,7 @@ P2 까지의 봇 playlist 는 `SongPackApplier.applyToBot` 가 봇 투입 직전
 
 ## 5. 갱신 사이클 (원자적 증분 교체)
 
-게이트 통과 룸에서만 실행. 목표 크기 T 를 유지하며 최저점 P 곡을 고반응 계열 신곡으로 교체한다.
+게이트 통과 룸에서만 실행. 최저점 P 곡을 고반응 계열 신곡으로 교체한다(원자적 swap이 크기를 보존 — 별도 목표크기 키 없음).
 
 ```
 입력: botUserId, roomId, 봇 playlistId, songPackId, roomPlaybackTimeLimit, 방 컨셉(RoomContextReader)
@@ -167,7 +167,7 @@ P2 까지의 봇 playlist 는 `SongPackApplier.applyToBot` 가 봇 투입 직전
 - **add-to-head 결정 근거:** [[project_playlist_cursor_redesign_pr263]] 에서 order_number 이중용도 분리 +
   add-to-head 기획. 신곡을 머리에 넣어 빠르게 노출하되 grab tail·재생 커서는 보존한다. 정확한 삽입 위치는
   PR263 의 Track ordering 헬퍼를 재사용한다(구현 시 확정).
-- **w_react / w_grab / N / T / P** 는 `system_config` 키(런타임 튜닝).
+- **w_react / w_grab / N / P** 는 `system_config` 키(런타임 튜닝). (크기는 swap이 보존하므로 목표크기 키 없음.)
 
 ---
 
@@ -208,7 +208,6 @@ P3-A 의 `vdj.playlist.self_update.enabled`(V28, 기본 false) 를 **활성 게�
 | `vdj.playlist.self_update.enabled` | `false` | 전역 게이트(V28 기존, INV-4) |
 | `vdj.playlist.self_update.cooldown_seconds` | (예: 1800) | 쿨다운(조건 3) |
 | `vdj.playlist.self_update.min_reactions` (K) | (예: 5) | 비용 게이트 임계(조건 4) |
-| `vdj.playlist.self_update.target_size` (T) | (예: 20) | 목표 playlist 크기 |
 | `vdj.playlist.self_update.replace_per_cycle` (P) | (예: 3) | 사이클당 최대 교체 수 |
 | `vdj.playlist.self_update.recommend_count` (N) | (예: 6) | LLM 곡명 추천 수 |
 | `vdj.playlist.self_update.weight.reaction` | (예: 1000‰=1.0) | w_react (순반응 가중치, 퍼밀) |


### PR DESCRIPTION
## 개요
가상 DJ **P3-B** 백엔드. 봇이 자기 플레이리스트를 청중 **반응(좋아요/grab)에 적응**시켜 주기적으로 자가갱신(저반응 곡 prune + 신규 곡 add-to-head)하는 사이클.

> ⚠️ **Stacked PR** — base = `feature/virtual-dj-p3-chat`(P3-A). diff는 P3-B 변경분(16커밋)만 표시됩니다. P3-A(#294) 머지 후 GitHub가 본 PR을 develop로 자동 retarget합니다.

## 변경 요지
- **반응 점수**: `ReactionScoreQueryRepository` + linkId별 순반응/grab 가중 점수 reader (IT 동반)
- **곡 추천**: `SongRecommendationProvider` 포트 + LLM 구현(best-effort 파싱) + `SongPackReservoir` 미시도 곡 폴백
- **원자적 swap**: `BotPlaylistEditor` add-to-head + prune로 **크기 불변** 보장 / `RecentlyPrunedStore`(Redis TTL)로 진동 방지
- **현재곡 보호**: `getCurrentPlaybackLinkId` 시임으로 재생 중인 곡 보호(INV-3)
- **사이클 조립**: `PlaylistSelfUpdateService`(게이트+score+refill+폴백+swap+watermark) → reconcile cron 자가갱신 패스(enabled 게이트 + 룸 격리)
- **OpenAI 프로바이더 추가** + provider 토글(`LLM_PROVIDER`, 기본 openai/gpt-4o-mini)
- **불변식 IT**: `PlaylistSelfUpdateIT`로 INV-1/2/3 실 DB 검증 / V29 watermark 컬럼

## 마이그레이션
V29 (P3-A의 V28 다음). ⚠️ validate 부팅 확인.

## ⚠️ 머지 차단 요인 (환경)
- **LLM 키 미주입**: 곡 추천/봇 채팅이 `OPENAI_API_KEY`(기본) 또는 `ANTHROPIC_API_KEY` 필요. 미설정 시 자가갱신 LLM 단계 skip.
- dev 머지 전 **로컬 풀스택 e2e** 1회.

## 머지 순서
P3-A(#294) → develop → 본 PR retarget → develop.