### PR TITLE
fix(party): reconcile 쿼리 JPQL 경로 오류 — pr.partyroomId.id → pr.id

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/DjRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/DjRepository.java
@@ -21,7 +21,7 @@ public interface DjRepository extends JpaRepository<DjData, Long> {
      */
     @Query("SELECT DISTINCT d.partyroomId FROM DjData d, CrewData c, PartyroomData pr " +
            "WHERE c.id = d.crewId.id AND c.isActive = false " +
-           "AND pr.partyroomId.id = d.partyroomId.id " +
+           "AND pr.id = d.partyroomId.id " +
            "AND pr.status = com.pfplaybackend.api.party.domain.enums.PartyroomStatus.ACTIVE")
     List<PartyroomId> findPartyroomIdsWithInactiveCrewDj();
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomPlaybackRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomPlaybackRepository.java
@@ -17,7 +17,7 @@ public interface PartyroomPlaybackRepository extends JpaRepository<PartyroomPlay
      */
     @Query("SELECT pp.partyroomId FROM PartyroomPlaybackData pp, PartyroomData pr " +
            "LEFT JOIN PlaybackData p ON p.id = pp.currentPlaybackId.id " +
-           "WHERE pr.partyroomId.id = pp.partyroomId.id " +
+           "WHERE pr.id = pp.partyroomId.id " +
            "AND pr.status = com.pfplaybackend.api.party.domain.enums.PartyroomStatus.ACTIVE " +
            "AND pp.isActivated = true AND (p IS NULL OR p.endTime < :threshold)")
     List<PartyroomId> findStuckActivatedPartyroomIds(@Param("threshold") long threshold);


### PR DESCRIPTION
## 문제 (dev 부팅 크래시, Flyway 다음 단계)
`UnknownPathException: Could not resolve attribute 'partyroomId' of PartyroomData` → bean 생성 실패.
#308/#309 reconcile cron의 2개 JPQL이 `pr.partyroomId.id`를 참조하는데, `PartyroomData.partyroomId`는 `id`에서 파생되는 **비영속(@Transient)** 필드라 JPQL 조회 불가. @Id는 `private Long id`(col partyroom_id).

## 수정 (2곳)
- `DjRepository.findPartyroomIdsWithInactiveCrewDj`: `pr.partyroomId.id` → `pr.id`
- `PartyroomPlaybackRepository.findStuckActivatedPartyroomIds`: 동일
- 전수 스캔: 다른 @Query엔 동일 오류 없음. `PartyroomRepository`가 이미 `p.id` 사용(정합).

## 배포
base=develop. 머지 즉시 재배포로 복구.

🤖 Generated with [Claude Code](https://claude.com/claude-code)