### PR TITLE
feat(party): playback/dj reconcile cron — 잔존 오염 자가치유 (Cluster G, #308)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/DjRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/DjRepository.java
@@ -4,6 +4,7 @@ import com.pfplaybackend.api.party.domain.entity.data.DjData;
 import com.pfplaybackend.api.party.domain.value.CrewId;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +14,14 @@ public interface DjRepository extends JpaRepository<DjData, Long> {
     Optional<DjData> findByPartyroomIdAndCrewId(PartyroomId partyroomId, CrewId crewId);
     boolean existsByPartyroomId(PartyroomId partyroomId);
     boolean existsByPartyroomIdAndCrewId(PartyroomId partyroomId, CrewId crewId);
+
+    /**
+     * orphan DJ(비활성 크루의 dj row)를 가진 ACTIVE 룸 목록 — reconcile cron Sweep A (#308).
+     * DjData↔CrewData JPA 연관이 없어 cross-join + 임베디드 .id 경로로 비교.
+     */
+    @Query("SELECT DISTINCT d.partyroomId FROM DjData d, CrewData c, PartyroomData pr " +
+           "WHERE c.id = d.crewId.id AND c.isActive = false " +
+           "AND pr.partyroomId.id = d.partyroomId.id " +
+           "AND pr.status = com.pfplaybackend.api.party.domain.enums.PartyroomStatus.ACTIVE")
+    List<PartyroomId> findPartyroomIdsWithInactiveCrewDj();
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomAggregateAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomAggregateAdapter.java
@@ -176,6 +176,18 @@ public class PartyroomAggregateAdapter implements PartyroomAggregatePort, Partyr
         djQueueRepository.save(djQueue);
     }
 
+    // ===== Reconcile cron (#308) =====
+
+    @Override
+    public List<PartyroomId> findPartyroomIdsWithInactiveCrewDj() {
+        return djRepository.findPartyroomIdsWithInactiveCrewDj();
+    }
+
+    @Override
+    public List<PartyroomId> findStuckActivatedPartyroomIds(long threshold) {
+        return partyroomPlaybackRepository.findStuckActivatedPartyroomIds(threshold);
+    }
+
     // ===== Query Port (DTO-returning QueryDSL methods) =====
 
     @Override

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomPlaybackRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomPlaybackRepository.java
@@ -3,6 +3,22 @@ package com.pfplaybackend.api.party.adapter.out.persistence;
 import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface PartyroomPlaybackRepository extends JpaRepository<PartyroomPlaybackData, PartyroomId> {
+
+    /**
+     * stuck playback(is_activated=1인데 현재 트랙 end_time이 threshold 이전, 또는 current_playback 부재)을 가진
+     * ACTIVE 룸 목록 — reconcile cron Sweep B (#308). end_time은 epoch-millis(Long, UTC).
+     * LEFT JOIN으로 "activated인데 current_playback null"도 stuck으로 포함.
+     */
+    @Query("SELECT pp.partyroomId FROM PartyroomPlaybackData pp, PartyroomData pr " +
+           "LEFT JOIN PlaybackData p ON p.id = pp.currentPlaybackId.id " +
+           "WHERE pr.partyroomId.id = pp.partyroomId.id " +
+           "AND pr.status = com.pfplaybackend.api.party.domain.enums.PartyroomStatus.ACTIVE " +
+           "AND pp.isActivated = true AND (p IS NULL OR p.endTime < :threshold)")
+    List<PartyroomId> findStuckActivatedPartyroomIds(@Param("threshold") long threshold);
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomPlaybackReconcileService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomPlaybackReconcileService.java
@@ -1,0 +1,134 @@
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.party.application.port.out.PlaybackControlPort;
+import com.pfplaybackend.api.party.application.service.lock.DistributedLockExecutor;
+import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.entity.data.DjData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
+import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * party 도메인 잔존-오염 자가치유 cron (Cluster G, #308).
+ * presence {@code reconcileStalePending} 미러 — 룸별 분산락 + 룸별 @Transactional heal + 락+txn 내 멱등 재검.
+ *
+ * <pre>
+ *   A. orphan DJ  : dj.crew 가 inactive (회전 유령, #304)  → 비활성 dj 제거 + (현재 DJ면) skipPlayback
+ *   B. stuck      : is_activated=1 ∧ end_time<now-BUFFER (정지 유령, #299/#195) → skipPlayback
+ * </pre>
+ *
+ * <p>안전: BUFFER(90s) + 락+txn 내 재검이 정상-path 레이스를 방어한다(정상 playback 커맨드는 분산락 미사용
+ * → 이 락은 멀티 인스턴스 cron 중복만 차단). 락 획득 실패는 WARN 후 다음 tick 재시도(잡 자체 멱등).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PartyroomPlaybackReconcileService {
+
+    static final long STUCK_BUFFER_MS = 90_000L;
+
+    private final PartyroomAggregatePort aggregatePort;
+    private final PlaybackReconcileHealer healer;
+    private final DistributedLockExecutor lock;
+    private final Clock clock;
+
+    @Scheduled(fixedDelay = 60_000)
+    public void reconcile() {
+        sweepOrphanDjs();
+        sweepStuckPlayback();
+    }
+
+    void sweepOrphanDjs() {
+        for (PartyroomId room : aggregatePort.findPartyroomIdsWithInactiveCrewDj()) {
+            try {
+                lock.performTaskWithLock("playback-reconcile:" + room.getId(), () -> {
+                    healer.healOrphan(room);
+                    return null;
+                });
+            } catch (Exception e) {
+                log.warn("[reconcile] orphan heal failed - room={}, {}", room.getId(), e.getMessage());
+            }
+        }
+    }
+
+    void sweepStuckPlayback() {
+        long threshold = clock.millis() - STUCK_BUFFER_MS;
+        for (PartyroomId room : aggregatePort.findStuckActivatedPartyroomIds(threshold)) {
+            try {
+                lock.performTaskWithLock("playback-reconcile:" + room.getId(), () -> {
+                    healer.healStuck(room, threshold);
+                    return null;
+                });
+            } catch (Exception e) {
+                log.warn("[reconcile] stuck heal failed - room={}, {}", room.getId(), e.getMessage());
+            }
+        }
+    }
+}
+
+/**
+ * 별 빈 — self-invocation 회피로 {@code @Transactional} AOP 가 적용되어 재검 + mutation 이 한 트랜잭션.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+class PlaybackReconcileHealer {
+
+    private final PartyroomAggregatePort aggregatePort;
+    private final PlaybackControlPort playbackControlPort;
+    private final PlaybackQueryService playbackQueryService;
+
+    @Transactional
+    public void healOrphan(PartyroomId room) {
+        List<DjData> djs = aggregatePort.findDjsOrdered(room);
+        if (djs.isEmpty()) {
+            return;
+        }
+        Map<Long, Boolean> activeByCrewId = aggregatePort
+                .findCrewsByIds(djs.stream().map(d -> d.getCrewId().getId()).toList())
+                .stream()
+                .collect(Collectors.toMap(CrewData::getId, CrewData::isActive));
+        List<DjData> orphans = djs.stream()
+                .filter(d -> !Boolean.TRUE.equals(activeByCrewId.get(d.getCrewId().getId())))
+                .toList();
+        if (orphans.isEmpty()) {
+            return; // 멱등 재검 — 탐지~락 사이 정상 경로가 이미 정리
+        }
+        PartyroomPlaybackData pp = aggregatePort.findPlaybackState(room);
+        boolean orphanWasCurrent = pp.isActivated()
+                && orphans.stream().anyMatch(d -> pp.isCurrentDj(d.getCrewId()));
+        log.info("[reconcile] orphan sweep - room={}, removing {} dj(s), wasCurrent={}",
+                room.getId(), orphans.size(), orphanWasCurrent);
+        aggregatePort.removeDjs(orphans);
+        if (orphanWasCurrent) {
+            playbackControlPort.skipPlayback(room);
+        }
+    }
+
+    @Transactional
+    public void healStuck(PartyroomId room, long threshold) {
+        PartyroomPlaybackData pp = aggregatePort.findPlaybackState(room);
+        if (!pp.isActivated()) {
+            return; // 이미 치유됨
+        }
+        Long endTime = pp.getCurrentPlaybackId() == null
+                ? null
+                : playbackQueryService.getPlaybackById(pp.getCurrentPlaybackId()).getEndTime();
+        if (endTime != null && endTime >= threshold) {
+            return; // 새 트랙이 시작됨 → 멱등 no-op
+        }
+        log.info("[reconcile] stuck sweep - room={}, endTime={}, threshold={}",
+                room.getId(), endTime, threshold);
+        playbackControlPort.skipPlayback(room);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/port/PartyroomAggregatePort.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/port/PartyroomAggregatePort.java
@@ -53,4 +53,8 @@ public interface PartyroomAggregatePort {
     // ===== DJ Queue State: DjQueueData =====
     DjQueueData findDjQueueState(PartyroomId partyroomId);
     void saveDjQueueState(DjQueueData djQueue);
+
+    // ===== Reconcile cron (#308) =====
+    List<PartyroomId> findPartyroomIdsWithInactiveCrewDj();
+    List<PartyroomId> findStuckActivatedPartyroomIds(long threshold);
 }

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomPlaybackReconcileServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomPlaybackReconcileServiceTest.java
@@ -1,0 +1,200 @@
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.party.application.port.out.PlaybackControlPort;
+import com.pfplaybackend.api.party.application.service.lock.DistributedLockExecutor;
+import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.entity.data.DjData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
+import com.pfplaybackend.api.party.domain.entity.data.PlaybackData;
+import com.pfplaybackend.api.party.domain.enums.GradeType;
+import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
+import com.pfplaybackend.api.party.domain.value.CrewId;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PartyroomPlaybackReconcileServiceTest {
+
+    private final PartyroomId room = new PartyroomId(1L);
+
+    private DjData dj(long crewId) {
+        DjData d = mock(DjData.class);
+        when(d.getCrewId()).thenReturn(new CrewId(crewId));
+        return d;
+    }
+
+    private CrewData crew(long id, boolean active) {
+        return CrewData.builder().id(id).partyroomId(room).gradeType(GradeType.LISTENER).isActive(active).build();
+    }
+
+    // ───────── Healer: orphan ─────────
+
+    @Test
+    @DisplayName("orphan=현재DJ → removeDjs + skipPlayback")
+    void healOrphanCurrentDjRemovesAndSkips() {
+        PartyroomAggregatePort port = mock(PartyroomAggregatePort.class);
+        PlaybackControlPort playback = mock(PlaybackControlPort.class);
+        PlaybackQueryService pq = mock(PlaybackQueryService.class);
+        PlaybackReconcileHealer healer = new PlaybackReconcileHealer(port, playback, pq);
+
+        DjData orphan = dj(67);
+        when(port.findDjsOrdered(room)).thenReturn(List.of(orphan));
+        when(port.findCrewsByIds(any())).thenReturn(List.of(crew(67, false)));
+        PartyroomPlaybackData pp = mock(PartyroomPlaybackData.class);
+        when(pp.isActivated()).thenReturn(true);
+        when(pp.isCurrentDj(new CrewId(67))).thenReturn(true);
+        when(port.findPlaybackState(room)).thenReturn(pp);
+
+        healer.healOrphan(room);
+
+        verify(port).removeDjs(argThat(l -> l.size() == 1 && l.get(0).getCrewId().equals(new CrewId(67))));
+        verify(playback).skipPlayback(room);
+    }
+
+    @Test
+    @DisplayName("orphan=비현재DJ → removeDjs, skipPlayback 미호출")
+    void healOrphanNonCurrentRemovesNoSkip() {
+        PartyroomAggregatePort port = mock(PartyroomAggregatePort.class);
+        PlaybackControlPort playback = mock(PlaybackControlPort.class);
+        PlaybackReconcileHealer healer = new PlaybackReconcileHealer(port, playback, mock(PlaybackQueryService.class));
+
+        DjData d67 = dj(67);
+        when(port.findDjsOrdered(room)).thenReturn(List.of(d67));
+        when(port.findCrewsByIds(any())).thenReturn(List.of(crew(67, false)));
+        PartyroomPlaybackData pp = mock(PartyroomPlaybackData.class);
+        when(pp.isActivated()).thenReturn(true);
+        when(pp.isCurrentDj(new CrewId(67))).thenReturn(false);
+        when(port.findPlaybackState(room)).thenReturn(pp);
+
+        healer.healOrphan(room);
+
+        verify(port).removeDjs(any());
+        verify(playback, never()).skipPlayback(any());
+    }
+
+    @Test
+    @DisplayName("orphan 없음(전부 active) → 멱등 no-op")
+    void healOrphanNoneIsNoOp() {
+        PartyroomAggregatePort port = mock(PartyroomAggregatePort.class);
+        PlaybackControlPort playback = mock(PlaybackControlPort.class);
+        PlaybackReconcileHealer healer = new PlaybackReconcileHealer(port, playback, mock(PlaybackQueryService.class));
+
+        DjData d67 = dj(67);
+        when(port.findDjsOrdered(room)).thenReturn(List.of(d67));
+        when(port.findCrewsByIds(any())).thenReturn(List.of(crew(67, true)));
+
+        healer.healOrphan(room);
+
+        verify(port, never()).removeDjs(any());
+        verify(playback, never()).skipPlayback(any());
+    }
+
+    // ───────── Healer: stuck ─────────
+
+    @Test
+    @DisplayName("stuck(endTime<threshold) → skipPlayback")
+    void healStuckExpiredSkips() {
+        PartyroomAggregatePort port = mock(PartyroomAggregatePort.class);
+        PlaybackControlPort playback = mock(PlaybackControlPort.class);
+        PlaybackQueryService pq = mock(PlaybackQueryService.class);
+        PlaybackReconcileHealer healer = new PlaybackReconcileHealer(port, playback, pq);
+
+        PartyroomPlaybackData pp = mock(PartyroomPlaybackData.class);
+        when(pp.isActivated()).thenReturn(true);
+        when(pp.getCurrentPlaybackId()).thenReturn(new PlaybackId(5L));
+        when(port.findPlaybackState(room)).thenReturn(pp);
+        PlaybackData track = mock(PlaybackData.class);
+        when(track.getEndTime()).thenReturn(1000L);
+        when(pq.getPlaybackById(new PlaybackId(5L))).thenReturn(track);
+
+        healer.healStuck(room, 2000L); // endTime 1000 < threshold 2000
+
+        verify(playback).skipPlayback(room);
+    }
+
+    @Test
+    @DisplayName("stuck(current playback null) → skipPlayback")
+    void healStuckNullPlaybackSkips() {
+        PartyroomAggregatePort port = mock(PartyroomAggregatePort.class);
+        PlaybackControlPort playback = mock(PlaybackControlPort.class);
+        PlaybackReconcileHealer healer = new PlaybackReconcileHealer(port, playback, mock(PlaybackQueryService.class));
+
+        PartyroomPlaybackData pp = mock(PartyroomPlaybackData.class);
+        when(pp.isActivated()).thenReturn(true);
+        when(pp.getCurrentPlaybackId()).thenReturn(null);
+        when(port.findPlaybackState(room)).thenReturn(pp);
+
+        healer.healStuck(room, 2000L);
+
+        verify(playback).skipPlayback(room);
+    }
+
+    @Test
+    @DisplayName("not stuck(endTime>=threshold) → 멱등 no-op")
+    void healStuckFreshNoOp() {
+        PartyroomAggregatePort port = mock(PartyroomAggregatePort.class);
+        PlaybackControlPort playback = mock(PlaybackControlPort.class);
+        PlaybackQueryService pq = mock(PlaybackQueryService.class);
+        PlaybackReconcileHealer healer = new PlaybackReconcileHealer(port, playback, pq);
+
+        PartyroomPlaybackData pp = mock(PartyroomPlaybackData.class);
+        when(pp.isActivated()).thenReturn(true);
+        when(pp.getCurrentPlaybackId()).thenReturn(new PlaybackId(5L));
+        when(port.findPlaybackState(room)).thenReturn(pp);
+        PlaybackData track = mock(PlaybackData.class);
+        when(track.getEndTime()).thenReturn(5000L);
+        when(pq.getPlaybackById(new PlaybackId(5L))).thenReturn(track);
+
+        healer.healStuck(room, 2000L); // 5000 >= 2000 → 새 트랙
+
+        verify(playback, never()).skipPlayback(any());
+    }
+
+    @Test
+    @DisplayName("not activated → no-op")
+    void healStuckDeactivatedNoOp() {
+        PartyroomAggregatePort port = mock(PartyroomAggregatePort.class);
+        PlaybackControlPort playback = mock(PlaybackControlPort.class);
+        PlaybackReconcileHealer healer = new PlaybackReconcileHealer(port, playback, mock(PlaybackQueryService.class));
+
+        PartyroomPlaybackData pp = mock(PartyroomPlaybackData.class);
+        when(pp.isActivated()).thenReturn(false);
+        when(port.findPlaybackState(room)).thenReturn(pp);
+
+        healer.healStuck(room, 2000L);
+
+        verify(playback, never()).skipPlayback(any());
+    }
+
+    // ───────── Service: sweep wiring ─────────
+
+    @Test
+    @DisplayName("sweep — 탐지된 룸마다 락 안에서 healer 호출")
+    void sweepsInvokeHealerUnderLock() {
+        PartyroomAggregatePort port = mock(PartyroomAggregatePort.class);
+        PlaybackReconcileHealer healer = mock(PlaybackReconcileHealer.class);
+        DistributedLockExecutor lock = mock(DistributedLockExecutor.class);
+        Clock clock = mock(Clock.class);
+        when(clock.millis()).thenReturn(1_000_000L);
+        // 락 실행기는 supplier 를 그대로 실행
+        doAnswer(inv -> { ((Supplier<?>) inv.getArgument(1)).get(); return null; })
+                .when(lock).performTaskWithLock(anyString(), any());
+        when(port.findPartyroomIdsWithInactiveCrewDj()).thenReturn(List.of(room));
+        when(port.findStuckActivatedPartyroomIds(anyLong())).thenReturn(List.of(room));
+
+        new PartyroomPlaybackReconcileService(port, healer, lock, clock).reconcile();
+
+        verify(healer).healOrphan(room);
+        verify(healer).healStuck(eq(room), eq(1_000_000L - PartyroomPlaybackReconcileService.STUCK_BUFFER_MS));
+    }
+}

--- a/docs/superpowers/plans/2026-06-19-playback-reconcile-cron.md
+++ b/docs/superpowers/plans/2026-06-19-playback-reconcile-cron.md
@@ -1,0 +1,168 @@
+# playback/dj reconcile cron Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 60초 cron으로 두 잔존-오염 클래스(orphan DJ, stuck playback)를 자가치유하되 건강한 룸은 손상시키지 않는다.
+
+**Architecture:** 신규 `PartyroomPlaybackReconcileService`가 `@Scheduled(60s)`로 2 sweep 실행. presence reconcile 미러 — 룸별 분산락 + 룸별 `@Transactional` heal + 락+txn 내 멱등 재검. 치유는 기존 `skipPlayback`/`removeDjs` 재사용.
+
+**Tech Stack:** Spring Boot, JPA(JPQL), JUnit5/Mockito. 스펙: `docs/superpowers/specs/2026-06-19-playback-reconcile-cron-design.md`.
+
+---
+
+## 파일 구조
+- Create `app/.../party/application/service/PartyroomPlaybackReconcileService.java` — cron + sweepOrphanDjs + sweepStuckPlayback + 락(no @Transactional).
+- Create `app/.../party/application/service/PlaybackReconcileHealer.java` — `@Transactional healOrphan/healStuck`(**별 빈** — self-invocation AOP 미적용 회피, re-check+mutation 1 txn 보장).
+- Modify `app/.../party/adapter/out/persistence/DjRepository.java` — `findPartyroomIdsWithInactiveCrewDj()`.
+- Modify `app/.../party/adapter/out/persistence/PartyroomPlaybackRepository.java` — `findStuckActivatedPartyroomIds(threshold)`.
+- Modify `app/.../party/domain/port/PartyroomAggregatePort.java` + `adapter/out/persistence/PartyroomAggregateAdapter.java` — 두 쿼리 노출.
+- Test `app/.../party/application/service/PartyroomPlaybackReconcileServiceTest.java` (unit, mock).
+- Test `app/.../party/adapter/out/persistence/PlaybackReconcileQueryIT.java` (쿼리 IT, 실 DB) — 선택, 기존 IT 패턴 따름.
+
+---
+
+## Chunk 1: 탐지 쿼리
+
+### Task 1: 두 신규 쿼리 + 포트 노출
+
+**Files:** `DjRepository.java`, `PartyroomPlaybackRepository.java`, `PartyroomAggregatePort.java`, `PartyroomAggregateAdapter.java`; Test `PlaybackReconcileQueryIT.java`
+
+- [ ] **Step 1: 쿼리 IT 작성** (기존 `@DataJpaTest`/IT 패턴 확인 후) — orphan dj 룸 선별(active crew dj 제외), stuck 룸 선별(BUFFER 내·is_activated=false·TERMINATED 제외, activated+null-playback 포함). 실패 확인.
+
+- [ ] **Step 2: 구현** — `DjRepository`:
+```java
+@Query("SELECT DISTINCT d.partyroomId FROM DjData d, CrewData c, PartyroomData pr " +
+       "WHERE c.id = d.crewId.id AND c.isActive = false " +
+       "AND pr.partyroomId = d.partyroomId AND pr.status = com.pfplaybackend.api.party.domain.enums.PartyroomStatus.ACTIVE")
+List<PartyroomId> findPartyroomIdsWithInactiveCrewDj();
+```
+`PartyroomPlaybackRepository`:
+```java
+@Query("SELECT pp.partyroomId FROM PartyroomPlaybackData pp, PartyroomData pr " +
+       "LEFT JOIN PlaybackData p ON p.id = pp.currentPlaybackId.id " +
+       "WHERE pr.partyroomId = pp.partyroomId " +
+       "AND pr.status = com.pfplaybackend.api.party.domain.enums.PartyroomStatus.ACTIVE " +
+       "AND pp.isActivated = true AND (p IS NULL OR p.endTime < :threshold)")
+List<PartyroomId> findStuckActivatedPartyroomIds(@Param("threshold") long threshold);
+```
+⚠️ 실제 임베디드 경로(`d.crewId.id`, `pp.currentPlaybackId.id`)·엔티티 필드명은 구현 시 `DjData`/`PartyroomPlaybackData`/`PlaybackData`/`CrewData` 실 매핑으로 검증(JPQL 바인딩). 연관 없으면 cross-join 형태 유지.
+- 포트(`PartyroomAggregatePort`)에 두 메서드 시그니처 + `PartyroomAggregateAdapter`에서 repo 위임.
+
+- [ ] **Step 3: IT 통과 확인.** Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "*PlaybackReconcileQueryIT"`
+- [ ] **Step 4: 커밋** — `git commit -m "feat(party): orphan-dj/stuck-playback 탐지 쿼리 (#308)"`
+
+---
+
+## Chunk 2: reconcile 서비스
+
+### Task 2: PartyroomPlaybackReconcileService (cron + 2 sweep)
+
+**Files:** Create `PartyroomPlaybackReconcileService.java`; Test `PartyroomPlaybackReconcileServiceTest.java`
+
+- [ ] **Step 1: 실패 단위 테스트** (mock aggregatePort/playbackControlPort/distributedLockExecutor/clock; `performTaskWithLock`는 supplier 실행하도록 stub)
+```java
+// 핵심 케이스:
+// A1) orphan=현재DJ → removeDjs + skipPlayback
+// A2) orphan=비현재DJ → removeDjs, skipPlayback 미호출
+// A3) orphan 없음(재검 no-op) → removeDjs/skip 미호출
+// B1) 여전히 stuck(activated & endTime<threshold 또는 null playback) → skipPlayback
+// B2) 재검 결과 not stuck(activated=false 또는 새 트랙) → skipPlayback 미호출(멱등)
+```
+예시(A1):
+```java
+when(distributedLockExecutor.performTaskWithLock(anyString(), any()))
+    .thenAnswer(inv -> ((java.util.function.Supplier<?>) inv.getArgument(1)).get());
+when(aggregatePort.findPartyroomIdsWithInactiveCrewDj()).thenReturn(List.of(roomId));
+// findDjsOrdered → [dj(crew 67)], findCrewsByIds → crew67 inactive
+// playbackState.isActivated()=true, currentDjCrewId=67
+service.reconcile();
+verify(aggregatePort).removeDjs(argThat(djs -> /* contains dj crew67 */));
+verify(playbackControlPort).skipPlayback(roomId);
+```
+
+- [ ] **Step 2: 실패 확인.** Run: `… --tests "*PartyroomPlaybackReconcileServiceTest"` · Expected: FAIL(클래스 없음).
+
+- [ ] **Step 3: 구현**
+```java
+// ── 빈 1: cron + sweep + 락 (no @Transactional) ──
+@Slf4j @Service @RequiredArgsConstructor
+public class PartyroomPlaybackReconcileService {
+    private static final long STUCK_BUFFER_MS = 90_000L;
+    private final PartyroomAggregatePort aggregatePort;
+    private final PlaybackReconcileHealer healer; // 별 빈 → @Transactional AOP 적용
+    private final DistributedLockExecutor lock;
+    private final Clock clock;
+
+    @Scheduled(fixedDelay = 60_000)
+    public void reconcile() {
+        sweepOrphanDjs();
+        sweepStuckPlayback();
+    }
+
+    void sweepOrphanDjs() {
+        for (PartyroomId room : aggregatePort.findPartyroomIdsWithInactiveCrewDj()) {
+            try {
+                lock.performTaskWithLock("playback-reconcile:" + room.getId(), () -> { healer.healOrphan(room); return null; });
+            } catch (Exception e) { log.warn("[reconcile] orphan heal failed room={} : {}", room.getId(), e.getMessage()); }
+        }
+    }
+
+    void sweepStuckPlayback() {
+        long threshold = clock.millis() - STUCK_BUFFER_MS;
+        for (PartyroomId room : aggregatePort.findStuckActivatedPartyroomIds(threshold)) {
+            try {
+                lock.performTaskWithLock("playback-reconcile:" + room.getId(), () -> { healer.healStuck(room, threshold); return null; });
+            } catch (Exception e) { log.warn("[reconcile] stuck heal failed room={} : {}", room.getId(), e.getMessage()); }
+        }
+    }
+}
+
+// ── 빈 2: @Transactional heal (별 빈) ──
+@Slf4j @Service @RequiredArgsConstructor
+class PlaybackReconcileHealer {
+    private final PartyroomAggregatePort aggregatePort;
+    private final PlaybackControlPort playbackControlPort;
+    private final PlaybackQueryService playbackQueryService; // getPlaybackById (endTime 재검)
+
+    @Transactional
+    public void healOrphan(PartyroomId room) {
+        List<DjData> djs = aggregatePort.findDjsOrdered(room);
+        if (djs.isEmpty()) return;
+        Map<Long, Boolean> active = aggregatePort.findCrewsByIds(djs.stream().map(d -> d.getCrewId().getId()).toList())
+                .stream().collect(Collectors.toMap(CrewData::getId, CrewData::isActive));
+        List<DjData> orphans = djs.stream().filter(d -> !Boolean.TRUE.equals(active.get(d.getCrewId().getId()))).toList();
+        if (orphans.isEmpty()) return; // 멱등 재검
+        PartyroomPlaybackData pp = aggregatePort.findPlaybackState(room);
+        boolean orphanWasCurrent = pp.isActivated() && pp.getCurrentDjCrewId() != null
+                && orphans.stream().anyMatch(d -> d.getCrewId().equals(pp.getCurrentDjCrewId()));
+        log.info("[reconcile] orphan sweep room={}, removing {} dj(s), wasCurrent={}", room.getId(), orphans.size(), orphanWasCurrent);
+        aggregatePort.removeDjs(orphans);
+        if (orphanWasCurrent) playbackControlPort.skipPlayback(room);
+    }
+
+    @Transactional
+    public void healStuck(PartyroomId room, long threshold) {
+        PartyroomPlaybackData pp = aggregatePort.findPlaybackState(room);
+        if (!pp.isActivated()) return; // 이미 치유됨
+        Long endTime = pp.getCurrentPlaybackId() == null ? null
+                : playbackQueryService.getPlaybackById(pp.getCurrentPlaybackId()).getEndTime();
+        if (endTime != null && endTime >= threshold) return; // 새 트랙 시작됨 → 멱등 no-op
+        log.info("[reconcile] stuck sweep room={}, endTime={}, threshold={}", room.getId(), endTime, threshold);
+        playbackControlPort.skipPlayback(room);
+    }
+}
+```
+⚠️ 구현 시 검증: `PartyroomPlaybackData.getCurrentDjCrewId()`/`getCurrentPlaybackId()` 접근자명, `aggregatePort.findCrewsByIds`/`findPlaybackState` 시그니처, `PlaybackQueryService.getPlaybackById` 존재(없으면 port/메서드 추가). **heal은 별 빈(`PlaybackReconcileHealer`)이라 `@Transactional` AOP 정상 적용** → re-check + removeDjs/skip가 한 txn. CrewId equals(`d.getCrewId().equals(pp.getCurrentDjCrewId())`)는 `CrewId` VO의 equals 동작 확인.
+
+- [ ] **Step 4: 통과 확인.** Run: `… --tests "*PartyroomPlaybackReconcileServiceTest"` · Expected: PASS.
+- [ ] **Step 5: 회귀.** Run: `… :app:test` · Expected: 풀 GREEN.
+- [ ] **Step 6: 커밋** — `git commit -m "feat(party): playback/dj reconcile cron — orphan/stuck 자가치유 (#308)"`
+
+---
+
+## 검증
+- `:app:test` 풀 GREEN.
+- (머지 전, 게이트) 로컬 풀스택: orphan dj/stuck playback 행을 SQL로 심고 cron 1tick 후 정리되는지 + BUFFER 내 정상 룸 무손상 스모크.
+
+## 범위 밖
+refresh(#306-①), WS 만료검증(#306-②). prod 잔존은 배포 후 첫 sweep이 자동 정리(로그 확인).

--- a/docs/superpowers/specs/2026-06-19-playback-reconcile-cron-design.md
+++ b/docs/superpowers/specs/2026-06-19-playback-reconcile-cron-design.md
@@ -1,0 +1,88 @@
+# playback/dj reconcile cron (Cluster G 잔존 오염 자가치유)
+
+- 날짜: 2026-06-19
+- 범위: pfplay-platform (party BC)
+- 이슈: platform #308 · Cluster G(#241 인접) · 포렌식 #299(stuck)·#304(orphan)
+- 상태: 설계 승인됨 (구현 전)
+
+## 1. 배경 / 문제
+
+party 도메인에는 presence에만 자가치유 안전망(`PartyroomPresenceService.reconcileStalePending`, 60s cron)이 있고, **playback/dj에는 대응 안전망이 없다**. 예방 fix(#300 deactivate 증발, #305 비활성 크루 enqueue 차단)는 **새 오염만 막을 뿐 이미 생긴 오염을 retroactive하게 치유하지 못한다**. 두 잔존-오염 클래스가 prod에 방치된다:
+
+- **A. orphan DJ (#304)** — `dj` row의 crew가 `is_active=false`. 회전 유령(오늘 룸1에서 목격). 비활성 크루의 트랙이 계속 회전 재생.
+- **B. stuck playback (#299/#195)** — `partyroom_playback.is_activated=1`인데 현재 트랙 `end_time`이 한참 과거(타이머 사망·빈 큐). 정지 유령 + tar pit(새 DJ enqueue도 start 안 됨).
+
+(forensic: `bugs/2026-06-12-...`(#299) "playback reconcile = 궁극 방어", `bugs/2026-06-18-...`(#304) "dj.crew inactive reconcile".)
+
+## 2. 목표 / 비목표
+
+**목표**
+- 두 잔존-오염 클래스를 **주기적으로(~60s) 자가치유** — presence reconcile의 playback/dj 대칭.
+- **건강한 룸을 절대 손상시키지 않는다**(정상 로테이션과 레이스 회피).
+
+**비목표**
+- 예방(이미 #300/#305) 재구현. refresh(#306-①)·WS 만료검증(#306-②).
+
+## 3. 설계
+
+신규 `PartyroomPlaybackReconcileService`(presence reconcile 미러). `@Scheduled(fixedDelay=60_000)` `reconcile()`가 두 sweep을 순차 실행. 각 sweep은 **룸별 분산락 + 룸별 트랜잭션 + txn 내 조건 재검(멱등)**.
+
+### 3.1 Sweep A — orphan DJ
+- **탐지(신규 쿼리)**: `DjData.crewId`는 임베디드 `CrewId`(스칼라 long 아님)이고 `DjData`↔`CrewData` JPA 연관 없음 → 임베디드 경로 `.id`로 비교, 교차조인:
+  `SELECT DISTINCT d.partyroomId FROM DjData d, CrewData c, PartyroomData pr WHERE c.id = d.crewId.id AND c.isActive = false AND pr.partyroomId = d.partyroomId AND pr.status = ACTIVE` → 반환 타입 **`List<PartyroomId>`**(VO, `List<Long>` 아님).
+- **치유**(룸 락 안, 멱등): 그 룸의 dj 중 crew가 inactive인 행을 `removeDjs`로 제거. 제거 대상에 **현재 DJ(`current_dj_crew_id`)가 포함됐고 `is_activated`** 면 `skipPlayback`(=cancelTask + tryProceed → 남은 실 DJ 회전 or 빈 큐 deactivate). 현재 DJ가 아니면 제거만(현재 재생 무중단). txn 내 재검(이미 정리됐으면 no-op).
+
+### 3.2 Sweep B — stuck playback
+- **탐지(신규 쿼리)**: `currentPlaybackId`도 임베디드 VO → `.id` 비교. **LEFT JOIN**으로 "is_activated=true인데 current_playback이 null/부재"(별개 오염 클래스)도 stuck으로 포함:
+  `SELECT pp.partyroomId FROM PartyroomPlaybackData pp, PartyroomData pr LEFT JOIN PlaybackData p ON p.id = pp.currentPlaybackId.id WHERE pr.partyroomId = pp.partyroomId AND pr.status = ACTIVE AND pp.isActivated = true AND (p IS NULL OR p.endTime < :threshold)`.
+  `threshold = nowEpochMillis − BUFFER_MS`. **`endTime`은 epoch-millis(Long, UTC `Instant.toEpochMilli`)** → `threshold = System.currentTimeMillis() - 90_000L`(명시적 millis, s/ms 혼동 차단).
+- **치유**(룸 락 안, 멱등): `skipPlayback`(cancelTask로 잔존 타이머 정리 + tryProceed → 다음 DJ 회전 or 빈 큐 deactivate) → 정지 해소. txn 내 재검(여전히 stuck인지 — 그 사이 정상 complete가 치유했으면 skip).
+
+### 3.3 안전 (핵심)
+- **generous BUFFER = 90초(ms)**: 정상 타이머 발화 지연(Redis pub/sub·GC) + reconcile 간격을 넘는 마진 → 정상 로테이션 룸을 절대 안 건드림. (worst-case 치유 지연 ≈ BUFFER + 60s ≈ 2.5분.)
+- **룸별 분산락** `DistributedLockExecutor`, key=`playback-reconcile:<roomId>` — **중복 cron tick(멀티 인스턴스) 차단 전용.** ⚠️ 정상 playback 커맨드(`complete`/`skipByManager`/`skipPlayback`)는 **분산락을 안 씀**(단일 Redis expiration task+DB txn 의존) → 이 락은 *정상 커맨드와 상호배제하지 않는다.* 정상-path vs reconcile 레이스 방어는 **BUFFER + in-txn 멱등 재검**이 담당.
+- **멱등 재검(락+txn 안)**: 탐지 목록을 신뢰하지 말고, **`performTaskWithLock` supplier 내부 + `@Transactional` 경계 안**에서 조건을 재조회·재확인(presence `forceOffline`가 락 안에서 DB 재읽기 하는 것과 동일). 탐지~락획득 사이 정상 로테이션이 완료됐으면 no-op.
+- **트랜잭션 구조**: sweep 루프 메서드는 `@Transactional` **금지**(한 룸 실패가 배치 전체 롤백 방지). **룸별 heal 메서드만 `@Transactional`**(presence 구조 그대로).
+- **락 획득 실패**: WARN만 남기고 미실행(재시도·예외 없음) → 60s마다 재실행이라 안전(liveness).
+- **sweep 로깅**: 무엇을(룸·dj·playback id·전이) 쓸었는지 `log.info`(트러블슈팅 자산).
+- 치유는 기존 `skipPlayback`/`removeDjs` 재사용 → 새 mutation 로직 최소, broadcast(활성 룸 화면 갱신)는 기존 경로가 처리.
+
+### 3.4 결정 (승인됨)
+- stuck 치유에 **DJ 포인트 미부여**(`complete` 아닌 `skipPlayback`): 장시간 정지된 트랙의 DJ는 이미 떠났으므로 retroactive 포인트 부적절 → advance/deactivate만.
+- BUFFER = 90초.
+
+## 4. 컴포넌트
+- 신규 `PartyroomPlaybackReconcileService` — cron + `sweepOrphanDjs()` + `sweepStuckPlayback()`.
+- 신규 쿼리 2개: `DjRepository.findPartyroomIdsWithInactiveCrewDj()`, `PartyroomPlaybackRepository.findStuckActivatedPartyroomIds(threshold)` (+ aggregatePort 노출).
+- 재사용: `PlaybackControlPort.skipPlayback`, `PartyroomAggregateService.removeDjs`/`removeDjFromQueue`, `DistributedLockExecutor`, `findDjsOrdered`/`findCrewById`/`findPlaybackState`.
+
+## 5. 데이터 흐름
+```
+@Scheduled(60s) reconcile()
+  ├─ sweepOrphanDjs():
+  │     rooms = findPartyroomIdsWithInactiveCrewDj()
+  │     for room: lock(playback-reconcile:room) → tx:
+  │        inactive dj 재조회 → removeDjs → (현재DJ 포함 & activated면) skipPlayback
+  └─ sweepStuckPlayback():
+        rooms = findStuckActivatedPartyroomIds(now-90s)
+        for room: lock(playback-reconcile:room) → tx:
+           재검(여전히 stuck) → skipPlayback
+```
+
+## 6. 엣지 케이스
+- 한 룸이 두 클래스 동시: A 먼저(orphan 제거+skip)가 stuck도 해소 → B는 재검 no-op. 순서 무해.
+- 정상 로테이션 직후(end_time 막 지남, BUFFER 내): B 탐지 제외 → 미손상.
+- orphan이 현재 DJ 아님: 제거만, 현재 재생 무중단.
+- 락 경합/획득 실패: presence 패턴대로 WARN 로깅 후 다음 tick에 재시도(잡 자체는 멱등).
+- 빈 룸(active crew 0): 치유 후 deactivate, broadcast 생략 무해.
+- **TERMINATED/SUSPENDED 룸**: 두 탐지 쿼리에 `PartyroomData`를 조인해 **`status = ACTIVE`만** 대상으로(죽은 룸에서 heal·이벤트 발행 노이즈 방지). TERMINATED row는 존재하므로 `getPartyroomById`는 안 던짐 → 명시적 status 필터 필요.
+- **is_activated=true ∧ current_playback null**: Sweep B의 LEFT JOIN `p IS NULL` 분기로 stuck 처리(skipPlayback→빈 큐면 deactivate).
+
+## 7. 테스트
+- **탐지 쿼리 IT**: orphan dj 선별(active crew의 dj 제외) / stuck 선별(BUFFER 내 트랙 제외·is_activated=false 제외·**activated+null playback 포함**·**TERMINATED 룸 제외**).
+- **치유 단위**: orphan=현재DJ → removeDjs+skipPlayback / orphan=비현재 → 제거만, skip 미호출 / stuck → skipPlayback / 멱등(조건 미충족 룸 → 아무 mutation 없음).
+- **안전 회귀**: BUFFER 내 정상 재생 룸·TERMINATED 룸은 sweep 대상 아님.
+
+## 8. 미해결 / 후속
+- prod 1회성 복구(이미 방치된 룸)는 cron이 첫 tick에 자동 처리 → 별도 SQL 불요(단 배포 직후 첫 sweep 로그 확인 권장).
+- 멀티 인스턴스 시 cron 중복 실행은 룸별 분산락이 흡수(presence와 동일).


### PR DESCRIPTION
## 무엇을 / 왜
party 도메인은 presence에만 자가치유 cron이 있고 playback/dj엔 없었다. 예방 fix(#300·#305)는 새 오염만 막을 뿐 **이미 생긴 오염을 retroactive하게 치유 못 함.** 두 잔존-오염 클래스를 60s cron으로 자가치유한다.

- **A. orphan DJ** (`dj.crew inactive`) — 회전 유령(오늘 룸1 목격, #304 잔재).
- **B. stuck playback** (`is_activated=1 ∧ end_time<now-90s` 또는 null playback) — 정지 유령(#299/#195).

## 설계/계획
- 스펙: `docs/superpowers/specs/2026-06-19-playback-reconcile-cron-design.md` (서브에이전트 리뷰 통과)
- 계획: `docs/superpowers/plans/2026-06-19-playback-reconcile-cron.md`

## 구현
- 신규 `PartyroomPlaybackReconcileService`(@Scheduled 60s + 2 sweep + 룸별 분산락) + 별 빈 `PlaybackReconcileHealer`(@Transactional heal — self-invocation 회피로 재검+mutation 1 txn).
- 신규 탐지쿼리 2개(`DjRepository`/`PartyroomPlaybackRepository`) — 임베디드 `.id` 경로, TERMINATED 룸 제외, stuck은 null-playback도 LEFT JOIN으로 포함.
- 치유: 기존 `skipPlayback`(cancel+tryProceed → 회전/deactivate)·`removeDjs` 재사용.

## 안전
- **BUFFER 90s + in-txn 멱등 재검**이 정상-path 레이스 방어. ⚠️ 정상 playback 커맨드는 분산락 미사용 → 이 락은 **멀티 인스턴스 cron 중복만 차단**(정상 커맨드와 상호배제 X). 락 실패는 WARN 후 다음 tick 재시도.
- stuck 치유에 DJ 포인트 미부여(skipPlayback). cron이 AuthContext 없이 호출 → 치유 경로 무-AuthContext 확인(리뷰 clean).

## 검증
- 신규 탐지쿼리 JPQL 컨텍스트 부팅 검증, 단위 9 GREEN(orphan current/non-current/none · stuck expired/null/fresh/deactivated · sweep wiring), **`:app:test` 풀 회귀 GREEN**.

## prod 잔존
배포 후 첫 sweep이 방치된 룸(오늘 룸1 류·#299 6일 stuck 전례)을 자동 정리 → 별도 복구 SQL 불요(첫 sweep 로그 확인 권장).

관련: Cluster G · #241(인접) · 포렌식 #299·#304 · 예방 #300·#305