### PR TITLE
fix(party): 비활성 크루의 DJ 등록 차단 — getCrewOrThrow active 계약 복원 (#304)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomQueryService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomQueryService.java
@@ -175,8 +175,16 @@ public class PartyroomQueryService {
     }
 
     @Transactional(readOnly = true)
+    /**
+     * 룸-스코프 커맨드용 "현재 활성 크루" 조회. 행이 없거나 {@code is_active=false}(소프트 재연결
+     * stale 멤버십 등)이면 absent 와 동일하게 {@code NOT_FOUND_ACTIVE_ROOM}(CRW-001) 으로 거부한다.
+     * <p>예외 이름이 약속하는 "active" 계약을 구현이 지키도록 정렬 — 비활성 크루의 enqueueDj 가
+     * 회전 유령 dj orphan 을 만들던 결함 차단(#304, web#402 백엔드 방어선). 호출 패밀리 전체
+     * (enqueue·dequeue·changePlaylist·grade·penalty·skip)가 active 크루를 전제로 한다.
+     */
     public CrewData getCrewOrThrow(PartyroomId partyroomId, UserId userId) {
         return aggregatePort.findCrew(partyroomId, userId)
+                .filter(CrewData::isActive)
                 .orElseThrow(() -> ExceptionCreator.create(CrewException.NOT_FOUND_ACTIVE_ROOM));
     }
 

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomQueryServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomQueryServiceTest.java
@@ -171,6 +171,20 @@ class PartyroomQueryServiceTest {
     }
 
     @Test
+    @DisplayName("getCrewOrThrow — 크루 행이 있어도 비활성이면 NOT_FOUND_ACTIVE_ROOM (WS 재연결 stale 멤버십 방어, #304)")
+    void getCrewOrThrowInactiveCrewThrows() {
+        // given: 크루 행은 존재하나 is_active=false (소프트 재연결 stale 윈도우)
+        CrewData inactiveCrew = CrewData.builder()
+                .id(1L).partyroomId(partyroomId).userId(userId)
+                .gradeType(GradeType.CLUBBER).isActive(false).build();
+        when(aggregatePort.findCrew(partyroomId, userId)).thenReturn(Optional.of(inactiveCrew));
+
+        // when & then: absent 와 동일하게 CRW-001 로 거부 (회전 유령 dj orphan 차단)
+        assertThatThrownBy(() -> partyroomQueryService.getCrewOrThrow(partyroomId, userId))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
     @DisplayName("getSummaryInfo — 재생 비활성 시 DJ 정보가 null이다")
     void getSummaryInfoPlaybackInactiveDjIsNull() {
         // given
@@ -531,11 +545,11 @@ class PartyroomQueryServiceTest {
     // ── getCrewOrThrow — 성공 케이스 ──
 
     @Test
-    @DisplayName("getCrewOrThrow — 크루가 존재하면 반환한다")
+    @DisplayName("getCrewOrThrow — 활성 크루가 존재하면 반환한다")
     void getCrewOrThrowFoundReturns() {
         // given
         CrewData crew = CrewData.builder()
-                .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+                .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).isActive(true).build();
         when(aggregatePort.findCrew(partyroomId, userId)).thenReturn(Optional.of(crew));
 
         // when


### PR DESCRIPTION
## 무엇을
`PartyroomQueryService.getCrewOrThrow`가 `is_active=false` 크루를 absent와 동일하게 `CRW-001 NOT_FOUND_ACTIVE_ROOM`으로 거부하도록 `.filter(CrewData::isActive)` 추가.

## 왜
WS 소프트 재연결 stale 멤버십 윈도우(web #402)에서 **비활성 크루가 `enqueueDj`로 회전 유령 dj orphan을 생성**하던 결함(#304). 예외명·메시지가 이미 "active"를 약속하는데 구현은 `findByPartyroomIdAndUserId`(active 미필터)라 비활성 행을 반환하던 semantic drift를 계약대로 정렬.

- prod 증거: `[enqueueDj] CREW_FOUND isActive=false → VALIDATION_PASSED → SAVED djId=145` (룸1, 2026-06-18)
- 포렌식: `bugs/2026-06-18-ws-reconnect-stale-membership-dj-enqueue-orphan.md`
- **#303(reaction 'No value present') 형제** — 같은 web#402 트리거의 백엔드 방어선. 좋아요는 `getMyActivePartyroom().orElseThrow()`로 크래시, enqueue는 비활성 행 통과로 **조용한 영속 오염**(더 위험).

## 범위
중앙 `getCrewOrThrow` 한 곳 수정 → 같은 lookup을 쓰는 커맨드 패밀리 8곳(enqueue·dequeue self/admin·changePlaylist·grade·penalty×2·skip, 전부 active 전제) 일괄 봉합.

## 검증
- TDD RED→GREEN: 비활성 크루 `getCrewOrThrow` → `NotFoundException(CRW-001)` (`PartyroomQueryServiceTest.getCrewOrThrowInactiveCrewThrows`)
- 기존 성공 케이스 fixture를 active로 정정
- `:app:test` 풀 회귀 GREEN

## 별도 트랙(본 PR 범위 외)
- 상류 root: web #402 (재연결 시 `tryEnter` 재실행) — 프론트
- 잔존 orphan 정리: `dj.crew inactive` reconcile cron (Cluster G, #241 인접)