### PR TITLE
feat(push): Web Push 구독·발송 백엔드 (시스템 공지 fan-out, dormant) — web#404 Phase B

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,6 +74,10 @@ dependencies {
 
 	// TSID (Snowflake ID generation)
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.3'
+
+	// Web Push (VAPID, RFC 8291). BouncyCastle 동반.
+	implementation 'nl.martijndwars:web-push:5.1.1'
+	implementation 'org.bouncycastle:bcprov-jdk18on:1.78.1'
 }
 
 // Aggregated JaCoCo report across all modules

--- a/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/AdminAnnouncementController.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/AdminAnnouncementController.java
@@ -80,7 +80,7 @@ public class AdminAnnouncementController {
                 req.type(), req.severity(),
                 req.titleKo(), req.titleEn(), req.messageKo(), req.messageEn(),
                 req.scheduledStartAt(), req.scheduledEndAt(), req.expiresAt(),
-                administratorId);
+                administratorId, req.sendPush());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiCommonResponse.success(Map.of("announcementId", id)));
     }

--- a/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/payload/request/AnnouncementCreateRequest.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/payload/request/AnnouncementCreateRequest.java
@@ -27,5 +27,6 @@ public record AnnouncementCreateRequest(
         @NotBlank @Size(max = 2000) String messageEn,
         LocalDateTime scheduledStartAt,
         LocalDateTime scheduledEndAt,
-        LocalDateTime expiresAt
+        LocalDateTime expiresAt,
+        boolean sendPush
 ) {}

