### PR TITLE
fix(party): @Modifying clear가 미flush playback deactivate를 폐기하던 빈 룸 유령 재생 수정 (#299)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/CrewRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/CrewRepository.java
@@ -26,7 +26,7 @@ public interface CrewRepository extends JpaRepository<CrewData, Long> {
      * Resets exited_at and pending_exit_at to NULL so stale values from prior sessions
      * do not poison the new active row (fixes Issue #193).
      */
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE CrewData c " +
            "SET c.isActive = true, c.enteredAt = :now, c.exitedAt = NULL, c.pendingExitAt = NULL " +
            "WHERE c.partyroomId = :partyroomId AND c.userId = :userId AND c.isActive = false")
@@ -47,7 +47,7 @@ public interface CrewRepository extends JpaRepository<CrewData, Long> {
      * PENDING_EXIT → ONLINE actually occurred (caller is the unique winner; race losers
      * see 0 and return idempotently).
      */
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE CrewData c SET c.pendingExitAt = NULL " +
            "WHERE c.partyroomId = :partyroomId AND c.userId = :userId " +
            "AND c.isActive = true AND c.pendingExitAt IS NOT NULL")
@@ -59,7 +59,7 @@ public interface CrewRepository extends JpaRepository<CrewData, Long> {
      * ONLINE → PENDING_EXIT actually occurred. Idempotent: returns 0 if already pending
      * (so the original timestamp/grace is not extended) or if crew is already inactive.
      */
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE CrewData c SET c.pendingExitAt = :now " +
            "WHERE c.partyroomId = :partyroomId AND c.userId = :userId " +
            "AND c.isActive = true AND c.pendingExitAt IS NULL")
@@ -72,7 +72,7 @@ public interface CrewRepository extends JpaRepository<CrewData, Long> {
      *  - 반환 1: is_active=true → false 전이 발생 (호출자는 EXIT 이벤트 발행 의무)
      *  - 반환 0: row 없거나 이미 inactive (호출자 idempotent return)
      */
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE CrewData c " +
            "SET c.isActive = false, c.exitedAt = :now " +
            "WHERE c.partyroomId = :partyroomId AND c.userId = :userId AND c.isActive = true")
@@ -89,7 +89,7 @@ public interface CrewRepository extends JpaRepository<CrewData, Long> {
      *  - 동시에 같은 룸에 enter 시도하는 crew는 별 race 영역
      *    (UNIQUE 제약 + B-3은 즉시 status=TERMINATED라 PartyroomEntrySpecification에서 거부됨)
      */
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE CrewData c SET c.isActive = false, c.exitedAt = :now " +
            "WHERE c.partyroomId = :partyroomId AND c.isActive = true")
     int bulkDeactivateByPartyroomId(@Param("partyroomId") PartyroomId partyroomId,

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomRepository.java
@@ -28,7 +28,7 @@ public interface PartyroomRepository extends JpaRepository<PartyroomData, Long>,
      * crew_count +1 + lastActivityAt 갱신. TERMINATED 룸은 거부 (반환 0).
      * Race A 차단: DB row lock이 동시 호출을 직렬화.
      */
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE PartyroomData p " +
            "SET p.activeCrewCount = p.activeCrewCount + 1, p.lastActivityAt = :now " +
            "WHERE p.id = :id " +
@@ -38,7 +38,7 @@ public interface PartyroomRepository extends JpaRepository<PartyroomData, Long>,
     /**
      * crew_count -1 + lastActivityAt 갱신. 음수 방지 (CASE WHEN). TERMINATED 룸 거부.
      */
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE PartyroomData p " +
            "SET p.activeCrewCount = CASE WHEN p.activeCrewCount > 0 THEN p.activeCrewCount - 1 ELSE 0 END, " +
            "    p.lastActivityAt = :now " +
@@ -50,7 +50,7 @@ public interface PartyroomRepository extends JpaRepository<PartyroomData, Long>,
      * lastActivityAt만 갱신. ACTIVE 룸만 (SUSPENDED/TERMINATED 룸은 거부).
      * Playback 이벤트가 SUSPENDED/TERMINATED 룸 lastActivity 갱신하는 건 의미 없음.
      */
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE PartyroomData p SET p.lastActivityAt = :now " +
            "WHERE p.id = :id " +
            "AND p.status = com.pfplaybackend.api.party.domain.enums.PartyroomStatus.ACTIVE")
@@ -63,7 +63,7 @@ public interface PartyroomRepository extends JpaRepository<PartyroomData, Long>,
      * status 가드 없음 — TERMINATED 룸의 reset이 본 use case.
      * 이미 0인 row를 reset해도 멱등 (UPDATE 자체는 실행, affected row 1).
      */
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE PartyroomData p SET p.activeCrewCount = 0 WHERE p.id = :id")
     int resetCrewCount(@Param("id") Long id);
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PlaybackAggregationRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PlaybackAggregationRepository.java
@@ -21,7 +21,7 @@ public interface PlaybackAggregationRepository extends JpaRepository<PlaybackAgg
      * JPQL 표준이 아니므로 MySQL native query 로 작성한다.
      * {@code @Modifying(clearAutomatically=true)} 로 1차 캐시는 비워진다(반환값 계약: affected rows).
      */
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = "UPDATE playback_aggregation " +
            "SET like_count = GREATEST(0, like_count + :deltaLike), " +
            "    dislike_count = GREATEST(0, dislike_count + :deltaDislike), " +

--- a/app/src/test/java/com/pfplaybackend/api/architecture/ModifyingQueryConventionTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/architecture/ModifyingQueryConventionTest.java
@@ -1,0 +1,57 @@
+package com.pfplaybackend.api.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.repository.Modifying;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+/**
+ * {@code @Modifying} 쿼리 컨벤션 규칙 (#299 재발 방지).
+ *
+ * <p>{@code clearAutomatically=true}는 벌크 쿼리 후 stale 1차 캐시를 방어하지만,
+ * {@code flushAutomatically=true} 없이 단독 사용하면 같은 트랜잭션에서 아직 flush되지 않은
+ * managed 엔티티 변경을 {@code em.clear()}가 조용히 폐기한다 — 2026-06-12 prod 빈 룸
+ * 유령 재생 사고(#299)의 root cause. Hibernate auto-flush는 벌크 쿼리의 query space와
+ * 겹치는 변경만 보호하므로 다른 테이블의 pending 변경은 구제받지 못한다.
+ */
+@DisplayName("@Modifying 쿼리 컨벤션 규칙")
+class ModifyingQueryConventionTest {
+
+    static JavaClasses allClasses;
+
+    @BeforeAll
+    static void setUp() {
+        allClasses = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("com.pfplaybackend.api");
+    }
+
+    @Test
+    @DisplayName("clearAutomatically=true인 @Modifying은 flushAutomatically=true를 동반해야 한다 (#299)")
+    void modifying_with_clear_must_also_flush() {
+        methods().that().areAnnotatedWith(Modifying.class)
+                .should(new ArchCondition<>("clearAutomatically=true이면 flushAutomatically=true 동반") {
+                    @Override
+                    public void check(JavaMethod method, ConditionEvents events) {
+                        Modifying modifying = method.getAnnotationOfType(Modifying.class);
+                        if (modifying.clearAutomatically() && !modifying.flushAutomatically()) {
+                            events.add(SimpleConditionEvent.violated(method,
+                                    method.getFullName()
+                                    + " — @Modifying(clearAutomatically=true)에 flushAutomatically=true 누락: "
+                                    + "미flush 엔티티 변경이 em.clear()에 폐기될 수 있다 (#299 유령 재생 클래스)"));
+                        }
+                    }
+                })
+                .because("clear 단독은 같은 트랜잭션의 미flush 변경을 폐기한다 (#299)")
+                .check(allClasses);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackDeactivateLostOnRoomSwitchIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackDeactivateLostOnRoomSwitchIT.java
@@ -1,0 +1,197 @@
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.aspect.context.AuthContext;
+import com.pfplaybackend.api.common.domain.value.Duration;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.enums.AuthorityTier;
+import com.pfplaybackend.api.party.adapter.out.persistence.DjQueueRepository;
+import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomPlaybackRepository;
+import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomRepository;
+import com.pfplaybackend.api.party.application.port.out.PlaylistCommandPort;
+import com.pfplaybackend.api.party.application.port.out.PlaylistQueryPort;
+import com.pfplaybackend.api.party.application.port.out.UserProfileQueryPort;
+import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
+import com.pfplaybackend.api.party.domain.enums.StageType;
+import com.pfplaybackend.api.party.domain.value.CountryCode;
+import com.pfplaybackend.api.party.domain.value.LinkDomain;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.playlist.application.dto.PlaybackTrackDto;
+import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 2026-06-12 prod 빈 룸 유령 재생 사고 재현 (binlog 포렌식으로 역추적한 시나리오).
+ *
+ * <p>시나리오: 룸A에서 단독 DJ로 재생 중인 사용자가 룸B로 직행 입장(tryEnter → autoExit).
+ * exit 경로의 {@code playbackState.deactivate()}는 managed 엔티티의 미flush 변경으로만
+ * 존재하는데, 직후 같은 트랜잭션에서 실행되는 {@code activateCrew(룸B)} —
+ * {@code @Modifying(clearAutomatically = true)} — 가 영속성 컨텍스트를 clear하면서
+ * 그 변경을 조용히 폐기한다(쿼리 스페이스 {crew}≠{partyroom_playback}라 auto-flush도
+ * 발동하지 않음). 결과: 빈 룸이 is_activated=1로 영구 고착(유령 재생 + tar pit).
+ *
+ * <p>이 테스트는 현재 코드에서 FAIL해야 정상(red) — 수정 후 GREEN이 회귀 잠금이 된다.
+ */
+class PlaybackDeactivateLostOnRoomSwitchIT extends AbstractIntegrationTest {
+
+    @Autowired private PartyroomAccessCommandService accessCommandService;
+    @Autowired private DjCommandService djCommandService;
+    @Autowired private PartyroomRepository partyroomRepository;
+    @Autowired private PartyroomPlaybackRepository partyroomPlaybackRepository;
+    @Autowired private DjQueueRepository djQueueRepository;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    private final List<Long> createdRoomIds = new ArrayList<>();
+
+    /** PA-7.1 프로필 게이트 무력화 — RaceIT/ClusterAPresenceIntegrationTest 동일 패턴. */
+    @MockBean
+    private UserProfileQueryPort userProfileQueryPort;
+
+    /** 플레이리스트 모듈 경계 — 실 픽스처 대신 포트 모킹 (버그는 party 모듈 JPA 레이어에 있음). */
+    @MockBean
+    private PlaylistQueryPort playlistQueryPort;
+    @MockBean
+    private PlaylistCommandPort playlistCommandPort;
+
+    @BeforeEach
+    void stubBoundaryPorts() {
+        lenient().when(userProfileQueryPort.getUsersProfileSetting(any()))
+                .thenAnswer(inv -> {
+                    List<UserId> ids = inv.getArgument(0);
+                    Map<UserId, ProfileSettingDto> result = new java.util.HashMap<>();
+                    for (UserId id : ids) {
+                        result.put(id, mock(ProfileSettingDto.class));
+                    }
+                    return result;
+                });
+        lenient().when(playlistQueryPort.isOwnedBy(anyLong(), anyLong())).thenReturn(true);
+        lenient().when(playlistQueryPort.isEmptyPlaylist(anyLong())).thenReturn(false);
+        // 룸 시간제한(5분) 이내 트랙 1곡 — doStart가 정상적으로 재생을 시작하게 한다.
+        lenient().when(playlistCommandPort.peekTracksFromCursor(any()))
+                .thenReturn(List.of(new PlaybackTrackDto(
+                        1L, "testLinkId", "재현용 트랙", "thumb.png",
+                        Duration.ofSeconds(180), 1)));
+    }
+
+    private long createActiveRoom(long hostUid, String linkSuffix) {
+        PartyroomData p = PartyroomData.create(
+                "ghost-playback", "intro", LinkDomain.of("link-ghost-" + linkSuffix),
+                PlaybackTimeLimit.ofMinutes(5), StageType.GENERAL,
+                new UserId(hostUid));
+        long id = partyroomRepository.saveAndFlush(p).getId();
+        // 실제 룸 생성 플로우(PartyroomCommandService.create)와 동일하게 상태 행 구성
+        partyroomPlaybackRepository.save(PartyroomPlaybackData.createFor(new PartyroomId(id)));
+        djQueueRepository.save(DjQueueData.createFor(new PartyroomId(id)));
+        createdRoomIds.add(id);
+        return id;
+    }
+
+    @AfterEach
+    void cleanupCreatedRooms() {
+        ThreadLocalContext.clearContext();
+        if (createdRoomIds.isEmpty()) return;
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            entityManager.createNativeQuery(
+                            "DELETE FROM playback_aggregation WHERE playback_id IN " +
+                            "(SELECT id FROM playback WHERE partyroom_id IN (:ids))")
+                    .setParameter("ids", createdRoomIds).executeUpdate();
+            entityManager.createNativeQuery(
+                            "DELETE FROM playback WHERE partyroom_id IN (:ids)")
+                    .setParameter("ids", createdRoomIds).executeUpdate();
+            entityManager.createNativeQuery(
+                            "DELETE FROM crew WHERE partyroom_id IN (:ids)")
+                    .setParameter("ids", createdRoomIds).executeUpdate();
+            entityManager.createNativeQuery(
+                            "DELETE FROM dj WHERE partyroom_id IN (:ids)")
+                    .setParameter("ids", createdRoomIds).executeUpdate();
+            entityManager.createNativeQuery(
+                            "DELETE FROM dj_queue WHERE partyroom_id IN (:ids)")
+                    .setParameter("ids", createdRoomIds).executeUpdate();
+            entityManager.createNativeQuery(
+                            "DELETE FROM partyroom_playback WHERE partyroom_id IN (:ids)")
+                    .setParameter("ids", createdRoomIds).executeUpdate();
+            entityManager.createNativeQuery(
+                            "DELETE FROM partyroom WHERE partyroom_id IN (:ids)")
+                    .setParameter("ids", createdRoomIds).executeUpdate();
+        });
+        createdRoomIds.clear();
+    }
+
+    @Test
+    @DisplayName("재생 중 DJ가 타 룸 직행 입장 → 원 룸 playback은 deactivate되어야 한다 (★ 2026-06-12 prod 유령 재생 재현)")
+    void playback_deactivate_must_survive_room_switch() {
+        long roomA = createActiveRoom(6001L, "a");
+        long roomB = createActiveRoom(6002L, "b");
+        UserId user = new UserId(7777L);
+
+        ThreadLocalContext.setContext(new AuthContext(user, AuthorityTier.GT));
+
+        // 1) 룸A 입장 + DJ 등록 → 재생 시작
+        accessCommandService.tryEnter(new PartyroomId(roomA), CountryCode.of("KR"));
+        djCommandService.enqueueDj(new PartyroomId(roomA), new PlaylistId(99L));
+
+        PartyroomPlaybackData afterStart = loadPlaybackState(roomA);
+        assertThat(afterStart.isActivated())
+                .as("전제: enqueue 직후 룸A 재생이 시작되어야 한다")
+                .isTrue();
+        assertThat(afterStart.getCurrentPlaybackId()).isNotNull();
+
+        // 2) 재생 중 룸B로 직행 입장 — autoExit(룸A)가 같은 트랜잭션에서 수행됨
+        accessCommandService.tryEnter(new PartyroomId(roomB), CountryCode.of("KR"));
+
+        // 3) 부분 커밋 증명 — 같은 트랜잭션의 벌크 쿼리들은 반영되어 있다
+        Number activeCrewInA = (Number) entityManager.createNativeQuery(
+                        "SELECT COUNT(*) FROM crew WHERE partyroom_id = :id AND is_active = 1")
+                .setParameter("id", roomA).getSingleResult();
+        Number djRowsInA = (Number) entityManager.createNativeQuery(
+                        "SELECT COUNT(*) FROM dj WHERE partyroom_id = :id")
+                .setParameter("id", roomA).getSingleResult();
+        assertThat(activeCrewInA.longValue()).as("룸A crew는 비활성화 커밋됨").isZero();
+        assertThat(djRowsInA.longValue()).as("룸A DJ 큐는 비워져 커밋됨").isZero();
+
+        // 4) ★ 핵심 단언 — deactivate()가 DB에 반영되어야 한다.
+        //    현재 코드에서는 activateCrew(룸B)의 @Modifying(clearAutomatically=true)가
+        //    미flush 변경을 폐기해 is_activated=1 유령 재생으로 남는다 (RED 기대).
+        PartyroomPlaybackData afterSwitch = loadPlaybackState(roomA);
+        assertThat(afterSwitch.isActivated())
+                .as("룸A playback deactivate가 커밋되어야 한다 — 유령 재생 금지")
+                .isFalse();
+        assertThat(afterSwitch.getCurrentPlaybackId())
+                .as("deactivate는 current_playback_id를 NULL로 비운다")
+                .isNull();
+        assertThat(afterSwitch.getCurrentDjCrewId())
+                .as("deactivate는 current_dj_crew_id를 NULL로 비운다")
+                .isNull();
+    }
+
+    /** 영속성 컨텍스트 캐시를 우회한 fresh 로드 — 커밋된 DB 상태만 본다. */
+    private PartyroomPlaybackData loadPlaybackState(long roomId) {
+        return new TransactionTemplate(transactionManager).execute(status -> {
+            entityManager.clear();
+            return entityManager.find(PartyroomPlaybackData.class, new PartyroomId(roomId));
+        });
+    }
+}

--- a/user/src/main/java/com/pfplaybackend/api/user/adapter/out/persistence/ActivityRepository.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/adapter/out/persistence/ActivityRepository.java
@@ -51,10 +51,10 @@ public interface ActivityRepository extends JpaRepository<ActivityData, Long> {
      *  - returns 1: row found and updated
      *  - returns 0: no row for (user, activityType) — caller decides (warn / create / throw)
      *
-     * <p>{@code @Modifying(clearAutomatically = true)} invalidates the 1st-level cache
+     * <p>{@code @Modifying(clearAutomatically = true, flushAutomatically = true)} invalidates the 1st-level cache
      * so subsequent reads in the same transaction see the persisted value.
      */
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = "UPDATE user_activity " +
            "SET score = GREATEST(0, CAST(score AS SIGNED) + :delta) " +
            "WHERE user_id = :#{#userId.uid} AND activity_type = :#{#activityType.name()}",


### PR DESCRIPTION
Closes #299

## 무엇이 문제였나

재생 중인 DJ가 타 룸으로 직행 입장(`tryEnter` autoExit)하면 원 룸의 playback deactivate가 DB에 반영되지 않아, **사람 0명인 룸이 is_activated=1로 영구 고착**(유령 재생 + tar pit). 2026-06-12 prod 1번룸(MAIN)에서 발생, binlog 포렌식(Xid=1691315)으로 root cause 확정 — 상세는 #299.

**메커니즘**: exit 경로의 `playbackState.deactivate()`는 managed 엔티티의 미flush 변경으로만 존재하는데, 직후 같은 트랜잭션의 `activateCrew(룸B)` — `@Modifying(clearAutomatically=true)` — 가 `em.clear()`로 폐기. 쿼리 스페이스가 달라 auto-flush도 미발동(`flushAutomatically` 기본 false). 동시성 무관, 결정론적.

## 수정

- **`clearAutomatically=true`인 `@Modifying` 11곳 전부에 `flushAutomatically=true` 동반** — clear 전에 flush가 선행되어 미flush 변경이 보존된다. (CrewRepository ×5 / PartyroomRepository ×4 / PlaybackAggregationRepository ×1 / ActivityRepository ×1)
- 구조적 개선(playback 상태 쓰기를 crew toggle처럼 원자적 @Modifying UPDATE로 전환 + reconcile 안전망)은 Cluster G에서 별도 — #299 수정방향 ① 참조.

## 검증

| 단계 | 결과 |
|---|---|
| 재현 IT `PlaybackDeactivateLostOnRoomSwitchIT` (수정 전) | **RED** — prod와 동일한 부분 커밋 형상(crew 비활성 ✓·dj 삭제 ✓·deactivate 증발 ✗) 재현 |
| 동일 IT (수정 후) | **GREEN** |
| ArchUnit `ModifyingQueryConventionTest` (신규) | GREEN — clearAutomatically=true에 flushAutomatically 누락 시 빌드 실패(재발 방지) |
| 전 모듈 유닛 테스트 | GREEN |
| 전체 integrationTest 스위트 | GREEN (8m11s) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
