### PR TITLE
IT lettuce 커넥션 안정화 — PartyroomAccessCommandServiceRaceIT 플래키 제거 (#320)

### DIFF
--- a/app/src/test/java/com/pfplaybackend/api/common/AbstractIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/common/AbstractIntegrationTest.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.junit.jupiter.api.Tag;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Tag("integration")
 @SpringBootTest
 @ActiveProfiles("test")
+@Import(TestRedisClientConfig.class)
 @TestExecutionListeners(
         value = DatabaseCleanupTestExecutionListener.class,
         mergeMode = MergeMode.MERGE_WITH_DEFAULTS)

--- a/app/src/test/java/com/pfplaybackend/api/common/TestRedisClientConfig.java
+++ b/app/src/test/java/com/pfplaybackend/api/common/TestRedisClientConfig.java
@@ -1,0 +1,46 @@
+package com.pfplaybackend.api.common;
+
+import io.lettuce.core.resource.ClientResources;
+import io.lettuce.core.resource.DefaultClientResources;
+import org.springframework.boot.autoconfigure.data.redis.LettuceClientConfigurationBuilderCustomizer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import java.time.Duration;
+
+/**
+ * IT 전용 Redis(lettuce) 클라이언트 안정화 — 이슈 #320.
+ *
+ * <p><b>배경:</b> 전량 IT를 단일 JVM으로 도는 동안 Spring 컨텍스트 캐시가 누적되며(서로 다른 {@code @MockBean}
+ * 조합마다 별도 컨텍스트), 컨텍스트마다 lettuce 가 자체 {@link ClientResources}(netty 이벤트루프 그룹)를
+ * 생성 → 코어가 적은 CI 러너에서 netty 스레드 폭증·리소스 고갈로 커넥션이 불안정해진다. 이때
+ * 부수적 Redis 명령이 lettuce <b>기본 commandTimeout 60초</b>를 블록하면
+ * {@code PartyroomAccessCommandServiceRaceIT} 의 {@code done.await(60s)} latch 가 타임아웃한다.
+ *
+ * <p><b>수정(테스트 인프라 한정, 프로덕션 무변경):</b>
+ * <ul>
+ *   <li>모든 IT 컨텍스트가 <b>단일 정적 {@link ClientResources}</b>를 공유 → netty 이벤트루프가
+ *       컨텍스트 수만큼 늘지 않는다(근원 완화).</li>
+ *   <li>{@code commandTimeout} 을 <b>5초</b>로 bound → 순간 커넥션 이상 시 60초 hang 대신 fast-fail.
+ *       (검증 대상 불변식 {@code crew_count==1} 은 DB atomic UPDATE + unique 제약으로 강제되며
+ *       Redis 는 best-effort 라 안전하다.)</li>
+ * </ul>
+ *
+ * <p>{@link AbstractIntegrationTest} 가 {@code @Import} 하여 전 IT 에 균일 적용한다.
+ */
+@TestConfiguration
+public class TestRedisClientConfig {
+
+    /**
+     * 전 IT 컨텍스트 공유 정적 싱글톤. 커스터마이저로 주입만 하고 Spring 빈으로 등록하지 않으므로
+     * 컨텍스트 종료 시 Spring 이 shutdown 하지 않는다(JVM 종료까지 유지). 컨텍스트마다 재생성 방지.
+     */
+    private static final ClientResources SHARED_CLIENT_RESOURCES = DefaultClientResources.create();
+
+    @Bean
+    LettuceClientConfigurationBuilderCustomizer lettuceItStabilityCustomizer() {
+        return builder -> builder
+                .clientResources(SHARED_CLIENT_RESOURCES)
+                .commandTimeout(Duration.ofSeconds(5));
+    }
+}


### PR DESCRIPTION
## 문제
`PartyroomAccessCommandServiceRaceIT`(100스레드 동시 tryEnter → crew_count==1)가 **CI에서만 간헐 실패**. develop CI를 상시 빨갛게 만들던 선재 플래키.

Closes #320

## 근본 원인
- 전량 IT를 **단일 JVM**으로 도는 동안 Spring 컨텍스트 캐시 누적(@MockBean 조합마다 별도 컨텍스트) → **컨텍스트마다 lettuce가 자체 ClientResources(netty 이벤트루프) 생성** → 코어 적은 CI 러너에서 netty 스레드 폭증·리소스 고갈로 커넥션 불안정.
- 이때 enter 경로의 **best-effort Redis 명령이 lettuce 기본 commandTimeout 60초를 블록** → `done.await(60s)` latch 타임아웃. (로컬 단독은 6.6초 통과, CI만 실패 = 결정론적 결함 아님)

## 수정 (테스트 인프라 한정, **프로덕션 무변경**)
- `TestRedisClientConfig`: 전 IT 컨텍스트가 **단일 정적 ClientResources 공유** + `commandTimeout` **5초** bound.
- `AbstractIntegrationTest` `@Import`로 균일 적용.

**안전성 근거**: 검증 불변식 `crew_count==1`은 DB atomic UPDATE + unique 제약 + row lock으로 강제(`PartyroomCounterListener`도 순수 DB, "분산락 불필요"). Redis는 best-effort라 5초 fast-fail이 불변식/카운트에 영향 없음. lettuce는 외부 제공 ClientResources를 factory가 shutdown하지 않아 컨텍스트 evict에도 안전.

## 검증
- 로컬 전량 IT **그린**(회귀 없음, 다중 컨텍스트 공유 ClientResources 안전성 확인), 레이스 테스트 단독 그린
- ⚠️ **CI-only 플래키라 로컬 실패 재현 불가** — commandTimeout 5초 bound가 60초 hang→latch 타임아웃 모드를 **결정적으로 제거**하고, 공유 ClientResources가 근원(커넥션 불안정)을 완화. CI 반복 관찰로 재발 여부 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)