### PR TITLE
test: 통합 테스트 하네스 Flyway+validate 전환 + integrationTest CI 배선 (#318)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -39,10 +39,18 @@ jobs:
       - name: Run tests
         run: ./gradlew test
 
+      # 통합 테스트 게이트: Testcontainers(Docker) 로 실 Flyway 스키마 부팅 + validate.
+      # ubuntu-latest 는 Docker 지원 → Testcontainers 동작. 직렬 실행(공유 스키마 truncate
+      # 상호파괴 방지) 은 build.gradle 의 maxParallelForks=1 로 강제됨.
+      - name: Run integration tests
+        run: ./gradlew :app:integrationTest
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: '**/build/test-results/test/*.xml'
+          path: |
+            **/build/test-results/test/*.xml
+            **/build/test-results/integrationTest/*.xml
           retention-days: 14

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/persistence/AdministratorRepositoryIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/persistence/AdministratorRepositoryIntegrationTest.java
@@ -8,8 +8,10 @@ import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
 import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,12 +28,11 @@ class AdministratorRepositoryIntegrationTest extends AbstractIntegrationTest {
     @Test
     void findAllByOrderByGrantedAtDesc_returnsRowsNewestFirst() {
         // Seed three user_account rows and three administrator rows.
-        // AdministratorData factories stamp grantedAt = LocalDateTime.now() at
-        // construction. We rely on the JVM clock advancing between the three
-        // sequential save() calls — true in practice (nanosecond resolution on
-        // Linux/Testcontainers MySQL) but architecturally fragile. If this ever
-        // becomes flaky, expose a Clock-injectable factory and pin grantedAt
-        // explicitly in tests.
+        // AdministratorData factories stamp grantedAt = LocalDateTime.now(), but the
+        // granted_at 컬럼은 DATETIME(0)(초 정밀)이라 세 save 가 같은 초에 들어가면
+        // grantedAt 가 동률로 붕괴해 DESC 정렬이 비결정적이다(옛 create-drop datetime(6)
+        // 시절엔 나노가 보존돼 우연히 통과했었다). 정렬 검증이 load-bearing 이므로
+        // grantedAt 를 1초 간격으로 명시 고정한다.
         userAccountRepository.save(
                 UserAccountData.createForLocalWithMandatoryChange(
                         new UserId(100L), "super@x", "h0"));
@@ -42,12 +43,16 @@ class AdministratorRepositoryIntegrationTest extends AbstractIntegrationTest {
                 UserAccountData.createForLocalWithMandatoryChange(
                         new UserId(102L), "a2@x", "h2"));
 
-        AdministratorData superAdmin = administratorRepository.save(
-                AdministratorData.createSuperAdmin(100L));
-        AdministratorData a1 = administratorRepository.save(
-                AdministratorData.createAdmin(101L, superAdmin.getAdministratorId()));
-        AdministratorData a2 = administratorRepository.save(
-                AdministratorData.createAdmin(102L, superAdmin.getAdministratorId()));
+        LocalDateTime base = LocalDateTime.of(2026, 5, 4, 0, 0, 0);
+        AdministratorData superAdmin = AdministratorData.createSuperAdmin(100L);
+        ReflectionTestUtils.setField(superAdmin, "grantedAt", base);            // oldest
+        superAdmin = administratorRepository.save(superAdmin);
+        AdministratorData a1 = AdministratorData.createAdmin(101L, superAdmin.getAdministratorId());
+        ReflectionTestUtils.setField(a1, "grantedAt", base.plusSeconds(1));
+        a1 = administratorRepository.save(a1);
+        AdministratorData a2 = AdministratorData.createAdmin(102L, superAdmin.getAdministratorId());
+        ReflectionTestUtils.setField(a2, "grantedAt", base.plusSeconds(2));     // newest
+        a2 = administratorRepository.save(a2);
 
         flushAndClear();
 

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/persistence/SystemAnnouncementRepositoryIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/persistence/SystemAnnouncementRepositoryIntegrationTest.java
@@ -1,9 +1,14 @@
 package com.pfplaybackend.api.administration.adapter.out.persistence;
 
+import com.pfplaybackend.api.administration.domain.entity.data.AdministratorData;
 import com.pfplaybackend.api.administration.domain.entity.data.SystemAnnouncementData;
 import com.pfplaybackend.api.administration.domain.value.AnnouncementSeverity;
 import com.pfplaybackend.api.administration.domain.value.AnnouncementType;
 import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,10 +25,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Transactional
 class SystemAnnouncementRepositoryIntegrationTest extends AbstractIntegrationTest {
 
+    private static final long ADMIN_USER_ID = 990101L;
+
     @Autowired
     SystemAnnouncementRepository repo;
+    @Autowired
+    AdministratorRepository administratorRepository;
+    @Autowired
+    UserAccountRepository userAccountRepository;
 
     private final LocalDateTime now = LocalDateTime.of(2026, 5, 4, 0, 0);
+
+    /** FK fk_announcement_sent_by / cancelled_by → administrator(administrator_id). */
+    private Long adminId;
+
+    @BeforeEach
+    void seedAdmin() {
+        userAccountRepository.saveAndFlush(
+                UserAccountData.createForLocal(new UserId(ADMIN_USER_ID), "sysann-repo-it@x", "h"));
+        adminId = administratorRepository
+                .saveAndFlush(AdministratorData.createSuperAdmin(ADMIN_USER_ID))
+                .getAdministratorId();
+    }
 
     @Test
     @DisplayName("findDueForMaintenanceActivation — start<=now, end>now, started=null, cancelled=null")
@@ -76,28 +99,28 @@ class SystemAnnouncementRepositoryIntegrationTest extends AbstractIntegrationTes
                                                 LocalDateTime started, LocalDateTime cancelled) {
         SystemAnnouncementData d = SystemAnnouncementData.create(
                 AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
-                "k", "e", "ko", "en", s, e, null, now, 1L, false);
+                "k", "e", "ko", "en", s, e, null, now, adminId, false);
         if (started != null) ReflectionTestUtils.setField(d, "maintenanceStartedAt", started);
         if (cancelled != null) {
             ReflectionTestUtils.setField(d, "cancelledAt", cancelled);
-            ReflectionTestUtils.setField(d, "cancelledByAdministratorId", 2L);
+            ReflectionTestUtils.setField(d, "cancelledByAdministratorId", adminId);
         }
         return d;
     }
 
     private SystemAnnouncementData event() {
         return SystemAnnouncementData.create(AnnouncementType.EVENT, AnnouncementSeverity.INFO,
-                "k", "e", "ko", "en", null, null, null, now, 1L, false);
+                "k", "e", "ko", "en", null, null, null, now, adminId, false);
     }
 
     private SystemAnnouncementData eventWithExpiry(LocalDateTime exp) {
         return SystemAnnouncementData.create(AnnouncementType.EVENT, AnnouncementSeverity.INFO,
-                "k", "e", "ko", "en", null, null, exp, now, 1L, false);
+                "k", "e", "ko", "en", null, null, exp, now, adminId, false);
     }
 
     private SystemAnnouncementData eventCancelled() {
         SystemAnnouncementData d = event();
-        d.cancel(2L, Clock.fixed(now.toInstant(ZoneOffset.UTC), ZoneOffset.UTC));
+        d.cancel(adminId, Clock.fixed(now.toInstant(ZoneOffset.UTC), ZoneOffset.UTC));
         return d;
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/persistence/SystemAnnouncementRepositoryTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/persistence/SystemAnnouncementRepositoryTest.java
@@ -1,9 +1,14 @@
 package com.pfplaybackend.api.administration.adapter.out.persistence;
 
+import com.pfplaybackend.api.administration.domain.entity.data.AdministratorData;
 import com.pfplaybackend.api.administration.domain.entity.data.SystemAnnouncementData;
 import com.pfplaybackend.api.administration.domain.value.AnnouncementSeverity;
 import com.pfplaybackend.api.administration.domain.value.AnnouncementType;
 import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,15 +22,31 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Transactional
 class SystemAnnouncementRepositoryTest extends AbstractIntegrationTest {
 
+    private static final long ADMIN_USER_ID = 990102L;
+
     @Autowired SystemAnnouncementRepository repository;
+    @Autowired AdministratorRepository administratorRepository;
+    @Autowired UserAccountRepository userAccountRepository;
 
     private static final ZoneId Z = ZoneId.of("Asia/Seoul");
     private Clock clockAt(LocalDateTime t) { return Clock.fixed(t.atZone(Z).toInstant(), Z); }
 
+    /** FK fk_announcement_sent_by / cancelled_by → administrator(administrator_id). */
+    private Long adminId;
+
+    @BeforeEach
+    void seedAdmin() {
+        userAccountRepository.saveAndFlush(
+                UserAccountData.createForLocal(new UserId(ADMIN_USER_ID), "sysann-repo-test@x", "h"));
+        adminId = administratorRepository
+                .saveAndFlush(AdministratorData.createSuperAdmin(ADMIN_USER_ID))
+                .getAdministratorId();
+    }
+
     private SystemAnnouncementData maintenance(LocalDateTime start, LocalDateTime end) {
         return SystemAnnouncementData.create(
                 AnnouncementType.MAINTENANCE_NOTICE, AnnouncementSeverity.WARN,
-                "점검", "m", "b", "b", start, end, null, start.minusHours(1), 1L, false);
+                "점검", "m", "b", "b", start, end, null, start.minusHours(1), adminId, false);
     }
 
     @Test
@@ -53,7 +74,7 @@ class SystemAnnouncementRepositoryTest extends AbstractIntegrationTest {
 
         SystemAnnouncementData cancelled = maintenance(now.minusHours(1), now.minusMinutes(1));
         cancelled.markMaintenanceStarted(clockAt(now.minusHours(1)));
-        cancelled.cancel(1L, clockAt(now.minusMinutes(30)));
+        cancelled.cancel(adminId, clockAt(now.minusMinutes(30)));
         SystemAnnouncementData completed = maintenance(now.minusHours(1), now.minusMinutes(1));
         completed.markMaintenanceStarted(clockAt(now.minusHours(1)));
         completed.markCompleted(clockAt(now.minusMinutes(20)));

--- a/app/src/test/java/com/pfplaybackend/api/administration/application/service/AdminMemberWithdrawCommandServiceIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/application/service/AdminMemberWithdrawCommandServiceIT.java
@@ -60,7 +60,11 @@ class AdminMemberWithdrawCommandServiceIT extends AbstractIntegrationTest {
                 new UserId(SEED_USER_ACCOUNT_ID), "wd-it@g4it.local", "h");
         ua.recordLogin();  // set lastLoginAt
         userAccountRepository.saveAndFlush(ua);
-        this.seedLastLoginAt = ua.getLastLoginAt();
+        // lastLoginAt 컬럼이 DATETIME(0)(초 정밀)이라 저장 시 초로 반올림된다. 베이스라인을
+        // DB 에서 다시 읽어 반올림된 값으로 잡아야 withdraw 후 값과 정확히 비교된다.
+        entityManager.clear();
+        this.seedLastLoginAt = userAccountRepository.findById(new UserId(SEED_USER_ACCOUNT_ID))
+                .orElseThrow().getLastLoginAt();
 
         MemberData member = MemberData.createForUserAccount(SEED_USER_ACCOUNT_ID);
         this.memberId = memberRepository.saveAndFlush(member).getMemberId();
@@ -89,8 +93,8 @@ class AdminMemberWithdrawCommandServiceIT extends AbstractIntegrationTest {
         assertThat(ua.isWithdrawn()).isTrue();
         assertThat(ua.getEmail()).startsWith("withdrawn-").endsWith("@withdrawn.local");
         // lastLoginAt 미변경 (roadmap §11.2.2 compliance)
-        // — MySQL DATETIME(6) round-trip can shift sub-microsecond; tolerance 1ms is sufficient
-        //   to assert "untouched" vs "reset to now" (which would diverge by seconds).
+        // — 베이스라인을 DB 저장값(DATETIME(0) 반올림)으로 잡았으므로 untouched 면 정확히 일치.
+        //   withdraw 가 now 로 리셋했다면 초 단위로 벌어진다.
         assertThat(ua.getLastLoginAt()).isCloseTo(seedLastLoginAt, within(1, ChronoUnit.MILLIS));
 
         Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {

--- a/app/src/test/java/com/pfplaybackend/api/administration/application/service/AdminReportCommandServiceIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/application/service/AdminReportCommandServiceIT.java
@@ -2,8 +2,10 @@ package com.pfplaybackend.api.administration.application.service;
 
 import com.pfplaybackend.api.administration.adapter.in.web.dto.AdminReportDetailResponse;
 import com.pfplaybackend.api.administration.adapter.in.web.dto.AdminReportStatusUpdateRequest;
+import com.pfplaybackend.api.administration.adapter.out.persistence.AdministratorRepository;
 import com.pfplaybackend.api.administration.adapter.out.persistence.PartyroomReportRepository;
 import com.pfplaybackend.api.administration.application.AdminContext;
+import com.pfplaybackend.api.administration.domain.entity.data.AdministratorData;
 import com.pfplaybackend.api.administration.domain.entity.data.PartyroomReportData;
 import com.pfplaybackend.api.administration.domain.enums.ReportCategory;
 import com.pfplaybackend.api.administration.domain.enums.ReportStatus;
@@ -53,8 +55,12 @@ class AdminReportCommandServiceIT extends AbstractIntegrationTest {
 
     private static final long HOST_UID = 8201L;
     private static final long REPORTER_UID = 8202L;
-    private static final long ADMIN_ID = 99L;
-    private static final long FIRST_REVIEWER_ADMIN_ID = 88L;
+    private static final long ADMIN_USER_ID = 990199L;
+    private static final long REVIEWER_USER_ID = 990188L;
+
+    // FK reviewed_by_administrator_id → administrator. AUTO_INCREMENT id 이므로 시드 후 생성 id 채택.
+    private Long adminId;
+    private Long firstReviewerAdminId;
     private static final String NOTE = "처리 완료 메모";
 
     @Autowired AdminReportCommandService service;
@@ -63,6 +69,7 @@ class AdminReportCommandServiceIT extends AbstractIntegrationTest {
     @Autowired PartyroomRepository partyroomRepository;
     @Autowired MemberRepository memberRepository;
     @Autowired UserAccountRepository userAccountRepository;
+    @Autowired AdministratorRepository administratorRepository;
     @Autowired TransactionTemplate transactionTemplate;
 
     @PersistenceContext EntityManager em;
@@ -77,17 +84,21 @@ class AdminReportCommandServiceIT extends AbstractIntegrationTest {
 
     @BeforeEach
     void seed() {
+        // FK reviewed_by_administrator_id → administrator. actor(현재 검토자) + 첫 검토자 2명 시드.
+        adminId = seedAdmin(ADMIN_USER_ID, "admin-g4it@g4it.local", null);
+        firstReviewerAdminId = seedAdmin(REVIEWER_USER_ID, "reviewer-admin-g4it@g4it.local", adminId);
+
         seedMember(HOST_UID, "host-g4it@g4it.local");
         seedMember(REPORTER_UID, "reporter-g4it@g4it.local");
         partyroomId = seedRoom(HOST_UID, "g4-active-room").getId();
 
         // 4 reports each in different from-state.
         pendingId = saveReport(ReportStatus.PENDING, ReportCategory.SPAM, null);
-        reviewingId = saveReport(ReportStatus.REVIEWING, ReportCategory.HARASSMENT, FIRST_REVIEWER_ADMIN_ID);
-        resolvedId = saveReport(ReportStatus.RESOLVED, ReportCategory.OTHER, FIRST_REVIEWER_ADMIN_ID);
-        dismissedId = saveReport(ReportStatus.DISMISSED, ReportCategory.SPAM, FIRST_REVIEWER_ADMIN_ID);
+        reviewingId = saveReport(ReportStatus.REVIEWING, ReportCategory.HARASSMENT, firstReviewerAdminId);
+        resolvedId = saveReport(ReportStatus.RESOLVED, ReportCategory.OTHER, firstReviewerAdminId);
+        dismissedId = saveReport(ReportStatus.DISMISSED, ReportCategory.SPAM, firstReviewerAdminId);
 
-        given(adminContext.currentAdministratorId()).willReturn(ADMIN_ID);
+        given(adminContext.currentAdministratorId()).willReturn(adminId);
     }
 
     @AfterEach
@@ -104,6 +115,16 @@ class AdminReportCommandServiceIT extends AbstractIntegrationTest {
         userAccountRepository.saveAndFlush(
                 UserAccountData.createForLocal(new UserId(uid), email, "h"));
         memberRepository.saveAndFlush(MemberData.createForUserAccount(uid));
+    }
+
+    /** grantedBy=null → super admin, else 일반 admin. 생성된 administrator_id 반환. */
+    private Long seedAdmin(long uid, String email, Long grantedBy) {
+        userAccountRepository.saveAndFlush(
+                UserAccountData.createForLocal(new UserId(uid), email, "h"));
+        AdministratorData admin = (grantedBy == null)
+                ? AdministratorData.createSuperAdmin(uid)
+                : AdministratorData.createAdmin(uid, grantedBy);
+        return administratorRepository.saveAndFlush(admin).getAdministratorId();
     }
 
     private PartyroomData seedRoom(long hostUid, String title) {
@@ -162,7 +183,7 @@ class AdminReportCommandServiceIT extends AbstractIntegrationTest {
         assertThat(response.status()).isEqualTo(ReportStatus.REVIEWING);
         PartyroomReportData persisted = reportRepository.findById(pendingId).orElseThrow();
         assertThat(persisted.getStatus()).isEqualTo(ReportStatus.REVIEWING);
-        assertThat(persisted.getReviewedByAdministratorId()).isEqualTo(ADMIN_ID);
+        assertThat(persisted.getReviewedByAdministratorId()).isEqualTo(adminId);
         assertThat(persisted.getResolvedAt()).isNull();
         assertThat(persisted.getResolutionNote()).isNull();
     }
@@ -176,7 +197,7 @@ class AdminReportCommandServiceIT extends AbstractIntegrationTest {
         assertThat(response.status()).isEqualTo(ReportStatus.DISMISSED);
         PartyroomReportData persisted = reportRepository.findById(pendingId).orElseThrow();
         assertThat(persisted.getStatus()).isEqualTo(ReportStatus.DISMISSED);
-        assertThat(persisted.getReviewedByAdministratorId()).isEqualTo(ADMIN_ID);
+        assertThat(persisted.getReviewedByAdministratorId()).isEqualTo(adminId);
         assertThat(persisted.getResolvedAt()).isNotNull();
         assertThat(persisted.getResolutionNote()).isEqualTo(NOTE);
     }
@@ -190,8 +211,8 @@ class AdminReportCommandServiceIT extends AbstractIntegrationTest {
         assertThat(response.status()).isEqualTo(ReportStatus.RESOLVED);
         PartyroomReportData persisted = reportRepository.findById(reviewingId).orElseThrow();
         assertThat(persisted.getStatus()).isEqualTo(ReportStatus.RESOLVED);
-        // D3.2: 첫 검토자(FIRST_REVIEWER_ADMIN_ID) 보존, 현재 ADMIN_ID는 덮어쓰지 않음
-        assertThat(persisted.getReviewedByAdministratorId()).isEqualTo(FIRST_REVIEWER_ADMIN_ID);
+        // D3.2: 첫 검토자(firstReviewerAdminId) 보존, 현재 adminId는 덮어쓰지 않음
+        assertThat(persisted.getReviewedByAdministratorId()).isEqualTo(firstReviewerAdminId);
         assertThat(persisted.getResolvedAt()).isNotNull();
         assertThat(persisted.getResolutionNote()).isEqualTo(NOTE);
     }
@@ -206,7 +227,7 @@ class AdminReportCommandServiceIT extends AbstractIntegrationTest {
         PartyroomReportData persisted = reportRepository.findById(reviewingId).orElseThrow();
         assertThat(persisted.getStatus()).isEqualTo(ReportStatus.PENDING);
         // D3.2: hold 시에도 첫 검토자(audit) 보존
-        assertThat(persisted.getReviewedByAdministratorId()).isEqualTo(FIRST_REVIEWER_ADMIN_ID);
+        assertThat(persisted.getReviewedByAdministratorId()).isEqualTo(firstReviewerAdminId);
         assertThat(persisted.getResolvedAt()).isNull();
     }
 
@@ -298,6 +319,6 @@ class AdminReportCommandServiceIT extends AbstractIntegrationTest {
         assertThat(response.partyroom().host()).isNotNull();
         assertThat(response.partyroom().host().userAccountId()).isEqualTo(HOST_UID);
         assertThat(response.review()).isNotNull();
-        assertThat(response.review().reviewedByAdministratorId()).isEqualTo(ADMIN_ID);
+        assertThat(response.review().reviewedByAdministratorId()).isEqualTo(adminId);
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/common/AbstractIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/common/AbstractIntegrationTest.java
@@ -7,11 +7,16 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.TestExecutionListeners.MergeMode;
 import org.springframework.transaction.annotation.Transactional;
 
 @Tag("integration")
 @SpringBootTest
 @ActiveProfiles("test")
+@TestExecutionListeners(
+        value = DatabaseCleanupTestExecutionListener.class,
+        mergeMode = MergeMode.MERGE_WITH_DEFAULTS)
 public abstract class AbstractIntegrationTest {
 
     @DynamicPropertySource

--- a/app/src/test/java/com/pfplaybackend/api/common/DatabaseCleaner.java
+++ b/app/src/test/java/com/pfplaybackend/api/common/DatabaseCleaner.java
@@ -1,0 +1,78 @@
+package com.pfplaybackend.api.common;
+
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 공유 Testcontainers MySQL 스키마를 각 테스트 시작 전 "깨끗한 슬레이트"로 복원한다 (스펙 §3.2).
+ *
+ * <h2>별도 autocommit 커넥션 (C1)</h2>
+ * MySQL {@code TRUNCATE} 는 DDL 이라 implicit COMMIT 을 유발한다. 스위트의 다수 IT 가 class-level
+ * {@code @Transactional}(롤백형)이므로, cleaner 를 test 커넥션에서 돌리면 test 트랜잭션이 강제 커밋되어
+ * 롤백 격리가 붕괴한다. 따라서 truncate 는 <b>test 트랜잭션과 무관한 별도 커넥션(autocommit=true)</b>에서
+ * 실행한다 — implicit commit 이 자기 커넥션에만 적용되므로 test tx 를 절대 깨지 않는다.
+ *
+ * <h2>PRESERVE_SET (레퍼런스 시드 보존)</h2>
+ * Flyway 시드가 채우는 참조 테이블은 truncate 하지 않는다. 전부 outgoing FK 가 없어 FK-closure 를
+ * 만족한다(FK_CHECKS=0 로 대상을 비워도 dangling 참조가 생기지 않음). {@code avatar_icon_resource}
+ * 는 V12 에서 DROP 되어 base table 로 나타나지 않지만 방어적으로 포함한다.
+ */
+@Component
+public class DatabaseCleaner {
+
+    private static final Set<String> PRESERVE = Set.of(
+            "flyway_schema_history",
+            "avatar_body_resource",
+            "avatar_face_resource",
+            "avatar_icon_resource",
+            "system_config");
+
+    private final DataSource dataSource;
+
+    public DatabaseCleaner(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public void clean() {
+        try (Connection c = dataSource.getConnection()) {
+            c.setAutoCommit(true);
+            List<String> tables = queryBaseTables(c);
+            try (Statement s = c.createStatement()) {
+                s.execute("SET FOREIGN_KEY_CHECKS=0");
+                try {
+                    for (String t : tables) {
+                        if (!PRESERVE.contains(t)) {
+                            s.execute("TRUNCATE TABLE `" + t + "`");
+                        }
+                    }
+                } finally {
+                    // 세션 변수(FOREIGN_KEY_CHECKS)는 HikariCP 가 리셋하지 않으므로,
+                    // 예외 경로에서도 반드시 복원해 FK 검사 꺼진 커넥션이 풀로 반환되는 오염을 막는다.
+                    s.execute("SET FOREIGN_KEY_CHECKS=1");
+                }
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("DB cleanup 실패", e);
+        }
+    }
+
+    private List<String> queryBaseTables(Connection c) throws SQLException {
+        List<String> tables = new ArrayList<>();
+        String sql = "SELECT table_name FROM information_schema.tables "
+                + "WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'";
+        try (Statement s = c.createStatement(); ResultSet rs = s.executeQuery(sql)) {
+            while (rs.next()) {
+                tables.add(rs.getString(1));
+            }
+        }
+        return tables;
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/common/DatabaseCleaner.java
+++ b/app/src/test/java/com/pfplaybackend/api/common/DatabaseCleaner.java
@@ -8,11 +8,18 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 /**
  * 공유 Testcontainers MySQL 스키마를 각 테스트 시작 전 "깨끗한 슬레이트"로 복원한다 (스펙 §3.2).
+ *
+ * <h2>더티 테이블만 truncate (2026-07-10 최적화)</h2>
+ * 현재 (0행 AND AUTO_INCREMENT=1) 인 테이블은 truncate 가 no-op 이므로 스킵한다. InnoDB TRUNCATE 는
+ * DDL fsync 를 유발하는데 Docker Desktop for Windows 에선 테이블당 1~2초로 매우 느리다. "더티" =
+ * (행 존재: 라이브 EXISTS) ∪ (AUTO_INCREMENT>1: MySQL 8.0 통계캐시 우회 후 information_schema).
+ * 사후 상태는 전 테이블 truncate 와 동일(스펙 §3.4).
  *
  * <h2>별도 autocommit 커넥션 (C1)</h2>
  * MySQL {@code TRUNCATE} 는 DDL 이라 implicit COMMIT 을 유발한다. 스위트의 다수 IT 가 class-level
@@ -22,8 +29,8 @@ import java.util.Set;
  *
  * <h2>PRESERVE_SET (레퍼런스 시드 보존)</h2>
  * Flyway 시드가 채우는 참조 테이블은 truncate 하지 않는다. 전부 outgoing FK 가 없어 FK-closure 를
- * 만족한다(FK_CHECKS=0 로 대상을 비워도 dangling 참조가 생기지 않음). {@code avatar_icon_resource}
- * 는 V12 에서 DROP 되어 base table 로 나타나지 않지만 방어적으로 포함한다.
+ * 만족한다. {@code avatar_icon_resource} 는 V12 에서 DROP 되어 base table 로 나타나지 않지만
+ * 방어적으로 포함한다.
  */
 @Component
 public class DatabaseCleaner {
@@ -44,12 +51,13 @@ public class DatabaseCleaner {
     public void clean() {
         try (Connection c = dataSource.getConnection()) {
             c.setAutoCommit(true);
-            List<String> tables = queryBaseTables(c);
+            List<String> targets = nonPreserveBaseTables(c);
+            Set<String> dirty = detectDirtyTables(c, targets);
             try (Statement s = c.createStatement()) {
                 s.execute("SET FOREIGN_KEY_CHECKS=0");
                 try {
-                    for (String t : tables) {
-                        if (!PRESERVE.contains(t)) {
+                    for (String t : targets) {
+                        if (dirty.contains(t)) {
                             s.execute("TRUNCATE TABLE `" + t + "`");
                         }
                     }
@@ -62,6 +70,74 @@ public class DatabaseCleaner {
         } catch (SQLException e) {
             throw new IllegalStateException("DB cleanup 실패", e);
         }
+    }
+
+    /** 화이트박스 검증용: truncate 없이 더티 테이블 집합만 계산해 반환. */
+    Set<String> selectDirtyTables() {
+        try (Connection c = dataSource.getConnection()) {
+            c.setAutoCommit(true);
+            return detectDirtyTables(c, nonPreserveBaseTables(c));
+        } catch (SQLException e) {
+            throw new IllegalStateException("더티 테이블 감지 실패", e);
+        }
+    }
+
+    private List<String> nonPreserveBaseTables(Connection c) throws SQLException {
+        List<String> out = new ArrayList<>();
+        for (String t : queryBaseTables(c)) {
+            if (!PRESERVE.contains(t)) {
+                out.add(t);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * pristine(0행 AND AUTO_INCREMENT=1) 이 아닌 테이블 집합.
+     * 조건① 행 존재(라이브 EXISTS 배치) ∪ 조건② AUTO_INCREMENT>1.
+     * ⚠️ MySQL 8.0 은 information_schema 의 AUTO_INCREMENT/TABLE_ROWS 를 캐시하며 DML 로 무효화되지
+     * 않는다. 조회 전 {@code SET SESSION information_schema_stats_expiry=0} 으로 live 값을 강제해야
+     * INSERT-롤백으로 "비었지만 AI 전진" 한 테이블을 놓치지 않는다(스펙 §3.2, §6). 조건①(EXISTS)는
+     * 라이브 데이터 쿼리라 캐시와 무관.
+     */
+    private Set<String> detectDirtyTables(Connection c, List<String> targets) throws SQLException {
+        Set<String> dirty = new HashSet<>();
+        if (targets.isEmpty()) {
+            return dirty;
+        }
+
+        // 조건① 행 존재 — 라이브 EXISTS 배치(fsync 없음).
+        StringBuilder sb = new StringBuilder();
+        for (String t : targets) {
+            if (sb.length() > 0) {
+                sb.append(" UNION ALL ");
+            }
+            sb.append("SELECT '").append(t).append("' AS t FROM DUAL WHERE EXISTS (SELECT 1 FROM `")
+              .append(t).append("`)");
+        }
+        try (Statement s = c.createStatement(); ResultSet rs = s.executeQuery(sb.toString())) {
+            while (rs.next()) {
+                dirty.add(rs.getString(1));
+            }
+        }
+
+        // 조건② AUTO_INCREMENT>1 — 8.0 통계캐시 우회(라이브).
+        try (Statement s = c.createStatement()) {
+            s.execute("SET SESSION information_schema_stats_expiry = 0");
+        }
+        Set<String> targetSet = new HashSet<>(targets);
+        try (Statement s = c.createStatement();
+             ResultSet rs = s.executeQuery(
+                     "SELECT table_name FROM information_schema.tables "
+                             + "WHERE table_schema = DATABASE() AND auto_increment > 1")) {
+            while (rs.next()) {
+                String t = rs.getString(1);
+                if (targetSet.contains(t)) {
+                    dirty.add(t);
+                }
+            }
+        }
+        return dirty;
     }
 
     private List<String> queryBaseTables(Connection c) throws SQLException {

--- a/app/src/test/java/com/pfplaybackend/api/common/DatabaseCleanerIsolationIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/common/DatabaseCleanerIsolationIT.java
@@ -4,8 +4,10 @@ import com.pfplaybackend.api.administration.adapter.out.persistence.BugReportRep
 import com.pfplaybackend.api.administration.domain.entity.data.BugReportData;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,6 +32,16 @@ class DatabaseCleanerIsolationIT extends AbstractIntegrationTest {
 
     @Autowired
     BugReportRepository bugReportRepository;
+    @Autowired
+    DatabaseCleaner databaseCleaner;
+    @Autowired
+    TransactionTemplate transactionTemplate;
+
+    private BugReportData newProbe(String desc) {
+        return BugReportData.create(
+                REPORTER_UID, desc, "https://pfplay.xyz/parties/lobby",
+                "Mozilla/5.0", null, LocalDateTime.of(2026, 7, 9, 12, 0));
+    }
 
     private void assertCleanThenWriteOne() {
         // cleaner 가 pre-transaction truncate → 매 메서드 시작 시 clean slate.
@@ -54,5 +66,37 @@ class DatabaseCleanerIsolationIT extends AbstractIntegrationTest {
     @Test
     void isolationC() {
         assertCleanThenWriteOne();
+    }
+
+    /** T5: pristine 테이블은 truncate 대상에서 제외되고 더티만 감지됨(선택적 truncate 증명). */
+    @Test
+    void selectDirtyTables_detectsOnlyDirtyTables() {
+        // pre-test clean() 이 이미 모든 비-PRESERVE 테이블을 pristine 으로 만든 상태.
+        bugReportRepository.save(newProbe("dirty probe"));   // 커밋 → bug_report 만 더티
+
+        Set<String> dirty = databaseCleaner.selectDirtyTables();
+
+        assertThat(dirty).contains("bug_report");
+        // 이 IT 가 건드리지 않는 비-PRESERVE 테이블 = pristine → 제외되어야 함.
+        assertThat(dirty).doesNotContain("system_announcement");
+    }
+
+    /** T2b: INSERT 후 롤백(행 0, engine AI 전진)도 더티로 감지되고 clean 후 AI=1 복원.
+     *  8.0 통계캐시 우회(stats_expiry=0)가 없으면 stale AI=1 로 미감지되어 실패한다. */
+    @Test
+    void autoIncrementReset_afterInsertRollback() {
+        // pre-test clean() → bug_report pristine(AI=1).
+        // INSERT 후 롤백: 행은 사라지지만 InnoDB 는 소비한 AUTO_INCREMENT 를 되돌리지 않는다.
+        transactionTemplate.executeWithoutResult(status -> {
+            bugReportRepository.saveAndFlush(newProbe("rollback probe"));
+            status.setRollbackOnly();
+        });
+        assertThat(bugReportRepository.count()).isZero();                        // 롤백 확인
+        assertThat(databaseCleaner.selectDirtyTables()).contains("bug_report");  // AI 전진 → 더티
+
+        databaseCleaner.clean();                                                // 더티 truncate → AI=1
+
+        BugReportData saved = bugReportRepository.save(newProbe("after clean"));
+        assertThat(saved.getBugReportId()).isEqualTo(1L);                       // AI 리셋됨
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/common/DatabaseCleanerIsolationIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/common/DatabaseCleanerIsolationIT.java
@@ -1,0 +1,58 @@
+package com.pfplaybackend.api.common;
+
+import com.pfplaybackend.api.administration.adapter.out.persistence.BugReportRepository;
+import com.pfplaybackend.api.administration.domain.entity.data.BugReportData;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * DatabaseCleaner 결정론 격리 검증 (스펙 §5.0a).
+ *
+ * <p><b>비-{@code @Transactional}(커밋형)</b> IT — 각 {@code @Test} 메서드의 {@code repository.save()}
+ * 는 즉시 커밋된다. 따라서 pre-transaction {@link DatabaseCleanupTestExecutionListener} 가 없으면
+ * 앞 메서드가 커밋한 행이 뒤 메서드에 누적되어 보인다.
+ *
+ * <p><b>대칭 단언(S4 — 순서의존 제거)</b>: 세 메서드가 각자
+ * "시작 시 clean(count==0) → 1건 커밋 삽입 → 1건 관측" 을 수행한다. 임의의 두 메서드가 서로의
+ * 잔재를 보지 않음을 실행 순서와 무관하게 결정론적으로 증명한다 — cleaner 가 실제로 하는 일.
+ *
+ * <p>대상 테이블은 {@code bug_report}(V19): PRESERVE_SET 이 아니라 매 메서드 truncate 되고,
+ * required-parent FK 가 없어(reporter_user_account_id/partyroom_id 는 순수 BIGINT) 부모 시드 없이
+ * 커밋 저장이 가능하다.
+ */
+class DatabaseCleanerIsolationIT extends AbstractIntegrationTest {
+
+    private static final long REPORTER_UID = 990001L;
+
+    @Autowired
+    BugReportRepository bugReportRepository;
+
+    private void assertCleanThenWriteOne() {
+        // cleaner 가 pre-transaction truncate → 매 메서드 시작 시 clean slate.
+        assertThat(bugReportRepository.count()).isZero();
+        // 커밋형 저장(클래스에 @Transactional 없음 → save 가 즉시 커밋).
+        bugReportRepository.save(BugReportData.create(
+                REPORTER_UID, "isolation probe", "https://pfplay.xyz/parties/lobby",
+                "Mozilla/5.0", null, LocalDateTime.of(2026, 7, 9, 12, 0)));
+        assertThat(bugReportRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void isolationA() {
+        assertCleanThenWriteOne();
+    }
+
+    @Test
+    void isolationB() {
+        assertCleanThenWriteOne();
+    }
+
+    @Test
+    void isolationC() {
+        assertCleanThenWriteOne();
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/common/DatabaseCleanupTestExecutionListener.java
+++ b/app/src/test/java/com/pfplaybackend/api/common/DatabaseCleanupTestExecutionListener.java
@@ -1,0 +1,88 @@
+package com.pfplaybackend.api.common;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+import java.util.Map;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * 각 test 메서드 <b>전(pre-transaction)</b> 에 async executor 를 idle 로 몰아넣고 DB 를 truncate 한다 (스펙 §3.2).
+ *
+ * <h2>실행 순서 (C1)</h2>
+ * {@link #getOrder()} = 2900 → DependencyInjectionTestExecutionListener(2000) 이후,
+ * TransactionalTestExecutionListener(4000) 이전. 즉 test 트랜잭션이 열리기 <b>전</b> 에 truncate 되므로,
+ * 롤백형 IT 의 test tx 를 침범하지 않는다. (truncate 자체는 {@link DatabaseCleaner} 의 별도 커넥션에서
+ * 실행되어 이중 안전.)
+ *
+ * <h2>async quiescence (C2)</h2>
+ * AFTER_COMMIT + {@code @Async} 리스너의 late write 가 다음 테스트 truncate 뒤에 착지하는 레이스를 막기 위해,
+ * truncate <b>직전</b> 에 컨텍스트의 모든 {@link ThreadPoolTaskExecutor} 빈(실재 3종: userActivityLogExecutor,
+ * webPushExecutor, vdjChatExecutor)이 idle 임을 확인한다. TOCTOU 방어를 위해 (activeCount==0 ∧ queue empty)
+ * 를 <b>연속 {@value #REQUIRED_IDLE_OBSERVATIONS}회</b> 관측할 때까지 폴링하고, 상한
+ * ({@value #QUIESCE_TIMEOUT_MILLIS}ms) 초과 시 fail-loud 예외를 던진다(조용한 오염 방지).
+ */
+public class DatabaseCleanupTestExecutionListener extends AbstractTestExecutionListener {
+
+    /** DI(2000) < 2900 < Transactional(4000). Micrometer TEL(2500) 과도 비충돌. */
+    private static final int ORDER = 2900;
+
+    private static final int REQUIRED_IDLE_OBSERVATIONS = 3;
+    private static final long QUIESCE_TIMEOUT_MILLIS = 5_000L;
+    private static final long POLL_INTERVAL_MILLIS = 20L;
+
+    @Override
+    public int getOrder() {
+        return ORDER;
+    }
+
+    @Override
+    public void beforeTestMethod(TestContext testContext) {
+        ApplicationContext appCtx = testContext.getApplicationContext();
+        quiesceAsyncExecutors(appCtx);
+        appCtx.getBean(DatabaseCleaner.class).clean();
+    }
+
+    private void quiesceAsyncExecutors(ApplicationContext appCtx) {
+        Map<String, ThreadPoolTaskExecutor> executors =
+                appCtx.getBeansOfType(ThreadPoolTaskExecutor.class);
+        long deadline = System.currentTimeMillis() + QUIESCE_TIMEOUT_MILLIS;
+        int consecutiveIdle = 0;
+        while (consecutiveIdle < REQUIRED_IDLE_OBSERVATIONS) {
+            String busy = firstBusyExecutor(executors);
+            if (busy == null) {
+                consecutiveIdle++;
+            } else {
+                consecutiveIdle = 0;
+                if (System.currentTimeMillis() >= deadline) {
+                    throw new IllegalStateException(
+                            "async executor quiescence 타임아웃(" + QUIESCE_TIMEOUT_MILLIS
+                                    + "ms): '" + busy + "' 가 여전히 바쁨 — truncate 진행 시 C2 오염 위험");
+                }
+            }
+            sleep();
+        }
+    }
+
+    /** 바쁜 executor 의 빈 이름을 반환, 전부 idle 이면 null. */
+    private String firstBusyExecutor(Map<String, ThreadPoolTaskExecutor> executors) {
+        for (Map.Entry<String, ThreadPoolTaskExecutor> e : executors.entrySet()) {
+            ThreadPoolExecutor pool = e.getValue().getThreadPoolExecutor();
+            if (pool.getActiveCount() != 0 || !pool.getQueue().isEmpty()) {
+                return e.getKey();
+            }
+        }
+        return null;
+    }
+
+    private void sleep() {
+        try {
+            Thread.sleep(POLL_INTERVAL_MILLIS);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("async quiescence 폴링 중 인터럽트", ie);
+        }
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/in/listener/PartyroomCounterListenerIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/in/listener/PartyroomCounterListenerIT.java
@@ -1,8 +1,12 @@
 package com.pfplaybackend.api.party.adapter.in.listener;
 
+import com.pfplaybackend.api.administration.adapter.out.persistence.AdministratorRepository;
+import com.pfplaybackend.api.administration.domain.entity.data.AdministratorData;
 import com.pfplaybackend.api.common.AbstractIntegrationTest;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomRepository;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
 import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
 import com.pfplaybackend.api.party.domain.enums.AccessType;
 import com.pfplaybackend.api.party.domain.enums.StageType;
@@ -36,6 +40,8 @@ class PartyroomCounterListenerIT extends AbstractIntegrationTest {
     @Autowired private ApplicationEventPublisher eventPublisher;
     @Autowired private TransactionTemplate transactionTemplate;
     @Autowired private EntityManager entityManager;
+    @Autowired private AdministratorRepository administratorRepository;
+    @Autowired private UserAccountRepository userAccountRepository;
 
     /** 각 케이스가 생성한 partyroom id 모아서 AfterEach 에서 cleanup —
      *  본 IT 가 partyroomRepository.saveAndFlush 로 별도 tx commit 하므로
@@ -151,9 +157,16 @@ class PartyroomCounterListenerIT extends AbstractIntegrationTest {
             );
         }
 
+        // FK fk_paa_administrator → administrator. terminate actor 를 실제 시드.
+        final long adminUid = 990999L;
+        userAccountRepository.saveAndFlush(
+                UserAccountData.createForLocal(new UserId(adminUid), "counter-term-admin@x", "h"));
+        Long adminId = administratorRepository
+                .saveAndFlush(AdministratorData.createSuperAdmin(adminUid)).getAdministratorId();
+
         transactionTemplate.executeWithoutResult(status ->
                 eventPublisher.publishEvent(new PartyroomTerminatedEvent(
-                        new PartyroomId(roomId), 999L, "test reason"))
+                        new PartyroomId(roomId), adminId, "test reason"))
         );
 
         PartyroomData reloaded = partyroomRepository.findById(roomId).orElseThrow();

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomRepositoryAtomicUpdateIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomRepositoryAtomicUpdateIT.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 
@@ -54,7 +55,8 @@ class PartyroomRepositoryAtomicUpdateIT extends AbstractIntegrationTest {
     @DisplayName("incrementCrewCount — ACTIVE 룸에서 +1, lastActivityAt 갱신, 1 affected")
     void increment_active() {
         PartyroomData p = createAndSaveActive(1001L);
-        LocalDateTime now = LocalDateTime.now();
+        // DB 컬럼이 DATETIME(0)(초 정밀)이라 MySQL 이 나노를 반올림 → 입력을 초로 절삭해 결정론 비교.
+        LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
 
         int affected = partyroomRepository.incrementCrewCount(p.getId(), now);
 
@@ -90,7 +92,7 @@ class PartyroomRepositoryAtomicUpdateIT extends AbstractIntegrationTest {
         partyroomRepository.incrementCrewCount(p.getId(), LocalDateTime.now());
         partyroomRepository.incrementCrewCount(p.getId(), LocalDateTime.now());
 
-        LocalDateTime decrementAt = LocalDateTime.now();
+        LocalDateTime decrementAt = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
         int affected = partyroomRepository.decrementCrewCount(p.getId(), decrementAt);
 
         assertThat(affected).isEqualTo(1);
@@ -129,7 +131,8 @@ class PartyroomRepositoryAtomicUpdateIT extends AbstractIntegrationTest {
     @DisplayName("touchLastActivity — ACTIVE 룸 갱신")
     void touch_active() {
         PartyroomData p = createAndSaveActive(1006L);
-        LocalDateTime now = LocalDateTime.now();
+        // DB 컬럼이 DATETIME(0)(초 정밀)이라 MySQL 이 나노를 반올림 → 입력을 초로 절삭해 결정론 비교.
+        LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
 
         int affected = partyroomRepository.touchLastActivity(p.getId(), now);
 

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAdminServiceIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/BotAvatarAdminServiceIT.java
@@ -65,12 +65,14 @@ class BotAvatarAdminServiceIT extends AbstractIntegrationTest {
 
     @BeforeEach
     void seedCatalog() {
+        // 이름은 테스트 전용(=V3 시드 ava_body_basic_* 과 uk_avatar_body_name 충돌 회피).
+        // 서비스/단언은 URI 기준이므로 이름 값 자체는 무의미.
         // combinable 바디: icon_uri NULL → face 합성이 강제됨.
-        seedBody("ava_body_basic_001", COMBINABLE_BODY_URI, null, true, true, 60, 41);
+        seedBody("bot-avatar-it-body-001", COMBINABLE_BODY_URI, null, true, true, 60, 41);
         // standalone 바디: 자체 icon_uri 보유.
-        seedBody("ava_body_basic_002", STANDALONE_BODY_URI, STANDALONE_ICON_URI, false, false, 0, 0);
+        seedBody("bot-avatar-it-body-002", STANDALONE_BODY_URI, STANDALONE_ICON_URI, false, false, 0, 0);
         // 기본 face: face-pair 아이콘 보유.
-        seedFace("ava_face_basic_001", FACE_URI, FACE_ICON_URI);
+        seedFace("bot-avatar-it-face-001", FACE_URI, FACE_ICON_URI);
     }
 
     private void seedBody(String name, String uri, String iconUri, boolean combinable,

--- a/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjEventListenerIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualdj/VirtualDjEventListenerIT.java
@@ -6,7 +6,11 @@ import com.pfplaybackend.api.avatar.domain.enums.ObtainmentType;
 import com.pfplaybackend.api.common.AbstractIntegrationTest;
 import com.pfplaybackend.api.common.ThreadLocalContext;
 import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.administration.adapter.out.persistence.AdministratorRepository;
+import com.pfplaybackend.api.administration.domain.entity.data.AdministratorData;
 import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
 import com.pfplaybackend.api.party.adapter.out.persistence.CrewRepository;
 import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomRepository;
 import com.pfplaybackend.api.party.application.port.out.UserProfileQueryPort;
@@ -82,6 +86,8 @@ class VirtualDjEventListenerIT extends AbstractIntegrationTest {
     @Autowired private VirtualSongPackTrackRepository packTrackRepository;
     @Autowired private CrewRepository crewRepository;
     @Autowired private AvatarBodyResourceRepository avatarBodyResourceRepository;
+    @Autowired private AdministratorRepository administratorRepository;
+    @Autowired private UserAccountRepository userAccountRepository;
 
     @SpyBean private DjCommandService djCommandService;
     @SpyBean private FlapGuard flapGuard;
@@ -89,9 +95,16 @@ class VirtualDjEventListenerIT extends AbstractIntegrationTest {
     @MockBean private UserProfileQueryPort userProfileQueryPort;
 
     private Long roomId;
+    /** FK fk_paa_administrator → administrator. terminate 이벤트 actor. */
+    private Long adminId;
 
     @BeforeEach
     void seed() {
+        userAccountRepository.saveAndFlush(
+                UserAccountData.createForLocal(new UserId(990900L), "vdj-evt-admin@x", "h"));
+        adminId = administratorRepository
+                .saveAndFlush(AdministratorData.createSuperAdmin(990900L)).getAdministratorId();
+
         lenient().when(userProfileQueryPort.getUsersProfileSetting(any()))
                 .thenAnswer(inv -> {
                     List<UserId> ids = inv.getArgument(0);
@@ -171,7 +184,7 @@ class VirtualDjEventListenerIT extends AbstractIntegrationTest {
     void terminated_turns_config_off_and_skips_reconcile() {
         transactionTemplate.executeWithoutResult(status ->
                 eventPublisher.publishEvent(new PartyroomTerminatedEvent(
-                        new PartyroomId(roomId), 9000L, "test-terminate")));
+                        new PartyroomId(roomId), adminId, "test-terminate")));
 
         Awaitility.await().atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(200))
                 .untilAsserted(() -> {

--- a/app/src/test/resources/application-test.yml
+++ b/app/src/test/resources/application-test.yml
@@ -2,7 +2,7 @@ spring:
   jpa:
     show-sql: false
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: false
@@ -12,7 +12,7 @@ spring:
       mode: never
 
   flyway:
-    enabled: false
+    enabled: true
 
   data:
     redis:

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ subprojects {
 		useJUnitPlatform {
 			includeTags 'integration'
 		}
+		// 직렬 실행 불변식: IT 는 단일 공유 Testcontainers 스키마를 DatabaseCleaner 로
+		// 각 테스트 전 truncate 한다. 병렬 fork 는 서로의 스키마를 truncate 해 상호파괴하므로
+		// maxParallelForks=1 을 유지한다(스키마-per-fork 격리 없이는 병렬화 불가).
 		maxParallelForks = 1
 		forkEvery = 0
 		jvmArgs '-XX:+UseParallelGC'

--- a/docs/superpowers/plans/2026-07-09-integration-test-harness-flyway-validate.md
+++ b/docs/superpowers/plans/2026-07-09-integration-test-harness-flyway-validate.md
@@ -1,0 +1,211 @@
+# 통합 테스트 하네스 Flyway+validate 전환 — 구현 플랜
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** pfplay-platform 통합 테스트(74개 IT)를 `create-drop`에서 프로덕션과 동일한 **Flyway+`validate`**로 전환하고, 공유 스키마 격리(`DatabaseCleaner`)를 도입해 전량 초록화한 뒤, `integrationTest`를 CI에 배선한다.
+
+**Architecture:** 설정 전환(`application-test.yml`) + pre-transaction `TestExecutionListener`에서 **별도 autocommit 커넥션**으로 동적 truncate(레퍼런스 시드 보존) + async executor 3종 quiescence. 제품 코드 무변경, 테스트/설정/CI만.
+
+**Tech Stack:** Spring Boot Test, Testcontainers(MySQL 8.0.30 싱글턴), Flyway, JUnit5, Gradle, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-07-09-integration-test-harness-flyway-validate-design.md` (**구현 전 정독 필수** — 이 플랜은 스펙의 C1/C2/FK-closure 결정을 전제로 함)
+
+**빌드/실행 노트:**
+- JDK 21: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7"` prefix.
+- 유닛/웹: `:app:test` / 통합: `:app:integrationTest`(tag-gated). Docker 필요.
+- ⚠️ **직렬 실행 불변식**: `maxParallelForks=1` 유지(병렬화 금지 — 공유 스키마 truncate가 fork 간 상호파괴).
+- Testcontainers 동시 2런 금지(Windows 파일락). 실행 전 `./gradlew --stop` + java 프로세스 정리.
+
+---
+
+## 파일 구조 (생성/수정 맵)
+**생성:**
+- `app/src/test/java/com/pfplaybackend/api/common/DatabaseCleaner.java` — 동적 truncate + PRESERVE_SET (별도 커넥션)
+- `app/src/test/java/com/pfplaybackend/api/common/DatabaseCleanupTestExecutionListener.java` — `beforeTestMethod`: async quiescence → cleaner
+- `app/src/test/java/com/pfplaybackend/api/common/DatabaseCleanerIsolationIT.java` — 결정론 격리 검증(§5.0a)
+
+**수정:**
+- `app/src/test/resources/application-test.yml` — `ddl-auto: validate`, `flyway.enabled: true`
+- `app/src/test/java/com/pfplaybackend/api/common/AbstractIntegrationTest.java` — `@TestExecutionListeners`로 cleaner 리스너 등록
+- 잔여 실패 IT들 — §Phase 3(재측정으로 확정)
+- `.github/workflows/ci-test.yml` — integrationTest 스텝
+- (필요 시) `build.gradle` — integrationTest 태스크 주석/가드(직렬 불변식)
+
+---
+
+## Chunk 1: 설정 전환 + 격리 메커니즘
+
+### Task 1: `application-test.yml` 전환 + 부팅 확인
+**Files:** Modify `app/src/test/resources/application-test.yml`
+
+- [ ] **Step 1: 설정 변경**
+`ddl-auto: create-drop` → `validate`, `flyway.enabled: false` → `true`. `sql.init.mode: never` 유지.
+
+- [ ] **Step 2: 컨텍스트 부팅만 확인(격리 전)**
+기존 IT 아무거나 1개 실행해 **Flyway가 V1~ 적용 + validate 통과 + 컨텍스트 부팅**을 확인(격리 없이도 부팅은 됨 — 디스커버리에서 0 errors로 입증).
+Run: `JAVA_HOME=... ./gradlew :app:integrationTest --tests '*AdminBugReportQueryRepositoryImplIT'`
+Expected: 부팅 성공(테스트 자체는 통과 예상 — 이 클래스는 격리 무관). Flyway 로그에 `Successfully applied N migrations ... now at version vNN` 확인.
+> ⚠️ **S1**: 이 브랜치(origin/develop 기준)의 소스 최대 마이그레이션은 **V31**이다(V32/V33은 미머지 vdj 소유, V34는 analytics 브랜치 것 — 둘 다 이 브랜치엔 없음). 로그의 최종 버전은 **V31 근방**을 기대할 것(V34 아님). `./gradlew clean` 후 실행해 스테일 `build/resources`의 V34 산출물이 섞이지 않게 한다.
+> 이 시점 커밋하지 않는다(격리 없이는 다수 red). Task 3까지 한 논리단위.
+
+### Task 2: `DatabaseCleaner` — 결정론 격리 검증 먼저(TDD)
+**Files:**
+- Create: `DatabaseCleanerIsolationIT.java` (검증)
+- Create: `DatabaseCleaner.java`, `DatabaseCleanupTestExecutionListener.java` (구현)
+- Modify: `AbstractIntegrationTest.java`
+
+- [ ] **Step 1: 실패하는 격리 검증 IT 작성(§5.0a 핵심단언)**
+`DatabaseCleanerIsolationIT extends AbstractIntegrationTest` — **비-`@Transactional`(커밋형)** 클래스. **대칭 단언(S4 — 순서의존 제거)**: 여러 메서드가 각자 "시작 시 clean → 커밋 삽입 → 1개 관측"을 수행 → 임의의 두 메서드가 서로의 잔재를 안 보는 것을 순서 무관하게 결정론 증명:
+```java
+// 대상 테이블은 required-parent FK 없는 것 선택(N2) — 커밋형이라 저장 즉시 실행됨.
+// 예: partyroom(host_id nullable) 또는 FK 자유 테이블. system_announcement가 필수 FK 없으면 그것도 가능.
+private void assertCleanThenWriteOne() {
+    assertThat(repo.count()).isZero();         // cleaner가 pre-transaction truncate → 매 메서드 시작 0
+    repo.save(<row>);                          // 커밋
+    assertThat(repo.count()).isEqualTo(1);
+}
+@Test void isolationA() { assertCleanThenWriteOne(); }
+@Test void isolationB() { assertCleanThenWriteOne(); }
+@Test void isolationC() { assertCleanThenWriteOne(); }
+```
++ 롤백형 방증(부수, 별 `@Transactional` 검증 메서드/클래스): "write→같은 메서드 롤백 소멸"이 cleaner와 충돌 없음(격리가 tx를 안 깸) 단언.
+
+- [ ] **Step 2: 실패 확인** — cleaner 미구현 → `nextMethodSeesCleanSlate`가 count=1로 FAIL(또는 리스너 미등록으로 truncate 안 됨).
+Run: `... :app:integrationTest --tests '*DatabaseCleanerIsolationIT'` → FAIL.
+
+- [ ] **Step 3: `DatabaseCleaner` 구현(별도 autocommit 커넥션)**
+```java
+@Component
+public class DatabaseCleaner {
+    private final DataSource dataSource;
+    // PRESERVE_SET: 시드 마이그레이션이 채우는 레퍼런스 테이블 (FK-closure 만족 — 전부 outgoing FK 없음).
+    // ⚠️ V27/V28/V29는 별도 테이블이 아니라 system_config에 INSERT할 뿐이고,
+    //    partyroom_virtual_dj_config(V29)는 컬럼 ALTER만(시드 행 없음) → truncate 대상. "vdj 설정 테이블" 없음.
+    private static final Set<String> PRESERVE = Set.of(
+        "flyway_schema_history",
+        "avatar_body_resource","avatar_face_resource","avatar_icon_resource",
+        "system_config");
+
+    public void clean() {
+        try (Connection c = dataSource.getConnection()) {   // test tx와 무관한 별도 커넥션
+            c.setAutoCommit(true);
+            List<String> tables = queryBaseTables(c);        // information_schema, 현 스키마
+            try (Statement s = c.createStatement()) {
+                s.execute("SET FOREIGN_KEY_CHECKS=0");
+                try {
+                    for (String t : tables) if (!PRESERVE.contains(t)) s.execute("TRUNCATE TABLE `"+t+"`");
+                } finally {
+                    s.execute("SET FOREIGN_KEY_CHECKS=1");   // S3: 예외경로에서도 반드시 복원(세션 스코프 오염 방지)
+                }
+            }
+        } catch (SQLException e) { throw new IllegalStateException("DB cleanup 실패", e); }
+    }
+}
+```
+> **S3 주의**: `FOREIGN_KEY_CHECKS`는 세션 변수이고 HikariCP는 리셋 안 함 → truncate 루프 예외 시 finally로 복원 안 하면 FK 검사 꺼진 커넥션이 풀로 반환돼 후속 test 오염. finally 필수.
+
+- [ ] **Step 3a (Task 2a): PRESERVE_SET FK-closure 확인**
+실행 전, 위 5개 보존 테이블의 **outgoing FK**를 `information_schema.key_column_usage`로 확인해 truncate 대상으로 나가는 FK가 **없음**을 검증(레퍼런스/KV 테이블이라 자명히 없을 것 — system_config는 standalone). 있으면 그 대상도 보존하거나 후보를 truncate 대상으로 강등(스펙 §8-1). **별도 vdj 테이블을 찾지 말 것(S2 — 존재하지 않음).**
+
+- [ ] **Step 4: `DatabaseCleanupTestExecutionListener` 구현(pre-transaction + quiescence)**
+```java
+public class DatabaseCleanupTestExecutionListener extends AbstractTestExecutionListener {
+    @Override public int getOrder() { return 2900; } // DI(2000) 이후·Transactional(4000) 이전. 2500은 Micrometer TEL과 충돌하므로 2900.
+    @Override public void beforeTestMethod(TestContext ctx) {
+        var appCtx = ctx.getApplicationContext();
+        quiesceAsyncExecutors(appCtx);   // 모든 ThreadPoolTaskExecutor 빈 idle 대기(연속 N회, fail-loud)
+        appCtx.getBean(DatabaseCleaner.class).clean();
+    }
+    // quiesce: appCtx.getBeansOfType(ThreadPoolTaskExecutor.class) 전부에 대해
+    //   activeCount==0 && queueSize==0 를 연속 3회(짧은 간격) 관측될 때까지 폴링,
+    //   상한(예 5s) 초과 시 IllegalStateException(fail-loud).
+}
+```
+
+- [ ] **Step 5: `AbstractIntegrationTest`에 리스너 등록**
+```java
+@TestExecutionListeners(
+    value = DatabaseCleanupTestExecutionListener.class,
+    mergeMode = MergeMode.MERGE_WITH_DEFAULTS)
+public abstract class AbstractIntegrationTest { ... }
+```
+
+- [ ] **Step 6: 격리 검증 통과 확인**
+Run: `... :app:integrationTest --tests '*DatabaseCleanerIsolationIT'` → PASS.
+
+### Task 3: 롤백 격리 결정론 스트레스(C1 검증)
+- [ ] **Step 1: 롤백형 `@Transactional` IT 표본 반복 실행**
+cleaner가 `@Transactional` IT의 롤백 격리를 **안 깬다**를 확인. 대표 롤백형 IT 3~5개를 **연속 3회** 실행해 flake 없음 확인(1회 초록≠증명).
+Run 예: `... :app:integrationTest --tests '*SystemConfigRepositoryIntegrationTest' --tests '*IamRepositoryIntegrationTest'` ×3.
+Expected: 매회 동일 초록.
+
+- [ ] **Step 2: 커밋(격리 메커니즘 한 단위)**
+```bash
+git add app/src/test/resources/application-test.yml \
+        app/src/test/java/com/pfplaybackend/api/common/DatabaseCleaner.java \
+        app/src/test/java/com/pfplaybackend/api/common/DatabaseCleanupTestExecutionListener.java \
+        app/src/test/java/com/pfplaybackend/api/common/DatabaseCleanerIsolationIT.java \
+        app/src/test/java/com/pfplaybackend/api/common/AbstractIntegrationTest.java
+git commit -m "test: IT 하네스 Flyway+validate 전환 + DatabaseCleaner 격리(pre-transaction)"
+```
+
+---
+
+## Chunk 2: 재측정 → 잔여 실패 개별 수정
+
+### Task 4: 전량 재측정 (§5.0b — 진실원천)
+- [ ] **Step 1: cleaner 적용 상태로 전량 실행 + 벽시계 기록(N3)**
+Run: `... :app:integrationTest --continue` (uncontended, 사전 `--stop`+프로세스 정리).
+전체 소요시간(BUILD 시간)을 기록 → Task 7의 CI 스텝 구성(단일 `test integrationTest` vs 분리, 스펙 Open Decision #3) 근거로 사용. `@MockBean` 컨텍스트 파편화가 시간 지배.
+- [ ] **Step 2: 실패 재분류**
+결과 XML에서 실패 클래스·메시지 수집 → 카테고리 분류표 작성:
+  - **자동해소 확인**: §2 디스커버리의 41 중 cleaner로 사라진 것.
+  - **잔여**: FK("Cannot add child row")=부모행 시드 누락 / Duplicate=시드 충돌 or 잔여 오염 / Assertion=시드-인지 / async=quiescence 후에도 남는 것.
+> 이 분류표가 Task 5의 작업목록. 재측정 없이 Task 5 착수 금지.
+
+### Task 5: 잔여 실패 클래스별 수정 (재측정 결과 기반, 클래스당 1커밋 권장)
+각 잔여 실패 클래스에 대해 원인별 플레이북 적용:
+- [ ] **FK "Cannot add child row"**: 테스트가 자식 삽입 전 **부모행을 먼저 시드**하도록 보강(참조 무결성 충족). truncate로는 안 풀림.
+- [ ] **"Duplicate entry"**: 참조 시드와 충돌하는 고정 키 → **테스트 전용 키 범위(990000+)**로 이동. 잔여 오염이면 해당 테스트의 async await 누락 보강(§3.2.2 목록 대조).
+- [ ] **AssertionError(시드-인지)**: 빈-테이블 전제 기대값을 시드 존재에 맞게 조정(단, 이중목적 시드 테이블은 truncate되므로 대부분 자동해소 — 재측정에서 확인).
+- [ ] **PRESERVE_SET 커밋 오염(§3.3)**: 보존 테이블에 커밋하는 비-`@Transactional` IT 열거 → `@AfterEach` 자체정리 or 클래스스코프 재시드.
+- [ ] **각 수정 후**: 해당 클래스 **연속 2회** 초록 확인 후 커밋.
+```bash
+git commit -m "test: <클래스> Flyway 하네스 대응 (<원인 요약>)"
+```
+
+### Task 6: 전량 초록 게이트 (§5.1)
+- [ ] **Step 1: 전량 2회 연속 초록**
+Run: `... :app:integrationTest` **연속 2회** → 매회 0 fail/0 error.
+- [ ] **Step 2: 유닛/웹 회귀 무변**
+Run: `... :app:test` → 초록(하네스 변경이 유닛에 영향 없음 확인).
+- [ ] **Step 3: 커밋(있으면 정리 커밋)**
+
+---
+
+## Chunk 3: CI 배선
+
+### Task 7: `ci-test.yml`에 integrationTest 배선
+**Files:** Modify `.github/workflows/ci-test.yml`
+- [ ] **Step 1: integrationTest 스텝 추가**
+기존 `./gradlew test` 스텝 뒤에 `./gradlew :app:integrationTest` 스텝 추가(또는 `./gradlew test integrationTest`). GitHub-hosted `ubuntu-latest`는 Docker 지원(Testcontainers 동작).
+- [ ] **Step 2: 로컬로 CI 명령 재현 검증**
+CI가 돌릴 명령을 로컬에서 그대로 실행해 초록 확인.
+- [ ] **Step 3: (선택) build.gradle 직렬 불변식 가드**
+`integrationTest` 태스크에 "병렬화 금지(스키마-per-fork 없인 불가)" 주석 추가.
+- [ ] **Step 4: 커밋**
+```bash
+git commit -m "ci: integrationTest를 ci-test.yml에 배선 (통합 게이트 활성화)"
+```
+> N2: CI 배선을 별 커밋으로 두어, first-run flake가 dev 자동배포 게이트를 막지 않게 함(사용자 규칙 정합).
+
+---
+
+## 실행 후 체크리스트
+- [ ] `:app:integrationTest` 전량 2회 연속 초록 (0 fail/0 error).
+- [ ] `@Transactional` IT 롤백 격리 flake 없음(C1), async 레이스 없음(C2).
+- [ ] `:app:test` 회귀 무변.
+- [ ] CI에서 integrationTest 실제 실행·초록.
+- [ ] validate 상시 활성 → 이후 마이그레이션 drift IT 부팅에서 검출.
+- [ ] 직렬 실행 불변식 유지(`maxParallelForks=1`).
+- [ ] 제품 코드 무변경(테스트/설정/CI만).

--- a/docs/superpowers/plans/2026-07-10-database-cleaner-dirty-table-optimization.md
+++ b/docs/superpowers/plans/2026-07-10-database-cleaner-dirty-table-optimization.md
@@ -1,0 +1,353 @@
+# DatabaseCleaner 더티-테이블 최적화 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `DatabaseCleaner.clean()`이 매 테스트 메서드 전 ~70개 테이블을 전부 TRUNCATE하던 것을, pristine(0행 AND AUTO_INCREMENT=1)이 아닌 "더티" 테이블만 TRUNCATE하도록 바꿔 로컬(Windows Docker) 통합 테스트 속도를 회복한다. 동작(사후 상태)은 현행과 동일.
+
+**Architecture:** `clean()`이 truncate 전에 더티 테이블 집합 = (행 존재: 라이브 `EXISTS`) ∪ (`AUTO_INCREMENT>1`: MySQL 8.0 통계캐시를 `stats_expiry=0`으로 우회한 `information_schema` 조회)을 계산하고, 그 집합만 truncate한다. 감지는 fsync 없는 읽기라 TRUNCATE의 fsync보다 훨씬 싸다. 별도 autocommit 커넥션·PRESERVE_SET·FK_CHECKS 로직은 현행 유지.
+
+**Tech Stack:** Java 21, Spring Boot, Testcontainers MySQL 8.0.30, JUnit5, AssertJ. 스펙: `docs/superpowers/specs/2026-07-10-database-cleaner-dirty-table-optimization-design.md`.
+
+**빌드/실행 주의(이 레포·이 머신):**
+- 모든 gradle 명령은 `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7"` prefix 필수.
+- 로컬 전량 IT 단일호출은 Windows Docker fsync로 매우 느리다(바로 이 플랜이 고치려는 문제). **검증은 소배치로**, 각 배치 전 잔존 gradle Worker JVM kill + `output.bin` 락 해제 + docker prune 필요(reference: killed run이 Worker 좀비를 남겨 `output.bin`을 점유). 단일 클래스 실행은 빠르다.
+
+---
+
+## 파일 구조 (생성/수정 맵)
+
+- Modify: `app/src/test/java/com/pfplaybackend/api/common/DatabaseCleaner.java`
+  - `clean()`을 "더티만 truncate"로 변경. `detectDirtyTables()`·`selectDirtyTables()`·`nonPreserveBaseTables()` 추가. 별도 커넥션·PRESERVE·FK_CHECKS 뼈대 유지.
+- Modify: `app/src/test/java/com/pfplaybackend/api/common/DatabaseCleanerIsolationIT.java`
+  - 신규 테스트 2개 추가: 선택적 truncate 화이트박스(T5), INSERT-롤백 후 AI 리셋(T2b). 기존 isolationA/B/C(T1/T3)는 그대로 유지(선택적 truncate 후에도 격리 보존 = 회귀 가드).
+
+책임 경계: `DatabaseCleaner`는 "테스트 간 DB를 pristine으로 복원"이라는 단일 책임 유지. 감지 로직은 같은 클래스의 private/package-private 헬퍼로 캡슐화(외부 인터페이스는 `clean()` 불변, 화이트박스 검증용 `selectDirtyTables()`만 package-private 노출).
+
+---
+
+## Chunk 1: 더티-테이블 선택적 truncate
+
+### Task 1: 실패하는 테스트 먼저 (T5 화이트박스 + T2b AI 리셋)
+
+**Files:**
+- Modify/Test: `app/src/test/java/com/pfplaybackend/api/common/DatabaseCleanerIsolationIT.java`
+
+먼저 `BugReportData`의 생성 id 게터 이름을 확인한다(플랜은 `getId()`를 가정):
+
+- [ ] **Step 1: 엔티티 id 게터 확인**
+
+Run: `grep -nE "getId|BugReportId|@Id|Long id" app/src/main/**/BugReportData.java` (또는 파일 찾기: `find . -name BugReportData.java -not -path '*/build/*'`)
+확인: 생성 PK 게터 이름(예 `getId()` 또는 `getBugReportId()`). 이후 Step에서 그 이름을 사용.
+
+- [ ] **Step 2: IsolationIT에 신규 테스트 2개 추가(실패 예정)**
+
+기존 import/필드에 더해 `DatabaseCleaner`·`TransactionTemplate`·`Set`·`assertThat` 사용. 아래를 클래스에 추가(기존 isolationA/B/C·`assertCleanThenWriteOne`은 유지):
+
+```java
+// --- 추가 import ---
+import org.springframework.transaction.support.TransactionTemplate;
+import java.util.Set;
+
+// --- 클래스 내부 필드 추가 ---
+@Autowired
+DatabaseCleaner databaseCleaner;
+@Autowired
+TransactionTemplate transactionTemplate;
+
+private BugReportData newProbe(String desc) {
+    return BugReportData.create(
+            REPORTER_UID, desc, "https://pfplay.xyz/parties/lobby",
+            "Mozilla/5.0", null, LocalDateTime.of(2026, 7, 9, 12, 0));
+}
+
+/** T5: pristine 테이블은 truncate 대상에서 제외되고 더티만 감지됨(선택적 truncate 증명). */
+@Test
+void selectDirtyTables_detectsOnlyDirtyTables() {
+    // pre-test clean() 이 이미 모든 비-PRESERVE 테이블을 pristine 으로 만든 상태.
+    bugReportRepository.save(newProbe("dirty probe"));   // 커밋 → bug_report 만 더티
+
+    Set<String> dirty = databaseCleaner.selectDirtyTables();
+
+    assertThat(dirty).contains("bug_report");
+    // 이 IT 가 건드리지 않는 비-PRESERVE 테이블 = pristine → 제외되어야 함.
+    assertThat(dirty).doesNotContain("system_announcement");
+}
+
+/** T2b: INSERT 후 롤백(행 0, engine AI 전진)도 더티로 감지되고 clean 후 AI=1 복원.
+ *  8.0 통계캐시 우회(stats_expiry=0)가 없으면 stale AI=1 로 미감지되어 실패한다. */
+@Test
+void autoIncrementReset_afterInsertRollback() {
+    // pre-test clean() → bug_report pristine(AI=1).
+    // INSERT 후 롤백: 행은 사라지지만 InnoDB 는 소비한 AUTO_INCREMENT 를 되돌리지 않는다.
+    transactionTemplate.executeWithoutResult(status -> {
+        bugReportRepository.saveAndFlush(newProbe("rollback probe"));
+        status.setRollbackOnly();
+    });
+    assertThat(bugReportRepository.count()).isZero();                 // 롤백 확인
+    assertThat(databaseCleaner.selectDirtyTables()).contains("bug_report");  // AI 전진 → 더티
+
+    databaseCleaner.clean();                                         // 더티(bug_report) truncate → AI=1
+
+    BugReportData saved = bugReportRepository.save(newProbe("after clean"));
+    assertThat(saved.getId()).isEqualTo(1L);                        // AI 리셋됨 (게터명 Step1 확인값으로 교체)
+}
+```
+
+> 주의: `saved.getId()` 는 Step 1에서 확인한 실제 게터명으로 교체. `system_announcement` 가 이 컨테이너 스키마에 실제 존재하는 비-PRESERVE base table 인지 확인(그렇다). 아니면 다른 미사용 비-PRESERVE 테이블명으로 교체.
+
+- [ ] **Step 3: 컴파일/실행해서 실패 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:compileTestJava`
+Expected: **컴파일 실패** — `DatabaseCleaner` 에 `selectDirtyTables()` 없음(cannot find symbol).
+
+- [ ] **Step 4: 커밋(실패 테스트)**
+
+```bash
+git add app/src/test/java/com/pfplaybackend/api/common/DatabaseCleanerIsolationIT.java
+git commit -m "test: DatabaseCleaner 선택적 truncate·AI리셋(롤백) 실패 테스트 추가"
+```
+
+### Task 2: DatabaseCleaner 더티 감지 구현
+
+**Files:**
+- Modify: `app/src/test/java/com/pfplaybackend/api/common/DatabaseCleaner.java`
+
+- [ ] **Step 1: clean() 을 더티-선택형으로 교체 + 헬퍼 추가**
+
+전체 파일을 아래로 교체(PRESERVE·생성자·`queryBaseTables` 는 동일 유지, `clean()` 변경 + 헬퍼 3개 추가):
+
+```java
+package com.pfplaybackend.api.common;
+
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 공유 Testcontainers MySQL 스키마를 각 테스트 시작 전 "깨끗한 슬레이트"로 복원한다 (스펙 §3.2).
+ *
+ * <h2>더티 테이블만 truncate (2026-07-10 최적화)</h2>
+ * 현재 (0행 AND AUTO_INCREMENT=1) 인 테이블은 truncate 가 no-op 이므로 스킵한다. InnoDB TRUNCATE 는
+ * DDL fsync 를 유발하는데 Docker Desktop for Windows 에선 테이블당 1~2초로 매우 느리다. "더티" =
+ * (행 존재: 라이브 EXISTS) ∪ (AUTO_INCREMENT>1: MySQL 8.0 통계캐시 우회 후 information_schema).
+ * 사후 상태는 전 테이블 truncate 와 동일(스펙 §3.4).
+ *
+ * <h2>별도 autocommit 커넥션 (C1)</h2>
+ * MySQL TRUNCATE 는 implicit COMMIT 이라 test 트랜잭션과 무관한 별도 커넥션에서 실행한다.
+ *
+ * <h2>PRESERVE_SET (레퍼런스 시드 보존)</h2>
+ * Flyway 시드가 채우는 참조 테이블은 truncate 하지 않는다.
+ */
+@Component
+public class DatabaseCleaner {
+
+    private static final Set<String> PRESERVE = Set.of(
+            "flyway_schema_history",
+            "avatar_body_resource",
+            "avatar_face_resource",
+            "avatar_icon_resource",
+            "system_config");
+
+    private final DataSource dataSource;
+
+    public DatabaseCleaner(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public void clean() {
+        try (Connection c = dataSource.getConnection()) {
+            c.setAutoCommit(true);
+            List<String> targets = nonPreserveBaseTables(c);
+            Set<String> dirty = detectDirtyTables(c, targets);
+            try (Statement s = c.createStatement()) {
+                s.execute("SET FOREIGN_KEY_CHECKS=0");
+                try {
+                    for (String t : targets) {
+                        if (dirty.contains(t)) {
+                            s.execute("TRUNCATE TABLE `" + t + "`");
+                        }
+                    }
+                } finally {
+                    // 세션 변수(FOREIGN_KEY_CHECKS)는 HikariCP 가 리셋하지 않으므로 예외 경로에서도 복원.
+                    s.execute("SET FOREIGN_KEY_CHECKS=1");
+                }
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("DB cleanup 실패", e);
+        }
+    }
+
+    /** 화이트박스 검증용: truncate 없이 더티 테이블 집합만 계산해 반환. */
+    Set<String> selectDirtyTables() {
+        try (Connection c = dataSource.getConnection()) {
+            c.setAutoCommit(true);
+            return detectDirtyTables(c, nonPreserveBaseTables(c));
+        } catch (SQLException e) {
+            throw new IllegalStateException("더티 테이블 감지 실패", e);
+        }
+    }
+
+    private List<String> nonPreserveBaseTables(Connection c) throws SQLException {
+        List<String> out = new ArrayList<>();
+        for (String t : queryBaseTables(c)) {
+            if (!PRESERVE.contains(t)) {
+                out.add(t);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * pristine(0행 AND AUTO_INCREMENT=1) 이 아닌 테이블 집합.
+     * 조건① 행 존재(라이브 EXISTS 배치) ∪ 조건② AUTO_INCREMENT>1.
+     * ⚠️ MySQL 8.0 은 information_schema 의 AUTO_INCREMENT/TABLE_ROWS 를 캐시하며 DML 로 무효화되지
+     * 않는다. 조회 전 SET SESSION information_schema_stats_expiry=0 으로 live 값을 강제해야
+     * INSERT-롤백으로 "비었지만 AI 전진" 한 테이블을 놓치지 않는다(스펙 §3.2, §6). 조건①(EXISTS)는
+     * 라이브 데이터 쿼리라 캐시와 무관.
+     */
+    private Set<String> detectDirtyTables(Connection c, List<String> targets) throws SQLException {
+        Set<String> dirty = new HashSet<>();
+        if (targets.isEmpty()) {
+            return dirty;
+        }
+
+        // 조건① 행 존재 — 라이브 EXISTS 배치(fsync 없음).
+        StringBuilder sb = new StringBuilder();
+        for (String t : targets) {
+            if (sb.length() > 0) {
+                sb.append(" UNION ALL ");
+            }
+            sb.append("SELECT '").append(t).append("' AS t FROM DUAL WHERE EXISTS (SELECT 1 FROM `")
+              .append(t).append("`)");
+        }
+        try (Statement s = c.createStatement(); ResultSet rs = s.executeQuery(sb.toString())) {
+            while (rs.next()) {
+                dirty.add(rs.getString(1));
+            }
+        }
+
+        // 조건② AUTO_INCREMENT>1 — 8.0 통계캐시 우회(라이브).
+        try (Statement s = c.createStatement()) {
+            s.execute("SET SESSION information_schema_stats_expiry = 0");
+        }
+        Set<String> targetSet = new HashSet<>(targets);
+        try (Statement s = c.createStatement();
+             ResultSet rs = s.executeQuery(
+                     "SELECT table_name FROM information_schema.tables "
+                             + "WHERE table_schema = DATABASE() AND auto_increment > 1")) {
+            while (rs.next()) {
+                String t = rs.getString(1);
+                if (targetSet.contains(t)) {
+                    dirty.add(t);
+                }
+            }
+        }
+        return dirty;
+    }
+
+    private List<String> queryBaseTables(Connection c) throws SQLException {
+        List<String> tables = new ArrayList<>();
+        String sql = "SELECT table_name FROM information_schema.tables "
+                + "WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'";
+        try (Statement s = c.createStatement(); ResultSet rs = s.executeQuery(sql)) {
+            while (rs.next()) {
+                tables.add(rs.getString(1));
+            }
+        }
+        return tables;
+    }
+}
+```
+
+- [ ] **Step 2: 컴파일 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:compileTestJava`
+Expected: **BUILD SUCCESSFUL**.
+
+- [ ] **Step 3: IsolationIT 실행(신규+기존 전부 그린)**
+
+먼저 잔존 gradle Worker/락 정리(이 머신 필수):
+```bash
+for p in $(wmic process where "name='java.exe'" get ProcessId 2>/dev/null | grep -oE '^[0-9]+'); do cl=$(wmic process where "ProcessId=$p" get CommandLine 2>/dev/null | tr -d '\r'); echo "$cl" | grep -qiE 'gradle|worker.tmpdir' && taskkill //F //PID "$p" >/dev/null 2>&1; done
+docker rm -f $(docker ps -q --filter "name=testcontainers-ryuk") 2>/dev/null; docker container prune -f >/dev/null 2>&1
+rm -rf app/build/test-results/integrationTest
+```
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:integrationTest --no-daemon --tests "com.pfplaybackend.api.common.DatabaseCleanerIsolationIT"`
+Expected: **BUILD SUCCESSFUL**, 5 tests(isolationA/B/C + selectDirtyTables_detectsOnlyDirtyTables + autoIncrementReset_afterInsertRollback) 전부 pass.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add app/src/test/java/com/pfplaybackend/api/common/DatabaseCleaner.java
+git commit -m "perf(test): DatabaseCleaner 더티 테이블만 truncate (no-op fsync 제거, 8.0 캐시우회)"
+```
+
+## Chunk 2: 전량 회귀 검증 + 속도 측정
+
+### Task 3: 대표 클래스로 정확성 회귀 확인(소배치)
+
+동작 불변이므로 기존에 그린이던 클래스가 그대로 그린이어야 한다. 이전에 FK/DUP/DATETIME 이슈가 있던 클래스들을 대표로 소배치 실행(각 배치 전 위 정리 스니펫 재실행).
+
+- [ ] **Step 1: 격리 민감 + AFTER_COMMIT 클래스 배치 실행**
+
+Run(정리 스니펫 후):
+```
+JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:integrationTest --no-daemon --continue \
+  --tests "com.pfplaybackend.api.common.DatabaseCleanerIsolationIT" \
+  --tests "com.pfplaybackend.api.administration.application.service.AdminReportCommandServiceIT" \
+  --tests "com.pfplaybackend.api.virtualdj.VirtualDjEventListenerIT" \
+  --tests "com.pfplaybackend.api.party.adapter.in.listener.PartyroomCounterListenerIT" \
+  --tests "com.pfplaybackend.api.administration.adapter.out.persistence.AdministratorRepositoryIntegrationTest"
+```
+Expected: **BUILD SUCCESSFUL**, 0 fail/0 error. (더티-선택이 격리를 깨지 않고 AI 리셋도 보존함을 확인.)
+
+- [ ] **Step 2: 결과 XML 확인**
+
+Run: `ls app/build/test-results/integrationTest/*.xml | wc -l` 및 실패 수 집계(0 이어야 함).
+
+### Task 4: 전량 2회 그린 + 유닛 무변 + 속도 측정
+
+- [ ] **Step 1: 전량 IT 를 소배치로 2회 초록**
+
+전량 단일호출은 이 머신에서 비현실적으로 느리다. 대신 72개 클래스를 ~6개씩 소배치로 나눠(각 배치 전 정리 스니펫) 실행, 완료 XML 을 별도 디렉터리에 누적해 총 0 fail/0 error 를 2회 확인한다(직전 IT 하네스 검증과 동일 절차). 배치별 `--no-daemon`.
+
+- [ ] **Step 2: 유닛 회귀 무변**
+
+Run(정리 후): `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --no-daemon`
+Expected: **BUILD SUCCESSFUL**(하네스 변경이 유닛에 영향 없음).
+
+- [ ] **Step 3: 속도 측정(전/후 비교) 기록**
+
+동일한 대표 배치(Task 3 Step 1 세트)를 최적화 전 커밋과 후 커밋에서 각각 실행해 벽시계 시간을 기록. 개선 폭을 커밋 메시지 또는 짧은 노트로 남긴다(선택). 최적화가 유의미한지 확인.
+
+- [ ] **Step 4: (필요 시) 정리 커밋**
+
+```bash
+git commit -m "docs(test): DatabaseCleaner 최적화 속도 측정 결과 기록" --allow-empty
+```
+
+### Task 5: 원격 검증(CI)
+
+- [ ] **Step 1: 브랜치 push → CI 그린 확인**
+
+이 변경은 `test/it-harness-flyway-validate` 브랜치(PR #319)에 얹힌다. push 후 CI 의 `Run integration tests` 스텝(`./gradlew :app:integrationTest`, clean ubuntu)이 초록인지 확인 — clean Linux 는 단일호출도 빠르므로 전량 그린이 여기서 최종 확인된다.
+
+Run: `git push` 후 `gh pr checks 319 --repo pfplay/pfplay-platform` 로 상태 확인.
+Expected: test 잡 pass.
+
+---
+
+## 실행 후 체크리스트
+- [ ] `DatabaseCleanerIsolationIT` 5개 그린(선택적 truncate + INSERT-롤백 AI 리셋 포함).
+- [ ] 대표 소배치 + 전량 소배치 2회 0 fail/0 error(동작 불변 확인).
+- [ ] `:app:test` 유닛 회귀 무변.
+- [ ] CI(리눅스) `:app:integrationTest` 그린.
+- [ ] 로컬 배치 속도 개선 확인(전/후 벽시계).

--- a/docs/superpowers/specs/2026-07-09-integration-test-harness-flyway-validate-design.md
+++ b/docs/superpowers/specs/2026-07-09-integration-test-harness-flyway-validate-design.md
@@ -49,23 +49,36 @@ origin/develop 워크트리에서 `application-test.yml`을 `ddl-auto: validate`
 
 공유·영속 스키마에서 각 테스트에 "깨끗한 슬레이트"를 복원한다.
 
-- **위치**: `AbstractIntegrationTest`의 `@BeforeEach`에서 호출(모든 IT 상속). 컴포넌트는 `common` 테스트 소스의 `DatabaseCleaner`(주입: `JdbcTemplate`/`EntityManager`).
-- **동작**:
-  1. `information_schema.tables`에서 현재 스키마(`pfplay_test`)의 **모든 base table**을 동적 조회 → 하드코딩 테이블 목록 불요(새 테이블 자동 포함).
-  2. `PRESERVE_SET` + `flyway_schema_history`를 제외한 나머지를 **truncate 대상**으로.
-  3. `SET FOREIGN_KEY_CHECKS=0` → 각 대상 `TRUNCATE TABLE` → `SET FOREIGN_KEY_CHECKS=1`.
-- **`PRESERVE_SET`(레퍼런스 시드, 보존)**: `avatar_body_resource`, `avatar_face_resource`, `avatar_icon_resource`, `system_config`, 그리고 가상DJ 설정 시드 테이블(V27/V28/V29 대상). 이들은 **제품 코드가 읽는 참조 데이터**(예: 기본 아바타)이고 대부분의 테스트가 count-단언하지 않는다.
-- **truncate 대상(비보존)**: 위를 제외한 전부. 특히 **이중목적 시드 테이블 `user_account`·`member`·`administrator`(V5 슈퍼어드민 시드)도 truncate**한다. 근거:
-  - 이들은 가장 빈번한 트랜잭션 테이블 → 보존하면 누적/충돌("Duplicate entry").
-  - 기존 IT는 create-drop(시드 없음) 전제라 V5 시드에 의존하지 않는다. 어드민이 필요한 테스트(예: `AdminPasswordChangeIntegrationTest`)는 이미 자체 생성한다.
-  - 부수효과: `administrator`/`member` truncate로 **AssertionError 3건 중 시드-존재 계열이 자동 해소**(빈 테이블 전제 복원).
+#### 3.2.1 실행 지점 — **반드시 test 트랜잭션 바깥(pre-transaction)** (C1)
+> **치명 함정**: MySQL의 `TRUNCATE`는 DDL이라 **implicit COMMIT**을 유발한다. 스위트의 **~31개 IT가 class-level `@Transactional`(롤백형)** 인데(전체의 42%), Spring은 test-managed 트랜잭션으로 `@BeforeEach`까지 감싼다. cleaner를 `@BeforeEach`에서 같은 커넥션으로 돌리면 test 트랜잭션이 **강제 커밋**되어 롤백 격리가 붕괴 → 비결정 오염/flake. **디스커버리(§2, 41 failures)는 cleaner 없이 config만 뒤집은 측정이라 이 상호작용은 미검증이다.**
 
-> **왜 "전부 truncate + test-seed.sql"이 아니라 "보존"인가**: 사용자 결정(유지보수할 시드 SQL 회피). 동적 조회 + 소수 명시 `PRESERVE_SET`으로 대부분 자기유지된다. 참조 시드는 Flyway가 제공(테스트가 재시드하지 않음).
+따라서:
+- cleaner는 **`TestExecutionListener.beforeTestMethod()`** 로 구현하고, **`TransactionalTestExecutionListener`보다 먼저** 순서를 배치(`@TestExecutionListeners(..., mergeMode=MERGE_WITH_DEFAULTS)` + `@Order`/우선순위)한다. 이 시점은 test 트랜잭션이 **아직 시작되기 전**이라 implicit commit이 test tx를 깨지 않는다.
+- 또는 cleaner 전용 **별도 `DataSource` 커넥션(autocommit=true)** 사용. 어느 쪽이든 "test tx 바깥"이 불변식.
+- **`@BeforeEach`에 넣지 않는다.**
 
-### 3.3 레퍼런스-변경 테스트의 잔여 처리
-`PRESERVE_SET` 테이블을 **직접 변경**하는 소수 테스트(아바타 어드민·설정 계열: `AvatarAdminActionListenerIT`, `BotAvatarAdminServiceIT` 등)는 보존 정책상 교차오염 여지가 있다. 처리:
-- 우선순위 1: 해당 테스트가 변경분을 **자체 정리**(`@AfterEach`)하도록 보강.
-- 대안: 그 테스트 클래스에 한해 해당 참조 테이블을 **truncate+최소 재시드**(클래스 스코프 훅). 스펙 구현 시 실패 원인별로 택1.
+**설계 통찰**: `@Transactional` 롤백형 IT는 스스로 롤백하므로 사실 정리 대상이 아니다. cleaner가 실제로 지워야 할 것은 **직전 "커밋형" 테스트가 남긴 오염**뿐이고, 그 정리는 다음 test tx가 열리기 **전(pre-transaction)** 에 일어나야 한다 → 위 실행 지점과 일치.
+
+#### 3.2.2 async quiescence — 커밋형 @Async 리스너 레이스 차단 (C2)
+AFTER_COMMIT + `@Async` 리스너(`UserActivityLogListener` 등)는 커밋 후 별 스레드에서 `user_activity_log` 등에 INSERT한다. async 부작용을 **트리거하지만 await하지 않는** 테스트가 있으면, 그 late INSERT가 **다음 테스트 truncate 이후 착지**해 오염(예: `hasSize(1)`→2)하거나 MDL과 충돌한다.
+- cleaner truncate **직전에 async executor idle 대기**(테스트용 `ThreadPoolTaskExecutor`의 active count 0 + queue empty를 폴링, 짧은 타임아웃). 이를 pre-transaction 훅에 포함.
+- 병행: **커밋형 async 부작용을 내는 IT 목록화**(`UserActivityLog*Listener*IT` 8개 + 파티룸 생성/제재 트리거 IT 1차 후보) → 필요 시 해당 테스트에 Awaitility await 보강(이미 `UserActivityLogListenerAdminPenaltyIT`는 그렇게 함 — 그 패턴을 표준으로).
+
+#### 3.2.3 truncate 로직
+1. `information_schema.tables`에서 현재 스키마(`pfplay_test`)의 **모든 base table** 동적 조회(하드코딩 목록 불요).
+2. `PRESERVE_SET` + `flyway_schema_history` 제외 → **truncate 대상**.
+3. `SET FOREIGN_KEY_CHECKS=0` → 각 대상 `TRUNCATE TABLE` → `SET FOREIGN_KEY_CHECKS=1` (cleaner 전용 커넥션 세션 스코프).
+
+- **`PRESERVE_SET`(레퍼런스 시드, 보존)**: `avatar_body_resource`, `avatar_face_resource`, `avatar_icon_resource`, `system_config`, 가상DJ 설정 시드 테이블(V27/V28/V29). 제품 코드가 읽는 참조 데이터(예: 기본 아바타). 최종 목록은 §8 오픈결정.
+- **truncate 대상(비보존)**: 위 제외 전부. 특히 이중목적 시드 테이블 `user_account`·`member`·`administrator`(V5)도 truncate. 근거: 최빈 트랜잭션 테이블이라 보존 시 누적/충돌; 기존 IT는 create-drop(무시드) 전제라 V5 시드 비의존; 어드민 필요 테스트는 자체 생성. 부수효과로 `administrator`/`member` 관련 AssertionError가 빈-테이블 전제 복원으로 해소.
+
+> **왜 "전부 truncate + test-seed.sql"이 아니라 "보존"인가**: 사용자 결정(유지보수 시드 SQL 회피). 동적 조회 + 소수 명시 `PRESERVE_SET`으로 대부분 자기유지. 참조 시드는 Flyway가 제공.
+
+### 3.3 레퍼런스-변경 테스트의 잔여 처리 (S3/S4)
+`PRESERVE_SET` 테이블은 truncate하지 않으므로, 여기에 **커밋으로 쓰는** 테스트만 교차오염원이 된다. **핵심 좁히기**: class-level `@Transactional`(롤백형) 테스트는 보존 테이블에 써도 **스스로 롤백**되어 오염되지 않는다(확인: `SystemConfigRepositoryIntegrationTest`, `SystemAnnouncementRepository*Test`, `AvatarAdminActionListenerIT` 전부 `@Transactional`). 따라서 대상은 **"보존 테이블에 커밋하는 비-`@Transactional` IT"** 로 한정된다.
+- 구현 1단계: 이 부분집합을 **실제로 열거**(grep: PRESERVE_SET 테이블 repo save/insert를 쓰면서 class-level `@Transactional`이 없는 IT). 예상 소수.
+- 처리: (a) 해당 테스트 `@AfterEach` 자체 정리, 또는 (b) 그 클래스에 한해 참조 테이블을 클래스-스코프 truncate+재시드. 실패별 택1.
+- **비대칭 주의(S4)**: 보존 테이블 자식행은 FK-off truncate로 지워지지만 보존 테이블 자신의 커밋 행은 안 지워짐 — 위 열거 대상이 이 유일 경로. count-단언 비전제(§3.2.3)가 깨지는 지점이므로 명시적으로 다룬다.
 
 ### 3.4 잔여 실패 개별 수정
 truncate 도입 후에도 남는 실패(시드 유니크 충돌·FK·단언)는 클래스별로 원인 규명해 수정:
@@ -80,14 +93,17 @@ truncate 도입 후에도 남는 실패(시드 유니크 충돌·FK·단언)는 
 - **선행조건**: §3.1~3.4로 74개가 초록이 된 뒤 배선(아니면 CI가 즉시 red).
 
 ## 4. 파일 맵 (예상)
-- 수정: `app/src/test/resources/application-test.yml`(설정 전환)
-- 생성: `.../common/DatabaseCleaner.java`(또는 `common` 테스트 유틸 패키지)
-- 수정: `AbstractIntegrationTest`(`@BeforeEach`에서 cleaner 호출)
-- 수정: 잔여 실패 IT들(§3.3~3.4, 최대 14클래스 — 다수는 §3.2로 자동 해소 예상)
-- 수정: `.github/workflows/ci-test.yml`(integrationTest 스텝)
+- 수정: `app/src/test/resources/application-test.yml`(설정 전환: validate + flyway)
+- 생성: `.../common/DatabaseCleaner.java`(동적 truncate + PRESERVE_SET, 전용 커넥션/JdbcTemplate)
+- 생성: `.../common/DatabaseCleanupTestExecutionListener.java`(`beforeTestMethod`에서 async quiescence + cleaner 호출; **Transactional TEL보다 앞 순서**)
+- 수정: `AbstractIntegrationTest`(`@TestExecutionListeners`로 위 리스너 등록 — `@BeforeEach` 아님)
+- 수정: 잔여 실패 IT들(§5.0 재측정으로 확정 — 개별수정/await 보강)
+- (검토) 기존 IT들의 자체 `@AfterEach deleteAll` 중복 정리(N1, §8-5 방침 따라)
+- 수정: `.github/workflows/ci-test.yml`(integrationTest 스텝; 74 초록 뒤 별 커밋/후속)
 
 ## 5. 검증 (DoD 게이트)
-1. `:app:integrationTest` **전량 초록**(279+ tests, 0 fail/0 error) — 로컬 uncontended 1회.
+0. **cleaner 적용 후 재측정(S2)**: config 전환 + `DatabaseCleaner`(§3.2 pre-transaction)까지 넣은 상태로 `:app:integrationTest --continue` 재실행 → 실패를 **재분류**(§3.2로 자동해소된 것 vs 개별수정 필요). §2의 41/14는 cleaner **이전** 수치라 신뢰 불가 — 이 재측정이 개별수정 범위의 진실원천.
+1. `:app:integrationTest` **전량 초록**(0 fail/0 error) — 로컬 uncontended 1회. 특히 `@Transactional` IT 31개가 cleaner와 flake 없이 통과하는지 확인(C1 검증).
 2. `:app:test` 회귀 무변(유닛/웹 여전히 초록).
 3. CI 배선 후 실제 워크플로에서 integrationTest 초록(또는 로컬로 CI 명령 재현).
 4. validate 상시 활성 → 이후 마이그레이션 drift는 IT 부팅에서 즉시 검출.
@@ -99,13 +115,15 @@ truncate 도입 후에도 남는 실패(시드 유니크 충돌·FK·단언)는 
 - Testcontainers 컨테이너 재사용 전략 대개편(현 싱글턴 유지, 데이터 격리만 추가).
 
 ## 7. 리스크 & 완화
-- **성능**: 매 테스트 40+ 테이블 truncate(FK off) — TRUNCATE는 빠르므로 테스트당 수십 ms 예상, 허용. 관측 후 필요 시 "변경된 테이블만 truncate"로 최적화(후속).
-- **PRESERVE_SET 누락/과다**: 너무 적게 보존하면 제품-코드 참조 데이터 소실(부팅 실패), 너무 많이 보존하면 오염. §2 실측 실패로 검증하며 조정.
-- **CI 러너 Docker**: self-hosted 러너면 Docker 데몬 확인 필요. GitHub-hosted면 무관.
-- **Flyway 슬롯(브랜치 교차)**: 본 브랜치는 마이그레이션을 추가하지 않으므로 슬롯 충돌 무관(단, IT가 Flyway를 타므로, 향후 슬롯 충돌 PR은 IT 부팅에서 즉시 red — 오히려 이점).
+- **⚠️직렬 실행이 불변식(S1)**: 공유 Testcontainers 스키마 + 전역 truncate는 **직렬 실행에서만 안전**하다. 현재 `build.gradle`이 `maxParallelForks=1` + `forkEvery=0`(확인)이라 안전. **누군가 속도 위해 병렬화하면 즉시 치명적**(fork 간 스키마 truncate 상호파괴). → `integrationTest` 태스크에 "병렬화 금지(스키마-per-fork 없인 불가)" 주석/가드 고정, Non-goals에도 명시.
+- **성능/CI 시간(S5)**: 매 테스트 40+ 테이블 truncate(FK off) — TRUNCATE 빠름, 테스트당 수십 ms 허용. 별개로 **`@MockBean` 사용 IT는 별도 Spring 컨텍스트 캐시 엔트리**를 만들어 캐시 스래싱→다수 풀부팅 유발(74 IT). CI 소요는 이 컨텍스트 파편화가 지배 → **DoD 재측정(§5.0) 때 실제 벽시계 측정**해 CI 예산 확정(Open Decision #3와 연동). 최적화("변경 테이블만 truncate", 컨텍스트 통합)는 후속.
+- **PRESERVE_SET 누락/과다**: 적게 보존하면 참조 데이터 소실(부팅 실패), 많이 보존하면 오염. §5.0 재측정으로 조정.
+- **CI 러너 Docker**: GitHub-hosted `ubuntu-latest`는 Docker 지원(확인) → Testcontainers 동작. self-hosted면 데몬 확인 필요.
+- **Flyway 슬롯**: 본 브랜치는 마이그레이션 무추가라 무관. 오히려 IT가 Flyway를 타므로 향후 슬롯 충돌 PR은 IT 부팅에서 즉시 red(이점).
 
 ## 8. 오픈 결정 (스펙 리뷰에서 확정)
 1. `PRESERVE_SET` 최종 목록(가상DJ 설정 테이블 포함 여부, `system_config` 보존/재시드).
-2. 레퍼런스-변경 테스트(§3.3): 자체정리 vs 클래스스코프 재시드 — 실패별 택1 기준.
-3. CI: `test`와 `integrationTest`를 한 스텝(`gradlew test integrationTest`)으로 묶을지 분리할지.
-4. `DatabaseCleaner` 구현 레벨: JDBC 직접 vs Hibernate 세션 — 트랜잭션 경계/AFTER_COMMIT 리스너 IT와의 상호작용 고려.
+2. 레퍼런스-변경 테스트(§3.3): "보존 테이블에 커밋하는 비-`@Transactional` IT" 열거 후 자체정리 vs 클래스스코프 재시드 택1.
+3. CI: `test`와 `integrationTest`를 한 스텝으로 묶을지 분리할지 — §5.0 벽시계 측정 후 결정. 배선은 74 초록 확인 뒤 **별 커밋/후속 PR** 권장(first-run flake가 dev 자동배포 게이트 막지 않게, N2).
+4. **cleaner 실행 지점 확정(C1 해소)**: `TestExecutionListener.beforeTestMethod()`(Transactional TEL보다 앞) vs 별도 autocommit 커넥션 — 둘 다 "test tx 바깥" 충족. async quiescence(§3.2.2)를 이 훅에 포함. **`@BeforeEach` 불가.**
+5. 기존 테스트들의 자체 `@AfterEach deleteAll`(N1): cleaner 도입 후 중복이 되면 제거할지 존치할지 정리 방침.

--- a/docs/superpowers/specs/2026-07-09-integration-test-harness-flyway-validate-design.md
+++ b/docs/superpowers/specs/2026-07-09-integration-test-harness-flyway-validate-design.md
@@ -1,0 +1,111 @@
+# 통합 테스트 하네스 현대화 — Flyway+validate 전환 · 격리 · CI 배선 설계
+
+- 작성일: 2026-07-09
+- 범위: pfplay-platform 통합 테스트(IT) 인프라 (제품 코드 변경 없음, 테스트/설정/CI만)
+- 상태: Draft → 스펙 리뷰 대기
+
+## 1. 배경 & 문제
+
+pfplay-platform의 통합 테스트(`@Tag("integration")`, `AbstractIntegrationTest` 상속, **74개 클래스**)는 현재 다음 하네스로 돈다:
+
+- `application-test.yml`: `spring.jpa.hibernate.ddl-auto: create-drop`, `spring.flyway.enabled: false`, `spring.sql.init.mode: never`
+- Testcontainers MySQL/Redis는 **정적 싱글턴**(`TestContainerConfig`, 프로세스당 1회 start, 전 IT 공유)
+
+이 구성의 근본 결함 두 가지:
+
+1. **하네스가 프로덕션과 불일치 → 마이그레이션 drift를 가림.** 스키마를 Flyway가 아니라 **엔티티에서 파생**(create-drop)하므로, 실제 마이그레이션(V1~)·시드가 테스트에서 검증되지 않는다. 프로덕션/로컬/스테이징/프로드 프로파일은 전부 `ddl-auto: validate` + `flyway.enabled: true`인데, IT만 다르다. (참고: `reference_ddl_auto_create_drop_hides_migration_drift`)
+   - 부작용: 시드 데이터(기본 아바타 등)가 테스트 DB에 없어, 멤버 프로비저닝 경로(사인업·어드민 로그인)가 `IllegalStateException: 기본 아바타 바디 리소스가 존재하지 않습니다` / 500으로 **현재 4개 IT가 red**. 제품은 정상(실 환경은 Flyway 시드 적용). 즉 **테스트 전용 위양성**.
+
+2. **CI가 통합 테스트를 아예 실행하지 않는다.** `ci-test.yml`은 `./gradlew test`만 실행하고, 루트 `build.gradle`의 `test` 태스크는 `excludeTags 'integration'`. `integrationTest`(`includeTags 'integration'`)는 **어느 워크플로도 호출하지 않음**(deploy는 `-x test`). → **통합 게이트가 무방비**, 위 red가 아무도 모르게 방치됨.
+
+**목표(DoD)**: IT를 Flyway+validate로 전환 → 74개 클래스 전부 초록 → `integrationTest`를 CI에 배선.
+
+## 2. 디스커버리 (실측)
+
+origin/develop 워크트리에서 `application-test.yml`을 `ddl-auto: validate` + `flyway.enabled: true`로 뒤집고 `:app:integrationTest --continue` 전량 실행한 결과:
+
+- **279 tests · 41 failures · 0 errors** (0 errors = **컨텍스트 부팅 정상 = drift 없음**. validate가 V1~V34 전체에 통과. 실패는 전부 데이터/상태 계열)
+- 기존 red 4건(아바타 시드)은 **사라짐**(시드가 들어와 통과) — 전환이 오히려 이들을 **고침**.
+- 대신 이전엔 숨어있던 **41 failures / 14 클래스**가 드러남:
+
+| 분류 | 원인 | 클래스(대표) |
+|---|---|---|
+| DataIntegrity/Constraint (~11클래스) | 공유·영속 스키마의 **교차오염 + 시드 유니크 충돌 + FK 강제** | AvatarAdminActionListenerIT, PartyroomAdminActionListenerIT, UserActivityLogListenerAdminPenaltyIT, SystemAnnouncementRepository(Impl/Test)IT, AdminReportCommandServiceIT, AnnouncementPushFlowIntegrationTest, PartyroomCounterListenerIT, BotAvatarAdminServiceIT, VirtualDjEventListenerIT, VirtualDjOrchestratorIT |
+| AssertionError (~3클래스) | **빈 테이블 전제**가 시드 존재로 깨짐 | AdministratorRepositoryIntegrationTest, AdminMemberWithdrawCommandServiceIT, PartyroomRepositoryAtomicUpdateIT |
+
+**루트 원인(단일)**: create-drop에선 새 Spring 컨텍스트마다 스키마가 리셋됐으나, validate+Flyway에선 **공유 Testcontainers 스키마가 74개 클래스 전반에 영속**하고 **시드 데이터가 존재**한다. 그래서 자기격리가 불완전한 테스트가 서로 충돌한다. 기존 IT들은 전부 **빈 스키마(시드 없음)** 전제로 작성됐다.
+
+## 3. 설계
+
+### 3.1 설정 전환
+`app/src/test/resources/application-test.yml`:
+- `ddl-auto: create-drop` → **`validate`**
+- `flyway.enabled: false` → **`true`**
+- `sql.init.mode: never`는 유지(Flyway가 시드 담당).
+
+이로써 IT가 프로덕션과 동일한 스키마+시드 경로를 타고, validate가 drift를 상시 검증한다.
+
+### 3.2 테스트 격리 — `DatabaseCleaner` (동적 truncate + 레퍼런스 보존)
+
+공유·영속 스키마에서 각 테스트에 "깨끗한 슬레이트"를 복원한다.
+
+- **위치**: `AbstractIntegrationTest`의 `@BeforeEach`에서 호출(모든 IT 상속). 컴포넌트는 `common` 테스트 소스의 `DatabaseCleaner`(주입: `JdbcTemplate`/`EntityManager`).
+- **동작**:
+  1. `information_schema.tables`에서 현재 스키마(`pfplay_test`)의 **모든 base table**을 동적 조회 → 하드코딩 테이블 목록 불요(새 테이블 자동 포함).
+  2. `PRESERVE_SET` + `flyway_schema_history`를 제외한 나머지를 **truncate 대상**으로.
+  3. `SET FOREIGN_KEY_CHECKS=0` → 각 대상 `TRUNCATE TABLE` → `SET FOREIGN_KEY_CHECKS=1`.
+- **`PRESERVE_SET`(레퍼런스 시드, 보존)**: `avatar_body_resource`, `avatar_face_resource`, `avatar_icon_resource`, `system_config`, 그리고 가상DJ 설정 시드 테이블(V27/V28/V29 대상). 이들은 **제품 코드가 읽는 참조 데이터**(예: 기본 아바타)이고 대부분의 테스트가 count-단언하지 않는다.
+- **truncate 대상(비보존)**: 위를 제외한 전부. 특히 **이중목적 시드 테이블 `user_account`·`member`·`administrator`(V5 슈퍼어드민 시드)도 truncate**한다. 근거:
+  - 이들은 가장 빈번한 트랜잭션 테이블 → 보존하면 누적/충돌("Duplicate entry").
+  - 기존 IT는 create-drop(시드 없음) 전제라 V5 시드에 의존하지 않는다. 어드민이 필요한 테스트(예: `AdminPasswordChangeIntegrationTest`)는 이미 자체 생성한다.
+  - 부수효과: `administrator`/`member` truncate로 **AssertionError 3건 중 시드-존재 계열이 자동 해소**(빈 테이블 전제 복원).
+
+> **왜 "전부 truncate + test-seed.sql"이 아니라 "보존"인가**: 사용자 결정(유지보수할 시드 SQL 회피). 동적 조회 + 소수 명시 `PRESERVE_SET`으로 대부분 자기유지된다. 참조 시드는 Flyway가 제공(테스트가 재시드하지 않음).
+
+### 3.3 레퍼런스-변경 테스트의 잔여 처리
+`PRESERVE_SET` 테이블을 **직접 변경**하는 소수 테스트(아바타 어드민·설정 계열: `AvatarAdminActionListenerIT`, `BotAvatarAdminServiceIT` 등)는 보존 정책상 교차오염 여지가 있다. 처리:
+- 우선순위 1: 해당 테스트가 변경분을 **자체 정리**(`@AfterEach`)하도록 보강.
+- 대안: 그 테스트 클래스에 한해 해당 참조 테이블을 **truncate+최소 재시드**(클래스 스코프 훅). 스펙 구현 시 실패 원인별로 택1.
+
+### 3.4 잔여 실패 개별 수정
+truncate 도입 후에도 남는 실패(시드 유니크 충돌·FK·단언)는 클래스별로 원인 규명해 수정:
+- FK "Cannot add child row": 부모 행 시드 누락 → 테스트가 부모를 먼저 시드하도록(또는 참조 무결성에 맞게 데이터 구성).
+- "Duplicate entry": 참조 시드와 충돌하는 고정 키 → 테스트 전용 키 범위(예: 990000+)로 회피.
+- AssertionError 잔여: 시드-인지로 기대값 조정.
+
+### 3.5 CI 배선
+`.github/workflows/ci-test.yml`에 `integrationTest` 스텝 추가:
+- 러너에 Docker 가용(Testcontainers) 확인 — GitHub-hosted `ubuntu-latest`는 Docker 지원. `./gradlew :app:integrationTest` 실행.
+- `test`와 별개 스텝(또는 `./gradlew test integrationTest`). 실패 시 빨간불.
+- **선행조건**: §3.1~3.4로 74개가 초록이 된 뒤 배선(아니면 CI가 즉시 red).
+
+## 4. 파일 맵 (예상)
+- 수정: `app/src/test/resources/application-test.yml`(설정 전환)
+- 생성: `.../common/DatabaseCleaner.java`(또는 `common` 테스트 유틸 패키지)
+- 수정: `AbstractIntegrationTest`(`@BeforeEach`에서 cleaner 호출)
+- 수정: 잔여 실패 IT들(§3.3~3.4, 최대 14클래스 — 다수는 §3.2로 자동 해소 예상)
+- 수정: `.github/workflows/ci-test.yml`(integrationTest 스텝)
+
+## 5. 검증 (DoD 게이트)
+1. `:app:integrationTest` **전량 초록**(279+ tests, 0 fail/0 error) — 로컬 uncontended 1회.
+2. `:app:test` 회귀 무변(유닛/웹 여전히 초록).
+3. CI 배선 후 실제 워크플로에서 integrationTest 초록(또는 로컬로 CI 명령 재현).
+4. validate 상시 활성 → 이후 마이그레이션 drift는 IT 부팅에서 즉시 검출.
+
+## 6. Non-goals
+- 제품 코드 로직 변경(순수 테스트/설정/CI).
+- 개별 IT의 테스트 설계 리팩토링(격리·시드 대응에 필요한 최소 수정만).
+- 어드민 파티룸 행동분석 기능(별 브랜치 `feat/admin-partyroom-behavior-analytics`, 무관).
+- Testcontainers 컨테이너 재사용 전략 대개편(현 싱글턴 유지, 데이터 격리만 추가).
+
+## 7. 리스크 & 완화
+- **성능**: 매 테스트 40+ 테이블 truncate(FK off) — TRUNCATE는 빠르므로 테스트당 수십 ms 예상, 허용. 관측 후 필요 시 "변경된 테이블만 truncate"로 최적화(후속).
+- **PRESERVE_SET 누락/과다**: 너무 적게 보존하면 제품-코드 참조 데이터 소실(부팅 실패), 너무 많이 보존하면 오염. §2 실측 실패로 검증하며 조정.
+- **CI 러너 Docker**: self-hosted 러너면 Docker 데몬 확인 필요. GitHub-hosted면 무관.
+- **Flyway 슬롯(브랜치 교차)**: 본 브랜치는 마이그레이션을 추가하지 않으므로 슬롯 충돌 무관(단, IT가 Flyway를 타므로, 향후 슬롯 충돌 PR은 IT 부팅에서 즉시 red — 오히려 이점).
+
+## 8. 오픈 결정 (스펙 리뷰에서 확정)
+1. `PRESERVE_SET` 최종 목록(가상DJ 설정 테이블 포함 여부, `system_config` 보존/재시드).
+2. 레퍼런스-변경 테스트(§3.3): 자체정리 vs 클래스스코프 재시드 — 실패별 택1 기준.
+3. CI: `test`와 `integrationTest`를 한 스텝(`gradlew test integrationTest`)으로 묶을지 분리할지.
+4. `DatabaseCleaner` 구현 레벨: JDBC 직접 vs Hibernate 세션 — 트랜잭션 경계/AFTER_COMMIT 리스너 IT와의 상호작용 고려.

--- a/docs/superpowers/specs/2026-07-09-integration-test-harness-flyway-validate-design.md
+++ b/docs/superpowers/specs/2026-07-09-integration-test-harness-flyway-validate-design.md
@@ -53,16 +53,20 @@ origin/develop 워크트리에서 `application-test.yml`을 `ddl-auto: validate`
 > **치명 함정**: MySQL의 `TRUNCATE`는 DDL이라 **implicit COMMIT**을 유발한다. 스위트의 **~31개 IT가 class-level `@Transactional`(롤백형)** 인데(전체의 42%), Spring은 test-managed 트랜잭션으로 `@BeforeEach`까지 감싼다. cleaner를 `@BeforeEach`에서 같은 커넥션으로 돌리면 test 트랜잭션이 **강제 커밋**되어 롤백 격리가 붕괴 → 비결정 오염/flake. **디스커버리(§2, 41 failures)는 cleaner 없이 config만 뒤집은 측정이라 이 상호작용은 미검증이다.**
 
 따라서:
-- cleaner는 **`TestExecutionListener.beforeTestMethod()`** 로 구현하고, **`TransactionalTestExecutionListener`보다 먼저** 순서를 배치(`@TestExecutionListeners(..., mergeMode=MERGE_WITH_DEFAULTS)` + `@Order`/우선순위)한다. 이 시점은 test 트랜잭션이 **아직 시작되기 전**이라 implicit commit이 test tx를 깨지 않는다.
-- 또는 cleaner 전용 **별도 `DataSource` 커넥션(autocommit=true)** 사용. 어느 쪽이든 "test tx 바깥"이 불변식.
+- **기본(권장) — cleaner 전용 별도 `DataSource` 커넥션(autocommit=true)에서 TRUNCATE.** implicit commit이 **자기 커넥션에만** 적용되므로 TTEL 순서와 **무관하게** test tx를 절대 깨지 않는다(순서 실수 내성).
+- 실행 훅은 `TestExecutionListener.beforeTestMethod()`(test body 전, MDL 회피 위해). test tx가 아직 안 열린 시점 + 별도 커넥션 → 이중 안전.
+- 대안(비권장 — footgun): 같은 커넥션 + `@Order`로 `TransactionalTestExecutionListener`(order 4000)보다 앞(2000<order<4000)에 배치. 순서를 **한 번이라도 잘못 매기면(order>4000) C1이 조용히 재발**한다. 별도 커넥션 방식이 이 함정을 원천 제거하므로 기본값으로 확정.
 - **`@BeforeEach`에 넣지 않는다.**
 
 **설계 통찰**: `@Transactional` 롤백형 IT는 스스로 롤백하므로 사실 정리 대상이 아니다. cleaner가 실제로 지워야 할 것은 **직전 "커밋형" 테스트가 남긴 오염**뿐이고, 그 정리는 다음 test tx가 열리기 **전(pre-transaction)** 에 일어나야 한다 → 위 실행 지점과 일치.
 
 #### 3.2.2 async quiescence — 커밋형 @Async 리스너 레이스 차단 (C2)
 AFTER_COMMIT + `@Async` 리스너(`UserActivityLogListener` 등)는 커밋 후 별 스레드에서 `user_activity_log` 등에 INSERT한다. async 부작용을 **트리거하지만 await하지 않는** 테스트가 있으면, 그 late INSERT가 **다음 테스트 truncate 이후 착지**해 오염(예: `hasSize(1)`→2)하거나 MDL과 충돌한다.
-- cleaner truncate **직전에 async executor idle 대기**(테스트용 `ThreadPoolTaskExecutor`의 active count 0 + queue empty를 폴링, 짧은 타임아웃). 이를 pre-transaction 훅에 포함.
-- 병행: **커밋형 async 부작용을 내는 IT 목록화**(`UserActivityLog*Listener*IT` 8개 + 파티룸 생성/제재 트리거 IT 1차 후보) → 필요 시 해당 테스트에 Awaitility await 보강(이미 `UserActivityLogListenerAdminPenaltyIT`는 그렇게 함 — 그 패턴을 표준으로).
+- cleaner truncate **직전에 커밋행을 쓰는 async executor를 전부 idle 대기**(activeCount 0 + queue empty 폴링).
+  - ⚠️ **executor는 단수가 아니라 최소 3개다**(반드시 전부 대기): `userActivityLogExecutor`·`webPushExecutor`(`AsyncConfig`), `vdjChatExecutor`(`VirtualDjChatAsyncConfig`). UAL 하나만 폴링하면 **webpush(`AnnouncementPushFlowIntegrationTest`)·vdj(`VirtualDjEventListenerIT`) 경로 레이스가 그대로 열린다** — 이 둘은 §2 실패목록에 실재. 구현은 `ThreadPoolTaskExecutor` 빈들을 컨텍스트에서 수집해 모두 quiesce.
+  - **타임아웃 만료 = fail-loud**(예외로 테스트 실패). 여전히 바쁜데 조용히 truncate 진행하면 C2 재발/침묵오염. 짧은 상한(예 수 초) 후 명시적 실패.
+  - 이 quiescence를 pre-transaction 훅(§3.2.1)에 truncate **직전** 배치 → 직전 테스트 async tx의 MDL도 해소됨.
+- 병행: **커밋형 async 부작용을 내는 IT 목록화**(`UserActivityLog*Listener*IT` 8개 + 파티룸 생성/제재 + push + vdj 트리거) → 필요 시 Awaitility await 보강(`UserActivityLogListenerAdminPenaltyIT` 패턴을 표준으로).
 
 #### 3.2.3 truncate 로직
 1. `information_schema.tables`에서 현재 스키마(`pfplay_test`)의 **모든 base table** 동적 조회(하드코딩 목록 불요).
@@ -102,8 +106,9 @@ truncate 도입 후에도 남는 실패(시드 유니크 충돌·FK·단언)는 
 - 수정: `.github/workflows/ci-test.yml`(integrationTest 스텝; 74 초록 뒤 별 커밋/후속)
 
 ## 5. 검증 (DoD 게이트)
-0. **cleaner 적용 후 재측정(S2)**: config 전환 + `DatabaseCleaner`(§3.2 pre-transaction)까지 넣은 상태로 `:app:integrationTest --continue` 재실행 → 실패를 **재분류**(§3.2로 자동해소된 것 vs 개별수정 필요). §2의 41/14는 cleaner **이전** 수치라 신뢰 불가 — 이 재측정이 개별수정 범위의 진실원천.
-1. `:app:integrationTest` **전량 초록**(0 fail/0 error) — 로컬 uncontended 1회. 특히 `@Transactional` IT 31개가 cleaner와 flake 없이 통과하는지 확인(C1 검증).
+0a. **cleaner 결정론 마이크로 검증(C1, 재측정 전 선행)**: 전량 실행 전에, cleaner가 롤백 격리를 **깨지 않음**을 결정론적으로 단언하는 전용 테스트를 먼저 통과시킨다 — 롤백형 `@Transactional` IT에서 "메서드가 비보존 테이블에 write → 같은 메서드 내 롤백으로 사라짐"과, 인접 두 메서드가 서로의 커밋 잔재를 **관측하지 않음**(clean 시작)을 명시 단언. **1회 초록은 flake 부재의 증명이 아니므로**(C1 발현형=비결정), 이 마이크로 검증 + 31개 반복/스트레스 실행으로 "격리가 살아있음"을 단언한다.
+0b. **cleaner 적용 후 재측정(S2)**: config 전환 + `DatabaseCleaner`(§3.2 pre-transaction, 별도 커넥션)까지 넣은 상태로 `:app:integrationTest --continue` 재실행 → 실패 **재분류**(자동해소 vs 개별수정). §2의 41/14는 cleaner **이전** 수치라 신뢰 불가 — 이 재측정이 개별수정 범위의 진실원천.
+1. `:app:integrationTest` **전량 초록**(0 fail/0 error) — 로컬 uncontended, 안정성 위해 **연속 2회 이상** 초록.
 2. `:app:test` 회귀 무변(유닛/웹 여전히 초록).
 3. CI 배선 후 실제 워크플로에서 integrationTest 초록(또는 로컬로 CI 명령 재현).
 4. validate 상시 활성 → 이후 마이그레이션 drift는 IT 부팅에서 즉시 검출.
@@ -119,11 +124,12 @@ truncate 도입 후에도 남는 실패(시드 유니크 충돌·FK·단언)는 
 - **성능/CI 시간(S5)**: 매 테스트 40+ 테이블 truncate(FK off) — TRUNCATE 빠름, 테스트당 수십 ms 허용. 별개로 **`@MockBean` 사용 IT는 별도 Spring 컨텍스트 캐시 엔트리**를 만들어 캐시 스래싱→다수 풀부팅 유발(74 IT). CI 소요는 이 컨텍스트 파편화가 지배 → **DoD 재측정(§5.0) 때 실제 벽시계 측정**해 CI 예산 확정(Open Decision #3와 연동). 최적화("변경 테이블만 truncate", 컨텍스트 통합)는 후속.
 - **PRESERVE_SET 누락/과다**: 적게 보존하면 참조 데이터 소실(부팅 실패), 많이 보존하면 오염. §5.0 재측정으로 조정.
 - **CI 러너 Docker**: GitHub-hosted `ubuntu-latest`는 Docker 지원(확인) → Testcontainers 동작. self-hosted면 데몬 확인 필요.
+- **`@BeforeAll` 커밋 픽스처 소실**: cleaner는 **메서드마다** pre-transaction으로 truncate하므로, 클래스 1회 `@BeforeAll`에서 **커밋**으로 시드한 공유 픽스처는 2번째 메서드부터 소실된다. create-drop 전제 IT엔 드물지만 전량 전환 시 잠재 — 커밋형 `@BeforeAll` 시드는 **메서드 스코프로 이전**하거나 그 대상을 보존대상화해야 한다(§5.0b 재측정에서 발현 시 처리).
 - **Flyway 슬롯**: 본 브랜치는 마이그레이션 무추가라 무관. 오히려 IT가 Flyway를 타므로 향후 슬롯 충돌 PR은 IT 부팅에서 즉시 red(이점).
 
 ## 8. 오픈 결정 (스펙 리뷰에서 확정)
-1. `PRESERVE_SET` 최종 목록(가상DJ 설정 테이블 포함 여부, `system_config` 보존/재시드).
+1. `PRESERVE_SET` 최종 목록(가상DJ 설정 테이블 포함 여부, `system_config` 보존/재시드). **FK-closure 기준(필수)**: 보존 테이블은 **truncate 대상으로 나가는 outgoing FK가 없어야** 한다. 있으면 FK_CHECKS=0로 대상을 비우는 순간 보존 테이블 행에 **dangling 참조**가 남고 MySQL은 FK_CHECKS=1 복원 시 **재검증하지 않아 조용히 잔존**한다. V27/V28/V29 가상DJ 설정 시드의 outgoing FK를 확인해, 참조 대상이 truncate 대상이면 그 대상도 보존(또는 보존 테이블을 truncate 대상으로 강등)해 FK-closure를 만족시킨다.
 2. 레퍼런스-변경 테스트(§3.3): "보존 테이블에 커밋하는 비-`@Transactional` IT" 열거 후 자체정리 vs 클래스스코프 재시드 택1.
 3. CI: `test`와 `integrationTest`를 한 스텝으로 묶을지 분리할지 — §5.0 벽시계 측정 후 결정. 배선은 74 초록 확인 뒤 **별 커밋/후속 PR** 권장(first-run flake가 dev 자동배포 게이트 막지 않게, N2).
-4. **cleaner 실행 지점 확정(C1 해소)**: `TestExecutionListener.beforeTestMethod()`(Transactional TEL보다 앞) vs 별도 autocommit 커넥션 — 둘 다 "test tx 바깥" 충족. async quiescence(§3.2.2)를 이 훅에 포함. **`@BeforeEach` 불가.**
+4. **cleaner 실행 지점(C1 — 확정)**: **별도 autocommit 커넥션 + `beforeTestMethod` 훅**을 기본으로 확정(§3.2.1). TEL-ordering 단독은 footgun이라 채택 안 함. async quiescence(§3.2.2, executor 전부)를 이 훅에 truncate 직전 포함. **`@BeforeEach` 불가.** (남은 결정: quiescence 타임아웃 상한값·fail-loud 메시지 등 세부.)
 5. 기존 테스트들의 자체 `@AfterEach deleteAll`(N1): cleaner 도입 후 중복이 되면 제거할지 존치할지 정리 방침.

--- a/docs/superpowers/specs/2026-07-09-integration-test-harness-flyway-validate-design.md
+++ b/docs/superpowers/specs/2026-07-09-integration-test-harness-flyway-validate-design.md
@@ -64,8 +64,10 @@ origin/develop 워크트리에서 `application-test.yml`을 `ddl-auto: validate`
 AFTER_COMMIT + `@Async` 리스너(`UserActivityLogListener` 등)는 커밋 후 별 스레드에서 `user_activity_log` 등에 INSERT한다. async 부작용을 **트리거하지만 await하지 않는** 테스트가 있으면, 그 late INSERT가 **다음 테스트 truncate 이후 착지**해 오염(예: `hasSize(1)`→2)하거나 MDL과 충돌한다.
 - cleaner truncate **직전에 커밋행을 쓰는 async executor를 전부 idle 대기**(activeCount 0 + queue empty 폴링).
   - ⚠️ **executor는 단수가 아니라 최소 3개다**(반드시 전부 대기): `userActivityLogExecutor`·`webPushExecutor`(`AsyncConfig`), `vdjChatExecutor`(`VirtualDjChatAsyncConfig`). UAL 하나만 폴링하면 **webpush(`AnnouncementPushFlowIntegrationTest`)·vdj(`VirtualDjEventListenerIT`) 경로 레이스가 그대로 열린다** — 이 둘은 §2 실패목록에 실재. 구현은 `ThreadPoolTaskExecutor` 빈들을 컨텍스트에서 수집해 모두 quiesce.
+  - **안정성 창(TOCTOU 방어)**: `ThreadPoolTaskExecutor`는 큐 dequeue↔activeCount 증가 사이 미세 창에서 (activeCount 0 ∧ queue empty)가 순간 참일 수 있다. 1회 스냅샷 대신 **연속 N회(예 3회, 짧은 간격) idle 관측**을 idle 조건으로 삼는다.
   - **타임아웃 만료 = fail-loud**(예외로 테스트 실패). 여전히 바쁜데 조용히 truncate 진행하면 C2 재발/침묵오염. 짧은 상한(예 수 초) 후 명시적 실패.
   - 이 quiescence를 pre-transaction 훅(§3.2.1)에 truncate **직전** 배치 → 직전 테스트 async tx의 MDL도 해소됨.
+  - **스케줄러 blind-spot**: `@EnableScheduling` 크론(재생/vdj reconcile)은 `ThreadPoolTaskScheduler`(≠TPTE)에서 돌아 collect-all-TPTE 대상이 아니다(과다대기 회피 이점). 단 스케줄 잡이 스위트 중 커밋행을 쓰면 잔여 flake 벡터 — 발현 시 `test` 프로파일에서 스케줄링 비활성화로 대응.
 - 병행: **커밋형 async 부작용을 내는 IT 목록화**(`UserActivityLog*Listener*IT` 8개 + 파티룸 생성/제재 + push + vdj 트리거) → 필요 시 Awaitility await 보강(`UserActivityLogListenerAdminPenaltyIT` 패턴을 표준으로).
 
 #### 3.2.3 truncate 로직
@@ -106,7 +108,7 @@ truncate 도입 후에도 남는 실패(시드 유니크 충돌·FK·단언)는 
 - 수정: `.github/workflows/ci-test.yml`(integrationTest 스텝; 74 초록 뒤 별 커밋/후속)
 
 ## 5. 검증 (DoD 게이트)
-0a. **cleaner 결정론 마이크로 검증(C1, 재측정 전 선행)**: 전량 실행 전에, cleaner가 롤백 격리를 **깨지 않음**을 결정론적으로 단언하는 전용 테스트를 먼저 통과시킨다 — 롤백형 `@Transactional` IT에서 "메서드가 비보존 테이블에 write → 같은 메서드 내 롤백으로 사라짐"과, 인접 두 메서드가 서로의 커밋 잔재를 **관측하지 않음**(clean 시작)을 명시 단언. **1회 초록은 flake 부재의 증명이 아니므로**(C1 발현형=비결정), 이 마이크로 검증 + 31개 반복/스트레스 실행으로 "격리가 살아있음"을 단언한다.
+0a. **cleaner 결정론 마이크로 검증(C1, 재측정 전 선행)**: 전량 실행 전에, cleaner가 롤백 격리를 **깨지 않음**을 결정론적으로 단언하는 전용 테스트를 먼저 통과시킨다 — **핵심 단언**은 "인접 두 (커밋형) 메서드가 서로의 잔재를 관측하지 않음(clean 시작)" — cleaner가 실제로 하는 일. 부수로 "롤백형 메서드 write가 같은 메서드 롤백으로 소멸"(cleaner가 tx를 안 깬다는 방증)도 단언. **1회 초록은 flake 부재의 증명이 아니므로**(C1 발현형=비결정), 이 마이크로 검증 + 31개 반복/스트레스 실행으로 "격리가 살아있음"을 단언한다.
 0b. **cleaner 적용 후 재측정(S2)**: config 전환 + `DatabaseCleaner`(§3.2 pre-transaction, 별도 커넥션)까지 넣은 상태로 `:app:integrationTest --continue` 재실행 → 실패 **재분류**(자동해소 vs 개별수정). §2의 41/14는 cleaner **이전** 수치라 신뢰 불가 — 이 재측정이 개별수정 범위의 진실원천.
 1. `:app:integrationTest` **전량 초록**(0 fail/0 error) — 로컬 uncontended, 안정성 위해 **연속 2회 이상** 초록.
 2. `:app:test` 회귀 무변(유닛/웹 여전히 초록).
@@ -124,7 +126,7 @@ truncate 도입 후에도 남는 실패(시드 유니크 충돌·FK·단언)는 
 - **성능/CI 시간(S5)**: 매 테스트 40+ 테이블 truncate(FK off) — TRUNCATE 빠름, 테스트당 수십 ms 허용. 별개로 **`@MockBean` 사용 IT는 별도 Spring 컨텍스트 캐시 엔트리**를 만들어 캐시 스래싱→다수 풀부팅 유발(74 IT). CI 소요는 이 컨텍스트 파편화가 지배 → **DoD 재측정(§5.0) 때 실제 벽시계 측정**해 CI 예산 확정(Open Decision #3와 연동). 최적화("변경 테이블만 truncate", 컨텍스트 통합)는 후속.
 - **PRESERVE_SET 누락/과다**: 적게 보존하면 참조 데이터 소실(부팅 실패), 많이 보존하면 오염. §5.0 재측정으로 조정.
 - **CI 러너 Docker**: GitHub-hosted `ubuntu-latest`는 Docker 지원(확인) → Testcontainers 동작. self-hosted면 데몬 확인 필요.
-- **`@BeforeAll` 커밋 픽스처 소실**: cleaner는 **메서드마다** pre-transaction으로 truncate하므로, 클래스 1회 `@BeforeAll`에서 **커밋**으로 시드한 공유 픽스처는 2번째 메서드부터 소실된다. create-drop 전제 IT엔 드물지만 전량 전환 시 잠재 — 커밋형 `@BeforeAll` 시드는 **메서드 스코프로 이전**하거나 그 대상을 보존대상화해야 한다(§5.0b 재측정에서 발현 시 처리).
+- **`@BeforeAll` 커밋 픽스처 소실**: cleaner는 **메서드마다** pre-transaction으로 truncate하므로, 클래스 1회 `@BeforeAll`에서 **커밋**으로 시드한 공유 픽스처는 2번째 메서드부터 소실된다. create-drop 전제 IT엔 드물지만 전량 전환 시 잠재 — 커밋형 `@BeforeAll` 시드는 **메서드 스코프로 이전**하거나 그 대상을 보존대상화(이때 §8-1 FK-closure 준수)해야 한다(§5.0b 재측정에서 발현 시 처리).
 - **Flyway 슬롯**: 본 브랜치는 마이그레이션 무추가라 무관. 오히려 IT가 Flyway를 타므로 향후 슬롯 충돌 PR은 IT 부팅에서 즉시 red(이점).
 
 ## 8. 오픈 결정 (스펙 리뷰에서 확정)

--- a/docs/superpowers/specs/2026-07-10-database-cleaner-dirty-table-optimization-design.md
+++ b/docs/superpowers/specs/2026-07-10-database-cleaner-dirty-table-optimization-design.md
@@ -43,11 +43,18 @@ truncate하는 것은 **관측 가능한 상태 변화가 없는 no-op**이다(�
 ### 3.1 "더티" 정의 (핵심 불변식)
 
 현행 `clean()`의 사후 보장 = **비-PRESERVE 테이블 전부가 (0행 AND AUTO_INCREMENT=1)**.
-비-PRESERVE 테이블은 Flyway 시드가 없어(참조 시드는 전부 PRESERVE_SET) 스키마 초기 상태가
-(0행, AI=1)이다. 따라서 다음이 성립한다:
+(주의: 비-PRESERVE 테이블 중 일부는 Flyway 시드가 있다 — 예: `V5__create_administrator.sql`가
+`user_account`/`administrator`/`member`를 시드하며 이들은 PRESERVE_SET이 아니다. 아래 논거는
+"시드 없음"에 의존하지 않는다.)
 
-> 테이블이 **(0행 AND AI=1)** 이면 = 한 번도 쓰이지 않았거나 이미 정리됨 = 오염원 없음 →
-> **truncate는 no-op → 스킵 안전**.
+무조건적 성립:
+
+> 테이블이 **현재 (0행 AND AI=1)** 상태이면, truncate해도 지울 행이 없고 이미 1인 AI를 1로
+> 리셋하는 것뿐 = **관측 가능한 상태 변화 없는 no-op → 스킵해도 사후 상태 동일 → 안전**.
+> (그 테이블이 과거에 시드됐든, 쓰였다 정리됐든, 한 번도 안 쓰였든 무관 — 지금 상태만이 결정.)
+
+시드된 비-PRESERVE 테이블(user_account 등)은 시드 행이 존재하므로 조건①(행 존재)로 더티 판정되어
+정상적으로 truncate된다(현행과 동일). 즉 "시드 없음" 전제 없이도 정확하다.
 
 **더티(= truncate 대상) ⟺ (행이 1개 이상 존재) OR (AUTO_INCREMENT > 1)**
 
@@ -63,25 +70,34 @@ truncate하는 것은 **관측 가능한 상태 변화가 없는 no-op**이다(�
 
 `clean()` 시작 시, 별도 autocommit 커넥션(현행과 동일)에서:
 
-1. **행 존재 테이블** — 비-PRESERVE base table 목록에 대해 한 번의 배치 쿼리:
+1. **행 존재 테이블 (조건①)** — 비-PRESERVE base table 목록에 대해 한 번의 배치 쿼리:
    ```sql
    SELECT 'tbl_a' AS t WHERE EXISTS (SELECT 1 FROM `tbl_a`)
    UNION ALL SELECT 'tbl_b' WHERE EXISTS (SELECT 1 FROM `tbl_b`)
    ... (비-PRESERVE 전 테이블)
    ```
-   → 비어있지 않은 테이블 이름 집합(1 라운드트립).
-2. **AI 전진 테이블** — 한 번의 메타데이터 조회:
+   → 비어있지 않은 테이블 이름 집합(1 라운드트립). **실데이터 라이브 쿼리 = 캐시 없음.**
+2. **AI 전진 테이블 (조건②)** — 한 번의 메타데이터 조회.
+   ⚠️ **MySQL 8.0 캐시 우회 필수**: `information_schema.tables.AUTO_INCREMENT`(및 `TABLE_ROWS`)는
+   8.0에서 **캐시된 통계**로, `information_schema_stats_expiry`(기본 86400초)에 지배된다. DML은
+   이 캐시를 무효화하지 않으므로, 조회 전 세션 변수로 **캐시를 꺼서 live 값**을 읽어야 한다
+   (안 그러면 INSERT-롤백 후에도 stale AI=1을 읽어 스킵 → 불변식 붕괴). 이 설정도 읽기라 fsync 무관.
    ```sql
+   SET SESSION information_schema_stats_expiry = 0;
    SELECT table_name FROM information_schema.tables
    WHERE table_schema = DATABASE() AND auto_increment > 1;
    ```
-   → AUTO_INCREMENT>1 테이블 집합(1 라운드트립).
-   (AI 컬럼 없는 테이블은 `auto_increment` NULL → 미포함. 그런 테이블은 조건①로만 판정 = 정확.)
+   → AUTO_INCREMENT>1 테이블 집합(1 라운드트립). (AI 컬럼 없는 테이블은 `auto_increment` NULL →
+   미포함. 그런 테이블은 조건①로만 판정 = 정확.)
+
+   세션 변수는 pooled 커넥션에 남을 수 있으나 `stats_expiry=0`은 무해(메타 조회가 항상 fresh일 뿐)
+   하며, 매 `clean()`이 재설정하므로 복원 불필요.
 
 두 집합의 **합집합 ∩ (비-PRESERVE base table)** = truncate 대상.
 
-감지는 전부 읽기(fsync 없음)이며 서버측에서 즉시 반환된다. 라운드트립 2회는 TRUNCATE 1건의
-fsync보다 훨씬 싸다.
+감지는 전부 읽기(fsync 없음)이며 서버측에서 즉시 반환된다. 라운드트립은 TRUNCATE 1건의
+fsync보다 훨씬 싸다. **비대칭 주의**: 조건①은 라이브 데이터 쿼리(캐시 무관), 조건②만 8.0 통계
+캐시 우회(`stats_expiry=0`)가 필요하다.
 
 ### 3.3 실행 (현행과 동일한 뼈대)
 
@@ -100,10 +116,11 @@ try (Connection c = dataSource.getConnection()) {   // autocommit=true, 별도 �
 
 ### 3.4 정확성 논거 (요약)
 
-- 비-PRESERVE 테이블은 시드가 없어 초기 (0행, AI=1).
-- (0행 AND AI=1) 테이블 truncate = no-op → 스킵해도 사후 상태 동일.
-- 더티 정의가 "pristine 아님"을 정확히(누락 없이) 덮음:
-  행 존재 / UPDATE(행 존재) / INSERT-롤백(AI>1) / INSERT-DELETE(AI>1) 모두 감지.
+- **핵심**: 현재 (0행 AND AI=1) 상태인 테이블은 truncate가 no-op → 스킵해도 사후 상태 동일.
+  (시드 여부·과거 이력 무관, 현재 상태만이 결정 — §3.1.)
+- 더티 정의가 "pristine 아님"을 **누락 없이** 덮음:
+  행 존재(시드행 포함) / UPDATE(행 존재) / INSERT-롤백(0행·AI>1) / INSERT-DELETE(0행·AI>1) 전부 감지.
+  단 조건②는 8.0 통계 캐시를 우회해야 live AI를 봄(§3.2) — 이 우회가 INSERT-롤백 케이스의 핵심.
 - 따라서 `clean()` 사후 상태(모든 비-PRESERVE 테이블 = 0행 & AI=1)는 현행과 **동일**.
 - FK: FK_CHECKS=0 하에 부분 집합 truncate는 dangling을 만들지 않음(현행과 동일).
 
@@ -112,12 +129,15 @@ try (Connection c = dataSource.getConnection()) {   // autocommit=true, 별도 �
 `DatabaseCleanerIsolationIT`(기존) 확장 — 별도 커밋의 검증:
 
 - **T1 더티 정리**: 비-PRESERVE 테이블에 행 커밋 → `clean()` 후 0행.
-- **T2 AI 전진 복원**: 테이블에 INSERT 후 DELETE(행 0, AI>1) → `clean()` 후 AI=1(다음 INSERT id=1).
+- **T2 AI 전진 복원(같은 커넥션)**: 테이블에 INSERT 후 DELETE(행 0, AI>1) → `clean()` 후
+  AI=1(다음 INSERT id=1).
+- **T2b AI 전진 복원(INSERT-롤백, 캐시 버그 직격)**: 한 메서드에서 INSERT 후 롤백(행 0, engine AI 전진)
+  → 다음 메서드 `clean()` → 그 다음 INSERT id=1 확인. **8.0 통계 캐시 우회(`stats_expiry=0`)가
+  없으면 이 테스트가 실패**한다(회귀 가드). 반드시 메서드 경계를 넘겨 캐시 stale 경로를 태운다.
 - **T3 pristine 스킵 후에도 격리 유지**: 기존 격리 검증(교차 테스트 오염 없음)이 그대로 그린.
 - **T4 PRESERVE 불변**: 참조 시드(avatar/system_config) 보존 확인(기존 유지).
-
-(선택) 화이트박스: `clean()`이 pristine 테이블에 TRUNCATE를 발행하지 않음을 검증 — 감지된 dirty
-목록을 관측 가능한 지점으로 노출하거나, 카운터/로그로 확인. 과설계면 생략하고 T1~T4로 충분.
+- **T5(화이트박스, 유지 권장)**: `clean()`이 pristine 테이블에 TRUNCATE를 발행하지 않음을 검증 —
+  감지된 dirty 목록/카운터를 관측 지점으로 노출. false-negative 회귀를 잡는 가장 싼 가드라 유지한다.
 
 ## 5. 검증(게이트)
 
@@ -130,8 +150,11 @@ try (Connection c = dataSource.getConnection()) {   // autocommit=true, 별도 �
 
 - **감지 누락(false-negative)로 더티 테이블 스킵 → 격리 붕괴**: 가장 큰 위험. 완화 = 정확성
   논거(3.4) + T1~T3 + 전량 2회 그린. 조건①②가 신뢰 판정이라 논리적 누락 없음.
-- **information_schema.auto_increment 신뢰성**: MySQL/InnoDB에서 `AUTO_INCREMENT`(다음 값)는
-  신뢰 가능(반면 `TABLE_ROWS`는 근사라 **사용하지 않음** — 행 판정은 EXISTS로만).
+- **information_schema 캐시(8.0)**: MySQL 8.0에서 `AUTO_INCREMENT`·`TABLE_ROWS` **둘 다 캐시된
+  통계**(`information_schema_stats_expiry` 기본 86400s, DML로 무효화 안 됨). 그래서 (a) 행 판정은
+  캐시 없는 라이브 `EXISTS`로만 하고, (b) AI 판정은 조회 전 `SET SESSION
+  information_schema_stats_expiry=0`으로 캐시를 꺼 live 값을 읽는다(§3.2). 이 우회를 빼면 stale
+  AI=1로 INSERT-롤백 테이블을 스킵해 격리가 조용히 깨진다 — 이번 최적화의 최대 함정.
 - **UNION 쿼리 길이(~70 테이블)**: 문자열이 길지만 단일 쿼리로 처리, 문제 없음. 테이블 목록은
   동적이라 하드코딩 없음.
 - **롤백 불가**: 순수 성능 최적화, 스키마/마이그레이션 무변경.

--- a/docs/superpowers/specs/2026-07-10-database-cleaner-dirty-table-optimization-design.md
+++ b/docs/superpowers/specs/2026-07-10-database-cleaner-dirty-table-optimization-design.md
@@ -1,0 +1,146 @@
+# DatabaseCleaner 더티-테이블 최적화 설계
+
+- 작성일: 2026-07-10
+- 브랜치: `test/it-harness-flyway-validate` (IT 하네스 현대화 후속)
+- 상태: 설계 승인 → 스펙 리뷰 대기
+
+## 1. 배경 / 문제
+
+IT 하네스 현대화(create-drop → Flyway+validate)에서 도입한 `DatabaseCleaner`는
+**각 테스트 메서드 전(`beforeTestMethod`)에 PRESERVE_SET을 제외한 모든 base table(~70개)을
+무조건 `TRUNCATE`** 한다. InnoDB의 `TRUNCATE`는 DDL(암시적 커밋)이라 테이블마다 스토리지
+커밋(fsync)을 유발한다.
+
+- **리눅스 CI**: fsync가 밀리초 → 전량 IT 4분39초. 문제 없음.
+- **Docker Desktop for Windows(virtiofs/overlay)**: fsync가 **테이블당 1~2초** → 매 메서드
+  ~70 TRUNCATE × 282 메서드 = 수십 분. 로컬 개발자가 통합 테스트를 습관적으로 안 돌리게 되는
+  실질 리스크(통합 게이트 도입 취지 무력화).
+
+스레드 덤프로 근본 확인: Test worker 가 `DatabaseCleaner.clean()` → `TRUNCATE TABLE ...`에서
+MySQL `waiting for handler commit`(InnoDB fsync) 대기. 데드락 아님, 순수 볼륨 비용.
+
+### 관측된 낭비
+`clean()`은 매 메서드마다 모든 테이블을 truncate하지만, 실제로 한 테스트가 건드리는 테이블은
+소수다. 대부분의 테이블은 이미 "빈 상태 + AUTO_INCREMENT=1"(pristine)이며, 그런 테이블을
+truncate하는 것은 **관측 가능한 상태 변화가 없는 no-op**이다(빈 것을 비우고, 1인 AI를 1로 리셋).
+
+## 2. 목표 / 비목표
+
+**목표**
+- `clean()`이 **pristine이 아닌(더티) 테이블만 truncate** 하도록 변경 → fsync 횟수를 메서드당
+  ~70에서 실제 건드린 소수(대개 0~5)로 축소.
+- **동작(post-state)을 현행과 글자 그대로 동일하게 보존** — 어떤 테스트도 차이를 관측 불가.
+- 로컬(Windows) 전량 IT 체감 속도 대폭 개선.
+
+**비목표(이번 스펙 범위 아님)**
+- Spring `@MockBean` 컨텍스트 파편화로 인한 컨텍스트 재빌드/클래스패스 스캔 비용(#2 슬로우니스).
+  별도 과제. 이번 변경은 per-method TRUNCATE 비용(#1)만 다룬다.
+- `@Transactional` 우선으로의 테스트 재분류(대안 B). 이번은 최소 침습(cleaner 내부만).
+- PRESERVE_SET·격리 커넥션(C1)·quiescence(C2)·직렬 불변식 등 하네스의 다른 부분 변경.
+
+## 3. 설계
+
+### 3.1 "더티" 정의 (핵심 불변식)
+
+현행 `clean()`의 사후 보장 = **비-PRESERVE 테이블 전부가 (0행 AND AUTO_INCREMENT=1)**.
+비-PRESERVE 테이블은 Flyway 시드가 없어(참조 시드는 전부 PRESERVE_SET) 스키마 초기 상태가
+(0행, AI=1)이다. 따라서 다음이 성립한다:
+
+> 테이블이 **(0행 AND AI=1)** 이면 = 한 번도 쓰이지 않았거나 이미 정리됨 = 오염원 없음 →
+> **truncate는 no-op → 스킵 안전**.
+
+**더티(= truncate 대상) ⟺ (행이 1개 이상 존재) OR (AUTO_INCREMENT > 1)**
+
+- 조건①(행 존재)은 커밋된 잔여 데이터(오염원)를 잡는다.
+- 조건②(AI>1)는 **"비었지만 AI가 전진한"** 케이스를 잡는다: `@Transactional` 테스트가 INSERT
+  후 롤백하면 행은 사라지지만 InnoDB는 소비한 AUTO_INCREMENT를 되돌리지 않는다. INSERT 후
+  자체 DELETE한 경우도 동일. 이들을 truncate해 AI=1로 복원 → 현행의 "AI 항상 1" 불변식 유지.
+
+두 조건 모두 신뢰 가능한 판정이다(아래 3.2). 합집합은 "pristine이 아닌" 모든 테이블을 정확히
+덮으므로, 이 집합만 truncate하면 사후 상태가 현행과 동일하다. **동작 불변, no-op만 제거.**
+
+### 3.2 감지 (fsync 없는 읽기)
+
+`clean()` 시작 시, 별도 autocommit 커넥션(현행과 동일)에서:
+
+1. **행 존재 테이블** — 비-PRESERVE base table 목록에 대해 한 번의 배치 쿼리:
+   ```sql
+   SELECT 'tbl_a' AS t WHERE EXISTS (SELECT 1 FROM `tbl_a`)
+   UNION ALL SELECT 'tbl_b' WHERE EXISTS (SELECT 1 FROM `tbl_b`)
+   ... (비-PRESERVE 전 테이블)
+   ```
+   → 비어있지 않은 테이블 이름 집합(1 라운드트립).
+2. **AI 전진 테이블** — 한 번의 메타데이터 조회:
+   ```sql
+   SELECT table_name FROM information_schema.tables
+   WHERE table_schema = DATABASE() AND auto_increment > 1;
+   ```
+   → AUTO_INCREMENT>1 테이블 집합(1 라운드트립).
+   (AI 컬럼 없는 테이블은 `auto_increment` NULL → 미포함. 그런 테이블은 조건①로만 판정 = 정확.)
+
+두 집합의 **합집합 ∩ (비-PRESERVE base table)** = truncate 대상.
+
+감지는 전부 읽기(fsync 없음)이며 서버측에서 즉시 반환된다. 라운드트립 2회는 TRUNCATE 1건의
+fsync보다 훨씬 싸다.
+
+### 3.3 실행 (현행과 동일한 뼈대)
+
+```
+try (Connection c = dataSource.getConnection()) {   // autocommit=true, 별도 커넥션 (C1)
+    tables = queryBaseTables(c) 중 !PRESERVE
+    dirty  = detectDirty(c, tables)                 // 3.2
+    SET FOREIGN_KEY_CHECKS=0
+    try { for t in dirty: TRUNCATE TABLE `t` }
+    finally { SET FOREIGN_KEY_CHECKS=1 }             // 예외 경로 복원 (현행 유지)
+}
+```
+
+- 별도 autocommit 커넥션·PRESERVE_SET·FK_CHECKS 복원 로직 전부 현행 그대로.
+- `dirty`가 비어있으면 TRUNCATE 0건(대부분의 @Transactional 롤백 테스트).
+
+### 3.4 정확성 논거 (요약)
+
+- 비-PRESERVE 테이블은 시드가 없어 초기 (0행, AI=1).
+- (0행 AND AI=1) 테이블 truncate = no-op → 스킵해도 사후 상태 동일.
+- 더티 정의가 "pristine 아님"을 정확히(누락 없이) 덮음:
+  행 존재 / UPDATE(행 존재) / INSERT-롤백(AI>1) / INSERT-DELETE(AI>1) 모두 감지.
+- 따라서 `clean()` 사후 상태(모든 비-PRESERVE 테이블 = 0행 & AI=1)는 현행과 **동일**.
+- FK: FK_CHECKS=0 하에 부분 집합 truncate는 dangling을 만들지 않음(현행과 동일).
+
+## 4. 테스트 (TDD)
+
+`DatabaseCleanerIsolationIT`(기존) 확장 — 별도 커밋의 검증:
+
+- **T1 더티 정리**: 비-PRESERVE 테이블에 행 커밋 → `clean()` 후 0행.
+- **T2 AI 전진 복원**: 테이블에 INSERT 후 DELETE(행 0, AI>1) → `clean()` 후 AI=1(다음 INSERT id=1).
+- **T3 pristine 스킵 후에도 격리 유지**: 기존 격리 검증(교차 테스트 오염 없음)이 그대로 그린.
+- **T4 PRESERVE 불변**: 참조 시드(avatar/system_config) 보존 확인(기존 유지).
+
+(선택) 화이트박스: `clean()`이 pristine 테이블에 TRUNCATE를 발행하지 않음을 검증 — 감지된 dirty
+목록을 관측 가능한 지점으로 노출하거나, 카운터/로그로 확인. 과설계면 생략하고 T1~T4로 충분.
+
+## 5. 검증(게이트)
+
+- `DatabaseCleanerIsolationIT` 그린(신규 T1~T4 포함).
+- **전량 IT 2회 연속 그린**(로컬 배치 + CI) — 동작 불변이므로 기존 282 통과가 유지되어야 함.
+- **CI 그린**(리눅스 단일호출) — 회귀 없음.
+- **속도 측정**: 변경 전/후 로컬 배치(동일 클래스 세트)의 벽시계 비교, 개선 폭 기록.
+
+## 6. 리스크 / 완화
+
+- **감지 누락(false-negative)로 더티 테이블 스킵 → 격리 붕괴**: 가장 큰 위험. 완화 = 정확성
+  논거(3.4) + T1~T3 + 전량 2회 그린. 조건①②가 신뢰 판정이라 논리적 누락 없음.
+- **information_schema.auto_increment 신뢰성**: MySQL/InnoDB에서 `AUTO_INCREMENT`(다음 값)는
+  신뢰 가능(반면 `TABLE_ROWS`는 근사라 **사용하지 않음** — 행 판정은 EXISTS로만).
+- **UNION 쿼리 길이(~70 테이블)**: 문자열이 길지만 단일 쿼리로 처리, 문제 없음. 테이블 목록은
+  동적이라 하드코딩 없음.
+- **롤백 불가**: 순수 성능 최적화, 스키마/마이그레이션 무변경.
+
+## 7. 대안 (기각)
+
+- **B: 트랜잭션 우선 재설계** — 롤백 가능 테스트를 @Transactional로, 커밋 필요 소수만 정리.
+  더 표준적이나 각 테스트 재분류로 침습·리스크 큼. 이번 목표(로컬 속도) 대비 과함 → 후순위.
+- **C: 빈 테이블도 AI 리셋(ALTER TABLE AUTO_INCREMENT=1)** — ALTER도 DDL이라 부분 fsync,
+  이득 축소. 3.1의 "AI>1만 truncate"가 동일 효과를 더 싸게 달성.
+- **A1: 빈 것 전부 스킵 + AI 리셋 포기** — 동작이 바뀌어(빈-AI-전진 테이블 미리셋) id=1 가정
+  테스트를 깨뜨릴 위험. 3.1이 이 위험을 감지비용 거의 없이 제거하므로 불필요.

--- a/docs/superpowers/specs/2026-07-10-database-cleaner-dirty-table-optimization-design.md
+++ b/docs/superpowers/specs/2026-07-10-database-cleaner-dirty-table-optimization-design.md
@@ -149,7 +149,7 @@ try (Connection c = dataSource.getConnection()) {   // autocommit=true, 별도 �
 ## 6. 리스크 / 완화
 
 - **감지 누락(false-negative)로 더티 테이블 스킵 → 격리 붕괴**: 가장 큰 위험. 완화 = 정확성
-  논거(3.4) + T1~T3 + 전량 2회 그린. 조건①②가 신뢰 판정이라 논리적 누락 없음.
+  논거(3.4) + T1~T3 + **T2b(캐시 함정 직격 가드)** + 전량 2회 그린. 조건①②가 신뢰 판정이라 논리적 누락 없음.
 - **information_schema 캐시(8.0)**: MySQL 8.0에서 `AUTO_INCREMENT`·`TABLE_ROWS` **둘 다 캐시된
   통계**(`information_schema_stats_expiry` 기본 86400s, DML로 무효화 안 됨). 그래서 (a) 행 판정은
   캐시 없는 라이브 `EXISTS`로만 하고, (b) AI 판정은 조회 전 `SET SESSION


### PR DESCRIPTION
## 요약
IT 하네스를 `create-drop` → **Flyway + validate**로 전환하고, 각 테스트를 `DatabaseCleaner`(pre-transaction, 별도 autocommit 커넥션)로 격리. 하네스 전환이 드러낸 실패 27건/9클래스를 3원인별로 수정. `integrationTest`를 CI에 배선. **제품 코드 무변경(테스트 하네스만).**

Closes #318

## 커밋 구성
- `96719fc2` 하네스 전환(validate+flyway) + `DatabaseCleaner` 격리 + async quiescence + 격리검증 IT
- `d9d068fc` **FK 5클래스**: administrator 부모 시드(패턴 A, 생성 id 채택)
- `9c69c347` **DUP 1클래스**: BotAvatar 테스트 아바타 이름 충돌(`uk_avatar_body_name`) 해소
- `00d88fe7` **DATETIME(0) 3클래스**: 초 정밀 현실 반영(now 초절삭·DB재read·grantedAt 고정)
- `731f6029` **CI**: `ci-test.yml`에 `:app:integrationTest` 배선(별도 커밋) + build.gradle 직렬 불변식 주석

## 환부 3원인 (전량 재측정 근거)
| 원인 | 내용 |
|---|---|
| FK 부모 결핍 | Flyway가 실 FK 강제(`fk_pr_reviewed_by`·`fk_announcement_sent_by`·`fk_paa_administrator`). `administrator_id` AUTO_INCREMENT라 매직 id 불가 → 실 admin 시드 |
| Duplicate | 보존 V3 아바타 시드와 이름 충돌 → 테스트 전용 이름 |
| DATETIME(0) | 옛 `datetime(6)`가 준 sub-second 정밀은 운영에 없던 허구 → 초 정밀로 조정 |

## 검증
- **전량 IT 2회 연속 GREEN**: 72 classes / 282 tests / 0 fail / 0 err (C1 롤백·C2 async flake 없음)
- **유닛 회귀 무변**: `:app:test` 1276 / 0
- 로컬 전량 단일호출은 로컬 인프라 제약(gradle Worker 좀비 락)으로 배치 우회 검증. clean CI(ubuntu)에서 단일호출 정상 예상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