--- a/app/src/main/java/com/pfplaybackend/api/administration/application/service/SystemAnnouncementCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/application/service/SystemAnnouncementCommandService.java
@@ -47,7 +47,7 @@ public class SystemAnnouncementCommandService {
     public Long publish(AnnouncementType type, AnnouncementSeverity severity,
                         String titleKo, String titleEn, String messageKo, String messageEn,
                         LocalDateTime scheduledStartAt, LocalDateTime scheduledEndAt, LocalDateTime expiresAt,
-                        Long administratorId) {
+                        Long administratorId, boolean sendPush) {
         LocalDateTime now = LocalDateTime.now(clock);
         if (type == AnnouncementType.MAINTENANCE_NOTICE
                 && scheduledStartAt != null
@@ -56,7 +56,7 @@ public class SystemAnnouncementCommandService {
         }
         SystemAnnouncementData entity = SystemAnnouncementData.create(
                 type, severity, titleKo, titleEn, messageKo, messageEn,
-                scheduledStartAt, scheduledEndAt, expiresAt, now, administratorId);
+                scheduledStartAt, scheduledEndAt, expiresAt, now, administratorId, sendPush);
         SystemAnnouncementData saved = repository.save(entity);
         eventPublisher.publishEvent(new AnnouncementPublishedEvent(saved));
         return saved.getId();

--- a/app/src/main/java/com/pfplaybackend/api/administration/domain/entity/data/SystemAnnouncementData.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/domain/entity/data/SystemAnnouncementData.java
@@ -31,12 +31,13 @@ public class SystemAnnouncementData extends BaseEntity {
     @Column(name = "cancelled_at") private LocalDateTime cancelledAt;
     @Column(name = "cancelled_by_administrator_id") private Long cancelledByAdministratorId;
     @Column(name = "completed_at") private LocalDateTime completedAt;
+    @Column(name = "push_enabled", nullable = false) private boolean pushEnabled;
 
     public static SystemAnnouncementData create(
             AnnouncementType type, AnnouncementSeverity severity,
             String titleKo, String titleEn, String messageKo, String messageEn,
             LocalDateTime scheduledStartAt, LocalDateTime scheduledEndAt, LocalDateTime expiresAt,
-            LocalDateTime sentAt, Long sentByAdministratorId) {
+            LocalDateTime sentAt, Long sentByAdministratorId, boolean pushEnabled) {
         if (type == AnnouncementType.MAINTENANCE_NOTICE) {
             if (scheduledStartAt == null || scheduledEndAt == null || expiresAt != null)
                 throw ExceptionCreator.create(AnnouncementException.INVALID_SCHEDULE_FOR_TYPE);
@@ -51,6 +52,7 @@ public class SystemAnnouncementData extends BaseEntity {
         e.titleKo = titleKo; e.titleEn = titleEn; e.messageKo = messageKo; e.messageEn = messageEn;
         e.scheduledStartAt = scheduledStartAt; e.scheduledEndAt = scheduledEndAt; e.expiresAt = expiresAt;
         e.sentAt = sentAt; e.sentByAdministratorId = sentByAdministratorId;
+        e.pushEnabled = pushEnabled;
         return e;
     }
 

--- a/app/src/main/java/com/pfplaybackend/api/common/config/AsyncConfig.java
+++ b/app/src/main/java/com/pfplaybackend/api/common/config/AsyncConfig.java
@@ -26,6 +26,9 @@ public class AsyncConfig {
     /** UserActivityLogListener `@Async` qualifier — 컴파일 타임 linkage. */
     public static final String UAL_EXECUTOR_BEAN = "userActivityLogExecutor";
 
+    /** AnnouncementPushNotifier `@Async` qualifier — 컴파일 타임 linkage. */
+    public static final String WEB_PUSH_EXECUTOR_BEAN = "webPushExecutor";
+
     @Bean(name = UAL_EXECUTOR_BEAN)
     public ThreadPoolTaskExecutor userActivityLogExecutor() {
         ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
@@ -37,6 +40,27 @@ public class AsyncConfig {
         exec.setTaskDecorator(new MdcTaskDecorator());
         exec.setWaitForTasksToCompleteOnShutdown(true);
         exec.setAwaitTerminationSeconds(10);
+        exec.initialize();
+        return exec;
+    }
+
+    /**
+     * 공지→Web Push fan-out 전용 executor.
+     * - AnnouncementPushNotifier (AFTER_COMMIT 리스너)가 @Async 로 위임
+     * - core=2, max=4, queue=500, CallerRunsPolicy (saturation 시 호출 thread가 직접 처리)
+     * - 그레이스풀 종료: 큐 비울 때까지 15초 대기 (push 발송 손실 최소화)
+     */
+    @Bean(name = WEB_PUSH_EXECUTOR_BEAN)
+    public ThreadPoolTaskExecutor webPushExecutor() {
+        ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
+        exec.setCorePoolSize(2);
+        exec.setMaxPoolSize(4);
+        exec.setQueueCapacity(500);
+        exec.setThreadNamePrefix("webpush-");
+        exec.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        exec.setTaskDecorator(new MdcTaskDecorator());
+        exec.setWaitForTasksToCompleteOnShutdown(true);
+        exec.setAwaitTerminationSeconds(15);
         exec.initialize();
         return exec;
     }

--- a/app/src/main/java/com/pfplaybackend/api/notification/adapter/in/listener/AnnouncementPushNotifier.java
+++ b/app/src/main/java/com/pfplaybackend/api/notification/adapter/in/listener/AnnouncementPushNotifier.java
@@ -1,0 +1,34 @@
+package com.pfplaybackend.api.notification.adapter.in.listener;
+
+import com.pfplaybackend.api.administration.domain.event.AnnouncementPublishedEvent;
+import com.pfplaybackend.api.common.config.AsyncConfig;
+import com.pfplaybackend.api.notification.application.service.PushFanoutService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 공지 발행 AFTER_COMMIT → Web Push fan-out 디스패치 리스너.
+ *
+ * <p>이 bean은 dispatch만 담당하고, 실제 fan-out(+GONE prune dirty-update)은
+ * 별도 {@link PushFanoutService#fanout}({@code @Transactional})에 위임한다.
+ * @Async + @TransactionalEventListener 와 @Transactional 을 한 메서드에 함께 두면
+ * proxy 충돌로 비동기 thread에서 TX가 열리지 않으므로, bean을 분리해 transactional
+ * proxy가 정상 적용되도록 한다. ({@code AnnouncementBroadcaster} 컨벤션 mirror.)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AnnouncementPushNotifier {
+
+    private final PushFanoutService fanoutService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    @Async(AsyncConfig.WEB_PUSH_EXECUTOR_BEAN)
+    public void on(AnnouncementPublishedEvent event) {
+        fanoutService.fanout(event.entity());
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/notification/adapter/in/web/PushSubscriptionController.java
+++ b/app/src/main/java/com/pfplaybackend/api/notification/adapter/in/web/PushSubscriptionController.java
@@ -1,0 +1,44 @@
+package com.pfplaybackend.api.notification.adapter.in.web;
+
+import com.pfplaybackend.api.common.ApiCommonResponse;
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.notification.adapter.in.web.payload.request.PushSubscribeRequest;
+import com.pfplaybackend.api.notification.adapter.in.web.payload.request.PushUnsubscribeRequest;
+import com.pfplaybackend.api.notification.application.service.PushSubscriptionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@Tag(name = "Push API")
+@RequestMapping("/api/v1/push/subscriptions")
+@RestController
+@RequiredArgsConstructor
+public class PushSubscriptionController {
+
+    private final PushSubscriptionService service;
+
+    @Operation(summary = "푸시 구독 등록/갱신")
+    @SecurityRequirement(name = "cookieAuth")
+    @PostMapping
+    public ResponseEntity<ApiCommonResponse<Map<String, Long>>> subscribe(@Valid @RequestBody PushSubscribeRequest req) {
+        Long userId = ThreadLocalContext.getAuthContext().getUserId().getUid();
+        Long id = service.subscribe(userId, req.endpoint(), req.p256dh(), req.auth(), req.lang());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiCommonResponse.success(Map.of("subscriptionId", id)));
+    }
+
+    @Operation(summary = "푸시 구독 해지")
+    @SecurityRequirement(name = "cookieAuth")
+    @DeleteMapping
+    public ResponseEntity<Void> unsubscribe(@Valid @RequestBody PushUnsubscribeRequest req) {
+        Long userId = ThreadLocalContext.getAuthContext().getUserId().getUid();
+        service.unsubscribe(userId, req.endpoint());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/notification/adapter/in/web/payload/request/PushSubscribeRequest.java
+++ b/app/src/main/java/com/pfplaybackend/api/notification/adapter/in/web/payload/request/PushSubscribeRequest.java
@@ -1,0 +1,13 @@
+package com.pfplaybackend.api.notification.adapter.in.web.payload.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Web Push 구독 등록/갱신 요청. endpoint UNIQUE, 동일 endpoint면 부활 upsert.
+ */
+public record PushSubscribeRequest(
+        @NotBlank String endpoint,
+        @NotBlank String p256dh,
+        @NotBlank String auth,
+        @NotBlank String lang
+) {}

--- a/app/src/main/java/com/pfplaybackend/api/notification/adapter/in/web/payload/request/PushSubscribeRequest.java
+++ b/app/src/main/java/com/pfplaybackend/api/notification/adapter/in/web/payload/request/PushSubscribeRequest.java
@@ -1,6 +1,7 @@
 package com.pfplaybackend.api.notification.adapter.in.web.payload.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 /**
  * Web Push 구독 등록/갱신 요청. endpoint UNIQUE, 동일 endpoint면 부활 upsert.
@@ -9,5 +10,5 @@ public record PushSubscribeRequest(
         @NotBlank String endpoint,
         @NotBlank String p256dh,
         @NotBlank String auth,
-        @NotBlank String lang
+        @NotBlank @Pattern(regexp = "(?i)KO|EN", message = "lang must be KO or EN") String lang
 ) {}

--- a/app/src/main/java/com/pfplaybackend/api/notification/adapter/in/web/payload/request/PushUnsubscribeRequest.java
+++ b/app/src/main/java/com/pfplaybackend/api/notification/adapter/in/web/payload/request/PushUnsubscribeRequest.java
@@ -1,0 +1,10 @@
+package com.pfplaybackend.api.notification.adapter.in.web.payload.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Web Push 구독 해지 요청. 소유자(userId) 스코프 내에서만 revoke 처리.
+ */
+public record PushUnsubscribeRequest(
+        @NotBlank String endpoint
+) {}

--- a/app/src/main/java/com/pfplaybackend/api/notification/adapter/out/persistence/PushSubscriptionRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/notification/adapter/out/persistence/PushSubscriptionRepository.java
@@ -1,15 +1,32 @@
 package com.pfplaybackend.api.notification.adapter.out.persistence;
 
 import com.pfplaybackend.api.notification.domain.entity.data.PushSubscriptionData;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface PushSubscriptionRepository extends JpaRepository<PushSubscriptionData, Long> {
     Optional<PushSubscriptionData> findByEndpoint(String endpoint);
 
-    @Query("SELECT s FROM PushSubscriptionData s WHERE s.revokedAt IS NULL")
-    List<PushSubscriptionData> findAllActive();
+    /**
+     * 활성(revoked_at IS NULL) 구독을 id 오름차순 keyset 페이지네이션 — fan-out 배치 로드 (web#404 B fast-follow).
+     * offset 방식과 달리 insert/delete 에도 페이지 드리프트가 없고 인덱스 시킹이라 대규모에서 안정적.
+     */
+    List<PushSubscriptionData> findByRevokedAtIsNullAndIdGreaterThanOrderByIdAsc(Long lastId, Pageable pageable);
+
+    /**
+     * GONE(404/410) 구독 일괄 revoke — fan-out 의 HTTP 루프 밖에서 id 기반 단일 짧은 트랜잭션으로 처리.
+     * (per-row dirty update + 장기 write TX 회피.)
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    @Query("UPDATE PushSubscriptionData s SET s.revokedAt = :now WHERE s.id IN :ids AND s.revokedAt IS NULL")
+    int revokeByIds(@Param("ids") List<Long> ids, @Param("now") LocalDateTime now);
 }

--- a/app/src/main/java/com/pfplaybackend/api/notification/adapter/out/persistence/PushSubscriptionRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/notification/adapter/out/persistence/PushSubscriptionRepository.java
@@ -1,0 +1,15 @@
+package com.pfplaybackend.api.notification.adapter.out.persistence;
+
+import com.pfplaybackend.api.notification.domain.entity.data.PushSubscriptionData;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PushSubscriptionRepository extends JpaRepository<PushSubscriptionData, Long> {
+    Optional<PushSubscriptionData> findByEndpoint(String endpoint);
+
+    @Query("SELECT s FROM PushSubscriptionData s WHERE s.revokedAt IS NULL")
+    List<PushSubscriptionData> findAllActive();
+}

--- a/app/src/main/java/com/pfplaybackend/api/notification/adapter/out/push/MartijndwarsWebPushAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/notification/adapter/out/push/MartijndwarsWebPushAdapter.java
@@ -1,0 +1,81 @@
+package com.pfplaybackend.api.notification.adapter.out.push;
+
+import com.pfplaybackend.api.notification.application.port.WebPushSender;
+import com.pfplaybackend.api.notification.config.WebPushProperties;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nl.martijndwars.webpush.Notification;
+import nl.martijndwars.webpush.PushService;
+import org.apache.http.HttpResponse;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Security;
+
+/**
+ * martijndwars web-push(5.1.1) 기반 {@link WebPushSender} 구현.
+ * - enabled=false 이면 pushService 를 만들지 않고(fail-closed) send 는 FAILED 반환.
+ * - HTTP status → Result 매핑: 2xx=OK, 404/410=GONE(구독 prune 대상), 그 외/예외=FAILED.
+ * - 절대 예외를 전파하지 않는다(fail-soft).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MartijndwarsWebPushAdapter implements WebPushSender {
+
+    private final WebPushProperties props;
+
+    private PushService pushService;
+
+    @PostConstruct
+    void init() {
+        if (!props.isEnabled()) {
+            log.warn("[web-push] disabled (app.web-push.enabled=false) — 푸시 발송 비활성. fail-closed.");
+            return;
+        }
+        try {
+            if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+                Security.addProvider(new BouncyCastleProvider());
+            }
+            this.pushService = new PushService(props.getPublicKey(), props.getPrivateKey(), props.getSubject());
+            log.info("[web-push] enabled — PushService initialized (subject={})", props.getSubject());
+        } catch (Exception e) {
+            // 키 형식 오류 등 — fail-closed 로 두고 발송은 FAILED 처리.
+            log.error("[web-push] PushService init 실패 — 푸시 발송 비활성화. cause={}", e.toString());
+            this.pushService = null;
+        }
+    }
+
+    @Override
+    public Result send(String endpoint, String p256dh, String auth, String payloadJson) {
+        if (pushService == null) {
+            return Result.FAILED;
+        }
+        try {
+            Notification notification = new Notification(
+                    endpoint, p256dh, auth, payloadJson.getBytes(StandardCharsets.UTF_8));
+            HttpResponse response = pushService.send(notification);
+            int statusCode = response.getStatusLine().getStatusCode();
+            return mapStatus(statusCode);
+        } catch (Exception e) {
+            log.warn("[web-push] send 실패 — endpoint={}, cause={}", endpoint, e.toString());
+            return Result.FAILED;
+        }
+    }
+
+    /**
+     * Push service HTTP status → Result 정규화.
+     * 404/410 = 구독 만료/삭제(prune 대상) → GONE, 2xx = OK, 그 외 = FAILED.
+     */
+    public static Result mapStatus(int statusCode) {
+        if (statusCode == 404 || statusCode == 410) {
+            return Result.GONE;
+        }
+        if (statusCode >= 200 && statusCode < 300) {
+            return Result.OK;
+        }
+        return Result.FAILED;
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/notification/application/port/WebPushSender.java
+++ b/app/src/main/java/com/pfplaybackend/api/notification/application/port/WebPushSender.java
@@ -1,0 +1,12 @@
+package com.pfplaybackend.api.notification.application.port;
+
+/**
+ * Web Push 발송 포트. 구현(martijndwars 어댑터 등)은 HTTP 결과를 OK/GONE/FAILED 로 정규화한다.
+ * 절대 예외를 던지지 않는다(fail-soft) — 호출부는 Result 만 보고 prune/재시도를 판단한다.
+ */
+public interface WebPushSender {
+
+    enum Result { OK, GONE, FAILED }   // GONE = 404/410 → prune
+
+    Result send(String endpoint, String p256dh, String auth, String payloadJson);
+}

--- a/app/src/main/java/com/pfplaybackend/api/notification/application/service/PushFanoutService.java
+++ b/app/src/main/java/com/pfplaybackend/api/notification/application/service/PushFanoutService.java
@@ -1,0 +1,65 @@
+package com.pfplaybackend.api.notification.application.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pfplaybackend.api.administration.domain.entity.data.SystemAnnouncementData;
+import com.pfplaybackend.api.notification.adapter.out.persistence.PushSubscriptionRepository;
+import com.pfplaybackend.api.notification.application.port.WebPushSender;
+import com.pfplaybackend.api.notification.domain.entity.data.PushSubscriptionData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * 공지 발행 → 전체 활성 구독자 Web Push fan-out.
+ *
+ * <p>{@code @Async} 디스패치 리스너({@code AnnouncementPushNotifier})가 호출하는 별도 bean —
+ * 비동기 thread에서 독립 TX를 열어, GONE(404/410) 구독을 revoke 한 dirty-update가
+ * 트랜잭션 커밋 시점에 flush 되도록 보장한다. (리스너에 직접 @Transactional 을 붙이면
+ * @Async + @TransactionalEventListener 와 충돌하므로 책임을 분리한다.)
+ *
+ * <p>{@link WebPushSender}는 fail-soft(예외 미발생)이므로 한 구독 실패가 fan-out 전체를
+ * 중단하지 않는다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PushFanoutService {
+
+    private final PushSubscriptionRepository repository;
+    private final WebPushSender sender;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    @Transactional
+    public void fanout(SystemAnnouncementData a) {
+        if (!a.isPushEnabled()) return;
+        for (PushSubscriptionData s : repository.findAllActive()) {
+            String payload = buildPayload(a, s.getLang());
+            WebPushSender.Result r = sender.send(s.getEndpoint(), s.getP256dh(), s.getAuth(), payload);
+            if (r == WebPushSender.Result.GONE) {
+                s.revoke(LocalDateTime.now(clock));
+            }
+        }
+    }
+
+    private String buildPayload(SystemAnnouncementData a, String lang) {
+        boolean ko = "KO".equalsIgnoreCase(lang);
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("title", ko ? a.getTitleKo() : a.getTitleEn());
+        body.put("body", ko ? a.getMessageKo() : a.getMessageEn());
+        body.put("url", "/");
+        body.put("tag", "announcement-" + a.getId());
+        try {
+            return objectMapper.writeValueAsString(body);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/notification/application/service/PushFanoutService.java
+++ b/app/src/main/java/com/pfplaybackend/api/notification/application/service/PushFanoutService.java
@@ -8,11 +8,12 @@ import com.pfplaybackend.api.notification.application.port.WebPushSender;
 import com.pfplaybackend.api.notification.domain.entity.data.PushSubscriptionData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,10 +21,13 @@ import java.util.Map;
 /**
  * 공지 발행 → 전체 활성 구독자 Web Push fan-out.
  *
- * <p>{@code @Async} 디스패치 리스너({@code AnnouncementPushNotifier})가 호출하는 별도 bean —
- * 비동기 thread에서 독립 TX를 열어, GONE(404/410) 구독을 revoke 한 dirty-update가
- * 트랜잭션 커밋 시점에 flush 되도록 보장한다. (리스너에 직접 @Transactional 을 붙이면
- * @Async + @TransactionalEventListener 와 충돌하므로 책임을 분리한다.)
+ * <p>{@code @Async} 디스패치 리스너({@code AnnouncementPushNotifier})가 호출하는 별도 bean.
+ *
+ * <p><b>오케스트레이터는 의도적으로 @Transactional 이 아니다</b>(web#404 B fast-follow): HTTP push I/O 를
+ * write TX 안에서 돌리면 느린 네트워크 동안 DB 커넥션을 점유한다. 따라서
+ * (1) 활성 구독을 <b>keyset 페이지네이션</b>으로 배치 로드(무제한 findAll 회피),
+ * (2) HTTP 발송은 <b>TX 밖</b>에서 수행,
+ * (3) GONE(404/410)은 id 를 모아 <b>단일 짧은 bulk revoke TX</b>로 정리(per-row dirty update 회피).
  *
  * <p>{@link WebPushSender}는 fail-soft(예외 미발생)이므로 한 구독 실패가 fan-out 전체를
  * 중단하지 않는다.
@@ -38,26 +42,42 @@ public class PushFanoutService {
     private final ObjectMapper objectMapper;
     private final Clock clock;
 
-    @Transactional
+    /** fan-out 배치 크기. (테스트에서 override.) */
+    int pageSize = 500;
+
     public void fanout(SystemAnnouncementData a) {
         if (!a.isPushEnabled()) return;
-        // 휴면 기능 첫 활성화 관측용 — fan-out 규모·결과를 남긴다.
-        List<PushSubscriptionData> active = repository.findAllActive();
         int sent = 0, gone = 0, failed = 0;
-        for (PushSubscriptionData s : active) {
-            String payload = buildPayload(a, s.getLang());
-            WebPushSender.Result r = sender.send(s.getEndpoint(), s.getP256dh(), s.getAuth(), payload);
-            if (r == WebPushSender.Result.GONE) {
-                s.revoke(LocalDateTime.now(clock));
-                gone++;
-            } else if (r == WebPushSender.Result.OK) {
-                sent++;
-            } else {
-                failed++;
+        long lastId = 0L;
+        List<Long> goneIds = new ArrayList<>();
+
+        while (true) {
+            List<PushSubscriptionData> page =
+                    repository.findByRevokedAtIsNullAndIdGreaterThanOrderByIdAsc(lastId, PageRequest.ofSize(pageSize));
+            if (page.isEmpty()) break;
+            for (PushSubscriptionData s : page) {
+                // ⚠️ HTTP 는 write TX 밖에서 — 커넥션 장기 점유 방지.
+                String payload = buildPayload(a, s.getLang());
+                WebPushSender.Result r = sender.send(s.getEndpoint(), s.getP256dh(), s.getAuth(), payload);
+                if (r == WebPushSender.Result.GONE) {
+                    goneIds.add(s.getId());
+                    gone++;
+                } else if (r == WebPushSender.Result.OK) {
+                    sent++;
+                } else {
+                    failed++;
+                }
             }
+            lastId = page.get(page.size() - 1).getId();
+            if (page.size() < pageSize) break;
         }
-        log.info("[web-push] announcement {} fan-out: subs={} ok={} gone(pruned)={} failed={}",
-                a.getId(), active.size(), sent, gone, failed);
+
+        if (!goneIds.isEmpty()) {
+            repository.revokeByIds(goneIds, LocalDateTime.now(clock));  // 단일 짧은 bulk revoke TX
+        }
+        // 휴면 기능 첫 활성화 관측용 — fan-out 결과를 남긴다.
+        log.info("[web-push] announcement {} fan-out: ok={} gone(pruned)={} failed={}",
+                a.getId(), sent, gone, failed);
     }
 
     private String buildPayload(SystemAnnouncementData a, String lang) {

--- a/app/src/main/java/com/pfplaybackend/api/notification/application/service/PushFanoutService.java
+++ b/app/src/main/java/com/pfplaybackend/api/notification/application/service/PushFanoutService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -40,13 +41,23 @@ public class PushFanoutService {
     @Transactional
     public void fanout(SystemAnnouncementData a) {
         if (!a.isPushEnabled()) return;
-        for (PushSubscriptionData s : repository.findAllActive()) {
+        // 휴면 기능 첫 활성화 관측용 — fan-out 규모·결과를 남긴다.
+        List<PushSubscriptionData> active = repository.findAllActive();
+        int sent = 0, gone = 0, failed = 0;
+        for (PushSubscriptionData s : active) {
             String payload = buildPayload(a, s.getLang());
             WebPushSender.Result r = sender.send(s.getEndpoint(), s.getP256dh(), s.getAuth(), payload);
             if (r == WebPushSender.Result.GONE) {
                 s.revoke(LocalDateTime.now(clock));
+                gone++;
+            } else if (r == WebPushSender.Result.OK) {
+                sent++;
+            } else {
+                failed++;
             }
         }
+        log.info("[web-push] announcement {} fan-out: subs={} ok={} gone(pruned)={} failed={}",
+                a.getId(), active.size(), sent, gone, failed);
     }
 
     private String buildPayload(SystemAnnouncementData a, String lang) {

--- a/app/src/main/java/com/pfplaybackend/api/notification/application/service/PushSubscriptionService.java
+++ b/app/src/main/java/com/pfplaybackend/api/notification/application/service/PushSubscriptionService.java
@@ -1,0 +1,36 @@
+package com.pfplaybackend.api.notification.application.service;
+
+import com.pfplaybackend.api.notification.adapter.out.persistence.PushSubscriptionRepository;
+import com.pfplaybackend.api.notification.domain.entity.data.PushSubscriptionData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class PushSubscriptionService {
+
+    private final PushSubscriptionRepository repository;
+    private final Clock clock;
+
+    @Transactional
+    public Long subscribe(Long userId, String endpoint, String p256dh, String auth, String lang) {
+        return repository.findByEndpoint(endpoint)
+                .map(existing -> {
+                    existing.revive(userId, p256dh, auth, lang);
+                    return existing.getId();
+                })
+                .orElseGet(() -> repository.save(
+                        PushSubscriptionData.create(userId, endpoint, p256dh, auth, lang)).getId());
+    }
+
+    @Transactional
+    public void unsubscribe(Long userId, String endpoint) {
+        repository.findByEndpoint(endpoint)
+                .filter(s -> s.getUserId().equals(userId))
+                .ifPresent(s -> s.revoke(LocalDateTime.now(clock)));
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/notification/application/service/PushSubscriptionService.java
+++ b/app/src/main/java/com/pfplaybackend/api/notification/application/service/PushSubscriptionService.java
@@ -3,6 +3,7 @@ package com.pfplaybackend.api.notification.application.service;
 import com.pfplaybackend.api.notification.adapter.out.persistence.PushSubscriptionRepository;
 import com.pfplaybackend.api.notification.domain.entity.data.PushSubscriptionData;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +21,14 @@ public class PushSubscriptionService {
     public Long subscribe(Long userId, String endpoint, String p256dh, String auth, String lang) {
         return repository.findByEndpoint(endpoint)
                 .map(existing -> {
+                    // IDOR 방어: endpoint 는 브라우저당 고유한 비밀 자격증명이다. 같은 row 를 재사용(revive)할 수 있는 건
+                    // (1) 같은 회원의 재구독(키 갱신)이거나 (2) 이전 소유자가 로그아웃하며 해지(revoked)한 기기를
+                    // 새 회원이 재점유하는 정당한 hand-off 뿐이다. 활성(active) + 타 회원 소유 endpoint 를 가로채는 것은
+                    // 차단한다(unique 제약상 새 row 도 못 만드므로 거부).
+                    boolean reclaimable = !existing.isActive() || existing.getUserId().equals(userId);
+                    if (!reclaimable) {
+                        throw new AccessDeniedException("push subscription endpoint owned by another active user");
+                    }
                     existing.revive(userId, p256dh, auth, lang);
                     return existing.getId();
                 })

--- a/app/src/main/java/com/pfplaybackend/api/notification/config/WebPushProperties.java
+++ b/app/src/main/java/com/pfplaybackend/api/notification/config/WebPushProperties.java
@@ -1,0 +1,20 @@
+package com.pfplaybackend.api.notification.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * VAPID(Web Push, RFC 8291) 설정. fail-closed: enabled 기본 false.
+ * 키 값은 배포 시 환경변수로 주입한다(코드/형상관리에 절대 커밋 금지).
+ */
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "app.web-push")
+public class WebPushProperties {
+
+    private boolean enabled = false;
+    private String publicKey;
+    private String privateKey;
+    private String subject = "mailto:admin@pfplay.io";
+}

--- a/app/src/main/java/com/pfplaybackend/api/notification/domain/entity/data/PushSubscriptionData.java
+++ b/app/src/main/java/com/pfplaybackend/api/notification/domain/entity/data/PushSubscriptionData.java
@@ -1,0 +1,49 @@
+package com.pfplaybackend.api.notification.domain.entity.data;
+
+import com.pfplaybackend.api.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "push_subscription")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PushSubscriptionData extends BaseEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) private Long id;
+    @Column(name = "user_id", nullable = false) private Long userId;
+    @Column(nullable = false, length = 512) private String endpoint;
+    @Column(nullable = false, length = 255) private String p256dh;
+    @Column(nullable = false, length = 255) private String auth;
+    @Column(nullable = false, length = 8) private String lang;
+    @Column(name = "revoked_at") private LocalDateTime revokedAt;
+
+    public static PushSubscriptionData create(Long userId, String endpoint, String p256dh, String auth, String lang) {
+        PushSubscriptionData e = new PushSubscriptionData();
+        e.userId = userId;
+        e.endpoint = endpoint;
+        e.p256dh = p256dh;
+        e.auth = auth;
+        e.lang = lang;
+        return e;
+    }
+
+    public void revive(Long userId, String p256dh, String auth, String lang) {
+        this.userId = userId;
+        this.p256dh = p256dh;
+        this.auth = auth;
+        this.lang = lang;
+        this.revokedAt = null;
+    }
+
+    public void revoke(LocalDateTime now) {
+        this.revokedAt = now;
+    }
+
+    public boolean isActive() {
+        return revokedAt == null;
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/notification/domain/entity/data/PushSubscriptionData.java
+++ b/app/src/main/java/com/pfplaybackend/api/notification/domain/entity/data/PushSubscriptionData.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 public class PushSubscriptionData extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) private Long id;
     @Column(name = "user_id", nullable = false) private Long userId;
-    @Column(nullable = false, length = 512) private String endpoint;
+    @Column(nullable = false, length = 1024) private String endpoint;
     @Column(nullable = false, length = 255) private String p256dh;
     @Column(nullable = false, length = 255) private String auth;
     @Column(nullable = false, length = 8) private String lang;

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -207,6 +207,13 @@ app:
       base-url-prefix: https://storage.googleapis.com
       max-file-size-bytes: 2097152   # 2 MiB
 
+  # Web Push (VAPID, RFC 8291). fail-closed: enabled 기본 false. 키는 배포 시 env 주입.
+  web-push:
+    enabled: ${WEB_PUSH_ENABLED:false}
+    public-key: ${WEB_PUSH_VAPID_PUBLIC_KEY:}
+    private-key: ${WEB_PUSH_VAPID_PRIVATE_KEY:}
+    subject: ${WEB_PUSH_SUBJECT:mailto:admin@pfplay.io}
+
 ---
 
 # 🟡 개발 환경

--- a/app/src/main/resources/db/migration/V30__create_push_subscription_and_announcement_push_flag.sql
+++ b/app/src/main/resources/db/migration/V30__create_push_subscription_and_announcement_push_flag.sql
@@ -1,0 +1,21 @@
+-- V30: Web Push 구독 테이블 + 공지 push_enabled 플래그
+-- 구독: 로그인 회원만(user_id=BIGINT). endpoint UNIQUE, soft-delete(revoked_at) + 부활 upsert.
+-- created_at/updated_at 정의는 BaseEntity 컨벤션(datetime default current_timestamp)과 동일.
+
+CREATE TABLE push_subscription (
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    user_id     BIGINT       NOT NULL,
+    endpoint    VARCHAR(512) NOT NULL,
+    p256dh      VARCHAR(255) NOT NULL,
+    auth        VARCHAR(255) NOT NULL,
+    lang        VARCHAR(8)   NOT NULL DEFAULT 'EN',
+    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    revoked_at  DATETIME     NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_push_subscription_endpoint (endpoint),
+    KEY idx_push_subscription_user (user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE system_announcement
+    ADD COLUMN push_enabled TINYINT(1) NOT NULL DEFAULT 0;

--- a/app/src/main/resources/db/migration/V30__create_push_subscription_and_announcement_push_flag.sql
+++ b/app/src/main/resources/db/migration/V30__create_push_subscription_and_announcement_push_flag.sql
@@ -5,7 +5,9 @@
 CREATE TABLE push_subscription (
     id          BIGINT       NOT NULL AUTO_INCREMENT,
     user_id     BIGINT       NOT NULL,
-    endpoint    VARCHAR(512) NOT NULL,
+    -- endpoint 는 ASCII push-service URL. CHARACTER SET ascii 로 1 byte/char →
+    -- UNIQUE 인덱스가 InnoDB 3072 byte 한계 안(1024 byte)에 들고, utf8mb4(512=2048byte) 대비 길이 여유 확보.
+    endpoint    VARCHAR(1024) CHARACTER SET ascii NOT NULL,
     p256dh      VARCHAR(255) NOT NULL,
     auth        VARCHAR(255) NOT NULL,
     lang        VARCHAR(8)   NOT NULL DEFAULT 'EN',

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/web/AdminAnnouncementControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/web/AdminAnnouncementControllerTest.java
@@ -20,6 +20,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -66,7 +67,7 @@ class AdminAnnouncementControllerTest extends AbstractAdminWebMvcTest {
                 any(AnnouncementType.class), any(AnnouncementSeverity.class),
                 any(), any(), any(), any(),
                 any(), any(), any(),
-                anyLong()))
+                anyLong(), anyBoolean()))
                 .willReturn(ANNOUNCEMENT_ID);
 
         mockMvc.perform(post("/api/v1/admin/announcements")
@@ -130,7 +131,7 @@ class AdminAnnouncementControllerTest extends AbstractAdminWebMvcTest {
                 AnnouncementType.EVENT, AnnouncementSeverity.INFO,
                 "제목", "title", "본문", "body",
                 null, null, null,
-                LocalDateTime.now(), 1L);
+                LocalDateTime.now(), 1L, false);
 
         Page<SystemAnnouncementData> page = new PageImpl<>(List.of(entity), Pageable.ofSize(20), 1);
         given(systemAnnouncementRepository.findAll(any(Pageable.class))).willReturn(page);

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/edge/VercelEdgeConfigAdapterTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/edge/VercelEdgeConfigAdapterTest.java
@@ -73,6 +73,6 @@ class VercelEdgeConfigAdapterTest {
         LocalDateTime s = LocalDateTime.parse("2026-05-04T03:00:00");
         return SystemAnnouncementData.create(
             AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
-            "점검", "M", "안내", "N", s, s.plusHours(1), null, s.minusDays(1), 1L);
+            "점검", "M", "안내", "N", s, s.plusHours(1), null, s.minusDays(1), 1L, false);
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/event/AnnouncementBroadcasterIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/event/AnnouncementBroadcasterIT.java
@@ -103,7 +103,7 @@ class AnnouncementBroadcasterIT extends AbstractIntegrationTest {
                         AnnouncementType.EVENT, AnnouncementSeverity.INFO,
                         "공지 제목", "Title EN", "본문", "Body EN",
                         null, null, null,
-                        administratorId));
+                        administratorId, false));
 
         assertThat(announcementId).isNotNull();
 
@@ -136,7 +136,7 @@ class AnnouncementBroadcasterIT extends AbstractIntegrationTest {
                         AnnouncementType.EVENT, AnnouncementSeverity.INFO,
                         "Snap KO", "Snap EN", "M-KO", "M-EN",
                         null, null, null,
-                        administratorId));
+                        administratorId, false));
 
         Awaitility.await().atMost(Duration.ofSeconds(2)).untilAsserted(() ->
                 verify(messagingTemplate, atLeastOnce()).convertAndSend(eq(TOPIC), any(Object.class))

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/event/AnnouncementBroadcasterTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/event/AnnouncementBroadcasterTest.java
@@ -32,7 +32,7 @@ class AnnouncementBroadcasterTest {
                 AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
                 "점검","m","b","b",
                 LocalDateTime.of(2026,5,4,3,0), LocalDateTime.of(2026,5,4,4,0),
-                null, LocalDateTime.of(2026,5,4,2,0), 1L);
+                null, LocalDateTime.of(2026,5,4,2,0), 1L, false);
         e.markMaintenanceStarted(clock);
         e.markCompleted(Clock.fixed(LocalDateTime.of(2026,5,4,4,0).atZone(z).toInstant(), z));
 

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/persistence/SystemAnnouncementRepositoryIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/persistence/SystemAnnouncementRepositoryIntegrationTest.java
@@ -76,7 +76,7 @@ class SystemAnnouncementRepositoryIntegrationTest extends AbstractIntegrationTes
                                                 LocalDateTime started, LocalDateTime cancelled) {
         SystemAnnouncementData d = SystemAnnouncementData.create(
                 AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
-                "k", "e", "ko", "en", s, e, null, now, 1L);
+                "k", "e", "ko", "en", s, e, null, now, 1L, false);
         if (started != null) ReflectionTestUtils.setField(d, "maintenanceStartedAt", started);
         if (cancelled != null) {
             ReflectionTestUtils.setField(d, "cancelledAt", cancelled);
@@ -87,12 +87,12 @@ class SystemAnnouncementRepositoryIntegrationTest extends AbstractIntegrationTes
 
     private SystemAnnouncementData event() {
         return SystemAnnouncementData.create(AnnouncementType.EVENT, AnnouncementSeverity.INFO,
-                "k", "e", "ko", "en", null, null, null, now, 1L);
+                "k", "e", "ko", "en", null, null, null, now, 1L, false);
     }
 
     private SystemAnnouncementData eventWithExpiry(LocalDateTime exp) {
         return SystemAnnouncementData.create(AnnouncementType.EVENT, AnnouncementSeverity.INFO,
-                "k", "e", "ko", "en", null, null, exp, now, 1L);
+                "k", "e", "ko", "en", null, null, exp, now, 1L, false);
     }
 
     private SystemAnnouncementData eventCancelled() {

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/persistence/SystemAnnouncementRepositoryTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/persistence/SystemAnnouncementRepositoryTest.java
@@ -25,7 +25,7 @@ class SystemAnnouncementRepositoryTest extends AbstractIntegrationTest {
     private SystemAnnouncementData maintenance(LocalDateTime start, LocalDateTime end) {
         return SystemAnnouncementData.create(
                 AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
-                "점검", "m", "b", "b", start, end, null, start.minusHours(1), 1L);
+                "점검", "m", "b", "b", start, end, null, start.minusHours(1), 1L, false);
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/administration/application/service/MaintenanceSchedulerServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/application/service/MaintenanceSchedulerServiceTest.java
@@ -100,7 +100,7 @@ class MaintenanceSchedulerServiceTest {
                 AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
                 "점검", "M", "안내", "N",
                 start, end, null,
-                start, 1L);
+                start, 1L, false);
     }
 
     /** ACTIVE maintenance: 이미 markMaintenanceStarted 가 호출된 entity (completedAt=null). */

--- a/app/src/test/java/com/pfplaybackend/api/administration/application/service/SystemAnnouncementCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/application/service/SystemAnnouncementCommandServiceTest.java
@@ -79,7 +79,7 @@ class SystemAnnouncementCommandServiceTest {
                 AnnouncementType.EVENT, AnnouncementSeverity.INFO,
                 "이벤트", "Event", "본문", "Body",
                 null, null, NOW.plusDays(1),
-                ADMIN_ID);
+                ADMIN_ID, false);
 
         assertThat(id).isEqualTo(42L);
 
@@ -111,7 +111,7 @@ class SystemAnnouncementCommandServiceTest {
                 AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
                 "점검", "Maintenance", "메시지", "msg",
                 pastStart, end, null,
-                ADMIN_ID))
+                ADMIN_ID, false))
                 .isInstanceOf(BadRequestException.class)
                 .hasFieldOrPropertyWithValue("errorCode", "ANN-005");
 
@@ -130,7 +130,7 @@ class SystemAnnouncementCommandServiceTest {
                 AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
                 "점검", "Maintenance", "메시지", "msg",
                 NOW, end, null,
-                ADMIN_ID))
+                ADMIN_ID, false))
                 .isInstanceOf(BadRequestException.class)
                 .hasFieldOrPropertyWithValue("errorCode", "ANN-005");
 
@@ -155,7 +155,7 @@ class SystemAnnouncementCommandServiceTest {
                 AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
                 "점검", "M", "안내", "N",
                 start, end, null,
-                ADMIN_ID);
+                ADMIN_ID, false);
 
         assertThat(id).isEqualTo(7L);
         verify(eventPublisher).publishEvent(any(AnnouncementPublishedEvent.class));
@@ -173,7 +173,7 @@ class SystemAnnouncementCommandServiceTest {
                 AnnouncementType.EVENT, AnnouncementSeverity.INFO,
                 "이벤트", "E", "본문", "B",
                 null, null, null,
-                NOW.minusDays(1), 1L);
+                NOW.minusDays(1), 1L, false);
         org.springframework.test.util.ReflectionTestUtils.setField(entity, "id", 100L);
         given(repository.findById(100L)).willReturn(Optional.of(entity));
 
@@ -215,7 +215,7 @@ class SystemAnnouncementCommandServiceTest {
                 AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
                 "점검", "m", "본문", "b",
                 start, end, null,
-                NOW.minusHours(1), 1L);
+                NOW.minusHours(1), 1L, false);
         org.springframework.test.util.ReflectionTestUtils.setField(entity, "id", 55L);
         entity.markMaintenanceStarted(clock);
         given(repository.findById(55L)).willReturn(Optional.of(entity));
@@ -257,7 +257,7 @@ class SystemAnnouncementCommandServiceTest {
                 AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
                 "점검", "m", "본문", "b",
                 start, originalEnd, null,
-                NOW.minusHours(1), 1L);
+                NOW.minusHours(1), 1L, false);
         org.springframework.test.util.ReflectionTestUtils.setField(entity, "id", 77L);
         entity.markMaintenanceStarted(clock);
         given(repository.findById(77L)).willReturn(Optional.of(entity));

--- a/app/src/test/java/com/pfplaybackend/api/administration/domain/entity/data/SystemAnnouncementDataTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/domain/entity/data/SystemAnnouncementDataTest.java
@@ -29,7 +29,7 @@ class SystemAnnouncementDataTest {
         SystemAnnouncementData e = SystemAnnouncementData.create(
                 AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
                 "점검", "maint", "본문", "body",
-                start, end, null, start.minusHours(1), 1L);
+                start, end, null, start.minusHours(1), 1L, false);
         e.markMaintenanceStarted(startedClock);
         return e;
     }
@@ -41,7 +41,7 @@ class SystemAnnouncementDataTest {
     void createEvent() {
         SystemAnnouncementData a = SystemAnnouncementData.create(
             AnnouncementType.EVENT, AnnouncementSeverity.INFO,
-            "이벤트", "Event", "본문", "Body", null, null, now.plusDays(1), now, 1L);
+            "이벤트", "Event", "본문", "Body", null, null, now.plusDays(1), now, 1L, false);
         assertThat(a.getScheduledStartAt()).isNull();
     }
 
@@ -50,7 +50,7 @@ class SystemAnnouncementDataTest {
     void maintenanceRequiresSchedule() {
         assertThatThrownBy(() -> SystemAnnouncementData.create(
             AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
-            "점검", "M", "안내", "N", null, null, null, now, 1L))
+            "점검", "M", "안내", "N", null, null, null, now, 1L, false))
             .isInstanceOf(BadRequestException.class)
             .hasFieldOrPropertyWithValue("errorCode", "ANN-003");
     }
@@ -61,7 +61,7 @@ class SystemAnnouncementDataTest {
         LocalDateTime s = now.plusHours(1);
         assertThatThrownBy(() -> SystemAnnouncementData.create(
             AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
-            "점검", "M", "안내", "N", s, s, null, now, 1L))
+            "점검", "M", "안내", "N", s, s, null, now, 1L, false))
             .isInstanceOf(BadRequestException.class)
             .hasFieldOrPropertyWithValue("errorCode", "ANN-004");
     }
