### PR TITLE
fix(party): reconcile stuck 쿼리 Hibernate6 join 오류 — LEFT JOIN → NOT EXISTS

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomPlaybackRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomPlaybackRepository.java
@@ -13,12 +13,14 @@ public interface PartyroomPlaybackRepository extends JpaRepository<PartyroomPlay
     /**
      * stuck playback(is_activated=1인데 현재 트랙 end_time이 threshold 이전, 또는 current_playback 부재)을 가진
      * ACTIVE 룸 목록 — reconcile cron Sweep B (#308). end_time은 epoch-millis(Long, UTC).
-     * LEFT JOIN으로 "activated인데 current_playback null"도 stuck으로 포함.
+     * "activated인데 current_playback null/orphan"도 stuck으로 포함.
+     * NOT EXISTS(정상 진행 playback) = (current null | orphan | end_time<threshold) 와 동치
+     * — Hibernate6가 다중 root FROM에서 ON이 형제 root(pp) 참조하는 엔티티 LEFT JOIN을 거부하므로 서브쿼리로.
      */
     @Query("SELECT pp.partyroomId FROM PartyroomPlaybackData pp, PartyroomData pr " +
-           "LEFT JOIN PlaybackData p ON p.id = pp.currentPlaybackId.id " +
            "WHERE pr.id = pp.partyroomId.id " +
            "AND pr.status = com.pfplaybackend.api.party.domain.enums.PartyroomStatus.ACTIVE " +
-           "AND pp.isActivated = true AND (p IS NULL OR p.endTime < :threshold)")
+           "AND pp.isActivated = true " +
+           "AND NOT EXISTS (SELECT 1 FROM PlaybackData p WHERE p.id = pp.currentPlaybackId.id AND p.endTime >= :threshold)")
     List<PartyroomId> findStuckActivatedPartyroomIds(@Param("threshold") long threshold);
 }


### PR DESCRIPTION
## 문제 (dev 부팅 크래시 3번째)
`findStuckActivatedPartyroomIds`의 `LEFT JOIN PlaybackData p ON p.id = pp.currentPlaybackId.id`가 다중 root FROM에서 ON이 형제 root(`pp`)를 참조 → Hibernate6 `SemanticException: SqmQualifiedJoin predicate referred to SqmRoot other than the join's root` → startup 실패.

## 수정
`currentPlaybackId`는 임베디드값이라 association join 불가 → **의미동일 NOT EXISTS 서브쿼리**로 재작성:
`(p IS NULL OR p.endTime < threshold)` ≡ `NOT EXISTS(정상 진행 playback: id매치 AND endTime>=threshold)`. null·orphan·오래된 playback 전부 stuck으로 동일 포함.

## 검증
**로컬 docker compose 풀부팅 통과** — fresh DB V1–V31 전체 적용 + 전 bean 생성 + Tomcat 8080 기동 (Started Application in 62s). #314(Flyway)·#315(pr.id)에 이은 마지막 startup 이슈.

🤖 Generated with [Claude Code](https://claude.com/claude-code)