### PR TITLE
fix(reaction): 룸 desync 시 'No value present' 누출 → CRW 도메인 예외 (web#402 백엔드 방어선)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackReactionCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackReactionCommandService.java
@@ -11,6 +11,7 @@ import com.pfplaybackend.api.party.application.port.out.AddedTrackInfo;
 import com.pfplaybackend.api.party.domain.entity.data.CrewData;
 import com.pfplaybackend.api.party.domain.entity.data.history.PlaybackReactionHistoryData;
 import com.pfplaybackend.api.party.domain.enums.ReactionType;
+import com.pfplaybackend.api.party.domain.exception.CrewException;
 import com.pfplaybackend.api.party.domain.exception.ReactionException;
 import com.pfplaybackend.api.party.domain.model.ReactionPostProcessResult;
 import com.pfplaybackend.api.party.domain.model.ReactionState;
@@ -45,7 +46,10 @@ public class PlaybackReactionCommandService {
             throw ExceptionCreator.create(ReactionException.INVALID_REACTION);
         }
 
-        ActivePartyroomDto myActivePartyroom = partyroomQueryService.getMyActivePartyroom().orElseThrow();
+        // 재연결 룸 desync(소프트 재연결이 멤버십 resync 누락) 시 여기서 빈 Optional 이 온다.
+        // 무메시지 orElseThrow → "No value present" 누출 대신 도메인 예외로 매핑(클라가 "다시 입장" 안내 가능).
+        ActivePartyroomDto myActivePartyroom = partyroomQueryService.getMyActivePartyroom()
+                .orElseThrow(() -> ExceptionCreator.create(CrewException.NOT_FOUND_ACTIVE_ROOM));
         PlaybackId playbackId = myActivePartyroom.currentPlaybackId();
         PlaybackReactionHistoryData historyData = getValidReactionHistoryData(authContext, playbackId);
         ReactionState existingState = getExistingState(historyData);
@@ -53,7 +57,7 @@ public class PlaybackReactionCommandService {
 
         ReactionPostProcessResult reactionPostProcessDto = executeProcess(historyData, existingState, targetState);
         Optional<CrewData> optional = partyroomQueryService.getCrewByUserId(partyroomId, authContext.getUserId());
-        CrewData crew = optional.orElseThrow();
+        CrewData crew = optional.orElseThrow(() -> ExceptionCreator.create(CrewException.NOT_FOUND_ROOM));
         AddedTrackInfo addedTrack = playbackReactionPostProcessCommandService.postProcess(
                 reactionPostProcessDto, reactionType, partyroomId, playbackId, new CrewId(crew.getId()));
         return ReactionHistoryDto.from(targetState, toAddedTrackDto(addedTrack));

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackReactionCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackReactionCommandServiceTest.java
@@ -10,6 +10,7 @@ import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.enums.AuthorityTier;
 import com.pfplaybackend.api.common.exception.http.ConflictException;
 import com.pfplaybackend.api.common.exception.http.ForbiddenException;
+import com.pfplaybackend.api.common.exception.http.NotFoundException;
 import com.pfplaybackend.api.party.adapter.out.persistence.PlaybackReactionHistoryRepository;
 import com.pfplaybackend.api.party.application.dto.partyroom.ActivePartyroomDto;
 import com.pfplaybackend.api.party.application.port.out.AddedTrackInfo;
@@ -215,6 +216,55 @@ class PlaybackReactionCommandServiceTest {
         // when & then
         assertThatThrownBy(() -> playbackReactionCommandService.reactToCurrentPlayback(partyroomId, ReactionType.GRAB))
                 .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("활성 파티룸이 없으면(소프트 재연결 룸 desync) raw 'No value present' 대신 NOT_FOUND(CRW-001) 도메인 예외로 매핑된다")
+    void reactToCurrentPlaybackNoActivePartyroomMapsToNotFound() {
+        // given — FM(비게스트) + LIKE 이지만 백엔드에 활성 파티룸 없음 (재연결 stale 윈도우 재현)
+        when(partyroomQueryService.getMyActivePartyroom()).thenReturn(Optional.empty());
+
+        // when & then — NoSuchElementException("No value present") 누출이 아니라 도메인 NOT_FOUND
+        assertThatThrownBy(() ->
+                playbackReactionCommandService.reactToCurrentPlayback(partyroomId, ReactionType.LIKE))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("참여 중인 파티룸을 찾을 수 없습니다");
+
+        // 히스토리 락/후처리까지 진행되지 않는다 (멤버십 없으면 즉시 차단)
+        verify(playbackReactionHistoryRepository, never()).findByPlaybackIdAndUserIdForUpdate(any(), any());
+        verify(playbackReactionPostProcessCommandService, never())
+                .postProcess(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("활성 파티룸은 있으나 해당 룸의 크루가 아니면 NOT_FOUND(CRW-003) 도메인 예외로 매핑된다")
+    void reactToCurrentPlaybackCrewNotFoundMapsToNotFound() {
+        // given — 활성 파티룸 있음, 히스토리 처리 통과하지만 getCrewByUserId 빈값(부분 desync)
+        ActivePartyroomDto activePartyroom = new ActivePartyroomDto(
+                partyroomId.getId(), false, 5L, true, playbackId, new CrewId(5L));
+        when(partyroomQueryService.getMyActivePartyroom()).thenReturn(Optional.of(activePartyroom));
+
+        PlaybackReactionHistoryData historyData = new PlaybackReactionHistoryData(userId, playbackId);
+        when(playbackReactionHistoryRepository.findByPlaybackIdAndUserIdForUpdate(playbackId, userId))
+                .thenReturn(Optional.empty());
+        when(playbackReactionHistoryRepository.saveAndFlush(any())).thenReturn(historyData);
+
+        ReactionState baseState = ReactionState.createBaseState();
+        ReactionState targetState = new ReactionState(true, false, false);
+        when(playbackReactionDomainService.getTargetReactionState(baseState, ReactionType.LIKE))
+                .thenReturn(targetState);
+        ReactionPostProcessResult postProcessResult = new ReactionPostProcessResult(false, false, false, false, null, 0, null);
+        when(playbackReactionDomainService.determinePostProcessing(baseState, targetState))
+                .thenReturn(postProcessResult);
+        when(playbackReactionHistoryRepository.save(any())).thenReturn(historyData);
+
+        when(partyroomQueryService.getCrewByUserId(partyroomId, userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                playbackReactionCommandService.reactToCurrentPlayback(partyroomId, ReactionType.LIKE))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("파티룸의 크루가 아닙니다");
     }
 
     @Test


### PR DESCRIPTION
## 개요
룸 desync 상황에서 리액션(좋아요 등)이 raw **"No value present"**(NoSuchElementException)를 누출하던 것을 도메인 예외로 하드닝. **defense-in-depth** — 윈도우 자체를 닫는 건 프론트(pfplay-web#402).

## 배경 (실제 발생)
AM 유저가 룸 입장·재생 후 좋아요 → "No value present" 모달. 원인 = WS 소프트 재연결이 룸 멤버십 resync(재입장)를 누락한 stale 윈도우에서 리액션 HTTP가 빈 활성-파티룸을 만남. `PlaybackReactionCommandService:48`의 무메시지 `orElseThrow()`가 그대로 누출.
전체 포렌식: `bugs/2026-06-17-ws-soft-reconnect-stale-membership-reaction-no-value-present.md`

## 변경
- `:48` 활성 파티룸 부재 → `CrewException.NOT_FOUND_ACTIVE_ROOM` (CRW-001, 404) — 같은 desync 때 다른 엔드포인트가 내던 코드와 일관.
- `:56` 크루 부재 → `CrewException.NOT_FOUND_ROOM` (CRW-003, 404).
- 효과: 클라가 "방에서 나가졌어요, 다시 입장" 류 친절 모달 + 안정 코드 수신(무로그/raw 500 누출 제거).

## 검증
- `PlaybackReactionCommandServiceTest` 8개(기존 6 + 신규 2: 활성파티룸 부재→NOT_FOUND, 크루 부재→NOT_FOUND) GREEN.
- `*Reaction*` 전체 GREEN (기존 happy-path·동시성·게스트GRAB 회귀 무영향).

## 한계 / 관계
- ⚠️ **근본 fix 아님**: stale 윈도우(액션 실패 자체)는 프론트 resync가 닫음 = **pfplay-web#402**(본 incident의 root cause, 스토리 코멘트 추가됨).
- 형제 패턴(같은 "No value present" brittle orElseThrow 계열): #297.

base=`develop`. 머지=사용자 게이트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