@@ -72,7 +72,7 @@ class SystemAnnouncementDataTest {
         LocalDateTime s = now.plusHours(1), e = s.plusHours(1);
         assertThatThrownBy(() -> SystemAnnouncementData.create(
             AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
-            "점검", "M", "안내", "N", s, e, now.plusDays(1), now, 1L))
+            "점검", "M", "안내", "N", s, e, now.plusDays(1), now, 1L, false))
             .isInstanceOf(BadRequestException.class)
             .hasFieldOrPropertyWithValue("errorCode", "ANN-003");
     }
@@ -82,7 +82,7 @@ class SystemAnnouncementDataTest {
     void markStartedTypeGuard() {
         SystemAnnouncementData event = SystemAnnouncementData.create(
             AnnouncementType.EVENT, AnnouncementSeverity.INFO,
-            "이벤트", "E", "본문", "B", null, null, null, now, 1L);
+            "이벤트", "E", "본문", "B", null, null, null, now, 1L, false);
         assertThatThrownBy(() -> event.markMaintenanceStarted(fixedClock))
             .isInstanceOf(IllegalStateException.class);
     }
@@ -92,7 +92,7 @@ class SystemAnnouncementDataTest {
     void cancelIdempotent() {
         SystemAnnouncementData a = SystemAnnouncementData.create(
             AnnouncementType.EVENT, AnnouncementSeverity.INFO,
-            "이벤트", "E", "본문", "B", null, null, null, now, 1L);
+            "이벤트", "E", "본문", "B", null, null, null, now, 1L, false);
         a.cancel(2L, fixedClock);
         assertThatThrownBy(() -> a.cancel(3L, fixedClock))
             .isInstanceOf(ConflictException.class)
@@ -105,7 +105,7 @@ class SystemAnnouncementDataTest {
         LocalDateTime s = now.plusHours(1), e = s.plusHours(1);
         SystemAnnouncementData a = SystemAnnouncementData.create(
             AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
-            "점검", "M", "안내", "N", s, e, null, now, 1L);
+            "점검", "M", "안내", "N", s, e, null, now, 1L, false);
         assertThat(a.isMaintenancePhaseActive()).isFalse();
         a.markMaintenanceStarted(fixedClock);
         assertThat(a.isMaintenancePhaseActive()).isTrue();
@@ -147,7 +147,7 @@ class SystemAnnouncementDataTest {
                 AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
                 "점검", "m", "b", "b",
                 LocalDateTime.of(2026, 5, 4, 3, 0), LocalDateTime.of(2026, 5, 4, 4, 0),
-                null, LocalDateTime.of(2026, 5, 4, 2, 0), 1L);
+                null, LocalDateTime.of(2026, 5, 4, 2, 0), 1L, false);
 
         assertThatThrownBy(() -> e.markCompleted(clockAt(LocalDateTime.of(2026, 5, 4, 2, 30))))
                 .isInstanceOf(ConflictException.class)
