### PR TITLE
fix(user): 신규 회원 디폴트 아바타 시드 + 빈-아바타 백필 (#312)

### DIFF
--- a/app/src/main/resources/db/migration/V30__backfill_empty_member_avatar.sql
+++ b/app/src/main/resources/db/migration/V30__backfill_empty_member_avatar.sql
@@ -1,0 +1,39 @@
+-- =====================================================
+-- V30: 빈-아바타 회원 백필 (#312)
+--
+-- Why:
+--   실제 OAuth 회원가입 경로(MemberSignService.initializeNewMember →
+--   UserProfileCommandService.createProfileDataForMember)가 디폴트 아바타를
+--   시드하지 않아, 신규 회원의 avatar body/face/icon 이 모두 '' 로 남았다
+--   (ProfileData.@PrePersist applyDefaults 가 null→'' 보정). 게스트/슈퍼어드민/
+--   임시 풀멤버는 buildDefaultAvatarProfile 로 디폴트를 받지만 회원만 누락.
+--   특히 모바일 가입자는 아바타 편집 진입이 막혀(web #393 의도된 desktop-only)
+--   영구 빈-아바타로 남는다. 코드 fix(createProfileDataForMember → 디폴트 시드)와
+--   함께 이미 빈-아바타로 박힌 기존 회원을 보정한다.
+--
+-- 무엇으로 채우나:
+--   신규 회원이 코드 fix 후 받는 디폴트와 '동일'해야 한다. 현재 디폴트 바디는
+--   ava_body_basic_003(유령, is_combinable=0)이므로 SINGLE_BODY 규약을 따른다
+--   (V20 과 동일):
+--     avatar_body_uri          = 003 바디 URL
+--     avatar_face_uri          = '' (SINGLE_BODY: face 합성 없음)
+--     avatar_icon_uri          = 003 body 페어 아이콘
+--     avatar_composition_type  = SINGLE_BODY
+--     face_source_type         = INTERNAL_IMAGE (빈-아바타 회원은 NULL 일 수 있어 명시 보정)
+--     combine_positionx/y      = 0,0 (003 시드값)
+--
+-- 식별 조건:
+--   avatar_body_uri = '' 인 user_profile 만 대상. 빈 바디는 회원 누락 경로의
+--   고유 시그니처다(게스트/슈퍼어드민은 항상 디폴트 바디를 받으므로 빈 바디가
+--   존재할 수 없다). 사용자가 설정한 아바타(비어있지 않은 바디)는 건드리지 않는다.
+-- =====================================================
+
+UPDATE user_profile up
+   SET up.avatar_body_uri          = 'https://firebasestorage.googleapis.com/v0/b/pfplay-firebase.appspot.com/o/ava_basic%2Fava_basic_003.png?alt=media',
+       up.avatar_face_uri          = '',
+       up.avatar_icon_uri          = 'https://firebasestorage.googleapis.com/v0/b/pfplay-firebase.appspot.com/o/ava_icon%2Fava_icon_body_basic_003.png?alt=media',
+       up.avatar_composition_type  = 'SINGLE_BODY',
+       up.face_source_type         = 'INTERNAL_IMAGE',
+       up.combine_positionx        = 0,
+       up.combine_positiony        = 0
+ WHERE up.avatar_body_uri = '';

--- a/user/src/main/java/com/pfplaybackend/api/user/application/service/UserProfileCommandService.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/service/UserProfileCommandService.java
@@ -25,10 +25,13 @@ public class UserProfileCommandService {
         return buildDefaultAvatarProfile(userId, new Nickname(generateUniqueGuestNickname()));
     }
 
+    // 회원도 게스트/슈퍼어드민과 동일하게 디폴트 아바타를 시드한다. 닉네임만 비워두고
+    // (회원 온보딩의 updateProfileBio 가 채움) 아바타 body/face/icon 은 디폴트로 채운다.
+    // 이 디폴트가 없으면 모바일 가입자는 아바타 편집 진입이 막혀 영구 빈-아바타로 남는다
+    // (모바일 온보딩 #393 이 전제한 '서버 자동 셋팅'을 충족). 디폴트 아바타는 is_profile_updated
+    // 와 무관하므로 데스크탑 강제 온보딩 게이트(profileUpdated 일회성)에 영향 없다.
     public ProfileData createProfileDataForMember(UserId userId) {
-        return ProfileData.builder()
-                .userId(userId)
-                .build();
+        return buildDefaultAvatarProfile(userId, null);
     }
 
     public ProfileData createProfileDataForSuperAdmin(UserId userId) {

--- a/user/src/test/java/com/pfplaybackend/api/user/application/service/UserProfileCommandServiceTest.java
+++ b/user/src/test/java/com/pfplaybackend/api/user/application/service/UserProfileCommandServiceTest.java
@@ -115,15 +115,32 @@ class UserProfileCommandServiceTest {
     }
 
     @Test
-    @DisplayName("createProfileDataForMember — 멤버 프로필이 생성된다")
-    void createProfileDataForMemberCreatesMinimalProfile() {
-        // given
+    @DisplayName("createProfileDataForMember — 멤버 프로필이 기본 아바타로 생성된다(닉네임은 온보딩에서 별도 설정)")
+    void createProfileDataForMemberCreatesWithDefaultAvatar() {
+        // given: 게스트/슈퍼어드민과 동일한 디폴트 아바타 시드.
+        // #393 모바일 온보딩 설계가 전제한 '서버 자동 셋팅'을 회원 경로에서도 충족해야 한다.
         UserId userId = new UserId(1L);
+        AvatarBodyDto defaultBody = AvatarBodyDto.builder()
+                .id(1L).name("default").resourceUri(DEFAULT_BODY)
+                .obtainableType(ObtainmentType.BASIC).obtainableScore(0)
+                .combinable(true).defaultSetting(true)
+                .combinePositionX(50).combinePositionY(100)
+                .build();
+        when(userAvatarQueryService.getDefaultAvatarBody()).thenReturn(defaultBody);
+        when(userAvatarQueryService.getDefaultAvatarBodyUri()).thenReturn(new AvatarBodyUri(DEFAULT_BODY));
+        when(userAvatarQueryService.getDefaultAvatarFaceUri()).thenReturn(new AvatarFaceUri("default-face"));
+        when(userAvatarQueryService.getDefaultAvatarIconUri()).thenReturn(new AvatarIconUri("default-icon"));
 
         // when
         ProfileData profile = userProfileCommandService.createProfileDataForMember(userId);
 
-        // then
+        // then: 아바타 3종이 비어있지 않고 디폴트로 채워진다 (크루 목록 렌더 가능).
         assertThat(profile.getUserId()).isEqualTo(userId);
+        assertThat(profile.getAvatarSetting().getAvatarBodyUri().getValue()).isEqualTo(DEFAULT_BODY);
+        assertThat(profile.getAvatarSetting().getAvatarFaceUri().getValue()).isEqualTo("default-face");
+        assertThat(profile.getAvatarSetting().getAvatarIconUri().getValue()).isEqualTo("default-icon");
+        assertThat(profile.getAvatarSetting().getAvatarCompositionType()).isEqualTo(AvatarCompositionType.BODY_WITH_FACE);
+        // 닉네임은 회원 온보딩(updateProfileBio)에서 설정 — 생성 시점엔 비어있다.
+        assertThat(profile.getNicknameValue()).isNull();
     }
 }


### PR DESCRIPTION
Closes #312

## 문제
신규 OAuth 회원의 avatar body/face/icon 이 모두 ''. `createProfileDataForMember` 가 아바타를 시드하지 않아 `@PrePersist applyDefaults()` 가 셋을 null→'' 보정. 게스트/슈퍼어드민/임시 풀멤버는 디폴트를 받지만 회원만 누락. 모바일 가입자는 아바타 편집이 막혀(web #393) 영구 빈-아바타.

## 수정
- `createProfileDataForMember` → `buildDefaultAvatarProfile(userId, null)` 위임 (게스트/슈퍼어드민과 대칭). 닉네임은 온보딩 `updateProfileBio` 가 채움.
- 디폴트 아바타는 `is_profile_updated` 와 무관(아바타 setter 미변경, true 전이는 bio 한 곳뿐) → 데스크탑 강제 온보딩 게이트 무영향. 모바일 가입자 데스크탑 재로그인 시 아바타 재유도 안 뜸.
- **V30**: 이미 빈-아바타로 박힌 기존 회원을 유령 바디 SINGLE_BODY 디폴트로 백필(V20 규약 동일).

## 테스트
- 단위: `UserProfileCommandServiceTest` — 회원 프로필이 디폴트 아바타로 생성됨(RED→GREEN), `:user:test` 풀 GREEN.
- 로컬 풀스택 e2e(모바일 온보딩 → 디폴트 아바타) = 머지 전 게이트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)