### PR TITLE
fix(party): 파티룸 목록 활성 크루 수 내림차순 정렬(동률 시 최신 생성순) (#310)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/impl/PartyroomRepositoryImpl.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/impl/PartyroomRepositoryImpl.java
@@ -98,7 +98,8 @@ public class PartyroomRepositoryImpl implements PartyroomRepositoryCustom {
                         playbackDto,
                         qCrewData.id,
                         qCrewData.userId,
-                        qCrewData.gradeType
+                        qCrewData.gradeType,
+                        qPartyroomData.createdAt
                 )
                 .from(qPartyroomData)
                 .join(qPlayback).on(qPlayback.partyroomId.id.eq(qPartyroomData.id))
@@ -145,6 +146,7 @@ public class PartyroomRepositoryImpl implements PartyroomRepositoryCustom {
                                 Boolean.TRUE.equals(tuple.get(qPlayback.isActivated)),
                                 Boolean.TRUE.equals(tuple.get(qDjQueue.isClosed)),
                                 tuple.get(crewCountSubquery),
+                                tuple.get(qPartyroomData.createdAt),
                                 tuple.get(8, PlaybackDto.class),
                                 crewsByPartyroomId.getOrDefault(tuple.get(qPartyroomData.id), List.of())
                         ),

--- a/app/src/main/java/com/pfplaybackend/api/party/application/dto/partyroom/PartyroomWithCrewDto.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/dto/partyroom/PartyroomWithCrewDto.java
@@ -5,6 +5,7 @@ import com.pfplaybackend.api.party.application.dto.crew.CrewDto;
 import com.pfplaybackend.api.party.application.dto.playback.PlaybackDto;
 import com.pfplaybackend.api.party.domain.enums.StageType;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record PartyroomWithCrewDto(
@@ -16,12 +17,13 @@ public record PartyroomWithCrewDto(
         boolean playbackActivated,
         boolean queueClosed,
         Long crewCount,
+        LocalDateTime createdAt,
         PlaybackDto playbackDto,
         List<CrewDto> crews
 ) {
     public static PartyroomWithCrewDto from(PartyroomWithCrewDto dto, List<CrewDto> members) {
         return new PartyroomWithCrewDto(
                 dto.partyroomId(), dto.stageType(), dto.hostId(), dto.title(), dto.introduction(),
-                dto.playbackActivated(), dto.queueClosed(), dto.crewCount(), dto.playbackDto(), members);
+                dto.playbackActivated(), dto.queueClosed(), dto.crewCount(), dto.createdAt(), dto.playbackDto(), members);
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomQueryService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomQueryService.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -45,13 +46,23 @@ public class PartyroomQueryService {
 
     @Transactional(readOnly = true)
     public List<PartyroomWithCrewDto> getAllPartyrooms() {
-        return queryPort.getCrewDataByPartyroomId().stream().map(partyroomWithCrewDto -> {
-            List<CrewDto> filteredCrews = partyroomWithCrewDto.crews().stream()
-                                .filter(crewDto -> crewDto.gradeType().isEqualOrHigherThan(GradeType.MODERATOR))
-                                .limit(3)
-                                .toList();
-            return PartyroomWithCrewDto.from(partyroomWithCrewDto, filteredCrews);
-        }).toList();
+        // 활성 크루 수 내림차순, 동률이면 최신 생성순(createdAt DESC). (#310)
+        // (조회 쿼리는 결과를 HashMap 으로 모아 순서가 비결정적이므로 여기서 결정론적으로 정렬한다.)
+        Comparator<PartyroomWithCrewDto> byCrewCountDesc = Comparator
+                .comparingLong((PartyroomWithCrewDto dto) -> dto.crewCount() == null ? 0L : dto.crewCount())
+                .reversed();
+        Comparator<PartyroomWithCrewDto> byCreatedAtDesc = Comparator
+                .comparing(PartyroomWithCrewDto::createdAt, Comparator.nullsLast(Comparator.reverseOrder()));
+
+        return queryPort.getCrewDataByPartyroomId().stream()
+                .sorted(byCrewCountDesc.thenComparing(byCreatedAtDesc))
+                .map(partyroomWithCrewDto -> {
+                    List<CrewDto> filteredCrews = partyroomWithCrewDto.crews().stream()
+                            .filter(crewDto -> crewDto.gradeType().isEqualOrHigherThan(GradeType.MODERATOR))
+                            .limit(3)
+                            .toList();
+                    return PartyroomWithCrewDto.from(partyroomWithCrewDto, filteredCrews);
+                }).toList();
     }
 
     @Transactional(readOnly = true)

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomQueryServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomQueryServiceTest.java
@@ -32,6 +32,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -80,7 +81,7 @@ class PartyroomQueryServiceTest {
 
         PartyroomWithCrewDto dto = new PartyroomWithCrewDto(
                 1L, StageType.GENERAL, new UserId(100L), "Test Room", "Hello",
-                false, false, 6L, null,
+                false, false, 6L, LocalDateTime.now(), null,
                 List.of(host, communityManager, moderator, moderator2, clubber, listener)
         );
         when(queryPort.getCrewDataByPartyroomId()).thenReturn(List.of(dto));
@@ -93,6 +94,33 @@ class PartyroomQueryServiceTest {
         List<CrewDto> filteredCrews = result.get(0).crews();
         assertThat(filteredCrews).hasSize(3)
                 .allMatch(c -> c.gradeType().isEqualOrHigherThan(GradeType.MODERATOR));
+    }
+
+    @Test
+    @DisplayName("getAllPartyrooms — 활성 크루 수 내림차순, 동률이면 최신 생성순 정렬 (#310)")
+    void getAllPartyroomsOrdersByCrewCountDescThenCreatedAtDesc() {
+        // given — 입력 순서는 무작위(정렬 비반영), 기대=크루수 DESC, 동률(5) 시 createdAt DESC
+        LocalDateTime older = LocalDateTime.of(2026, 6, 1, 0, 0);
+        LocalDateTime newer = LocalDateTime.of(2026, 6, 18, 0, 0);
+        PartyroomWithCrewDto roomA = roomWith(1L, 3L, older);      // crew 3
+        PartyroomWithCrewDto roomB_old = roomWith(2L, 5L, older);  // crew 5, 오래된
+        PartyroomWithCrewDto roomB_new = roomWith(3L, 5L, newer);  // crew 5, 최신
+        PartyroomWithCrewDto roomC = roomWith(4L, 9L, older);      // crew 9 (최다)
+        when(queryPort.getCrewDataByPartyroomId())
+                .thenReturn(List.of(roomA, roomB_old, roomB_new, roomC));
+
+        // when
+        List<PartyroomWithCrewDto> result = partyroomQueryService.getAllPartyrooms();
+
+        // then — 9 / 5(최신) / 5(오래된) / 3
+        assertThat(result).extracting(PartyroomWithCrewDto::partyroomId)
+                .containsExactly(4L, 3L, 2L, 1L);
+    }
+
+    private PartyroomWithCrewDto roomWith(long id, long crewCount, LocalDateTime createdAt) {
+        return new PartyroomWithCrewDto(
+                id, StageType.GENERAL, new UserId(100L), "room" + id, "intro",
+                false, false, crewCount, createdAt, null, List.of());
     }
 
     @Test
@@ -357,7 +385,7 @@ class PartyroomQueryServiceTest {
 
         PartyroomWithCrewDto dto = new PartyroomWithCrewDto(
                 1L, StageType.GENERAL, user1, "Room", "Intro",
-                false, false, 2L, null, List.of(crew1, crew2));
+                false, false, 2L, LocalDateTime.now(), null, List.of(crew1, crew2));
 
         ProfileSettingDto setting1 = new ProfileSettingDto(
                 "Nick1", AvatarCompositionType.BODY_WITH_FACE, "body1.png", "face1.png", "icon1.png",


### PR DESCRIPTION
## 문제
파티룸 목록(`getAllPartyrooms`)이 **기준 없이** 반환. 원인 2가지: ① QueryDSL 정렬이 `id asc, grade asc`라 활성 크루 수 기준 없음 ② 결과를 3-arg `toMap`(HashMap)으로 모아 `.values()` → **쿼리 orderBy 순서 소실**(HashMap 버킷 순).

## 수정
활성 크루 수는 이미 `crewCount` 서브쿼리로 집계됨. tie-break용 `createdAt`을 `PartyroomWithCrewDto`에 노출(QueryDSL select + from 팩토리)하고, **`getAllPartyrooms`에서 `crewCount DESC, 동률 시 createdAt DESC`로 결정론적 정렬**.
- 서비스 레이어 정렬 → HashMap 비결정성과 무관하게 출력 확정 + 단위 테스트 가능.
- `getCrewDataByPartyroomId` 소비자=`getAllPartyrooms` 하나라 범위 안전. 컨트롤러 매핑은 accessor 기반이라 DTO 필드 추가 무파손.

## 검증
- TDD: 무작위 입력(크루수·createdAt 섞임) → `[9, 5(최신), 5(오래된), 3]` 순서 단언 RED→GREEN.
- `:app:test` 풀 회귀 GREEN.