### PR TITLE
feat(party): tryEnter 응답에 reactivated 노출 (web#402 재연결 resync 신호)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/PartyroomAccessCommandController.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/PartyroomAccessCommandController.java
@@ -5,7 +5,6 @@ import com.pfplaybackend.api.common.config.swagger.ApiErrorCodes;
 import com.pfplaybackend.api.party.adapter.in.web.payload.request.access.EnterPartyroomRequest;
 import com.pfplaybackend.api.party.adapter.in.web.payload.response.access.EnterPartyroomResponse;
 import com.pfplaybackend.api.party.application.service.PartyroomAccessCommandService;
-import com.pfplaybackend.api.party.domain.entity.data.CrewData;
 import com.pfplaybackend.api.party.domain.exception.CrewException;
 import com.pfplaybackend.api.party.domain.exception.PartyroomException;
 import com.pfplaybackend.api.party.domain.exception.PenaltyException;
@@ -41,8 +40,9 @@ public class PartyroomAccessCommandController {
         CountryCode countryCode = (request == null || request.countryCode() == null)
                 ? null
                 : CountryCode.of(request.countryCode());
-        CrewData crew = partyroomAccessCommandService.tryEnter(new PartyroomId(partyroomId), countryCode);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiCommonResponse.success(EnterPartyroomResponse.from(crew)));
+        var result = partyroomAccessCommandService.tryEnter(new PartyroomId(partyroomId), countryCode);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiCommonResponse.success(EnterPartyroomResponse.from(result.crew(), result.reactivated())));
     }
 
     @Operation(summary = "파티룸 퇴장", description = "현재 입장한 파티룸에서 퇴장합니다. DJ 큐에 등록된 경우 자동으로 해제됩니다.")

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/payload/response/access/EnterPartyroomResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/payload/response/access/EnterPartyroomResponse.java
@@ -13,8 +13,10 @@ import lombok.Getter;
 public class EnterPartyroomResponse {
     private long crewId;
     private GradeType gradeType;
+    /** WS 재연결 resync 신호: 멤버십이 inactive→active 로 재활성됐는지 (web#402). */
+    private boolean reactivated;
 
-    public static EnterPartyroomResponse from(CrewData crew) {
-        return new EnterPartyroomResponse(crew.getId(), crew.getGradeType());
+    public static EnterPartyroomResponse from(CrewData crew, boolean reactivated) {
+        return new EnterPartyroomResponse(crew.getId(), crew.getGradeType(), reactivated);
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
@@ -60,7 +60,7 @@ public class PartyroomAccessCommandService {
     }
 
     @Transactional
-    public CrewData tryEnter(PartyroomId partyroomId, CountryCode countryCode) {
+    public TryEnterResult tryEnter(PartyroomId partyroomId, CountryCode countryCode) {
         AuthContext authContext = ThreadLocalContext.getAuthContext();
         UserId userId = authContext.getUserId();
         log.info("[tryEnter] START - userId={}, targetPartyroomId={}", userId, partyroomId.getId());
@@ -109,7 +109,8 @@ public class PartyroomAccessCommandService {
                             userId, partyroomId.getId());
                 }
                 enforceHostInvariant(partyroom, userId, saved);
-                return saved;
+                // 멤버십 유지(이미 active) → reactivated=false (web#402)
+                return new TryEnterResult(saved, false);
             }
         }
 
@@ -126,7 +127,8 @@ public class PartyroomAccessCommandService {
         if (!result.raceLoser) {
             enforceHostInvariant(partyroom, userId, result.crew);
         }
-        return result.crew;
+        // transitioned(inactive→active 재활성 또는 신규 INSERT) → reactivated. web#402 재연결 소비자용 신호.
+        return new TryEnterResult(result.crew, result.transitioned);
     }
 
     /**
@@ -211,6 +213,12 @@ public class PartyroomAccessCommandService {
     }
 
     private record CrewActivationResult(CrewData crew, boolean transitioned, boolean raceLoser) {}
+
+    /**
+     * tryEnter 결과. {@code reactivated}=true 는 inactive→active 재활성(또는 신규 INSERT)을 뜻한다.
+     * web#402 재연결 resync 소비자에게만 유의미 — 재연결은 crew row가 이미 존재해 INSERT 분기에 닿지 않는다.
+     */
+    public record TryEnterResult(CrewData crew, boolean reactivated) {}
 
     private void publishAccessChangedEvent(PartyroomId partyroomId, CrewData crew, UserId userId) {
         eventPublisher.publishEvent(new CrewAccessedEvent(partyroomId, new CrewId(crew.getId()), userId, AccessType.ENTER));

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/PartyroomAccessCommandControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/PartyroomAccessCommandControllerTest.java
@@ -1,5 +1,6 @@
 package com.pfplaybackend.api.party.adapter.in.web;
 
+import com.pfplaybackend.api.party.application.service.PartyroomAccessCommandService;
 import com.pfplaybackend.api.party.domain.entity.data.CrewData;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
 import org.junit.jupiter.api.DisplayName;
@@ -24,7 +25,8 @@ class PartyroomAccessCommandControllerTest extends AbstractPartyCommandWebMvcTes
         CrewData crew = mock(CrewData.class);
         when(crew.getId()).thenReturn(1L);
         when(crew.getGradeType()).thenReturn(GradeType.CLUBBER);
-        when(partyroomAccessCommandService.tryEnter(any(), any())).thenReturn(crew);
+        when(partyroomAccessCommandService.tryEnter(any(), any()))
+                .thenReturn(new PartyroomAccessCommandService.TryEnterResult(crew, false));
 
         // when & then
         mockMvc.perform(post("/api/v1/partyrooms/1/crews")
@@ -42,7 +44,8 @@ class PartyroomAccessCommandControllerTest extends AbstractPartyCommandWebMvcTes
         CrewData crew = mock(CrewData.class);
         when(crew.getId()).thenReturn(1L);
         when(crew.getGradeType()).thenReturn(GradeType.CLUBBER);
-        when(partyroomAccessCommandService.tryEnter(any(), any())).thenReturn(crew);
+        when(partyroomAccessCommandService.tryEnter(any(), any()))
+                .thenReturn(new PartyroomAccessCommandService.TryEnterResult(crew, false));
 
         // when & then
         mockMvc.perform(post("/api/v1/partyrooms/1/crews")
@@ -60,7 +63,8 @@ class PartyroomAccessCommandControllerTest extends AbstractPartyCommandWebMvcTes
         CrewData crew = mock(CrewData.class);
         when(crew.getId()).thenReturn(1L);
         when(crew.getGradeType()).thenReturn(GradeType.CLUBBER);
-        when(partyroomAccessCommandService.tryEnter(any(), any())).thenReturn(crew);
+        when(partyroomAccessCommandService.tryEnter(any(), any()))
+                .thenReturn(new PartyroomAccessCommandService.TryEnterResult(crew, false));
 
         // when & then — no .content(), no .contentType()
         mockMvc.perform(post("/api/v1/partyrooms/1/crews")
@@ -76,7 +80,8 @@ class PartyroomAccessCommandControllerTest extends AbstractPartyCommandWebMvcTes
         CrewData crew = mock(CrewData.class);
         when(crew.getId()).thenReturn(1L);
         when(crew.getGradeType()).thenReturn(GradeType.CLUBBER);
-        when(partyroomAccessCommandService.tryEnter(any(), any())).thenReturn(crew);
+        when(partyroomAccessCommandService.tryEnter(any(), any()))
+                .thenReturn(new PartyroomAccessCommandService.TryEnterResult(crew, false));
 
         // when & then — empty JSON object
         mockMvc.perform(post("/api/v1/partyrooms/1/crews")

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceTest.java
@@ -126,10 +126,12 @@ class PartyroomAccessCommandServiceTest {
         when(partyroomQueryService.getMyActivePartyroom(userId)).thenReturn(Optional.of(activeRoomInfo));
 
         // when
-        partyroomAccessCommandService.tryEnter(partyroomId, null);
+        var result = partyroomAccessCommandService.tryEnter(partyroomId, null);
 
         // then — spec §7.2: 같은 룸 재진입 시 ENTER 이벤트 발행 금지 (counter inflate 방지)
         verifyNoInteractions(eventPublisher);
+        // 멤버십 유지(이미 active) → reactivated=false (#402)
+        assertThat(result.reactivated()).isFalse();
     }
 
     @Test
@@ -190,10 +192,12 @@ class PartyroomAccessCommandServiceTest {
         when(aggregatePort.saveCrew(any(CrewData.class))).thenReturn(newRoomCrew);
 
         // when — 예외 없이 정상 실행되어야 함
-        partyroomAccessCommandService.tryEnter(newRoomId, null);
+        var result = partyroomAccessCommandService.tryEnter(newRoomId, null);
 
         // then — EXIT event (from old room exit) + ENTER event (new room) = exactly 2 publish calls
         verify(eventPublisher, times(2)).publishEvent(any(Object.class));
+        // inactive→active 재활성(transitioned) → reactivated=true (#402)
+        assertThat(result.reactivated()).isTrue();
     }
 
     @Test
@@ -301,7 +305,7 @@ class PartyroomAccessCommandServiceTest {
             ReflectionTestUtils.invokeMethod(partyroomAccessCommandService, "initTxTemplates");
 
             // when
-            CrewData result = partyroomAccessCommandService.tryEnter(racePartyroomId, CountryCode.of("KR"));
+            CrewData result = partyroomAccessCommandService.tryEnter(racePartyroomId, CountryCode.of("KR")).crew();
 
             // then: returned crew is the winner row found in the REQUIRES_NEW transaction
             assertThat(result).isSameAs(winnerCrew);
@@ -341,7 +345,7 @@ class PartyroomAccessCommandServiceTest {
                 });
 
         // when
-        CrewData result = partyroomAccessCommandService.tryEnter(partyroomId, null);
+        CrewData result = partyroomAccessCommandService.tryEnter(partyroomId, null).crew();
 
         // then
         assertThat(result.getGradeType()).isEqualTo(GradeType.LISTENER);
@@ -375,7 +379,7 @@ class PartyroomAccessCommandServiceTest {
         when(aggregatePort.saveCrew(any(CrewData.class))).thenAnswer(inv -> inv.getArgument(0));
 
         // when
-        CrewData result = partyroomAccessCommandService.tryEnter(partyroomId, null);
+        CrewData result = partyroomAccessCommandService.tryEnter(partyroomId, null).crew();
 
         // then
         assertThat(result.getGradeType()).isEqualTo(GradeType.LISTENER);
@@ -406,7 +410,7 @@ class PartyroomAccessCommandServiceTest {
                 });
 
         // when
-        CrewData result = partyroomAccessCommandService.tryEnter(partyroomId, null);
+        CrewData result = partyroomAccessCommandService.tryEnter(partyroomId, null).crew();
 
         // then
         assertThat(result.getGradeType()).isEqualTo(GradeType.HOST);
@@ -438,7 +442,7 @@ class PartyroomAccessCommandServiceTest {
         when(aggregatePort.saveCrew(any(CrewData.class))).thenAnswer(inv -> inv.getArgument(0));
 
         // when
-        CrewData result = partyroomAccessCommandService.tryEnter(partyroomId, null);
+        CrewData result = partyroomAccessCommandService.tryEnter(partyroomId, null).crew();
 
         // then
         assertThat(result.getGradeType()).isEqualTo(GradeType.HOST);
@@ -505,7 +509,7 @@ class PartyroomAccessCommandServiceTest {
         when(partyroomQueryService.getMyActivePartyroom(userId)).thenReturn(Optional.of(activeRoomInfo));
 
         // when
-        CrewData result = partyroomAccessCommandService.tryEnter(partyroomId, null);
+        CrewData result = partyroomAccessCommandService.tryEnter(partyroomId, null).crew();
 
         // then
         assertThat(result.getGradeType()).isEqualTo(GradeType.HOST);
@@ -712,7 +716,7 @@ class PartyroomAccessCommandServiceTest {
             ReflectionTestUtils.invokeMethod(partyroomAccessCommandService, "initTxTemplates");
 
             // when
-            CrewData result = partyroomAccessCommandService.tryEnter(racePartyroomId, null);
+            CrewData result = partyroomAccessCommandService.tryEnter(racePartyroomId, null).crew();
 
             // then — guard prevents the helper from invoking updateGrade or extra saveCrew
             assertThat(result).isSameAs(winnerCrew);


### PR DESCRIPTION
## 무엇을 / 왜
WS 재연결 시 프론트(web #402)가 "멤버십 유지 vs 상실(재활성)"을 구별해 경량/풀 재수화를 분기하도록, `tryEnter` 반환을 `TryEnterResult(crew, reactivated)`로 노출.
- 같은-룸 재입장(이미 active) → `reactivated=false`
- `ensureCrewActive transitioned`(inactive→active) → `reactivated=true`

**도메인 로직·이벤트 무변경 — 신호 노출만.** 백엔드는 이미 분기를 계산하고 있었음.

## 범위
- `tryEnter`: `CrewData` → `TryEnterResult`. 호출처 2곳(컨트롤러=매핑, 봇=반환 무시).
- `EnterPartyroomResponse`에 `reactivated` 필드.

## 검증
- 기존 tryEnter 테스트에 reactivated 단언 추가(같은-룸=false, 재활성=true), `:app:test` 풀 회귀 GREEN.

## 가족
상위 platform #306 · web #402(이 신호 소비) · #304 · #303