@@ -186,7 +186,7 @@ class SystemAnnouncementDataTest {
                 AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
                 "점검", "m", "b", "b",
                 LocalDateTime.of(2026, 5, 4, 3, 0), LocalDateTime.of(2026, 5, 4, 4, 0),
-                null, LocalDateTime.of(2026, 5, 4, 2, 0), 1L);
+                null, LocalDateTime.of(2026, 5, 4, 2, 0), 1L, false);
 
         assertThatThrownBy(() -> e.adjustScheduledEndTime(
                 LocalDateTime.of(2026, 5, 4, 5, 0), clockAt(LocalDateTime.of(2026, 5, 4, 2, 30))))

--- a/app/src/test/java/com/pfplaybackend/api/notification/AnnouncementPushFlowIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/notification/AnnouncementPushFlowIntegrationTest.java
@@ -45,8 +45,8 @@ import static org.mockito.Mockito.when;
  *   <li>{@code @TransactionalEventListener(AFTER_COMMIT) @Async(webPushExecutor)}
  *       리스너({@code AnnouncementPushNotifier})가 별도 thread 에서 발사,</li>
  *   <li>{@link com.pfplaybackend.api.notification.application.service.PushFanoutService#fanout}
- *       의 {@code @Transactional} 이 비동기 thread 에서 독립 TX 를 열어,
- *       GONE 으로 보고된 구독의 {@code revoke()} dirty-update 가 실제로 DB 에 flush/commit 된다.</li>
+ *       이 비동기 thread 에서 keyset 페이지네이션으로 활성 구독을 배치 로드하고(HTTP 는 write TX 밖),
+ *       GONE 으로 보고된 구독 id 를 모아 {@code revokeByIds} 단일 bulk revoke TX 로 실제 DB 에 영속한다.</li>
  * </ol>
  *
  * <p>⚠️ AFTER_COMMIT 리스너는 publish TX 가 COMMIT 되어야만 발사되므로, publish 를

--- a/app/src/test/java/com/pfplaybackend/api/notification/AnnouncementPushFlowIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/notification/AnnouncementPushFlowIntegrationTest.java
@@ -1,0 +1,184 @@
+package com.pfplaybackend.api.notification;
+
+import com.pfplaybackend.api.administration.adapter.out.persistence.AdministratorRepository;
+import com.pfplaybackend.api.administration.adapter.out.persistence.SystemAnnouncementRepository;
+import com.pfplaybackend.api.administration.application.service.SystemAnnouncementCommandService;
+import com.pfplaybackend.api.administration.domain.entity.data.AdministratorData;
+import com.pfplaybackend.api.administration.domain.value.AnnouncementSeverity;
+import com.pfplaybackend.api.administration.domain.value.AnnouncementType;
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.notification.adapter.out.persistence.PushSubscriptionRepository;
+import com.pfplaybackend.api.notification.application.port.WebPushSender;
+import com.pfplaybackend.api.notification.domain.entity.data.PushSubscriptionData;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Phase B 최상위 가드 IT — 공지 발행 → async fan-out → GONE(410/404) 구독 prune 영속.
+ *
+ * <p>증명 체인:
+ * <ol>
+ *   <li>{@link SystemAnnouncementCommandService#publish}(sendPush=true) 가 row 를 커밋,</li>
+ *   <li>{@code @TransactionalEventListener(AFTER_COMMIT) @Async(webPushExecutor)}
+ *       리스너({@code AnnouncementPushNotifier})가 별도 thread 에서 발사,</li>
+ *   <li>{@link com.pfplaybackend.api.notification.application.service.PushFanoutService#fanout}
+ *       의 {@code @Transactional} 이 비동기 thread 에서 독립 TX 를 열어,
+ *       GONE 으로 보고된 구독의 {@code revoke()} dirty-update 가 실제로 DB 에 flush/commit 된다.</li>
+ * </ol>
+ *
+ * <p>⚠️ AFTER_COMMIT 리스너는 publish TX 가 COMMIT 되어야만 발사되므로, publish 를
+ * {@link TransactionTemplate} 안에서 호출한다(테스트 메서드 자체는 비-transactional —
+ * {@link AbstractIntegrationTest} 에 @Transactional 없음). 자기 정리는 {@code @AfterEach}.
+ *
+ * <p>{@code @EnableAsync}({@code AsyncConfig}) 가 풀 컨텍스트에 활성이므로 리스너는
+ * {@code webpush-} executor thread 에서 실행된다 → 진짜 cross-thread TX 경계를 검증한다.
+ * (executor thread name 을 캡처해 발행 thread 와 다름을 단언한다.)
+ */
+class AnnouncementPushFlowIntegrationTest extends AbstractIntegrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(AnnouncementPushFlowIntegrationTest.class);
+
+    private static final Long ADMIN_USER_ID = 99720L;
+    private static final String ADMIN_EMAIL = "push-flow-it@x";
+    private static final String EP_OK = "ep-ok";
+    private static final String EP_GONE = "ep-gone";
+
+    @Autowired private SystemAnnouncementCommandService commandService;
+    @Autowired private SystemAnnouncementRepository announcementRepository;
+    @Autowired private AdministratorRepository administratorRepository;
+    @Autowired private UserAccountRepository userAccountRepository;
+    @Autowired private PushSubscriptionRepository pushSubscriptionRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+    @Autowired private TransactionTemplate transactionTemplate;
+
+    @MockBean private WebPushSender sender;
+
+    private Long administratorId;
+
+    @BeforeEach
+    void seed() {
+        // FK fk_announcement_sent_by → administrator(administrator_id)
+        UserAccountData ua = UserAccountData.createForLocal(
+                new UserId(ADMIN_USER_ID), ADMIN_EMAIL, passwordEncoder.encode("secret123"));
+        userAccountRepository.saveAndFlush(ua);
+        AdministratorData admin = administratorRepository
+                .saveAndFlush(AdministratorData.createSuperAdmin(ADMIN_USER_ID));
+        this.administratorId = admin.getAdministratorId();
+
+        // 2 active subscriptions — push_subscription 은 user FK 없음, 임의 userId 허용
+        pushSubscriptionRepository.saveAndFlush(
+                PushSubscriptionData.create(1001L, EP_OK, "p256dh-ok", "auth-ok", "KO"));
+        pushSubscriptionRepository.saveAndFlush(
+                PushSubscriptionData.create(1002L, EP_GONE, "p256dh-gone", "auth-gone", "EN"));
+    }
+
+    @AfterEach
+    void cleanup() {
+        transactionTemplate.executeWithoutResult(status -> {
+            pushSubscriptionRepository.deleteAll();
+            announcementRepository.deleteAll();
+            administratorRepository.deleteAll();
+            userAccountRepository.deleteAll();
+        });
+    }
+
+    @Test
+    @DisplayName("publish EVENT(sendPush=true) → async fan-out → GONE 구독은 revoke 영속, OK 구독은 active 유지")
+    void publish_with_push_prunes_gone_subscription() {
+        // ep-gone → GONE(410/404) → prune, ep-ok → OK → keep.
+        // thenAnswer 로 endpoint 별 결과 + 실행 thread name 을 함께 캡처한다.
+        AtomicReference<String> executorThread = new AtomicReference<>();
+        when(sender.send(any(), any(), any(), any())).thenAnswer(invocation -> {
+            executorThread.set(Thread.currentThread().getName());
+            String endpoint = invocation.getArgument(0);
+            return EP_GONE.equals(endpoint) ? WebPushSender.Result.GONE : WebPushSender.Result.OK;
+        });
+
+        String publishThread = Thread.currentThread().getName();
+
+        // when — publish in its own transaction so AFTER_COMMIT listener fires
+        Long announcementId = transactionTemplate.execute(status ->
+                commandService.publish(
+                        AnnouncementType.EVENT, AnnouncementSeverity.INFO,
+                        "공지 제목", "Title EN", "본문", "Body EN",
+                        null, null, null,
+                        administratorId, true));
+        assertThat(announcementId).isNotNull();
+
+        // then — async fan-out (webpush- executor thread) 가 GONE 구독을 prune, 영속될 때까지 await
+        Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            PushSubscriptionData gone = freshFind(EP_GONE);
+            assertThat(gone).isNotNull();
+            assertThat(gone.getRevokedAt()).as("GONE 구독은 revoke 되어야 함").isNotNull();
+            assertThat(gone.isActive()).isFalse();
+        });
+
+        // OK 구독은 그대로 active
+        PushSubscriptionData ok = freshFind(EP_OK);
+        assertThat(ok).isNotNull();
+        assertThat(ok.getRevokedAt()).isNull();
+        assertThat(ok.isActive()).isTrue();
+
+        // 2 구독 모두 발송 시도
+        verify(sender, times(2)).send(any(), any(), any(), any());
+
+        // cross-thread TX 경계 검증 finding: 리스너가 발행 thread 와 다른 webpush- thread 에서 실행됐는지
+        String fanoutThread = executorThread.get();
+        assertThat(fanoutThread).isNotNull();
+        log.info("[push-flow-it] publishThread={} fanoutThread={}", publishThread, fanoutThread);
+        assertThat(fanoutThread)
+                .as("fan-out 은 @Async webpush- executor thread 에서 실행되어야 함 (publish thread 와 다름)")
+                .startsWith("webpush-")
+                .isNotEqualTo(publishThread);
+    }
+
+    @Test
+    @DisplayName("publish EVENT(sendPush=false) → fan-out 미수행, sender 무호출, 두 구독 모두 active 유지")
+    void publish_without_push_does_not_fan_out() {
+        Long announcementId = transactionTemplate.execute(status ->
+                commandService.publish(
+                        AnnouncementType.EVENT, AnnouncementSeverity.INFO,
+                        "공지 제목", "Title EN", "본문", "Body EN",
+                        null, null, null,
+                        administratorId, false));
+        assertThat(announcementId).isNotNull();
+
+        // 잠시 대기 — 혹시 async 리스너가 발사되어 send 를 호출하면 잡아낸다
+        Awaitility.await().during(Duration.ofMillis(800)).atMost(Duration.ofSeconds(2))
+                .untilAsserted(() -> verify(sender, never()).send(any(), any(), any(), any()));
+        verifyNoInteractions(sender);
+
+        // 두 구독 모두 active 유지
+        assertThat(freshFind(EP_OK).isActive()).isTrue();
+        assertThat(freshFind(EP_GONE).isActive()).isTrue();
+    }
+
+    /** 항상 DB 에서 새로 읽어 prune 의 영속 여부를 검증 (영속성 컨텍스트 1-level 캐시 우회). */
+    private PushSubscriptionData freshFind(String endpoint) {
+        return transactionTemplate.execute(status ->
+                pushSubscriptionRepository.findByEndpoint(endpoint).orElse(null));
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/notification/MartijndwarsWebPushAdapterTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/notification/MartijndwarsWebPushAdapterTest.java
@@ -1,0 +1,33 @@
+package com.pfplaybackend.api.notification;
+
+import com.pfplaybackend.api.notification.adapter.out.push.MartijndwarsWebPushAdapter;
+import com.pfplaybackend.api.notification.application.port.WebPushSender.Result;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MartijndwarsWebPushAdapterTest {
+
+    @Test
+    @DisplayName("2xx 상태코드는 OK 로 매핑된다")
+    void maps2xxToOk() {
+        assertThat(MartijndwarsWebPushAdapter.mapStatus(200)).isEqualTo(Result.OK);
+        assertThat(MartijndwarsWebPushAdapter.mapStatus(201)).isEqualTo(Result.OK);
+    }
+
+    @Test
+    @DisplayName("404/410 은 GONE(구독 prune 대상)으로 매핑된다")
+    void maps404And410ToGone() {
+        assertThat(MartijndwarsWebPushAdapter.mapStatus(404)).isEqualTo(Result.GONE);
+        assertThat(MartijndwarsWebPushAdapter.mapStatus(410)).isEqualTo(Result.GONE);
+    }
+
+    @Test
+    @DisplayName("그 외 상태코드(5xx 등)는 FAILED 로 매핑된다")
+    void mapsOtherToFailed() {
+        assertThat(MartijndwarsWebPushAdapter.mapStatus(500)).isEqualTo(Result.FAILED);
+        assertThat(MartijndwarsWebPushAdapter.mapStatus(400)).isEqualTo(Result.FAILED);
+        assertThat(MartijndwarsWebPushAdapter.mapStatus(429)).isEqualTo(Result.FAILED);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/notification/PushFanoutServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/notification/PushFanoutServiceTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -41,6 +42,12 @@ class PushFanoutServiceTest {
         return new PushFanoutService(repository, sender, objectMapper, clock);
     }
 
+    private PushSubscriptionData sub(long id, String endpoint, String lang) {
+        PushSubscriptionData s = PushSubscriptionData.create(id, endpoint, "p-" + id, "a-" + id, lang);
+        ReflectionTestUtils.setField(s, "id", id);
+        return s;
+    }
+
     private SystemAnnouncementData announcement(boolean pushEnabled) {
         SystemAnnouncementData a = SystemAnnouncementData.create(
                 AnnouncementType.EVENT, AnnouncementSeverity.INFO,
@@ -52,57 +59,70 @@ class PushFanoutServiceTest {
     }
 
     @Test
-    @DisplayName("pushEnabled=false면 sender를 전혀 호출하지 않는다")
+    @DisplayName("pushEnabled=false면 구독 조회·발송을 전혀 하지 않는다")
     void disabled_noSend() {
-        // given
-        PushFanoutService service = service();
-
-        // when
-        service.fanout(announcement(false));
-
-        // then
-        verifyNoInteractions(sender);
+        service().fanout(announcement(false));
+        verifyNoInteractions(sender, repository);
     }
 
     @Test
-    @DisplayName("pushEnabled=true면 활성 구독마다 lang별 payload로 발송한다")
-    void enabled_sendsPerSubscriptionWithLangPayload() {
-        // given
-        PushFanoutService service = service();
-        PushSubscriptionData ko = PushSubscriptionData.create(1L, "ep-ko", "p-ko", "a-ko", "KO");
-        PushSubscriptionData en = PushSubscriptionData.create(2L, "ep-en", "p-en", "a-en", "EN");
-        when(repository.findAllActive()).thenReturn(List.of(ko, en));
+    @DisplayName("활성 구독마다 lang별 payload로 발송하고, GONE 없으면 revoke 하지 않는다")
+    void enabled_sendsPerSubscriptionWithLangPayload_noRevokeWhenNoGone() {
+        PushSubscriptionData ko = sub(1L, "ep-ko", "KO");
+        PushSubscriptionData en = sub(2L, "ep-en", "EN");
+        when(repository.findByRevokedAtIsNullAndIdGreaterThanOrderByIdAsc(eq(0L), any()))
+                .thenReturn(List.of(ko, en));
         when(sender.send(any(), any(), any(), any())).thenReturn(WebPushSender.Result.OK);
 
-        // when
-        service.fanout(announcement(true));
+        service().fanout(announcement(true));
 
-        // then
         ArgumentCaptor<String> koPayload = ArgumentCaptor.forClass(String.class);
-        verify(sender).send(eq("ep-ko"), eq("p-ko"), eq("a-ko"), koPayload.capture());
+        verify(sender).send(eq("ep-ko"), eq("p-1"), eq("a-1"), koPayload.capture());
         assertThat(koPayload.getValue()).contains("한국어제목").contains("한국어본문");
-
         ArgumentCaptor<String> enPayload = ArgumentCaptor.forClass(String.class);
-        verify(sender).send(eq("ep-en"), eq("p-en"), eq("a-en"), enPayload.capture());
+        verify(sender).send(eq("ep-en"), eq("p-2"), eq("a-2"), enPayload.capture());
         assertThat(enPayload.getValue()).contains("EnglishTitle").contains("EnglishBody");
+        // GONE 없음 → bulk revoke 미호출
+        verify(repository, never()).revokeByIds(anyList(), any());
     }
 
     @Test
-    @DisplayName("GONE 응답 구독은 revoke 되고, OK 구독은 활성 유지된다")
-    void gone_revokesThatSubscriptionOnly() {
-        // given
-        PushFanoutService service = service();
-        PushSubscriptionData ko = PushSubscriptionData.create(1L, "ep-ko", "p-ko", "a-ko", "KO");
-        PushSubscriptionData en = PushSubscriptionData.create(2L, "ep-en", "p-en", "a-en", "EN");
-        when(repository.findAllActive()).thenReturn(List.of(ko, en));
+    @DisplayName("GONE 응답 구독 id만 모아 단일 bulk revoke 한다 (per-row revoke 아님)")
+    void gone_bulkRevokesGoneIdsOnly() {
+        PushSubscriptionData ko = sub(1L, "ep-ko", "KO");
+        PushSubscriptionData en = sub(2L, "ep-en", "EN");
+        when(repository.findByRevokedAtIsNullAndIdGreaterThanOrderByIdAsc(eq(0L), any()))
+                .thenReturn(List.of(ko, en));
         when(sender.send(eq("ep-ko"), any(), any(), any())).thenReturn(WebPushSender.Result.OK);
         when(sender.send(eq("ep-en"), any(), any(), any())).thenReturn(WebPushSender.Result.GONE);
 
-        // when
+        service().fanout(announcement(true));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Long>> ids = ArgumentCaptor.forClass(List.class);
+        verify(repository).revokeByIds(ids.capture(), eq(LocalDateTime.now(clock)));
+        assertThat(ids.getValue()).containsExactly(2L); // GONE 인 en(id=2)만
+    }
+
+    @Test
+    @DisplayName("keyset 페이지네이션 — 가득 찬 페이지면 다음 페이지(lastId 초과)를 이어 조회한다")
+    void paginatesByKeysetUntilPartialPage() {
+        PushFanoutService service = service();
+        ReflectionTestUtils.setField(service, "pageSize", 2);
+        PushSubscriptionData s1 = sub(1L, "ep-1", "KO");
+        PushSubscriptionData s2 = sub(2L, "ep-2", "KO");
+        PushSubscriptionData s3 = sub(3L, "ep-3", "KO");
+        // page1: 가득 참(2개=pageSize) → 계속 / page2: 1개<pageSize → 종료
+        when(repository.findByRevokedAtIsNullAndIdGreaterThanOrderByIdAsc(eq(0L), any()))
+                .thenReturn(List.of(s1, s2));
+        when(repository.findByRevokedAtIsNullAndIdGreaterThanOrderByIdAsc(eq(2L), any()))
+                .thenReturn(List.of(s3));
+        when(sender.send(any(), any(), any(), any())).thenReturn(WebPushSender.Result.OK);
+
         service.fanout(announcement(true));
 
-        // then
-        assertThat(ko.isActive()).isTrue();   // OK → 유지
-        assertThat(en.isActive()).isFalse();  // GONE → revoke
+        verify(repository).findByRevokedAtIsNullAndIdGreaterThanOrderByIdAsc(eq(0L), any());
+        verify(repository).findByRevokedAtIsNullAndIdGreaterThanOrderByIdAsc(eq(2L), any());
+        verify(sender, times(3)).send(any(), any(), any(), any());
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/notification/PushFanoutServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/notification/PushFanoutServiceTest.java
@@ -1,0 +1,108 @@
+package com.pfplaybackend.api.notification;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pfplaybackend.api.administration.domain.entity.data.SystemAnnouncementData;
+import com.pfplaybackend.api.administration.domain.value.AnnouncementSeverity;
+import com.pfplaybackend.api.administration.domain.value.AnnouncementType;
+import com.pfplaybackend.api.notification.adapter.out.persistence.PushSubscriptionRepository;
+import com.pfplaybackend.api.notification.application.port.WebPushSender;
+import com.pfplaybackend.api.notification.application.service.PushFanoutService;
+import com.pfplaybackend.api.notification.domain.entity.data.PushSubscriptionData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PushFanoutServiceTest {
+
+    private static final Clock clock = Clock.fixed(Instant.parse("2026-06-16T00:00:00Z"), ZoneId.of("UTC"));
+
+    @Mock PushSubscriptionRepository repository;
+    @Mock WebPushSender sender;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private PushFanoutService service() {
+        return new PushFanoutService(repository, sender, objectMapper, clock);
+    }
+
+    private SystemAnnouncementData announcement(boolean pushEnabled) {
+        SystemAnnouncementData a = SystemAnnouncementData.create(
+                AnnouncementType.EVENT, AnnouncementSeverity.INFO,
+                "한국어제목", "EnglishTitle", "한국어본문", "EnglishBody",
+                null, null, null,
+                LocalDateTime.now(clock), 1L, pushEnabled);
+        ReflectionTestUtils.setField(a, "id", 99L);
+        return a;
+    }
+
+    @Test
+    @DisplayName("pushEnabled=false면 sender를 전혀 호출하지 않는다")
+    void disabled_noSend() {
+        // given
+        PushFanoutService service = service();
+
+        // when
+        service.fanout(announcement(false));
+
+        // then
+        verifyNoInteractions(sender);
+    }
+
+    @Test
+    @DisplayName("pushEnabled=true면 활성 구독마다 lang별 payload로 발송한다")
+    void enabled_sendsPerSubscriptionWithLangPayload() {
+        // given
+        PushFanoutService service = service();
+        PushSubscriptionData ko = PushSubscriptionData.create(1L, "ep-ko", "p-ko", "a-ko", "KO");
+        PushSubscriptionData en = PushSubscriptionData.create(2L, "ep-en", "p-en", "a-en", "EN");
+        when(repository.findAllActive()).thenReturn(List.of(ko, en));
+        when(sender.send(any(), any(), any(), any())).thenReturn(WebPushSender.Result.OK);
+
+        // when
+        service.fanout(announcement(true));
+
+        // then
+        ArgumentCaptor<String> koPayload = ArgumentCaptor.forClass(String.class);
+        verify(sender).send(eq("ep-ko"), eq("p-ko"), eq("a-ko"), koPayload.capture());
+        assertThat(koPayload.getValue()).contains("한국어제목").contains("한국어본문");
+
+        ArgumentCaptor<String> enPayload = ArgumentCaptor.forClass(String.class);
+        verify(sender).send(eq("ep-en"), eq("p-en"), eq("a-en"), enPayload.capture());
+        assertThat(enPayload.getValue()).contains("EnglishTitle").contains("EnglishBody");
+    }
+
+    @Test
+    @DisplayName("GONE 응답 구독은 revoke 되고, OK 구독은 활성 유지된다")
+    void gone_revokesThatSubscriptionOnly() {
+        // given
+        PushFanoutService service = service();
+        PushSubscriptionData ko = PushSubscriptionData.create(1L, "ep-ko", "p-ko", "a-ko", "KO");
+        PushSubscriptionData en = PushSubscriptionData.create(2L, "ep-en", "p-en", "a-en", "EN");
+        when(repository.findAllActive()).thenReturn(List.of(ko, en));
+        when(sender.send(eq("ep-ko"), any(), any(), any())).thenReturn(WebPushSender.Result.OK);
+        when(sender.send(eq("ep-en"), any(), any(), any())).thenReturn(WebPushSender.Result.GONE);
+
+        // when
+        service.fanout(announcement(true));
+
+        // then
+        assertThat(ko.isActive()).isTrue();   // OK → 유지
+        assertThat(en.isActive()).isFalse();  // GONE → revoke
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/notification/PushSubscriptionServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/notification/PushSubscriptionServiceTest.java
@@ -77,6 +77,27 @@ class PushSubscriptionServiceTest {
     }
 
     @Test
+    @DisplayName("subscribe — 같은 회원 활성 재구독이면 키를 갱신한다(새 row 없음)")
+    void subscribeSameUserActiveRotatesKeys() {
+        // given: 같은 회원이 해지 없이 재구독(브라우저 키 회전)
+        initService();
+        PushSubscriptionData existing = PushSubscriptionData.create(user, "ep-1", "old-p256dh", "old-auth", "EN");
+        ReflectionTestUtils.setField(existing, "id", 7L);
+        assertThat(existing.isActive()).isTrue();
+        when(repository.findByEndpoint("ep-1")).thenReturn(Optional.of(existing));
+
+        // when
+        Long id = service.subscribe(user, "ep-1", "rot-p256dh", "rot-auth", "KO");
+
+        // then
+        assertThat(id).isEqualTo(7L);
+        assertThat(existing.getP256dh()).isEqualTo("rot-p256dh");
+        assertThat(existing.getAuth()).isEqualTo("rot-auth");
+        assertThat(existing.getLang()).isEqualTo("KO");
+        verify(repository, never()).save(any());
+    }
+
+    @Test
     @DisplayName("subscribe — 폐기된 타인 row 재구독은 기기 hand-off로 허용(새 소유자로 부활)")
     void subscribeRevivesRevokedRowOfDifferentUserAsHandoff() {
         // given: 이전 소유자(otherUser)가 로그아웃하며 해지한 endpoint를 새 회원(user)이 재점유

--- a/app/src/test/java/com/pfplaybackend/api/notification/PushSubscriptionServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/notification/PushSubscriptionServiceTest.java
@@ -17,6 +17,7 @@ import java.time.ZoneId;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -73,6 +74,45 @@ class PushSubscriptionServiceTest {
         assertThat(existing.getAuth()).isEqualTo("new-auth"); // auth updated
         assertThat(existing.getP256dh()).isEqualTo("new-p256dh");
         verify(repository, never()).save(any());            // NOT a new row
+    }
+
+    @Test
+    @DisplayName("subscribe — 폐기된 타인 row 재구독은 기기 hand-off로 허용(새 소유자로 부활)")
+    void subscribeRevivesRevokedRowOfDifferentUserAsHandoff() {
+        // given: 이전 소유자(otherUser)가 로그아웃하며 해지한 endpoint를 새 회원(user)이 재점유
+        initService();
+        Long otherUser = 2002L;
+        PushSubscriptionData existing = PushSubscriptionData.create(otherUser, "ep-1", "old-p256dh", "old-auth", "EN");
+        ReflectionTestUtils.setField(existing, "id", 7L);
+        existing.revoke(LocalDateTime.now(clock));
+        when(repository.findByEndpoint("ep-1")).thenReturn(Optional.of(existing));
+
+        // when
+        Long id = service.subscribe(user, "ep-1", "new-p256dh", "new-auth", "KO");
+
+        // then
+        assertThat(id).isEqualTo(7L);
+        assertThat(existing.isActive()).isTrue();
+        assertThat(existing.getUserId()).isEqualTo(user);   // 새 소유자로 reassign
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("subscribe — 활성 + 타인 소유 endpoint 점유는 거부(IDOR 방어)")
+    void subscribeRejectsActiveForeignEndpoint() {
+        // given: 다른 회원이 활성으로 소유 중인 endpoint
+        initService();
+        Long otherUser = 2002L;
+        PushSubscriptionData existing = PushSubscriptionData.create(otherUser, "ep-1", "p256dh", "auth", "EN");
+        ReflectionTestUtils.setField(existing, "id", 7L);
+        assertThat(existing.isActive()).isTrue();
+        when(repository.findByEndpoint("ep-1")).thenReturn(Optional.of(existing));
+
+        // when / then
+        assertThatThrownBy(() -> service.subscribe(user, "ep-1", "x", "y", "KO"))
+                .isInstanceOf(org.springframework.security.access.AccessDeniedException.class);
+        assertThat(existing.getUserId()).isEqualTo(otherUser); // 변조 안 됨
+        verify(repository, never()).save(any());
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/notification/PushSubscriptionServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/notification/PushSubscriptionServiceTest.java
@@ -1,0 +1,111 @@
+package com.pfplaybackend.api.notification;
+
+import com.pfplaybackend.api.notification.adapter.out.persistence.PushSubscriptionRepository;
+import com.pfplaybackend.api.notification.application.service.PushSubscriptionService;
+import com.pfplaybackend.api.notification.domain.entity.data.PushSubscriptionData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PushSubscriptionServiceTest {
+
+    private static final Long user = 1001L;
+    private static final Clock clock = Clock.fixed(Instant.parse("2026-06-16T00:00:00Z"), ZoneId.of("UTC"));
+
+    @Mock PushSubscriptionRepository repository;
+    PushSubscriptionService service;
+
+    private void initService() {
+        service = new PushSubscriptionService(repository, clock);
+    }
+
+    @Test
+    @DisplayName("subscribe — 신규 endpoint면 새 구독을 저장한다")
+    void subscribeNewEndpointSaves() {
+        // given
+        initService();
+        when(repository.findByEndpoint("ep-new")).thenReturn(Optional.empty());
+        when(repository.save(any(PushSubscriptionData.class))).thenAnswer(inv -> {
+            PushSubscriptionData data = inv.getArgument(0);
+            ReflectionTestUtils.setField(data, "id", 42L);
+            return data;
+        });
+
+        // when
+        Long id = service.subscribe(user, "ep-new", "p256dh-1", "auth-1", "KO");
+
+        // then
+        assertThat(id).isEqualTo(42L);
+        verify(repository).save(any(PushSubscriptionData.class));
+    }
+
+    @Test
+    @DisplayName("subscribe — 폐기된 endpoint 재구독이면 새 row가 아닌 기존 row를 부활시킨다")
+    void subscribeRevivesRevokedRow() {
+        // given
+        initService();
+        PushSubscriptionData existing = PushSubscriptionData.create(user, "ep-1", "old-p256dh", "old-auth", "EN");
+        ReflectionTestUtils.setField(existing, "id", 7L);
+        existing.revoke(LocalDateTime.now(clock));
+        assertThat(existing.isActive()).isFalse();
+        when(repository.findByEndpoint("ep-1")).thenReturn(Optional.of(existing));
+
+        // when
+        Long id = service.subscribe(user, "ep-1", "new-p256dh", "new-auth", "KO");
+
+        // then
+        assertThat(id).isEqualTo(7L);
+        assertThat(existing.isActive()).isTrue();           // revokedAt cleared
+        assertThat(existing.getAuth()).isEqualTo("new-auth"); // auth updated
+        assertThat(existing.getP256dh()).isEqualTo("new-p256dh");
+        verify(repository, never()).save(any());            // NOT a new row
+    }
+
+    @Test
+    @DisplayName("unsubscribe — 소유자가 해지하면 revoke 처리된다")
+    void unsubscribeByOwnerRevokes() {
+        // given
+        initService();
+        PushSubscriptionData existing = PushSubscriptionData.create(user, "ep-1", "p256dh", "auth", "KO");
+        ReflectionTestUtils.setField(existing, "id", 7L);
+        when(repository.findByEndpoint("ep-1")).thenReturn(Optional.of(existing));
+
+        // when
+        service.unsubscribe(user, "ep-1");
+
+        // then
+        assertThat(existing.isActive()).isFalse();
+        assertThat(existing.getRevokedAt()).isEqualTo(LocalDateTime.now(clock));
+    }
+
+    @Test
+    @DisplayName("unsubscribe — 타인의 endpoint 해지는 no-op이다 (userId 스코프)")
+    void unsubscribeOtherUserIsNoOp() {
+        // given
+        initService();
+        Long otherUser = 2002L;
+        PushSubscriptionData existing = PushSubscriptionData.create(otherUser, "ep-1", "p256dh", "auth", "KO");
+        ReflectionTestUtils.setField(existing, "id", 7L);
+        when(repository.findByEndpoint("ep-1")).thenReturn(Optional.of(existing));
+
+        // when
+        service.unsubscribe(user, "ep-1");
+
+        // then
+        assertThat(existing.isActive()).isTrue(); // untouched
+    }
+}


### PR DESCRIPTION
## 개요
PWA 전환(web #404)의 **Phase B — Web Push 구독·발송 백엔드**. 어드민이 발행하는 시스템 공지("20:00에 xx 파티룸 열림"류)를 구독 회원에게 1:N 브로드캐스트. 기존 `AnnouncementPublishedEvent`에 fan-out 리스너를 하나 더 붙이는 방식(WS `AnnouncementBroadcaster`와 나란히).

⚠️ **기능은 dormant로 출시** — `app.web-push.enabled=false`(기본) fail-closed. VAPID env(`WEB_PUSH_VAPID_PUBLIC_KEY`/`_PRIVATE_KEY`) + `WEB_PUSH_ENABLED=true` 주입 전엔 어떤 푸시도 나가지 않음(어댑터 `pushService=null` → 발송 시 FAILED).

## 변경
- **V30 마이그레이션**: `push_subscription`(user_id BIGINT, endpoint UNIQUE(ascii 1024), p256dh/auth, lang, soft-delete revoked_at) + `system_announcement.push_enabled`.
- **구독**: `PushSubscriptionData`(엔티티)/`PushSubscriptionRepository`/`PushSubscriptionService`(upsert·부활·soft-delete, **userId 스코프 + IDOR 방어**: 활성+타인 소유 endpoint 점유 거부, 폐기 row 재점유는 기기 hand-off로 허용). 회원 API `POST/DELETE /api/v1/push/subscriptions`.
- **VAPID/발송**: `WebPushProperties`(app.web-push), `WebPushSender` 포트 + `MartijndwarsWebPushAdapter`(`nl.martijndwars:web-push:5.1.1`, fail-soft·fail-closed, 404/410→GONE 매핑).
- **fan-out**: `AnnouncementPushNotifier`(`@TransactionalEventListener(AFTER_COMMIT)+@Async`, 디스패치만) → `PushFanoutService`(`@Transactional`, 활성 구독 fan-out·lang별 payload·GONE prune). **삼중 애노테이션 footgun 회피 위해 책임 분리.**
- **sendPush 전파**: `AnnouncementCreateRequest.sendPush` → `SystemAnnouncementData.push_enabled`. 푸시는 publish 이벤트에만 연결(cancel/maintenance 무관).

## 검증
- **유닛 풀회귀 `:app:test` GREEN** (sendPush 전파로 `create(...)`/`publish(...)` 시그니처 변경 → 27개 positional 호출부 전수 수선 포함).
- 단위: 구독 서비스 7(부활·IDOR·키회전·userId 스코프), 어댑터 매핑 3(200/404/410/500), fan-out 3(gating·lang payload·GONE prune).
- **IT `AnnouncementPushFlowIntegrationTest`**(`:app:integrationTest`, TestContainers MySQL): 공지 발행→**별 스레드(`webpush-`)** async fan-out→GONE 구독이 **실제 DB에 revoked로 영속**됨을 await로 단언(=`@Async`+`@Transactional` 경계 prune 영속 직접 가드). sendPush=false면 미발송.
- ⏳ **deferred(라이브 게이트)**: 실 web-push 직렬화/전송 라이브 스모크는 VAPID 키 + dev 배포 후(라이브만 잡힘). V30 검증은 docker 부팅(테스트는 flyway disabled).

## 알려진 fast-follow (비차단, 휴면 중 미발현)
- `PushFanoutService.fanout`이 HTTP 발송을 write TX 안에서·`findAllActive()` 무제한 로드 → 대규모 활성화 시 커넥션 점유/장시간 TX. 활성화 전 별도 이슈로 (a) HTTP를 write TX 밖으로 + id 기반 bulk revoke (b) 페이지네이션 처리 예정.

## 머지
base=`develop`. 머지=사용자 게이트. epic=web #404. 후속 C(admin 토글)·D(web 설정 토글). prod 활성화는 VAPID 시크릿 주입 + `WEB_PUSH_ENABLED=true` 별도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
