### PR TITLE
fix(party): skipByManager 권한 검사를 경로 partyroomId 기준 crew로 정렬 (#297)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java
@@ -6,7 +6,6 @@ import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
 import com.pfplaybackend.api.party.adapter.out.persistence.PlaybackAggregationRepository;
 import com.pfplaybackend.api.party.adapter.out.persistence.PlaybackRepository;
-import com.pfplaybackend.api.party.application.dto.partyroom.ActivePartyroomDto;
 import com.pfplaybackend.api.party.application.dto.playback.PlaybackDurationWaitDto;
 import com.pfplaybackend.api.party.application.port.out.ExpirationTaskPort;
 import com.pfplaybackend.api.party.application.port.out.PlaybackControlPort;
@@ -73,8 +72,9 @@ public class PlaybackCommandService implements PlaybackControlPort {
     @Transactional
     public void skipByManager(PartyroomId partyroomId) {
         AuthContext authContext = ThreadLocalContext.getAuthContext();
-        ActivePartyroomDto activePartyroomDto = partyroomQueryService.getMyActivePartyroom(authContext.getUserId()).orElseThrow();
-        CrewData adjusterCrew = partyroomQueryService.getCrewOrThrow(new PartyroomId(activePartyroomDto.id()), authContext.getUserId());
+        // #297: 등급 검사는 skip이 적용되는 경로의 룸 기준이어야 한다.
+        // '내 active 룸' 우회 조회는 active crew 부재 시 500, 타 룸 운영진의 cross-room skip을 허용했다.
+        CrewData adjusterCrew = partyroomQueryService.getCrewOrThrow(partyroomId, authContext.getUserId());
         if (adjusterCrew.isBelowGrade(GradeType.MODERATOR)) throw ExceptionCreator.create(GradeException.MANAGER_GRADE_REQUIRED);
         cancelTask(partyroomId);
         tryProceed(partyroomId);

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackCommandServiceTest.java
@@ -6,10 +6,12 @@ import com.pfplaybackend.api.common.domain.value.Duration;
 import com.pfplaybackend.api.common.domain.value.PlaylistId;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.enums.AuthorityTier;
+import com.pfplaybackend.api.common.exception.ExceptionCreator;
 import com.pfplaybackend.api.common.exception.http.ForbiddenException;
+import com.pfplaybackend.api.common.exception.http.NotFoundException;
+import com.pfplaybackend.api.party.domain.exception.CrewException;
 import com.pfplaybackend.api.party.adapter.out.persistence.PlaybackAggregationRepository;
 import com.pfplaybackend.api.party.adapter.out.persistence.PlaybackRepository;
-import com.pfplaybackend.api.party.application.dto.partyroom.ActivePartyroomDto;
 import com.pfplaybackend.api.party.application.port.out.ExpirationTaskPort;
 import com.pfplaybackend.api.party.application.port.out.PlaylistCommandPort;
 import com.pfplaybackend.api.party.application.port.out.UserActivityPort;
@@ -40,6 +42,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -117,15 +120,13 @@ class PlaybackCommandServiceTest {
     @Test
     @DisplayName("skipByManager — MODERATOR 이상 등급이면 스킵이 실행된다")
     void skipByManagerModeratorSucceeds() {
-        // given
-        ActivePartyroomDto activeDto = new ActivePartyroomDto(partyroomId.getId(), false, 1L, true, new PlaybackId(1L), new CrewId(1L));
+        // given — #297: 가드는 경로 partyroomId 기준 crew
         CrewData adjuster = CrewData.builder()
                 .id(1L).userId(userId).gradeType(GradeType.MODERATOR).build();
         PartyroomData partyroom = PartyroomData.builder().id(partyroomId.getId()).partyroomId(partyroomId)
                 .playbackTimeLimit(PlaybackTimeLimit.ofMinutes(10)).build();
 
-        when(partyroomQueryService.getMyActivePartyroom(userId)).thenReturn(Optional.of(activeDto));
-        when(partyroomQueryService.getCrewOrThrow(new PartyroomId(activeDto.id()), userId)).thenReturn(adjuster);
+        when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(adjuster);
         when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
         when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(List.of());
 
@@ -140,17 +141,54 @@ class PlaybackCommandServiceTest {
     @Test
     @DisplayName("skipByManager — MODERATOR 미만 등급이면 예외가 발생한다")
     void skipByManagerBelowModeratorThrows() {
-        // given
-        ActivePartyroomDto activeDto = new ActivePartyroomDto(partyroomId.getId(), false, 1L, true, new PlaybackId(1L), new CrewId(1L));
+        // given — #297: 가드는 경로 partyroomId 기준 crew
         CrewData adjuster = CrewData.builder()
                 .id(1L).userId(userId).gradeType(GradeType.CLUBBER).build();
 
-        when(partyroomQueryService.getMyActivePartyroom(userId)).thenReturn(Optional.of(activeDto));
-        when(partyroomQueryService.getCrewOrThrow(new PartyroomId(activeDto.id()), userId)).thenReturn(adjuster);
+        when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(adjuster);
 
         // when & then
         assertThatThrownBy(() -> playbackCommandService.skipByManager(partyroomId))
                 .isInstanceOf(ForbiddenException.class);
+    }
+
+    // ── #297 skipByManager 권한 검사를 경로 partyroomId 기준으로 정렬 ──
+    // 운영진 가드 관례(CrewGrade/CrewPenalty/DjCommand)와 동일하게 경로 룸의 crew로 검증한다.
+    // '내 active 룸' 우회 조회는 (1) active crew 부재 시 bare orElseThrow → 500,
+    // (2) 등급 검사 룸 ≠ skip 적용 룸 cross-room 결함의 원인.
+
+    @Test
+    @DisplayName("#297 skipByManager — 권한 검사는 '내 active 룸' 조회 없이 경로의 partyroomId 기준 crew로 수행한다")
+    void skipByManagerGuardsByPathPartyroom() {
+        // given — 경로 룸의 crew만 스텁 (getMyActivePartyroom 스텁 없음)
+        CrewData adjuster = CrewData.builder()
+                .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.MODERATOR).build();
+        when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(adjuster);
+
+        PartyroomData partyroom = PartyroomData.builder().id(partyroomId.getId()).partyroomId(partyroomId)
+                .playbackTimeLimit(PlaybackTimeLimit.ofMinutes(10)).build();
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+        when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(List.of());
+
+        // when
+        playbackCommandService.skipByManager(partyroomId);
+
+        // then — 스킵 수행 + active 룸 우회 조회 미사용
+        verify(expirationTaskPort).cancelExpiration(String.valueOf(partyroomId.getId()));
+        verify(partyroomQueryService, never()).getMyActivePartyroom(any(UserId.class));
+    }
+
+    @Test
+    @DisplayName("#297 skipByManager — 경로 룸의 crew가 아니면 CRW-001 NotFoundException(4xx)이며 NoSuchElementException(500)이 아니다")
+    void skipByManagerNonCrewThrowsDomainNotFound() {
+        // given — 경로 룸에 crew 없음 (getCrewOrThrow 실제 계약과 동일한 도메인 예외)
+        when(partyroomQueryService.getCrewOrThrow(partyroomId, userId))
+                .thenThrow(ExceptionCreator.create(CrewException.NOT_FOUND_ACTIVE_ROOM));
+
+        // when & then — 어드민 세션 덮어쓰기 등으로 crew가 아닌 사용자가 호출해도 500이 아닌 404
+        assertThatThrownBy(() -> playbackCommandService.skipByManager(partyroomId))
+                .isInstanceOf(NotFoundException.class)
+                .isNotInstanceOf(NoSuchElementException.class);
     }
 
     @Test
@@ -268,11 +306,9 @@ class PlaybackCommandServiceTest {
     @Test
     @DisplayName("#222 skipByManager — MODERATOR 타의 skip 도 DJ큐 회전 + 플레이리스트 커서 갱신(advancePlaybackCursor)을 함께 호출한다")
     void skipByManagerWithQueuedDjRotatesQueueAndPlaylist() {
-        // given — MODERATOR 권한 컨텍스트
-        ActivePartyroomDto activeDto = new ActivePartyroomDto(partyroomId.getId(), false, 1L, true, new PlaybackId(1L), new CrewId(1L));
+        // given — MODERATOR 권한 컨텍스트 (#297: 경로 partyroomId 기준 crew)
         CrewData adjuster = CrewData.builder().id(1L).userId(userId).gradeType(GradeType.MODERATOR).build();
-        when(partyroomQueryService.getMyActivePartyroom(userId)).thenReturn(Optional.of(activeDto));
-        when(partyroomQueryService.getCrewOrThrow(new PartyroomId(activeDto.id()), userId)).thenReturn(adjuster);
+        when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(adjuster);
 
         DjData dj = stubDoStartWithQueuedDj(PlaybackTimeLimit.ofMinutes(10), Duration.fromString("3:30"));
 


### PR DESCRIPTION
Closes #297

## 변경

`PlaybackCommandService.skipByManager()`의 권한 검사를 다른 운영진 가드(`CrewGradeCommandService`, `CrewPenaltyCommandService`, `DjCommandService`)와 동일한 관례인 **경로 partyroomId 기준 `getCrewOrThrow`** 로 정렬.

- `getMyActivePartyroom(userId).orElseThrow()` (bare) 우회 조회 제거
  - active crew 부재 시 `NoSuchElementException` → **500** 이던 것을 `CRW-001 NotFoundException` → **404** 로
- 등급 검사 룸 ≠ skip 적용 룸 **cross-room 결함 봉합** (내 룸 MODERATOR로 타 룸 스킵 가능했음)

## 근거 (prod 실측, 2026-06-12 KST)

```
00:57:01  admin_login.success user_id=1 role=SUPER_ADMIN   ← shared 쿠키가 uid=1로 교체
01:03:29  "No value present" userId=1                      ← 스킵 500
01:03:33  "No value present" userId=1                      ← 재시도 500
```

회원으로 파티룸 입장+디제잉 중 다른 탭에서 어드민 로그인 → shared 세션이 uid=1로 덮어써짐 → 이후 스킵 HTTP가 crew 없는 uid=1로 인증되어 500. (어드민 로그인의 세션 덮어쓰기 자체는 수정 스코프 밖 — 운영 주의사항으로 관리, #297 참고 섹션)

## 검증

- TDD: 회귀 테스트 2건 신규 (RED에서 prod와 동일한 `NoSuchElementException` 재현 확인 후 GREEN)
- 기존 skipByManager 테스트 3건 새 계약으로 갱신, `PlaybackCommandServiceTest` 14/14 GREEN
- 전 모듈 `test` GREEN / `integrationTest`(Testcontainers) GREEN
- **로컬 docker-compose 풀스택 라이브 스모크**: 어드민 시드 로그인 → `DELETE /api/v1/partyrooms/1/playbacks/current` → `404 {"errorCode":"CRW-001"}` (수정 전 동일 시나리오 500 재현 → 수정 후 404 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)