### PR TITLE
어드민 파티룸 행동분석 백엔드 — 입퇴장 집계·무음이탈·디제잉 이력 (#324)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/AdminPartyroomQueryController.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/AdminPartyroomQueryController.java
@@ -1,8 +1,11 @@
 package com.pfplaybackend.api.administration.adapter.in.web;
 
+import com.pfplaybackend.api.administration.adapter.in.web.payload.response.AdminDjHistoryItemResponse;
 import com.pfplaybackend.api.administration.adapter.in.web.payload.response.AdminPartyroomDetailResponse;
 import com.pfplaybackend.api.administration.adapter.in.web.payload.response.AdminPartyroomListItemResponse;
+import com.pfplaybackend.api.administration.adapter.in.web.payload.response.PartyroomAnalyticsResponse;
 import com.pfplaybackend.api.administration.application.dto.AdminPartyroomListFilter;
+import com.pfplaybackend.api.administration.application.service.AdminPartyroomAnalyticsQueryService;
 import com.pfplaybackend.api.administration.application.service.AdminPartyroomQueryService;
 import com.pfplaybackend.api.common.ApiCommonResponse;
 import com.pfplaybackend.api.common.exception.http.BadRequestException;
@@ -47,6 +50,7 @@ public class AdminPartyroomQueryController {
     private static final int MAX_PAGE_SIZE = 200;
 
     private final AdminPartyroomQueryService queryService;
+    private final AdminPartyroomAnalyticsQueryService analyticsService;
 
     @Operation(summary = "B-1 룸 목록 (페이징/필터/정렬)")
     @PreAuthorize("@adminAuth.isAdmin()")
@@ -79,5 +83,28 @@ public class AdminPartyroomQueryController {
     @GetMapping("/{partyroomId}")
     public ResponseEntity<ApiCommonResponse<AdminPartyroomDetailResponse>> detail(@PathVariable Long partyroomId) {
         return ResponseEntity.ok(ApiCommonResponse.success(queryService.detail(new PartyroomId(partyroomId))));
+    }
+
+    @Operation(summary = "B-3 룸 행동분석 (입퇴장 집계 + 무음이탈 근사)")
+    @PreAuthorize("@adminAuth.isAdmin()")
+    @GetMapping("/{partyroomId}/analytics")
+    public ResponseEntity<ApiCommonResponse<PartyroomAnalyticsResponse>> analytics(
+            @PathVariable Long partyroomId,
+            @RequestParam(defaultValue = "20") int days) {
+        return ResponseEntity.ok(ApiCommonResponse.success(
+                analyticsService.getAnalytics(new PartyroomId(partyroomId), days)));
+    }
+
+    @Operation(summary = "B-4 룸 디제잉 이력 (페이지네이션)")
+    @PreAuthorize("@adminAuth.isAdmin()")
+    @GetMapping("/{partyroomId}/dj-history")
+    public ResponseEntity<ApiCommonResponse<Page<AdminDjHistoryItemResponse>>> djHistory(
+            @PathVariable Long partyroomId,
+            @PageableDefault(size = 20) Pageable pageable) {
+        Pageable bounded = pageable.getPageSize() > MAX_PAGE_SIZE
+                ? PageRequest.of(pageable.getPageNumber(), MAX_PAGE_SIZE)
+                : pageable;
+        return ResponseEntity.ok(ApiCommonResponse.success(
+                analyticsService.getDjHistory(new PartyroomId(partyroomId), bounded)));
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/payload/response/AdminDjHistoryItemResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/payload/response/AdminDjHistoryItemResponse.java
@@ -1,0 +1,11 @@
+package com.pfplaybackend.api.administration.adapter.in.web.payload.response;
+
+import java.time.LocalDateTime;
+
+/**
+ * B-4 디제잉 이력 아이템. avatarIconUri 는 미설정 DJ의 경우 "" (빈 문자열).
+ */
+public record AdminDjHistoryItemResponse(Long playbackId, String trackName,
+                                         Long djUserAccountId, String djNickname,
+                                         String avatarIconUri, String thumbnailImage,
+                                         LocalDateTime playedAt) {}

--- a/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/payload/response/PartyroomAnalyticsResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/payload/response/PartyroomAnalyticsResponse.java
@@ -1,0 +1,16 @@
+package com.pfplaybackend.api.administration.adapter.in.web.payload.response;
+
+import com.pfplaybackend.api.administration.application.dto.AttendanceAnalytics;
+
+/**
+ * B-3 룸 행동분석 응답 (② 입퇴장 집계 + ③ 무음 이탈 근사).
+ * silenceExit.approximate 는 항상 true — playback 트랙구간 근사 지표임을 명시.
+ * silenceExit.totalExits == attendance.totalExited (같은 윈도우·같은 이벤트원, 항상 동일).
+ */
+public record PartyroomAnalyticsResponse(int windowDays,
+                                         AttendanceAnalytics attendance,
+                                         SilenceExit silenceExit) {
+    public record SilenceExit(boolean approximate, long totalExits,
+                              long exitsDuringSilence, Double silenceExitRatio,
+                              long totalSilenceMinutes) {}
+}

--- a/app/src/main/java/com/pfplaybackend/api/administration/adapter/out/persistence/UserActivityLogAnalyticsRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/adapter/out/persistence/UserActivityLogAnalyticsRepository.java
@@ -1,0 +1,78 @@
+package com.pfplaybackend.api.administration.adapter.out.persistence;
+
+import com.pfplaybackend.api.administration.application.dto.DailyAttendanceBucket;
+import com.pfplaybackend.api.administration.domain.entity.QUserActivityLogData;
+import com.pfplaybackend.api.administration.domain.enums.UserActivityEventType;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.DateTemplate;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * user_activity_log 파티룸 입퇴장 집계 리포지토리 (QueryDSL).
+ *
+ * <p>어드민 파티룸 행동분석 ② "입장/퇴장 집계" + 침묵지표가 소비하는 EXIT 타임스탬프 목록을 생산한다.
+ * partyroom_id(plain Long) + occurred_at 범위 [from, now) 로 키잉.
+ * V34 인덱스 {@code idx_ual_partyroom_event_time(partyroom_id, event_type, occurred_at DESC)} 를 탄다.
+ *
+ * <p>eventType 은 VARCHAR(64) 컬럼(enum.name() 직렬화)이라 String 비교.
+ *
+ * Spec: docs/superpowers/specs/2026-07-09-admin-partyroom-behavior-analytics-design.md
+ */
+@Repository
+@RequiredArgsConstructor
+public class UserActivityLogAnalyticsRepository {
+
+    private static final String ENTERED = UserActivityEventType.PARTYROOM_ENTERED.name();
+    private static final String EXITED  = UserActivityEventType.PARTYROOM_EXITED.name();
+
+    private final JPAQueryFactory queryFactory;
+
+    /** 일자별 entered/exited. date = occurred_at 벽시계 달력일(DATE()). 발생한 날만, asc. */
+    public List<DailyAttendanceBucket> findDailyAttendance(Long partyroomId, LocalDateTime from, LocalDateTime now) {
+        QUserActivityLogData q = QUserActivityLogData.userActivityLogData;
+        DateTemplate<java.sql.Date> day = Expressions.dateTemplate(java.sql.Date.class, "DATE({0})", q.occurredAt);
+        NumberExpression<Integer> enteredCase = new CaseBuilder().when(q.eventType.eq(ENTERED)).then(1).otherwise(0).sum();
+        NumberExpression<Integer> exitedCase  = new CaseBuilder().when(q.eventType.eq(EXITED)).then(1).otherwise(0).sum();
+        return queryFactory
+                .select(day, enteredCase, exitedCase)
+                .from(q)
+                .where(q.partyroomId.eq(partyroomId)
+                        .and(q.eventType.in(ENTERED, EXITED))
+                        .and(q.occurredAt.goe(from))
+                        .and(q.occurredAt.lt(now)))
+                .groupBy(day)
+                .orderBy(day.asc())
+                .fetch()
+                .stream()
+                .map(t -> new DailyAttendanceBucket(t.get(day).toLocalDate(), nz(t.get(enteredCase)), nz(t.get(exitedCase))))
+                .toList();
+    }
+
+    /** 윈도우 내 ENTERED distinct user 수. */
+    public long countUniqueVisitors(Long partyroomId, LocalDateTime from, LocalDateTime now) {
+        QUserActivityLogData q = QUserActivityLogData.userActivityLogData;
+        Long c = queryFactory.select(q.userAccountId.countDistinct()).from(q)
+                .where(q.partyroomId.eq(partyroomId).and(q.eventType.eq(ENTERED))
+                        .and(q.occurredAt.goe(from)).and(q.occurredAt.lt(now)))
+                .fetchOne();
+        return c == null ? 0L : c;
+    }
+
+    /** 윈도우 내 EXITED occurred_at 목록 (침묵지표 소비용). */
+    public List<LocalDateTime> findExitOccurredAt(Long partyroomId, LocalDateTime from, LocalDateTime now) {
+        QUserActivityLogData q = QUserActivityLogData.userActivityLogData;
+        return queryFactory.select(q.occurredAt).from(q)
+                .where(q.partyroomId.eq(partyroomId).and(q.eventType.eq(EXITED))
+                        .and(q.occurredAt.goe(from)).and(q.occurredAt.lt(now)))
+                .fetch();
+    }
+
+    private static int nz(Integer v) { return v == null ? 0 : v; }
+}

--- a/app/src/main/java/com/pfplaybackend/api/administration/application/analytics/PlaybackInterval.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/application/analytics/PlaybackInterval.java
@@ -1,0 +1,4 @@
+package com.pfplaybackend.api.administration.application.analytics;
+
+/** playback 트랙의 활성 구간 재구성용 입력. 모든 시각 epoch millis(KST 변환 완료). */
+public record PlaybackInterval(long createdAtMs, long endTimeMs) {}

--- a/app/src/main/java/com/pfplaybackend/api/administration/application/analytics/SilenceExitCalculator.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/application/analytics/SilenceExitCalculator.java
@@ -13,6 +13,15 @@ public final class SilenceExitCalculator {
     public record Result(long totalExits, long exitsDuringSilence,
                          Double silenceExitRatio, long totalSilenceMinutes) {}
 
+    /**
+     * 무음 이탈 지표 계산 (근사). 모든 시각 epoch millis.
+     *
+     * @param rawIntervals playback 트랙 구간. <b>createdAtMs ASC 정렬 전제</b> — skip-clamp가
+     *                     {@code next.createdAtMs()}를 raw 순서로 참조하므로, 미정렬 입력이면
+     *                     구간이 잘못 폐기될 수 있다(현재 caller {@code findPlaybackForInterval}가 ASC 보장).
+     * @param exitMsList   윈도우 내 EXIT occurred_at(ms). <b>{@code [fromMs, nowMs)} 안의 값 전제</b> —
+     *                     윈도우 밖 값이 섞이면 전부 무음으로 분류되어 silence 지표가 부풀려진다.
+     */
     public static Result compute(List<PlaybackInterval> rawIntervals,
                                  List<Long> exitMsList, long fromMs, long nowMs) {
         List<long[]> clamped = new ArrayList<>();

--- a/app/src/main/java/com/pfplaybackend/api/administration/application/analytics/SilenceExitCalculator.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/application/analytics/SilenceExitCalculator.java
@@ -1,0 +1,67 @@
+package com.pfplaybackend.api.administration.application.analytics;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public final class SilenceExitCalculator {
+
+    private SilenceExitCalculator() {}
+
+    public record Result(long totalExits, long exitsDuringSilence,
+                         Double silenceExitRatio, long totalSilenceMinutes) {}
+
+    public static Result compute(List<PlaybackInterval> rawIntervals,
+                                 List<Long> exitMsList, long fromMs, long nowMs) {
+        List<long[]> clamped = new ArrayList<>();
+        for (int i = 0; i < rawIntervals.size(); i++) {
+            PlaybackInterval it = rawIntervals.get(i);
+            long start = Math.max(it.createdAtMs(), fromMs);
+            long rawEnd = it.endTimeMs();
+            if (i + 1 < rawIntervals.size()) {
+                rawEnd = Math.min(rawEnd, rawIntervals.get(i + 1).createdAtMs());
+            }
+            long end = Math.min(rawEnd, nowMs);
+            if (start < end) {
+                clamped.add(new long[]{start, end});
+            }
+        }
+        clamped.sort(Comparator.comparingLong(a -> a[0]));
+        List<long[]> merged = new ArrayList<>();
+        for (long[] iv : clamped) {
+            if (!merged.isEmpty() && iv[0] <= merged.get(merged.size() - 1)[1]) {
+                long[] last = merged.get(merged.size() - 1);
+                last[1] = Math.max(last[1], iv[1]);
+            } else {
+                merged.add(new long[]{iv[0], iv[1]});
+            }
+        }
+        long silence = 0;
+        for (long exit : exitMsList) {
+            if (!coveredByMusic(merged, exit)) silence++;
+        }
+        long totalExits = exitMsList.size();
+        Double ratio = totalExits == 0 ? null
+                : BigDecimal.valueOf((double) silence / totalExits)
+                        .setScale(2, RoundingMode.HALF_UP).doubleValue();
+        long musicMs = 0;
+        for (long[] iv : merged) musicMs += (iv[1] - iv[0]);
+        long silenceMs = (nowMs - fromMs) - musicMs;
+        long silenceMinutes = Math.round(silenceMs / 60_000.0);
+        return new Result(totalExits, silence, ratio, silenceMinutes);
+    }
+
+    private static boolean coveredByMusic(List<long[]> merged, long exit) {
+        int lo = 0, hi = merged.size() - 1;
+        while (lo <= hi) {
+            int mid = (lo + hi) >>> 1;
+            long[] iv = merged.get(mid);
+            if (exit < iv[0]) hi = mid - 1;
+            else if (exit >= iv[1]) lo = mid + 1;   // half-open: end 미포함
+            else return true;
+        }
+        return false;
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/administration/application/dto/AttendanceAnalytics.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/application/dto/AttendanceAnalytics.java
@@ -1,0 +1,6 @@
+package com.pfplaybackend.api.administration.application.dto;
+
+import java.util.List;
+
+public record AttendanceAnalytics(long totalEntered, long totalExited,
+                                  long uniqueVisitors, List<DailyAttendanceBucket> daily) {}

--- a/app/src/main/java/com/pfplaybackend/api/administration/application/dto/DailyAttendanceBucket.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/application/dto/DailyAttendanceBucket.java
@@ -1,0 +1,5 @@
+package com.pfplaybackend.api.administration.application.dto;
+
+import java.time.LocalDate;
+
+public record DailyAttendanceBucket(LocalDate date, int entered, int exited) {}

--- a/app/src/main/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomAnalyticsQueryService.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomAnalyticsQueryService.java
@@ -120,9 +120,10 @@ public class AdminPartyroomAnalyticsQueryService {
         return (m == null || m.getProfileData() == null) ? null : m.getProfileData().getNicknameValue();
     }
 
+    /** avatarIconUri 계약: 항상 non-null 문자열. member/profile 부재 시에도 "" 반환(DTO 문서와 일치). */
     private static String avatarUri(MemberData m) {
         if (m == null || m.getProfileData() == null || m.getProfileData().getAvatarSetting() == null) {
-            return null;
+            return "";
         }
         return m.getProfileData().getAvatarSetting().getAvatarIconUriValue();
     }

--- a/app/src/main/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomAnalyticsQueryService.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomAnalyticsQueryService.java
@@ -1,0 +1,129 @@
+package com.pfplaybackend.api.administration.application.service;
+
+import com.pfplaybackend.api.administration.adapter.in.web.payload.response.AdminDjHistoryItemResponse;
+import com.pfplaybackend.api.administration.adapter.in.web.payload.response.PartyroomAnalyticsResponse;
+import com.pfplaybackend.api.administration.adapter.out.persistence.UserActivityLogAnalyticsRepository;
+import com.pfplaybackend.api.administration.application.analytics.PlaybackInterval;
+import com.pfplaybackend.api.administration.application.analytics.SilenceExitCalculator;
+import com.pfplaybackend.api.administration.application.dto.AttendanceAnalytics;
+import com.pfplaybackend.api.administration.application.dto.DailyAttendanceBucket;
+import com.pfplaybackend.api.common.exception.ExceptionCreator;
+import com.pfplaybackend.api.common.exception.http.BadRequestException;
+import com.pfplaybackend.api.party.domain.entity.data.PlaybackData;
+import com.pfplaybackend.api.party.domain.exception.PartyroomException;
+import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.user.adapter.out.persistence.MemberRepository;
+import com.pfplaybackend.api.user.domain.entity.data.MemberData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * B-3/B-4 룸 행동분석 조합 서비스.
+ *
+ * <p>② 입퇴장 집계({@link UserActivityLogAnalyticsRepository}), ③ 무음 이탈 근사
+ * ({@link SilenceExitCalculator}), ④ 디제잉 이력(닉네임/아바타 enrichment)을 조합한다.
+ * 모든 시각 계산은 Asia/Seoul 벽시계 기준 — DB occurred_at/created_at 이 KST 로컬시각이므로
+ * epoch millis 변환도 동일 존을 사용한다.
+ *
+ * <p>Cross-BC 읽기는 {@link PartyroomAggregatePort}(Party)/{@link MemberRepository}(User)를 통해서만
+ * 이뤄지며, Administration BC 는 Party/User 엔티티 타입을 직접 다루지 않는다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminPartyroomAnalyticsQueryService {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+    private static final int MIN_DAYS = 1;
+    private static final int MAX_DAYS = 90;
+
+    private final PartyroomAggregatePort aggregatePort;
+    private final UserActivityLogAnalyticsRepository activityRepo;
+    private final MemberRepository memberRepository;
+
+    public PartyroomAnalyticsResponse getAnalytics(PartyroomId partyroomId, int days) {
+        if (days < MIN_DAYS || days > MAX_DAYS) {
+            throw new BadRequestException("ADM-PR-002", "days out of range (1..90): " + days);
+        }
+        requireRoom(partyroomId);
+
+        LocalDateTime now = LocalDateTime.now(SEOUL);
+        LocalDateTime from = now.minusDays(days);
+        long pid = partyroomId.getId();
+
+        List<DailyAttendanceBucket> daily = activityRepo.findDailyAttendance(pid, from, now);
+        long totalEntered = daily.stream().mapToLong(DailyAttendanceBucket::entered).sum();
+        long totalExited = daily.stream().mapToLong(DailyAttendanceBucket::exited).sum();
+        long unique = activityRepo.countUniqueVisitors(pid, from, now);
+        AttendanceAnalytics attendance = new AttendanceAnalytics(totalEntered, totalExited, unique, daily);
+
+        long fromMs = ms(from);
+        long nowMs = ms(now);
+        List<PlaybackInterval> intervals = aggregatePort.findPlaybackForInterval(partyroomId, from, now).stream()
+                .filter(p -> p.getEndTime() != null)
+                .map(p -> new PlaybackInterval(ms(p.getCreatedAt()), p.getEndTime()))
+                .toList();
+        List<Long> exits = activityRepo.findExitOccurredAt(pid, from, now).stream()
+                .map(this::ms)
+                .toList();
+        SilenceExitCalculator.Result s = SilenceExitCalculator.compute(intervals, exits, fromMs, nowMs);
+        PartyroomAnalyticsResponse.SilenceExit silence = new PartyroomAnalyticsResponse.SilenceExit(
+                true, s.totalExits(), s.exitsDuringSilence(), s.silenceExitRatio(), s.totalSilenceMinutes());
+
+        return new PartyroomAnalyticsResponse(days, attendance, silence);
+    }
+
+    public Page<AdminDjHistoryItemResponse> getDjHistory(PartyroomId partyroomId, Pageable pageable) {
+        requireRoom(partyroomId);
+        Page<PlaybackData> page = aggregatePort.findPlaybackHistory(partyroomId, pageable);
+        List<Long> userIds = page.getContent().stream()
+                .map(p -> p.getUserId().getUid())
+                .distinct()
+                .toList();
+        Map<Long, MemberData> byId = userIds.isEmpty()
+                ? Map.of()
+                : memberRepository.findAllByUserAccountIdIn(userIds).stream()
+                        .collect(Collectors.toMap(MemberData::getUserAccountId, m -> m, (a, b) -> a));
+        return page.map(p -> {
+            MemberData m = byId.get(p.getUserId().getUid());
+            return new AdminDjHistoryItemResponse(
+                    p.getId(),
+                    p.getName(),
+                    p.getUserId().getUid(),
+                    nickname(m),
+                    avatarUri(m),
+                    p.getThumbnailImage(),
+                    p.getCreatedAt());
+        });
+    }
+
+    private void requireRoom(PartyroomId id) {
+        aggregatePort.findPartyroomById(id.getId())
+                .orElseThrow(() -> ExceptionCreator.create(PartyroomException.NOT_FOUND_ROOM));
+    }
+
+    private long ms(LocalDateTime t) {
+        return t.atZone(SEOUL).toInstant().toEpochMilli();
+    }
+
+    private static String nickname(MemberData m) {
+        return (m == null || m.getProfileData() == null) ? null : m.getProfileData().getNicknameValue();
+    }
+
+    private static String avatarUri(MemberData m) {
+        if (m == null || m.getProfileData() == null || m.getProfileData().getAvatarSetting() == null) {
+            return null;
+        }
+        return m.getProfileData().getAvatarSetting().getAvatarIconUriValue();
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomAnalyticsQueryService.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomAnalyticsQueryService.java
@@ -35,8 +35,10 @@ import java.util.stream.Collectors;
  * 모든 시각 계산은 Asia/Seoul 벽시계 기준 — DB occurred_at/created_at 이 KST 로컬시각이므로
  * epoch millis 변환도 동일 존을 사용한다.
  *
- * <p>Cross-BC 읽기는 {@link PartyroomAggregatePort}(Party)/{@link MemberRepository}(User)를 통해서만
- * 이뤄지며, Administration BC 는 Party/User 엔티티 타입을 직접 다루지 않는다.
+ * <p>Cross-BC 접근은 오직 {@link PartyroomAggregatePort}(Party)/{@link MemberRepository}(User) 포트를
+ * 통해서만 이뤄진다 — Party/User의 adapter/persistence 내부에는 의존하지 않는다(sibling
+ * {@code AdminPartyroomQueryService.detail()}과 동일 전략). 포트가 반환하는 {@code PlaybackData}
+ * (Party)·{@code MemberData}(User)는 읽기 전용으로 소비한다.
  */
 @Service
 @RequiredArgsConstructor

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomAggregateAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomAggregateAdapter.java
@@ -10,6 +10,8 @@ import com.pfplaybackend.api.party.domain.value.CrewId;
 import com.pfplaybackend.api.party.domain.value.LinkDomain;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -193,6 +195,11 @@ public class PartyroomAggregateAdapter implements PartyroomAggregatePort, Partyr
     @Override
     public List<PlaybackData> findPlaybackForInterval(PartyroomId partyroomId, LocalDateTime from, LocalDateTime now) {
         return partyroomRepository.findPlaybackForInterval(partyroomId, from, now);
+    }
+
+    @Override
+    public Page<PlaybackData> findPlaybackHistory(PartyroomId partyroomId, Pageable pageable) {
+        return partyroomRepository.findPlaybackHistory(partyroomId, pageable);
     }
 
     // ===== Query Port (DTO-returning QueryDSL methods) =====

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomAggregateAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/PartyroomAggregateAdapter.java
@@ -188,6 +188,13 @@ public class PartyroomAggregateAdapter implements PartyroomAggregatePort, Partyr
         return partyroomPlaybackRepository.findStuckActivatedPartyroomIds(threshold);
     }
 
+    // ===== Playback interval 재구성 (어드민 행동분석) =====
+
+    @Override
+    public List<PlaybackData> findPlaybackForInterval(PartyroomId partyroomId, LocalDateTime from, LocalDateTime now) {
+        return partyroomRepository.findPlaybackForInterval(partyroomId, from, now);
+    }
+
     // ===== Query Port (DTO-returning QueryDSL methods) =====
 
     @Override

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/custom/PartyroomRepositoryCustom.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/custom/PartyroomRepositoryCustom.java
@@ -7,6 +7,7 @@ import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
 import com.pfplaybackend.api.party.domain.entity.data.PlaybackData;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +16,11 @@ public interface PartyroomRepositoryCustom {
     List<PartyroomWithCrewDto> getCrewDataByPartyroomId();
     List<PlaybackData> getRecentPlaybackHistory(PartyroomId partyroomId);
     List<PartyroomData> findAllUnusedPartyroomDataByDay(int days);
+
+    /**
+     * 음악 재생 구간 재구성용 playback 조회.
+     * created_at ∈ [from, now) 인 모든 row + from 직전 최신 1건(straddle, 윈도우 open 시점에
+     * 재생 중이었을 수 있는 트랙)을 created_at ASC 로 반환.
+     */
+    List<PlaybackData> findPlaybackForInterval(PartyroomId partyroomId, LocalDateTime from, LocalDateTime now);
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/custom/PartyroomRepositoryCustom.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/custom/PartyroomRepositoryCustom.java
@@ -6,6 +6,8 @@ import com.pfplaybackend.api.party.application.dto.partyroom.PartyroomWithCrewDt
 import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
 import com.pfplaybackend.api.party.domain.entity.data.PlaybackData;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,4 +25,9 @@ public interface PartyroomRepositoryCustom {
      * 재생 중이었을 수 있는 트랙)을 created_at ASC 로 반환.
      */
     List<PlaybackData> findPlaybackForInterval(PartyroomId partyroomId, LocalDateTime from, LocalDateTime now);
+
+    /**
+     * 디제잉 이력 페이지네이션 조회. created_at DESC 고정 정렬.
+     */
+    Page<PlaybackData> findPlaybackHistory(PartyroomId partyroomId, Pageable pageable);
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/impl/PartyroomRepositoryImpl.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/impl/PartyroomRepositoryImpl.java
@@ -18,6 +18,9 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -189,6 +192,23 @@ public class PartyroomRepositoryImpl implements PartyroomRepositoryCustom {
         result.add(straddle);
         result.addAll(inWindow);
         return result;
+    }
+
+    @Override
+    public Page<PlaybackData> findPlaybackHistory(PartyroomId partyroomId, Pageable pageable) {
+        QPlaybackData q = QPlaybackData.playbackData;
+        List<PlaybackData> content = queryFactory
+                .select(q).from(q)
+                .where(q.partyroomId.id.eq(partyroomId.getId()))
+                .orderBy(q.createdAt.desc())            // 정렬 고정
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        Long total = queryFactory
+                .select(q.count()).from(q)
+                .where(q.partyroomId.id.eq(partyroomId.getId()))
+                .fetchOne();
+        return new PageImpl<>(content, pageable, total == null ? 0L : total);
     }
 
     @Override

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/impl/PartyroomRepositoryImpl.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/impl/PartyroomRepositoryImpl.java
@@ -169,6 +169,29 @@ public class PartyroomRepositoryImpl implements PartyroomRepositoryCustom {
     }
 
     @Override
+    public List<PlaybackData> findPlaybackForInterval(PartyroomId partyroomId, LocalDateTime from, LocalDateTime now) {
+        QPlaybackData q = QPlaybackData.playbackData;
+        List<PlaybackData> inWindow = queryFactory
+                .select(q).from(q)
+                .where(q.partyroomId.id.eq(partyroomId.getId())
+                        .and(q.createdAt.goe(from))
+                        .and(q.createdAt.lt(now)))
+                .orderBy(q.createdAt.asc())
+                .fetch();
+        PlaybackData straddle = queryFactory
+                .select(q).from(q)
+                .where(q.partyroomId.id.eq(partyroomId.getId())
+                        .and(q.createdAt.lt(from)))
+                .orderBy(q.createdAt.desc())
+                .fetchFirst();
+        if (straddle == null) return inWindow;
+        List<PlaybackData> result = new ArrayList<>(inWindow.size() + 1);
+        result.add(straddle);
+        result.addAll(inWindow);
+        return result;
+    }
+
+    @Override
     public List<PartyroomData> findAllUnusedPartyroomDataByDay(int days) {
         QPartyroomData qPartyroomData = QPartyroomData.partyroomData;
 

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/PlaybackData.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/PlaybackData.java
@@ -19,7 +19,7 @@ import java.time.Instant;
 @Table(
         name = "PLAYBACK",
         indexes = {
-                @Index(name = "playback_partyroom_id_IDX", columnList = "partyroom_id")
+                @Index(name = "idx_playback_partyroom_time", columnList = "partyroom_id, created_at")
         }
 )
 @Entity

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/port/PartyroomAggregatePort.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/port/PartyroomAggregatePort.java
@@ -5,6 +5,8 @@ import com.pfplaybackend.api.party.domain.entity.data.*;
 import com.pfplaybackend.api.party.domain.value.CrewId;
 import com.pfplaybackend.api.party.domain.value.LinkDomain;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -64,4 +66,9 @@ public interface PartyroomAggregatePort {
      * created_at ∈ [from, now) 인 모든 row + from 직전 최신 1건(straddle)을 created_at ASC 로 반환.
      */
     List<PlaybackData> findPlaybackForInterval(PartyroomId partyroomId, LocalDateTime from, LocalDateTime now);
+
+    /**
+     * 디제잉 이력 페이지네이션 조회. created_at DESC 고정 정렬.
+     */
+    Page<PlaybackData> findPlaybackHistory(PartyroomId partyroomId, Pageable pageable);
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/port/PartyroomAggregatePort.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/port/PartyroomAggregatePort.java
@@ -57,4 +57,11 @@ public interface PartyroomAggregatePort {
     // ===== Reconcile cron (#308) =====
     List<PartyroomId> findPartyroomIdsWithInactiveCrewDj();
     List<PartyroomId> findStuckActivatedPartyroomIds(long threshold);
+
+    // ===== Playback interval 재구성 (어드민 행동분석) =====
+    /**
+     * 음악 재생 구간 재구성용 playback 조회.
+     * created_at ∈ [from, now) 인 모든 row + from 직전 최신 1건(straddle)을 created_at ASC 로 반환.
+     */
+    List<PlaybackData> findPlaybackForInterval(PartyroomId partyroomId, LocalDateTime from, LocalDateTime now);
 }

--- a/app/src/main/resources/db/migration/V34__admin_analytics_indexes.sql
+++ b/app/src/main/resources/db/migration/V34__admin_analytics_indexes.sql
@@ -1,0 +1,18 @@
+-- =====================================================
+-- V34: 어드민 파티룸 행동분석 — 범위/정렬 인덱스
+-- Spec: docs/superpowers/specs/2026-07-09-admin-partyroom-behavior-analytics-design.md §7
+--
+-- user_activity_log: partyroom_id 인덱스 신규(기존 부재).
+--   ②는 event_type IN (ENTERED,EXITED)+GROUP BY date, ③은 event_type=EXITED.
+--   등가 컬럼(partyroom_id, event_type)을 앞, 범위/정렬(occurred_at)을 뒤에 둔다.
+-- playback: 기존 단일컬럼 playback_partyroom_id_IDX(V1)를 복합으로 대체
+--   (신규가 완전 상위집합 → 중복 제거).
+-- =====================================================
+
+ALTER TABLE user_activity_log
+    ADD INDEX idx_ual_partyroom_event_time (partyroom_id, event_type, occurred_at DESC);
+
+ALTER TABLE playback
+    ADD INDEX idx_playback_partyroom_time (partyroom_id, created_at DESC);
+
+DROP INDEX playback_partyroom_id_IDX ON playback;

--- a/app/src/test/java/com/pfplaybackend/api/admin/adapter/in/web/AbstractAdminWebMvcTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/admin/adapter/in/web/AbstractAdminWebMvcTest.java
@@ -30,6 +30,7 @@ import com.pfplaybackend.api.administration.application.service.AdminMemberQuery
 import com.pfplaybackend.api.administration.application.service.AdminMemberTierCommandService;
 import com.pfplaybackend.api.administration.application.service.AdminMemberWithdrawCommandService;
 import com.pfplaybackend.api.administration.application.service.AdminPartyroomCommandService;
+import com.pfplaybackend.api.administration.application.service.AdminPartyroomAnalyticsQueryService;
 import com.pfplaybackend.api.administration.application.service.AdminPartyroomQueryService;
 import com.pfplaybackend.api.administration.application.service.AdminReportCommandService;
 import com.pfplaybackend.api.administration.application.service.AdminReportQueryService;
@@ -98,6 +99,7 @@ public abstract class AbstractAdminWebMvcTest {
     @MockBean protected AdminPasswordService adminPasswordService;
     @MockBean protected AdminPartyroomCommandService adminPartyroomCommandService;
     @MockBean protected AdminPartyroomQueryService adminPartyroomQueryService;
+    @MockBean protected AdminPartyroomAnalyticsQueryService adminPartyroomAnalyticsQueryService;
     @MockBean protected AdminMemberQueryService adminMemberQueryService;
     @MockBean protected AdminGuestQueryService adminGuestQueryService;
     @MockBean protected AdminMemberTierCommandService adminMemberTierCommandService;

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/web/AdminPartyroomAnalyticsControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/in/web/AdminPartyroomAnalyticsControllerTest.java
@@ -1,0 +1,110 @@
+package com.pfplaybackend.api.administration.adapter.in.web;
+
+import com.pfplaybackend.api.admin.adapter.in.web.AbstractAdminWebMvcTest;
+import com.pfplaybackend.api.administration.adapter.in.web.payload.response.AdminDjHistoryItemResponse;
+import com.pfplaybackend.api.administration.adapter.in.web.payload.response.PartyroomAnalyticsResponse;
+import com.pfplaybackend.api.administration.application.dto.AttendanceAnalytics;
+import com.pfplaybackend.api.common.exception.ExceptionCreator;
+import com.pfplaybackend.api.common.exception.http.BadRequestException;
+import com.pfplaybackend.api.party.domain.exception.PartyroomException;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * WebMvcTest for the B-3 analytics / B-4 dj-history endpoints on
+ * {@link AdminPartyroomQueryController}.
+ *
+ * <p>Locks the HTTP contract: admin gating (403 non-admin), 200 body schema,
+ * days-reject → 400 (ADM-PR-002), missing room → 404, and dj-history size cap (200).
+ */
+class AdminPartyroomAnalyticsControllerTest extends AbstractAdminWebMvcTest {
+
+    // ── B-3 analytics ──
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    @DisplayName("analytics — 비어드민 → 403")
+    void analytics_비어드민_403() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/partyrooms/1/analytics"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("analytics — 200 스키마 (attendance + silenceExit.approximate)")
+    void analytics_200_스키마() throws Exception {
+        PartyroomAnalyticsResponse response = new PartyroomAnalyticsResponse(
+                20,
+                new AttendanceAnalytics(4L, 3L, 3L, Collections.emptyList()),
+                new PartyroomAnalyticsResponse.SilenceExit(true, 3L, 1L, 0.33, 12L));
+        given(adminPartyroomAnalyticsQueryService.getAnalytics(eq(new PartyroomId(1L)), anyInt()))
+                .willReturn(response);
+
+        mockMvc.perform(get("/api/v1/admin/partyrooms/1/analytics"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.attendance").exists())
+                .andExpect(jsonPath("$.data.silenceExit.approximate").value(true));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("analytics — days 범위밖 → 400 (ADM-PR-002)")
+    void analytics_days_범위밖_400() throws Exception {
+        given(adminPartyroomAnalyticsQueryService.getAnalytics(any(PartyroomId.class), anyInt()))
+                .willThrow(new BadRequestException("ADM-PR-002", "days out of range (1..90): 91"));
+
+        mockMvc.perform(get("/api/v1/admin/partyrooms/1/analytics")
+                        .param("days", "91"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("analytics — 없는 방 → 404")
+    void analytics_없는방_404() throws Exception {
+        given(adminPartyroomAnalyticsQueryService.getAnalytics(any(PartyroomId.class), anyInt()))
+                .willThrow(ExceptionCreator.create(PartyroomException.NOT_FOUND_ROOM));
+
+        mockMvc.perform(get("/api/v1/admin/partyrooms/404/analytics"))
+                .andExpect(status().isNotFound());
+    }
+
+    // ── B-4 dj-history ──
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("djHistory — size 200 초과 → 200으로 clamp")
+    void djHistory_size_200_초과_clamp() throws Exception {
+        Page<AdminDjHistoryItemResponse> emptyPage = new PageImpl<>(List.of());
+        given(adminPartyroomAnalyticsQueryService.getDjHistory(any(PartyroomId.class), any(Pageable.class)))
+                .willReturn(emptyPage);
+
+        mockMvc.perform(get("/api/v1/admin/partyrooms/1/dj-history")
+                        .param("size", "500"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(adminPartyroomAnalyticsQueryService)
+                .getDjHistory(any(PartyroomId.class), pageableCaptor.capture());
+        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(200);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/persistence/impl/UserActivityLogAnalyticsRepositoryImplIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/persistence/impl/UserActivityLogAnalyticsRepositoryImplIT.java
@@ -1,0 +1,117 @@
+package com.pfplaybackend.api.administration.adapter.out.persistence.impl;
+
+import com.pfplaybackend.api.administration.adapter.out.persistence.UserActivityLogAnalyticsRepository;
+import com.pfplaybackend.api.administration.adapter.out.persistence.UserActivityLogRepository;
+import com.pfplaybackend.api.administration.application.dto.DailyAttendanceBucket;
+import com.pfplaybackend.api.administration.domain.entity.UserActivityLogData;
+import com.pfplaybackend.api.administration.domain.enums.UserActivityEventType;
+import com.pfplaybackend.api.administration.domain.value.JsonMetadata;
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * UserActivityLogAnalyticsRepository IT — Testcontainers MySQL, V34 인덱스 자동 적용.
+ *
+ * 시나리오(test room P = 990001):
+ * - D-1(2026-06-20): ENTERED user 10/11/10 (3건), EXITED 2건
+ * - D-0(2026-06-21): ENTERED user 12 (1건), EXITED 1건
+ * - 격리 검증: 다른 룸(990002) ENTERED/EXITED, 같은 룸의 SIGNED_IN 은 집계 제외되어야 함.
+ *
+ * cleanup: AfterEach native DELETE (테스트 전용 고번호 partyroom id).
+ */
+class UserActivityLogAnalyticsRepositoryImplIT extends AbstractIntegrationTest {
+
+    private static final long ROOM_P = 990001L;
+    private static final long ROOM_OTHER = 990002L;
+
+    private static final LocalDate D_MINUS_1 = LocalDate.of(2026, 6, 20);
+    private static final LocalDate D_ZERO = LocalDate.of(2026, 6, 21);
+
+    private static final LocalDateTime FROM = D_MINUS_1.atStartOfDay();
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 6, 22, 0, 0);
+
+    @Autowired UserActivityLogAnalyticsRepository analyticsRepository;
+    @Autowired UserActivityLogRepository userActivityLogRepository;
+    @Autowired TransactionTemplate transactionTemplate;
+    @Autowired EntityManager entityManager;
+
+    @AfterEach
+    void cleanup() {
+        transactionTemplate.executeWithoutResult(status ->
+                entityManager.createNativeQuery(
+                                "DELETE FROM user_activity_log WHERE partyroom_id IN (:ids)")
+                        .setParameter("ids", List.of(ROOM_P, ROOM_OTHER))
+                        .executeUpdate());
+    }
+
+    private void seed(long userAccountId, UserActivityEventType eventType, Long partyroomId,
+                      LocalDateTime occurredAt) {
+        transactionTemplate.executeWithoutResult(status ->
+                userActivityLogRepository.saveAndFlush(UserActivityLogData.of(
+                        userAccountId, eventType, partyroomId, JsonMetadata.empty(), occurredAt)));
+    }
+
+    private void seedScenario() {
+        // D-1: ENTERED 10/11/10, EXITED 10/11
+        seed(10L, UserActivityEventType.PARTYROOM_ENTERED, ROOM_P, LocalDateTime.of(2026, 6, 20, 10, 0));
+        seed(11L, UserActivityEventType.PARTYROOM_ENTERED, ROOM_P, LocalDateTime.of(2026, 6, 20, 11, 0));
+        seed(10L, UserActivityEventType.PARTYROOM_ENTERED, ROOM_P, LocalDateTime.of(2026, 6, 20, 12, 0));
+        seed(10L, UserActivityEventType.PARTYROOM_EXITED, ROOM_P, LocalDateTime.of(2026, 6, 20, 13, 0));
+        seed(11L, UserActivityEventType.PARTYROOM_EXITED, ROOM_P, LocalDateTime.of(2026, 6, 20, 14, 0));
+        // D-0: ENTERED 12, EXITED 12
+        seed(12L, UserActivityEventType.PARTYROOM_ENTERED, ROOM_P, LocalDateTime.of(2026, 6, 21, 9, 0));
+        seed(12L, UserActivityEventType.PARTYROOM_EXITED, ROOM_P, LocalDateTime.of(2026, 6, 21, 10, 0));
+        // 격리: 같은 룸 SIGNED_IN (집계/방문/퇴장 모두 제외)
+        seed(10L, UserActivityEventType.SIGNED_IN, ROOM_P, LocalDateTime.of(2026, 6, 20, 15, 0));
+        // 격리: 다른 룸 ENTERED/EXITED
+        seed(20L, UserActivityEventType.PARTYROOM_ENTERED, ROOM_OTHER, LocalDateTime.of(2026, 6, 20, 10, 0));
+        seed(20L, UserActivityEventType.PARTYROOM_EXITED, ROOM_OTHER, LocalDateTime.of(2026, 6, 20, 11, 0));
+    }
+
+    @Test
+    @DisplayName("findDailyAttendance — 발생일만 asc, 일자별 entered/exited 집계")
+    void findDailyAttendance() {
+        seedScenario();
+
+        List<DailyAttendanceBucket> buckets = analyticsRepository.findDailyAttendance(ROOM_P, FROM, NOW);
+
+        assertThat(buckets).hasSize(2);
+        assertThat(buckets.get(0).date()).isEqualTo(D_MINUS_1);
+        assertThat(buckets.get(0).entered()).isEqualTo(3);
+        assertThat(buckets.get(0).exited()).isEqualTo(2);
+        assertThat(buckets.get(1).date()).isEqualTo(D_ZERO);
+        assertThat(buckets.get(1).entered()).isEqualTo(1);
+        assertThat(buckets.get(1).exited()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("countUniqueVisitors — ENTERED distinct user (10,11,12) = 3")
+    void countUniqueVisitors() {
+        seedScenario();
+
+        long unique = analyticsRepository.countUniqueVisitors(ROOM_P, FROM, NOW);
+
+        assertThat(unique).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("findExitOccurredAt — 윈도우 내 EXITED 3건, 타룸/타이벤트 제외")
+    void findExitOccurredAt() {
+        seedScenario();
+
+        List<LocalDateTime> exits = analyticsRepository.findExitOccurredAt(ROOM_P, FROM, NOW);
+
+        assertThat(exits).hasSize(3);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/administration/application/analytics/SilenceExitCalculatorTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/application/analytics/SilenceExitCalculatorTest.java
@@ -23,6 +23,14 @@ class SilenceExitCalculatorTest {
         assertThat(r.exitsDuringSilence()).isEqualTo(1);
     }
     @Test
+    void 분리된_두트랙_갭내퇴장은_무음_둘째트랙내퇴장은_음악() {
+        // 실제 갭이 보존되는 다중구간(merge 후 disjoint 2개) + 이진탐색 right 분기 검증
+        var intervals = List.of(new PlaybackInterval(0, m(10)), new PlaybackInterval(m(20), m(30)));
+        var r = SilenceExitCalculator.compute(intervals, List.of(m(15), m(25)), 0, m(30));
+        assertThat(r.exitsDuringSilence()).isEqualTo(1);            // @15 갭=무음, @25 둘째트랙=음악
+        assertThat(r.totalSilenceMinutes()).isEqualTo(10);         // 갭 [10,20) = 10분
+    }
+    @Test
     void 경계_half_open_start는_음악_end는_무음() {
         var intervals = List.of(new PlaybackInterval(m(5), m(10)));
         var r = SilenceExitCalculator.compute(intervals, List.of(m(5), m(10)), 0, m(20));

--- a/app/src/test/java/com/pfplaybackend/api/administration/application/analytics/SilenceExitCalculatorTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/application/analytics/SilenceExitCalculatorTest.java
@@ -1,0 +1,57 @@
+package com.pfplaybackend.api.administration.application.analytics;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SilenceExitCalculatorTest {
+    static long m(long min) { return min * 60_000L; }
+
+    @Test
+    void 음악_중_퇴장은_무음카운트_제외() {
+        var r = SilenceExitCalculator.compute(
+                List.of(new PlaybackInterval(0, m(10))), List.of(m(5)), 0, m(20));
+        assertThat(r.exitsDuringSilence()).isEqualTo(0);
+        assertThat(r.totalExits()).isEqualTo(1);
+    }
+    @Test
+    void 무음_중_퇴장은_카운트() {
+        var r = SilenceExitCalculator.compute(
+                List.of(new PlaybackInterval(0, m(10))), List.of(m(15)), 0, m(20));
+        assertThat(r.exitsDuringSilence()).isEqualTo(1);
+    }
+    @Test
+    void 경계_half_open_start는_음악_end는_무음() {
+        var intervals = List.of(new PlaybackInterval(m(5), m(10)));
+        var r = SilenceExitCalculator.compute(intervals, List.of(m(5), m(10)), 0, m(20));
+        assertThat(r.exitsDuringSilence()).isEqualTo(1); // @5=음악, @10=무음
+    }
+    @Test
+    void 스킵_클램프_다음트랙_시작으로_종료() {
+        var intervals = List.of(new PlaybackInterval(0, m(30)), new PlaybackInterval(m(10), m(40)));
+        var r = SilenceExitCalculator.compute(intervals, List.of(m(35)), 0, m(35));
+        assertThat(r.exitsDuringSilence()).isEqualTo(1); // @35==now==end → half-open 무음
+    }
+    @Test
+    void now_클램프로_totalSilence_음수불가() {
+        var r = SilenceExitCalculator.compute(
+                List.of(new PlaybackInterval(0, m(30))), List.of(), 0, m(20));
+        assertThat(r.totalSilenceMinutes()).isEqualTo(0);
+    }
+    @Test
+    void straddle_start_클램프_from으로() {
+        var r = SilenceExitCalculator.compute(
+                List.of(new PlaybackInterval(0, m(40))), List.of(m(12)), m(10), m(30));
+        assertThat(r.exitsDuringSilence()).isEqualTo(0);
+        assertThat(r.totalSilenceMinutes()).isEqualTo(0);
+    }
+    @Test
+    void 퇴장_없으면_ratio_null() {
+        var r = SilenceExitCalculator.compute(List.of(), List.of(), 0, m(20));
+        assertThat(r.totalExits()).isEqualTo(0);
+        assertThat(r.silenceExitRatio()).isNull();
+        assertThat(r.totalSilenceMinutes()).isEqualTo(20);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomAnalyticsQueryServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomAnalyticsQueryServiceTest.java
@@ -158,7 +158,7 @@ class AdminPartyroomAnalyticsQueryServiceTest {
         assertThat(item.trackName()).isEqualTo("Song A");
         assertThat(item.djUserAccountId()).isEqualTo(11L);
         assertThat(item.djNickname()).isEqualTo("djNick");
-        assertThat(item.avatarIconUri()).isNotNull();
+        assertThat(item.avatarIconUri()).isEqualTo("");   // 미설정 아바타 계약: "" (non-null)
         assertThat(item.thumbnailImage()).isEqualTo("thumb.png");
         assertThat(item.playedAt()).isEqualTo(playedAt);
     }

--- a/app/src/test/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomAnalyticsQueryServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomAnalyticsQueryServiceTest.java
@@ -1,0 +1,210 @@
+package com.pfplaybackend.api.administration.application.service;
+
+import com.pfplaybackend.api.administration.adapter.in.web.payload.response.AdminDjHistoryItemResponse;
+import com.pfplaybackend.api.administration.adapter.in.web.payload.response.PartyroomAnalyticsResponse;
+import com.pfplaybackend.api.administration.adapter.out.persistence.UserActivityLogAnalyticsRepository;
+import com.pfplaybackend.api.administration.application.dto.DailyAttendanceBucket;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.exception.http.BadRequestException;
+import com.pfplaybackend.api.common.exception.http.NotFoundException;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.entity.data.PlaybackData;
+import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.user.adapter.out.persistence.MemberRepository;
+import com.pfplaybackend.api.user.domain.entity.data.MemberData;
+import com.pfplaybackend.api.user.domain.entity.data.ProfileData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminPartyroomAnalyticsQueryServiceTest {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+    @Mock private PartyroomAggregatePort aggregatePort;
+    @Mock private UserActivityLogAnalyticsRepository activityRepo;
+    @Mock private MemberRepository memberRepository;
+
+    @InjectMocks
+    private AdminPartyroomAnalyticsQueryService service;
+
+    private static final PartyroomId PID = new PartyroomId(100L);
+
+    // ── getAnalytics: days 가드 ──
+
+    @Test
+    @DisplayName("getAnalytics - days=0 → BadRequestException, 존재확인 이전 검증")
+    void analytics_days_too_small() {
+        assertThatThrownBy(() -> service.getAnalytics(PID, 0))
+                .isInstanceOf(BadRequestException.class);
+        verify(aggregatePort, never()).findPartyroomById(any());
+    }
+
+    @Test
+    @DisplayName("getAnalytics - days=91 → BadRequestException")
+    void analytics_days_too_large() {
+        assertThatThrownBy(() -> service.getAnalytics(PID, 91))
+                .isInstanceOf(BadRequestException.class);
+        verify(aggregatePort, never()).findPartyroomById(any());
+    }
+
+    @Test
+    @DisplayName("getAnalytics - 방 없음 → PartyroomException(NOT_FOUND_ROOM)")
+    void analytics_room_not_found() {
+        when(aggregatePort.findPartyroomById(PID.getId())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getAnalytics(PID, 7))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("파티룸을 찾을 수 없습니다");
+
+        verify(activityRepo, never()).findDailyAttendance(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("getAnalytics - happy path: 입퇴장 합산 + 무음지표 조합, totalExits == totalExited 불변식")
+    void analytics_happy() {
+        PartyroomData room = PartyroomData.create(
+                "T", "i", com.pfplaybackend.api.party.domain.value.LinkDomain.of("l"),
+                com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit.ofMinutes(5),
+                com.pfplaybackend.api.party.domain.enums.StageType.GENERAL, new UserId(7L));
+        when(aggregatePort.findPartyroomById(PID.getId())).thenReturn(Optional.of(room));
+
+        List<DailyAttendanceBucket> daily = List.of(
+                new DailyAttendanceBucket(LocalDate.of(2026, 7, 8), 3, 2),
+                new DailyAttendanceBucket(LocalDate.of(2026, 7, 9), 1, 1));
+        when(activityRepo.findDailyAttendance(eq(100L), any(), any())).thenReturn(daily);
+        when(activityRepo.countUniqueVisitors(eq(100L), any(), any())).thenReturn(3L);
+
+        // 3개의 EXIT 타임스탬프 → totalExits == totalExited == 3 이어야 함
+        LocalDateTime base = LocalDateTime.now(SEOUL).minusHours(2);
+        when(activityRepo.findExitOccurredAt(eq(100L), any(), any()))
+                .thenReturn(List.of(base, base.plusMinutes(10), base.plusMinutes(20)));
+
+        // playback 구간 하나 (endTime non-null)
+        PlaybackData pb = PlaybackData.builder()
+                .id(1L).partyroomId(PID).userId(new UserId(7L)).name("track")
+                .endTime(base.plusMinutes(5).atZone(SEOUL).toInstant().toEpochMilli())
+                .build();
+        setField(pb, "createdAt", base);
+        when(aggregatePort.findPlaybackForInterval(eq(PID), any(), any())).thenReturn(List.of(pb));
+
+        PartyroomAnalyticsResponse resp = service.getAnalytics(PID, 7);
+
+        assertThat(resp.windowDays()).isEqualTo(7);
+        assertThat(resp.attendance().totalEntered()).isEqualTo(4L);
+        assertThat(resp.attendance().totalExited()).isEqualTo(3L);
+        assertThat(resp.attendance().uniqueVisitors()).isEqualTo(3L);
+        assertThat(resp.attendance().daily()).hasSize(2);
+        assertThat(resp.silenceExit().approximate()).isTrue();
+        // 불변식: totalExits == attendance.totalExited
+        assertThat(resp.silenceExit().totalExits()).isEqualTo(resp.attendance().totalExited());
+        assertThat(resp.silenceExit().totalExits()).isEqualTo(3L);
+    }
+
+    // ── getDjHistory ──
+
+    @Test
+    @DisplayName("getDjHistory - 필드 매핑 + 닉네임/아바타 enrichment")
+    void djHistory_enriches() {
+        when(aggregatePort.findPartyroomById(PID.getId()))
+                .thenReturn(Optional.of(PartyroomData.create(
+                        "T", "i", com.pfplaybackend.api.party.domain.value.LinkDomain.of("l"),
+                        com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit.ofMinutes(5),
+                        com.pfplaybackend.api.party.domain.enums.StageType.GENERAL, new UserId(7L))));
+
+        LocalDateTime playedAt = LocalDateTime.of(2026, 7, 9, 12, 0);
+        PlaybackData pb = PlaybackData.builder()
+                .id(42L).partyroomId(PID).userId(new UserId(11L))
+                .name("Song A").thumbnailImage("thumb.png")
+                .endTime(1L).build();
+        setField(pb, "createdAt", playedAt);
+        Pageable pageable = PageRequest.of(0, 20);
+        when(aggregatePort.findPlaybackHistory(PID, pageable))
+                .thenReturn(new PageImpl<>(List.of(pb), pageable, 1L));
+
+        MemberData member = memberWithNickname(11L, "djNick");
+        when(memberRepository.findAllByUserAccountIdIn(anyList())).thenReturn(List.of(member));
+
+        Page<AdminDjHistoryItemResponse> page = service.getDjHistory(PID, pageable);
+
+        assertThat(page.getTotalElements()).isEqualTo(1L);
+        AdminDjHistoryItemResponse item = page.getContent().get(0);
+        assertThat(item.playbackId()).isEqualTo(42L);
+        assertThat(item.trackName()).isEqualTo("Song A");
+        assertThat(item.djUserAccountId()).isEqualTo(11L);
+        assertThat(item.djNickname()).isEqualTo("djNick");
+        assertThat(item.avatarIconUri()).isNotNull();
+        assertThat(item.thumbnailImage()).isEqualTo("thumb.png");
+        assertThat(item.playedAt()).isEqualTo(playedAt);
+    }
+
+    @Test
+    @DisplayName("getDjHistory - 빈 페이지 → 예외 없이 빈 content, member 조회 skip")
+    void djHistory_empty_page() {
+        when(aggregatePort.findPartyroomById(PID.getId()))
+                .thenReturn(Optional.of(PartyroomData.create(
+                        "T", "i", com.pfplaybackend.api.party.domain.value.LinkDomain.of("l"),
+                        com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit.ofMinutes(5),
+                        com.pfplaybackend.api.party.domain.enums.StageType.GENERAL, new UserId(7L))));
+        Pageable pageable = PageRequest.of(0, 20);
+        when(aggregatePort.findPlaybackHistory(PID, pageable)).thenReturn(Page.empty(pageable));
+
+        Page<AdminDjHistoryItemResponse> page = service.getDjHistory(PID, pageable);
+
+        assertThat(page.getContent()).isEmpty();
+        verify(memberRepository, never()).findAllByUserAccountIdIn(anyList());
+    }
+
+    // ── Helpers ──
+
+    private static MemberData memberWithNickname(Long userAccountId, String nickname) {
+        MemberData m = MemberData.createForUserAccount(userAccountId);
+        ProfileData p = ProfileData.builder()
+                .userId(new UserId(userAccountId))
+                .build();
+        p.updateBio(nickname, null);
+        m.initializeProfile(p);
+        return m;
+    }
+
+    private static void setField(Object target, String fieldName, Object value) {
+        try {
+            Class<?> c = target.getClass();
+            Field f = null;
+            while (c != null) {
+                try { f = c.getDeclaredField(fieldName); break; }
+                catch (NoSuchFieldException ignored) { c = c.getSuperclass(); }
+            }
+            if (f == null) throw new NoSuchFieldException(fieldName);
+            f.setAccessible(true);
+            f.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set field " + fieldName, e);
+        }
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/impl/PartyroomRepositoryPlaybackHistoryIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/impl/PartyroomRepositoryPlaybackHistoryIT.java
@@ -1,0 +1,111 @@
+package com.pfplaybackend.api.party.adapter.out.persistence.impl;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomRepository;
+import com.pfplaybackend.api.party.domain.entity.data.PlaybackData;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import jakarta.persistence.EntityManager;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * findPlaybackHistory IT — Testcontainers MySQL.
+ *
+ * 어드민 파티룸 행동분석: "디제잉 이력" 페이지네이션 조회.
+ * 반환 계약: 해당 파티룸의 playback row 를 created_at DESC 로 고정 정렬, Pageable 페이지네이션.
+ *
+ * created_at 은 JPA auditing 으로 자동 채워지므로 특정 시각 seed 를 위해
+ * native INSERT 로 created_at 을 명시. cleanup 은 AfterEach native DELETE.
+ * 충돌 회피 위해 test-only high range(990000+) id 사용.
+ */
+class PartyroomRepositoryPlaybackHistoryIT extends AbstractIntegrationTest {
+
+    private static final long ROOM_P = 990001L;
+    private static final long ROOM_OTHER = 990002L;
+    private static final long USER = 990100L;
+
+    @Autowired PartyroomRepository partyroomRepository;
+    @Autowired TransactionTemplate transactionTemplate;
+    @Autowired EntityManager entityManager;
+
+    @AfterEach
+    void cleanup() {
+        transactionTemplate.executeWithoutResult(status ->
+                entityManager.createNativeQuery(
+                                "DELETE FROM playback WHERE partyroom_id IN (:ids)")
+                        .setParameter("ids", List.of(ROOM_P, ROOM_OTHER))
+                        .executeUpdate());
+    }
+
+    private void seedPlayback(long partyroomId, LocalDateTime createdAt, String name) {
+        transactionTemplate.executeWithoutResult(status ->
+                entityManager.createNativeQuery(
+                                "INSERT INTO playback (partyroom_id, user_id, name, end_time, created_at) " +
+                                        "VALUES (:pid, :uid, :name, :endTime, :createdAt)")
+                        .setParameter("pid", partyroomId)
+                        .setParameter("uid", USER)
+                        .setParameter("name", name)
+                        .setParameter("endTime", 0L)
+                        .setParameter("createdAt", createdAt)
+                        .executeUpdate());
+    }
+
+    @Test
+    @DisplayName("첫 페이지: totalElements=5, content 2건, created_at desc, 다른 룸 제외")
+    void 첫_페이지는_created_at_desc로_페이지네이션_다른_룸_제외() {
+        LocalDateTime base = LocalDateTime.of(2026, 6, 1, 12, 0, 0);
+        // 오래된 → 최신 순서로 seed (조회 결과는 desc 이므로 역순이어야 함)
+        seedPlayback(ROOM_P, base.plusMinutes(0), "t0");
+        seedPlayback(ROOM_P, base.plusMinutes(10), "t1");
+        seedPlayback(ROOM_P, base.plusMinutes(20), "t2");
+        seedPlayback(ROOM_P, base.plusMinutes(30), "t3");
+        seedPlayback(ROOM_P, base.plusMinutes(40), "t4");
+        seedPlayback(ROOM_OTHER, base.plusMinutes(25), "otherRoom");
+
+        Page<PlaybackData> page = partyroomRepository.findPlaybackHistory(
+                new PartyroomId(ROOM_P), PageRequest.of(0, 2));
+
+        assertThat(page.getTotalElements()).isEqualTo(5);
+        assertThat(page.getContent()).hasSize(2);
+        // created_at DESC: 가장 최신 t4, 그다음 t3
+        assertThat(page.getContent()).extracting(PlaybackData::getName)
+                .containsExactly("t4", "t3");
+        // 첫 원소 created_at >= 두 번째 원소 created_at
+        assertThat(page.getContent().get(0).getCreatedAt())
+                .isAfterOrEqualTo(page.getContent().get(1).getCreatedAt());
+        // 다른 룸 제외
+        assertThat(page.getContent()).extracting(PlaybackData::getName)
+                .doesNotContain("otherRoom");
+    }
+
+    @Test
+    @DisplayName("마지막 페이지: page index 2, size 2 → 1건")
+    void 마지막_페이지는_1건() {
+        LocalDateTime base = LocalDateTime.of(2026, 6, 1, 12, 0, 0);
+        seedPlayback(ROOM_P, base.plusMinutes(0), "t0");
+        seedPlayback(ROOM_P, base.plusMinutes(10), "t1");
+        seedPlayback(ROOM_P, base.plusMinutes(20), "t2");
+        seedPlayback(ROOM_P, base.plusMinutes(30), "t3");
+        seedPlayback(ROOM_P, base.plusMinutes(40), "t4");
+
+        Page<PlaybackData> page = partyroomRepository.findPlaybackHistory(
+                new PartyroomId(ROOM_P), PageRequest.of(2, 2));
+
+        assertThat(page.getTotalElements()).isEqualTo(5);
+        assertThat(page.getContent()).hasSize(1);
+        // desc 정렬 3페이지(index 2)의 유일 원소 = 가장 오래된 t0
+        assertThat(page.getContent()).extracting(PlaybackData::getName)
+                .containsExactly("t0");
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/impl/PartyroomRepositoryPlaybackIntervalIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/impl/PartyroomRepositoryPlaybackIntervalIT.java
@@ -1,0 +1,113 @@
+package com.pfplaybackend.api.party.adapter.out.persistence.impl;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomRepository;
+import com.pfplaybackend.api.party.domain.entity.data.PlaybackData;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import jakarta.persistence.EntityManager;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * findPlaybackForInterval IT — Testcontainers MySQL.
+ *
+ * 어드민 파티룸 행동분석: "음악 재생 구간" 재구성을 위한 playback row 조회.
+ * 반환 계약: created_at ∈ [from, now) 인 모든 row + from 직전 최신 1건(straddle),
+ *           created_at ASC 정렬.
+ *
+ * created_at 은 JPA auditing 으로 자동 채워지므로 특정 시각 seed 를 위해
+ * native INSERT 로 created_at 을 명시. cleanup 은 AfterEach native DELETE.
+ * 충돌 회피 위해 test-only high range(990000+) id 사용.
+ */
+class PartyroomRepositoryPlaybackIntervalIT extends AbstractIntegrationTest {
+
+    private static final long ROOM_P = 990001L;
+    private static final long ROOM_OTHER = 990002L;
+    private static final long USER = 990100L;
+
+    @Autowired PartyroomRepository partyroomRepository;
+    @Autowired TransactionTemplate transactionTemplate;
+    @Autowired EntityManager entityManager;
+
+    @AfterEach
+    void cleanup() {
+        transactionTemplate.executeWithoutResult(status ->
+                entityManager.createNativeQuery(
+                                "DELETE FROM playback WHERE partyroom_id IN (:ids)")
+                        .setParameter("ids", List.of(ROOM_P, ROOM_OTHER))
+                        .executeUpdate());
+    }
+
+    private void seedPlayback(long partyroomId, LocalDateTime createdAt, String name) {
+        transactionTemplate.executeWithoutResult(status ->
+                entityManager.createNativeQuery(
+                                "INSERT INTO playback (partyroom_id, user_id, name, end_time, created_at) " +
+                                        "VALUES (:pid, :uid, :name, :endTime, :createdAt)")
+                        .setParameter("pid", partyroomId)
+                        .setParameter("uid", USER)
+                        .setParameter("name", name)
+                        .setParameter("endTime", 0L)
+                        .setParameter("createdAt", createdAt)
+                        .executeUpdate());
+    }
+
+    @Test
+    @DisplayName("윈도우 내 트랙과 straddle 1건을 created_at asc 로 반환, 다른 룸 제외")
+    void 윈도우_내_트랙과_straddle_1건을_created_at_asc로_반환() {
+        LocalDateTime base = LocalDateTime.of(2026, 6, 1, 12, 0, 0);
+        LocalDateTime straddle = base.minusMinutes(10);
+        LocalDateTime in1 = base.plusMinutes(10);
+        LocalDateTime in2 = base.plusMinutes(30);
+
+        seedPlayback(ROOM_P, straddle, "straddle");
+        seedPlayback(ROOM_P, in1, "in1");
+        seedPlayback(ROOM_P, in2, "in2");
+        seedPlayback(ROOM_OTHER, base.plusMinutes(5), "otherRoom");
+
+        List<PlaybackData> result = partyroomRepository.findPlaybackForInterval(
+                new PartyroomId(ROOM_P), base, base.plusHours(2));
+
+        assertThat(result).hasSize(3);
+        assertThat(result).extracting(p -> p.getCreatedAt().truncatedTo(ChronoUnit.SECONDS))
+                .containsExactly(
+                        straddle.truncatedTo(ChronoUnit.SECONDS),
+                        in1.truncatedTo(ChronoUnit.SECONDS),
+                        in2.truncatedTo(ChronoUnit.SECONDS));
+        assertThat(result).extracting(PlaybackData::getName)
+                .containsExactly("straddle", "in1", "in2");
+    }
+
+    @Test
+    @DisplayName("straddle 후보가 여러개면 from 직전 최신 1건만")
+    void straddle_후보가_여러개면_from_직전_최신_1건만() {
+        LocalDateTime base = LocalDateTime.of(2026, 6, 1, 12, 0, 0);
+        LocalDateTime older = base.minusMinutes(30);
+        LocalDateTime straddle = base.minusMinutes(10);
+        LocalDateTime in1 = base.plusMinutes(10);
+
+        seedPlayback(ROOM_P, older, "older");
+        seedPlayback(ROOM_P, straddle, "straddle");
+        seedPlayback(ROOM_P, in1, "in1");
+
+        List<PlaybackData> result = partyroomRepository.findPlaybackForInterval(
+                new PartyroomId(ROOM_P), base, base.plusHours(2));
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(p -> p.getCreatedAt().truncatedTo(ChronoUnit.SECONDS))
+                .containsExactly(
+                        straddle.truncatedTo(ChronoUnit.SECONDS),
+                        in1.truncatedTo(ChronoUnit.SECONDS));
+        assertThat(result).extracting(PlaybackData::getName)
+                .containsExactly("straddle", "in1");
+    }
+}

--- a/docs/superpowers/plans/2026-07-09-admin-partyroom-behavior-analytics.md
+++ b/docs/superpowers/plans/2026-07-09-admin-partyroom-behavior-analytics.md
@@ -1,0 +1,871 @@
+# 어드민 파티룸 행동분석 백엔드 구현 플랜
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 어드민이 특정 파티룸 상세에서 최근 N일 입장/퇴장 집계(②), "무음 이탈" 가설 지표(③), 디제잉 이력 페이지네이션(④)을 조회하는 플랫폼 백엔드 API를 추가한다.
+
+**Architecture:** 기존 헥사고날 구조 확장. `administration` BC의 `AdminPartyroomQueryController`에 엔드포인트 2개(`/analytics`, `/dj-history`) 추가. ②는 administration 소유 `user_activity_log`를 QueryDSL로 집계, ③④의 `playback`은 `PartyroomAggregatePort` 경유(ArchUnit 경계 유지). ③의 무음구간 연산은 `Asia/Seoul` epoch-millis 기반 순수함수로 분리해 단위테스트.
+
+**Tech Stack:** Spring Boot, JPA/Hibernate, QueryDSL, MySQL, Flyway, JUnit5 + AssertJ, Spring Security(`@PreAuthorize`).
+
+**Spec:** `docs/superpowers/specs/2026-07-09-admin-partyroom-behavior-analytics-design.md`
+
+**빌드/실행 노트(reference):**
+- JDK 21 빌드: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7"` prefix 필수.
+- 단위/IT: `./gradlew :app:test --tests '<FQCN>'`
+- 마이그레이션/JPQL 오류는 **로컬 docker 풀부팅(fresh DB)** 에서만 잡히므로, Task 1·9 후 부팅 게이트 수행.
+
+**Flyway 슬롯:** 본 플랜은 잠정 `V34`로 표기한다. **머지 직전** `origin/develop` HEAD 및 인플라이트 마이그레이션 PR과 대조해 충돌 없는 다음 슬롯으로 재번호(V32/V33은 미머지 virtualcrew 브랜치 점유). `ls db/migration | sort | uniq -d` 사전 스캔.
+
+---
+
+## 파일 구조 (생성/수정 맵)
+
+**생성:**
+- `app/src/main/resources/db/migration/V34__admin_analytics_indexes.sql` — 인덱스 마이그레이션
+- `.../administration/application/service/AdminPartyroomAnalyticsQueryService.java` — ②③④ 조합 read-only 서비스
+- `.../administration/application/analytics/SilenceExitCalculator.java` — ③ 순수함수(구간병합·분류)
+- `.../administration/application/analytics/PlaybackInterval.java` — ③ 내부 값(레코드)
+- `.../administration/adapter/out/persistence/UserActivityLogAnalyticsRepository.java` — ② QueryDSL 집계 리포지토리
+- `.../administration/application/dto/AttendanceAnalytics.java` — ② 집계 DTO(레코드)
+- `.../administration/application/dto/DailyAttendanceBucket.java` — 일자 버킷(레코드)
+- `.../administration/adapter/in/web/payload/response/PartyroomAnalyticsResponse.java` — `/analytics` 응답(레코드)
+- `.../administration/adapter/in/web/payload/response/AdminDjHistoryItemResponse.java` — `/dj-history` 아이템(레코드)
+- 테스트: `SilenceExitCalculatorTest`, `UserActivityLogAnalyticsRepositoryImplIT`, `AdminPartyroomAnalyticsQueryServiceIT`, `AdminPartyroomAnalyticsControllerTest`
+
+**수정:**
+- `.../party/domain/entity/data/PlaybackData.java` — `@Index`를 복합으로 교체
+- `.../party/domain/port/PartyroomAggregatePort.java` — 메서드 2개 추가
+- `.../party/adapter/out/persistence/PartyroomAggregateAdapter.java` — 위 구현 위임
+- `.../party/adapter/out/persistence/custom/PartyroomRepositoryCustom.java` — 메서드 2개 추가
+- `.../party/adapter/out/persistence/impl/PartyroomRepositoryImpl.java` — QueryDSL 구현
+- `.../administration/adapter/in/web/AdminPartyroomQueryController.java` — 엔드포인트 2개 추가
+
+---
+
+## Chunk 1: 인덱스 마이그레이션 + 엔티티 정합
+
+### Task 1: Flyway 인덱스 마이그레이션 + PlaybackData @Index 교체
+
+**Files:**
+- Create: `app/src/main/resources/db/migration/V34__admin_analytics_indexes.sql`
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/PlaybackData.java` (@Table indexes)
+
+- [ ] **Step 1: 마이그레이션 작성**
+
+`V34__admin_analytics_indexes.sql`:
+```sql
+-- =====================================================
+-- V34: 어드민 파티룸 행동분석 — 범위/정렬 인덱스
+-- Spec: docs/superpowers/specs/2026-07-09-admin-partyroom-behavior-analytics-design.md §7
+--
+-- user_activity_log: partyroom_id 인덱스 신규(기존 부재).
+--   ②는 event_type IN (ENTERED,EXITED)+GROUP BY date, ③은 event_type=EXITED.
+--   등가 컬럼(partyroom_id, event_type)을 앞, 범위/정렬(occurred_at)을 뒤에 둔다.
+-- playback: 기존 단일컬럼 playback_partyroom_id_IDX(V1)를 복합으로 대체
+--   (신규가 완전 상위집합 → 중복 제거).
+-- =====================================================
+
+ALTER TABLE user_activity_log
+    ADD INDEX idx_ual_partyroom_event_time (partyroom_id, event_type, occurred_at DESC);
+
+ALTER TABLE playback
+    ADD INDEX idx_playback_partyroom_time (partyroom_id, created_at DESC);
+
+DROP INDEX playback_partyroom_id_IDX ON playback;
+```
+
+- [ ] **Step 2: 엔티티 @Index 교체**
+
+`PlaybackData.java`의 `@Table` 애노테이션 인덱스를 신규 복합으로 교체. (주의: Hibernate `validate`는 테이블/컬럼/타입만 검증하고 **secondary index는 검증하지 않으므로** 미교체가 부팅을 깨진 않는다. 그러나 `create-drop` 테스트 컨텍스트의 생성 DDL 정합을 위해 애노테이션을 마이그레이션과 동기화하는 것이 위생 — 반드시 함께 교체한다.):
+```java
+@Table(
+        name = "PLAYBACK",
+        indexes = {
+                @Index(name = "idx_playback_partyroom_time", columnList = "partyroom_id, created_at")
+        }
+)
+```
+
+- [ ] **Step 3: 로컬 docker 풀부팅(fresh DB)으로 마이그레이션·validate 검증**
+
+Run(reference `reference_local_docker_compose`): fresh volume로 컨테이너 기동 → Flyway V34 적용 + Hibernate `validate` 통과 확인.
+Expected: 부팅 성공, `Successfully applied ... V34`, validate 에러 없음.
+> 부팅 게이트 전 `./gradlew :app:bootJar` 필수(Dockerfile은 호스트 빌드 jar COPY — stale jar 방지, `reference_local_docker_boot_stale_host_jar`).
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add app/src/main/resources/db/migration/V34__admin_analytics_indexes.sql \
+        app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/PlaybackData.java
+git commit -m "feat: 어드민 행동분석용 인덱스 추가 (user_activity_log 신규 + playback 복합 대체)"
+```
+
+---
+
+## Chunk 2: Playback 포트 확장 (③④ 데이터 접근)
+
+### Task 2: `findPlaybackForInterval` — ③용 구간 재구성 소스
+
+윈도우 내 트랙 전부 + `created_at < from` 최신 1건(straddle). 정렬 `created_at ASC`.
+
+**Files:**
+- Modify: `.../party/adapter/out/persistence/custom/PartyroomRepositoryCustom.java`
+- Modify: `.../party/adapter/out/persistence/impl/PartyroomRepositoryImpl.java`
+- Modify: `.../party/domain/port/PartyroomAggregatePort.java`
+- Modify: `.../party/adapter/out/persistence/PartyroomAggregateAdapter.java`
+- Test: `.../party/adapter/out/persistence/impl/PartyroomRepositoryPlaybackIntervalIT.java` (신규)
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`PartyroomRepositoryPlaybackIntervalIT`(기존 `@DataJpaTest`/`*IT` 패턴 따름):
+```java
+// 시나리오: 룸에 트랙 3개 — t0(from 이전 시작, straddle), t1·t2(윈도우 내), 다른 룸 t_other
+// from = base, now = base+2h
+@Test
+void 윈도우_내_트랙과_straddle_1건을_created_at_asc로_반환() {
+    // given: playback rows 저장 (partyroom=1: created_at base-10m, base+10m, base+30m; partyroom=2: base+5m)
+    // when
+    List<PlaybackData> result = repository.findPlaybackForInterval(
+            new PartyroomId(1L), base, base.plusHours(2));
+    // then: 3건(straddle 1 + in-window 2), created_at asc, 다른 룸 제외
+    assertThat(result).extracting(p -> p.getCreatedAt())
+            .containsExactly(base.minusMinutes(10), base.plusMinutes(10), base.plusMinutes(30));
+}
+
+@Test
+void straddle_후보가_여러개면_from_직전_최신_1건만() {
+    // given: partyroom=1 created_at base-30m, base-10m (둘 다 from 이전)
+    // when/then: base-10m 만 포함(base-30m 제외)
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `./gradlew :app:test --tests '*PartyroomRepositoryPlaybackIntervalIT'`
+Expected: FAIL — `findPlaybackForInterval` 메서드 없음(컴파일 에러).
+
+- [ ] **Step 3: 인터페이스 시그니처 추가**
+
+`PartyroomRepositoryCustom.java`:
+```java
+List<PlaybackData> findPlaybackForInterval(PartyroomId partyroomId, LocalDateTime from, LocalDateTime now);
+```
+`PartyroomAggregatePort.java` 동일 시그니처 추가.
+
+- [ ] **Step 4: QueryDSL 구현**
+
+`PartyroomRepositoryImpl.java` — 윈도우 내 조회 + straddle 1건 조회 후 병합:
+```java
+@Override
+public List<PlaybackData> findPlaybackForInterval(PartyroomId partyroomId, LocalDateTime from, LocalDateTime now) {
+    QPlaybackData q = QPlaybackData.playbackData;
+
+    // 윈도우 내: created_at ∈ [from, now)
+    List<PlaybackData> inWindow = queryFactory
+            .select(q).from(q)
+            .where(q.partyroomId.id.eq(partyroomId.getId())
+                    .and(q.createdAt.goe(from))
+                    .and(q.createdAt.lt(now)))
+            .orderBy(q.createdAt.asc())
+            .fetch();
+
+    // straddle: created_at < from 중 최신 1건 (윈도우 시작 시점에 재생 중이었을 수 있음)
+    PlaybackData straddle = queryFactory
+            .select(q).from(q)
+            .where(q.partyroomId.id.eq(partyroomId.getId())
+                    .and(q.createdAt.lt(from)))
+            .orderBy(q.createdAt.desc())
+            .fetchFirst();
+
+    if (straddle == null) {
+        return inWindow;
+    }
+    List<PlaybackData> result = new ArrayList<>(inWindow.size() + 1);
+    result.add(straddle);          // 가장 이른 시작 → asc 정렬 선두
+    result.addAll(inWindow);
+    return result;
+}
+```
+`PartyroomAggregateAdapter.java`: `return partyroomRepository.findPlaybackForInterval(partyroomId, from, now);` 위임.
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `./gradlew :app:test --tests '*PartyroomRepositoryPlaybackIntervalIT'`
+Expected: PASS.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/...
+git commit -m "feat: playback 구간 재구성 조회(findPlaybackForInterval) 추가"
+```
+
+### Task 3: `findPlaybackHistory` — ④용 페이지네이션
+
+**Files:** Task 2와 동일 4개 파일 + Test: `PartyroomRepositoryPlaybackHistoryIT`
+
+- [ ] **Step 1: 실패 테스트**
+
+```java
+@Test
+void created_at_desc_페이지네이션_반환() {
+    // given: partyroom=1 트랙 5건(서로 다른 created_at)
+    Page<PlaybackData> page = repository.findPlaybackHistory(new PartyroomId(1L), PageRequest.of(0, 2));
+    assertThat(page.getTotalElements()).isEqualTo(5);
+    assertThat(page.getContent()).hasSize(2);
+    // created_at 내림차순 검증
+    assertThat(page.getContent().get(0).getCreatedAt())
+            .isAfterOrEqualTo(page.getContent().get(1).getCreatedAt());
+}
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `./gradlew :app:test --tests '*PartyroomRepositoryPlaybackHistoryIT'` → FAIL(메서드 없음).
+
+- [ ] **Step 3: 시그니처 추가**
+
+`PartyroomRepositoryCustom`/`PartyroomAggregatePort`:
+```java
+Page<PlaybackData> findPlaybackHistory(PartyroomId partyroomId, Pageable pageable);
+```
+
+- [ ] **Step 4: QueryDSL 구현**
+
+`PartyroomRepositoryImpl`:
+```java
+@Override
+public Page<PlaybackData> findPlaybackHistory(PartyroomId partyroomId, Pageable pageable) {
+    QPlaybackData q = QPlaybackData.playbackData;
+
+    List<PlaybackData> content = queryFactory
+            .select(q).from(q)
+            .where(q.partyroomId.id.eq(partyroomId.getId()))
+            .orderBy(q.createdAt.desc())            // 정렬 고정(§9)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+    Long total = queryFactory
+            .select(q.count()).from(q)
+            .where(q.partyroomId.id.eq(partyroomId.getId()))
+            .fetchOne();
+
+    return new PageImpl<>(content, pageable, total == null ? 0L : total);
+}
+```
+Adapter 위임 추가.
+
+- [ ] **Step 5: 통과 확인** — Run 위 테스트 → PASS.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git commit -am "feat: playback 이력 페이지네이션 조회(findPlaybackHistory) 추가"
+```
+
+---
+
+## Chunk 3: ② 입퇴장 집계 리포지토리
+
+### Task 4: UserActivityLogAnalyticsRepository (QueryDSL)
+
+administration BC 소유 `user_activity_log`를 파티룸+윈도우로 집계. 세 가지 산출: 일자 버킷(entered/exited), uniqueVisitors(ENTERED distinct), EXIT occurred_at 리스트(③ 입력).
+
+**Files:**
+- Create: `.../administration/adapter/out/persistence/UserActivityLogAnalyticsRepository.java`
+- Test: `.../administration/adapter/out/persistence/impl/UserActivityLogAnalyticsRepositoryImplIT.java`
+
+> 구현은 QueryDSL이므로 클래스명 관례상 `...Repository`(인터페이스)+`...RepositoryImpl` 또는 단일 `@Repository` 클래스. 기존 `AdminPartyroomQueryRepositoryImpl`이 단일 `@Repository` 클래스 패턴이므로 **단일 `@Repository` 클래스**로 작성(인터페이스 불필요).
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`UserActivityLogAnalyticsRepositoryImplIT`:
+```java
+// given: partyroom=1 에 대해
+//   day D-1: ENTERED x3 (user 10,11,10), EXITED x2
+//   day D-0: ENTERED x1 (user 12), EXITED x1
+//   다른 룸/다른 event_type row 다수(격리 검증용)
+// window = [D-1 00:00, now)
+@Test
+void 일자버킷_totals_uniqueVisitors() {
+    List<DailyAttendanceBucket> daily = repo.findDailyAttendance(1L, from, now);
+    assertThat(daily).extracting(DailyAttendanceBucket::date)
+            .containsExactly(dMinus1, dZero);            // KST 달력일 asc
+    assertThat(daily.get(0).entered()).isEqualTo(3);
+    assertThat(daily.get(0).exited()).isEqualTo(2);
+
+    long unique = repo.countUniqueVisitors(1L, from, now); // ENTERED distinct user
+    assertThat(unique).isEqualTo(3);                        // user 10,11,12
+}
+
+@Test
+void EXIT_occurredAt_리스트_윈도우_내_only() {
+    List<LocalDateTime> exits = repo.findExitOccurredAt(1L, from, now);
+    assertThat(exits).hasSize(3);   // D-1 2건 + D-0 1건
+}
+```
+
+- [ ] **Step 2: 실패 확인** — Run → FAIL(클래스 없음).
+
+- [ ] **Step 3: 리포지토리 구현**
+
+```java
+@Repository
+@RequiredArgsConstructor
+public class UserActivityLogAnalyticsRepository {
+
+    private static final String ENTERED = UserActivityEventType.PARTYROOM_ENTERED.name();
+    private static final String EXITED  = UserActivityEventType.PARTYROOM_EXITED.name();
+
+    private final JPAQueryFactory queryFactory;
+
+    /** 일자별 entered/exited 카운트. date = KST 달력일(occurred_at 벽시계). 발생한 날만, asc. */
+    public List<DailyAttendanceBucket> findDailyAttendance(Long partyroomId, LocalDateTime from, LocalDateTime now) {
+        QUserActivityLogData q = QUserActivityLogData.userActivityLogData;
+        DateTemplate<java.sql.Date> day = Expressions.dateTemplate(
+                java.sql.Date.class, "DATE({0})", q.occurredAt);
+
+        // entered/exited 를 조건부 합으로 한 번에 집계
+        NumberExpression<Integer> enteredCase =
+                new CaseBuilder().when(q.eventType.eq(ENTERED)).then(1).otherwise(0).sum();
+        NumberExpression<Integer> exitedCase =
+                new CaseBuilder().when(q.eventType.eq(EXITED)).then(1).otherwise(0).sum();
+
+        return queryFactory
+                .select(day, enteredCase, exitedCase)
+                .from(q)
+                .where(q.partyroomId.eq(partyroomId)
+                        .and(q.eventType.in(ENTERED, EXITED))
+                        .and(q.occurredAt.goe(from))
+                        .and(q.occurredAt.lt(now)))
+                .groupBy(day)
+                .orderBy(day.asc())
+                .fetch()
+                .stream()
+                .map(t -> new DailyAttendanceBucket(
+                        t.get(day).toLocalDate(),
+                        nz(t.get(enteredCase)),
+                        nz(t.get(exitedCase))))
+                .toList();
+    }
+
+    public long countUniqueVisitors(Long partyroomId, LocalDateTime from, LocalDateTime now) {
+        QUserActivityLogData q = QUserActivityLogData.userActivityLogData;
+        Long c = queryFactory
+                .select(q.userAccountId.countDistinct())
+                .from(q)
+                .where(q.partyroomId.eq(partyroomId)
+                        .and(q.eventType.eq(ENTERED))
+                        .and(q.occurredAt.goe(from))
+                        .and(q.occurredAt.lt(now)))
+                .fetchOne();
+        return c == null ? 0L : c;
+    }
+
+    public List<LocalDateTime> findExitOccurredAt(Long partyroomId, LocalDateTime from, LocalDateTime now) {
+        QUserActivityLogData q = QUserActivityLogData.userActivityLogData;
+        return queryFactory
+                .select(q.occurredAt)
+                .from(q)
+                .where(q.partyroomId.eq(partyroomId)
+                        .and(q.eventType.eq(EXITED))
+                        .and(q.occurredAt.goe(from))
+                        .and(q.occurredAt.lt(now)))
+                .fetch();
+    }
+
+    private static int nz(Integer v) { return v == null ? 0 : v; }
+}
+```
+> `DateTemplate`/`CaseBuilder`/`Expressions`는 `com.querydsl.core.types.dsl.*`. `DATE()`는 MySQL 함수, occurred_at 벽시계 그대로 → KST 달력일.
+
+- [ ] **Step 4: 통과 확인** — Run → PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git commit -am "feat: user_activity_log 파티룸 입퇴장 집계 리포지토리"
+```
+
+---
+
+## Chunk 4: ③ 무음 이탈 순수함수
+
+### Task 5: SilenceExitCalculator (구간병합 + 분류)
+
+`Asia/Seoul` epoch-millis 기반. 입력이 전부 `long`이라 DB 없이 단위테스트.
+
+**Files:**
+- Create: `.../administration/application/analytics/PlaybackInterval.java`
+- Create: `.../administration/application/analytics/SilenceExitCalculator.java`
+- Test: `.../administration/application/analytics/SilenceExitCalculatorTest.java`
+
+- [ ] **Step 1: 값 타입 + 실패 테스트**
+
+`PlaybackInterval.java`:
+```java
+/** playback 트랙의 활성 구간 재구성용 입력. 모든 시각 epoch millis(KST 변환 완료). */
+public record PlaybackInterval(long createdAtMs, long endTimeMs) {}
+```
+
+`SilenceExitCalculatorTest.java` — 순수 로직 테스트(JVM TZ 무관 검증 위해 epoch 직접):
+```java
+class SilenceExitCalculatorTest {
+    // 편의: 분 단위 → ms
+    static long m(long min) { return min * 60_000L; }
+
+    @Test
+    void 음악_중_퇴장은_무음카운트_제외() {
+        // 활성구간 [0, 10m). 퇴장 @5m → 음악 중.
+        var r = SilenceExitCalculator.compute(
+                List.of(new PlaybackInterval(0, m(10))),
+                List.of(m(5)), 0, m(20));
+        assertThat(r.exitsDuringSilence()).isEqualTo(0);
+        assertThat(r.totalExits()).isEqualTo(1);
+    }
+
+    @Test
+    void 무음_중_퇴장은_카운트() {
+        // 활성구간 [0,10m). 퇴장 @15m → 무음.
+        var r = SilenceExitCalculator.compute(
+                List.of(new PlaybackInterval(0, m(10))),
+                List.of(m(15)), 0, m(20));
+        assertThat(r.exitsDuringSilence()).isEqualTo(1);
+    }
+
+    @Test
+    void 경계_half_open_start는_음악_end는_무음() {
+        var intervals = List.of(new PlaybackInterval(m(5), m(10)));
+        var r = SilenceExitCalculator.compute(intervals, List.of(m(5), m(10)), 0, m(20));
+        // @5m(start)=음악, @10m(end)=무음  → 무음 1
+        assertThat(r.exitsDuringSilence()).isEqualTo(1);
+    }
+
+    @Test
+    void 스킵_클램프_다음트랙_시작으로_종료() {
+        // t0 [0, endTime=30m] 이지만 t1 이 10m 에 시작 → t0 은 [0,10m) 로 클램프
+        var intervals = List.of(
+                new PlaybackInterval(0, m(30)),
+                new PlaybackInterval(m(10), m(40)));
+        // 퇴장 @35m: t0 클램프로 [0,10m), t1 [10,35m)(now=35 클램프)... now=35m
+        var r = SilenceExitCalculator.compute(intervals, List.of(m(35)), 0, m(35));
+        // @35m == now == t1 end(클램프) → half-open 무음
+        assertThat(r.exitsDuringSilence()).isEqualTo(1);
+    }
+
+    @Test
+    void now_클램프로_totalSilence_음수불가() {
+        // 진행중 트랙 endTime 이 now(20m) 보다 미래(30m)
+        var r = SilenceExitCalculator.compute(
+                List.of(new PlaybackInterval(0, m(30))), List.of(), 0, m(20));
+        assertThat(r.totalSilenceMinutes()).isEqualTo(0);   // [0,20m) 전부 음악
+    }
+
+    @Test
+    void straddle_start_클램프_from으로() {
+        // from=10m, 트랙 [0, 40m] → [10m,40m→now=30m 클램프)=[10,30)
+        var r = SilenceExitCalculator.compute(
+                List.of(new PlaybackInterval(0, m(40))), List.of(m(12)), m(10), m(30));
+        assertThat(r.exitsDuringSilence()).isEqualTo(0);    // @12m 음악 중
+        assertThat(r.totalSilenceMinutes()).isEqualTo(0);
+    }
+
+    @Test
+    void 퇴장_없으면_ratio_null() {
+        var r = SilenceExitCalculator.compute(List.of(), List.of(), 0, m(20));
+        assertThat(r.totalExits()).isEqualTo(0);
+        assertThat(r.silenceExitRatio()).isNull();
+        assertThat(r.totalSilenceMinutes()).isEqualTo(20);  // 전부 무음
+    }
+}
+```
+
+- [ ] **Step 2: 실패 확인** — Run: `./gradlew :app:test --tests '*SilenceExitCalculatorTest'` → FAIL(클래스 없음).
+
+- [ ] **Step 3: 계산기 구현**
+
+`SilenceExitCalculator.java`:
+```java
+public final class SilenceExitCalculator {
+
+    private SilenceExitCalculator() {}
+
+    /** 결과. ratio 는 totalExits==0 이면 null. */
+    public record Result(long totalExits, long exitsDuringSilence,
+                         Double silenceExitRatio, long totalSilenceMinutes) {}
+
+    /**
+     * @param rawIntervals playback 트랙 구간(createdAtMs asc 가정). endTime 은 예정 종료(미래 가능).
+     * @param exitMsList   EXIT occurred_at(ms) 리스트.
+     * @param fromMs/nowMs 윈도우 경계(ms).
+     */
+    public static Result compute(List<PlaybackInterval> rawIntervals,
+                                 List<Long> exitMsList, long fromMs, long nowMs) {
+        // 1) 클램프하여 [start,end) 정규화
+        List<long[]> clamped = new ArrayList<>();
+        for (int i = 0; i < rawIntervals.size(); i++) {
+            PlaybackInterval it = rawIntervals.get(i);
+            long start = Math.max(it.createdAtMs(), fromMs);          // straddle → from 클램프
+            long rawEnd = it.endTimeMs();
+            if (i + 1 < rawIntervals.size()) {                        // 스킵 클램프: 다음 트랙 시작
+                rawEnd = Math.min(rawEnd, rawIntervals.get(i + 1).createdAtMs());
+            }
+            long end = Math.min(rawEnd, nowMs);                       // now 클램프(C2)
+            if (start < end) {
+                clamped.add(new long[]{start, end});
+            }
+        }
+        // 2) 병합(정렬 후 인접/겹침)
+        clamped.sort(Comparator.comparingLong(a -> a[0]));
+        List<long[]> merged = new ArrayList<>();
+        for (long[] iv : clamped) {
+            if (!merged.isEmpty() && iv[0] <= merged.get(merged.size() - 1)[1]) {
+                long[] last = merged.get(merged.size() - 1);
+                last[1] = Math.max(last[1], iv[1]);
+            } else {
+                merged.add(new long[]{iv[0], iv[1]});
+            }
+        }
+        // 3) 퇴장 분류 — half-open [start,end)
+        long silence = 0;
+        for (long exit : exitMsList) {
+            if (!coveredByMusic(merged, exit)) {
+                silence++;
+            }
+        }
+        long totalExits = exitMsList.size();
+        Double ratio = totalExits == 0 ? null
+                : BigDecimal.valueOf((double) silence / totalExits)
+                        .setScale(2, RoundingMode.HALF_UP).doubleValue();
+        // 4) 무음 시간 = 윈도우 − 음악합집합 (union ⊆ 윈도우 보장 → 음수 불가)
+        long musicMs = 0;
+        for (long[] iv : merged) musicMs += (iv[1] - iv[0]);
+        long silenceMs = (nowMs - fromMs) - musicMs;
+        long silenceMinutes = Math.round(silenceMs / 60_000.0);
+        return new Result(totalExits, silence, ratio, silenceMinutes);
+    }
+
+    /** merged(정렬 disjoint)에서 exit 이 [start,end) 에 포함되는지 이진탐색. */
+    private static boolean coveredByMusic(List<long[]> merged, long exit) {
+        int lo = 0, hi = merged.size() - 1;
+        while (lo <= hi) {
+            int mid = (lo + hi) >>> 1;
+            long[] iv = merged.get(mid);
+            if (exit < iv[0]) hi = mid - 1;
+            else if (exit >= iv[1]) lo = mid + 1;   // half-open: end 는 미포함
+            else return true;                        // start <= exit < end
+        }
+        return false;
+    }
+}
+```
+> import: `java.util.*`, `java.math.BigDecimal`, `java.math.RoundingMode`.
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `./gradlew :app:test --tests '*SilenceExitCalculatorTest'`
+Expected: PASS(7 케이스). 필요 시 테스트 JVM에 `-Duser.timezone=UTC` 부여해도 동일 통과(순수 epoch 로직이라 TZ 무관).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git commit -am "feat: 무음 이탈 계산기(SilenceExitCalculator) + 단위테스트"
+```
+
+---
+
+## Chunk 5: DTO + 조합 서비스
+
+### Task 6: 응답/집계 DTO 레코드
+
+**Files (모두 Create):**
+- `.../administration/application/dto/AttendanceAnalytics.java`
+- `.../administration/application/dto/DailyAttendanceBucket.java`
+- `.../administration/adapter/in/web/payload/response/PartyroomAnalyticsResponse.java`
+- `.../administration/adapter/in/web/payload/response/AdminDjHistoryItemResponse.java`
+
+- [ ] **Step 1: 레코드 작성**(테스트 불필요 — 순수 데이터 홀더, 서비스 IT에서 커버)
+
+```java
+// DailyAttendanceBucket.java
+public record DailyAttendanceBucket(LocalDate date, int entered, int exited) {}
+
+// AttendanceAnalytics.java
+public record AttendanceAnalytics(long totalEntered, long totalExited,
+                                  long uniqueVisitors, List<DailyAttendanceBucket> daily) {}
+
+// PartyroomAnalyticsResponse.java  (/analytics 응답)
+public record PartyroomAnalyticsResponse(int windowDays,
+                                         AttendanceAnalytics attendance,
+                                         SilenceExit silenceExit) {
+    public record SilenceExit(boolean approximate, long totalExits,
+                              long exitsDuringSilence, Double silenceExitRatio,
+                              long totalSilenceMinutes) {}
+}
+
+// AdminDjHistoryItemResponse.java  (/dj-history 아이템)
+public record AdminDjHistoryItemResponse(Long playbackId, String trackName,
+                                         Long djUserAccountId, String djNickname,
+                                         String avatarIconUri, String thumbnailImage,
+                                         LocalDateTime playedAt) {}
+```
+> 스펙 §6은 `SilenceExitAnalytics`를 별도 DTO로 명명했으나, 본 플랜은 응답 응집을 위해 `PartyroomAnalyticsResponse.SilenceExit` 중첩 레코드로 둔다(기능 동일, 의도된 divergence). `avatarIconUri`는 미설정 DJ의 경우 `""`(빈 문자열).
+
+- [ ] **Step 2: 컴파일 확인** — Run: `./gradlew :app:compileJava` → 성공.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git commit -am "feat: 행동분석 응답/집계 DTO 레코드"
+```
+
+### Task 7: AdminPartyroomAnalyticsQueryService
+
+②③④ 조합. 진입 시 파티룸 존재검증(404). ④는 playback → 닉네임/아바타 enrichment(기존 detail 전략 재사용).
+
+**Files:**
+- Create: `.../administration/application/service/AdminPartyroomAnalyticsQueryService.java`
+- Test: `.../administration/application/service/AdminPartyroomAnalyticsQueryServiceIT.java`
+
+- [ ] **Step 1: 실패 테스트(IT — 풀 컨텍스트, 시드 후 검증)**
+
+```java
+@Test
+void analytics_없는_방이면_NOT_FOUND_ROOM() {
+    assertThatThrownBy(() -> service.getAnalytics(new PartyroomId(999L), 20))
+            .isInstanceOf(PartyroomException.class); // NOT_FOUND_ROOM
+}
+
+@Test
+void analytics_days_범위밖이면_예외() {
+    assertThatThrownBy(() -> service.getAnalytics(existingRoomId, 0))
+            .isInstanceOf(BadRequestException.class);
+    assertThatThrownBy(() -> service.getAnalytics(existingRoomId, 91))
+            .isInstanceOf(BadRequestException.class);
+}
+
+@Test
+void analytics_집계와_무음지표_조합() {
+    // given: 방에 ENTERED/EXITED 로그 + playback 트랙 시드
+    PartyroomAnalyticsResponse r = service.getAnalytics(existingRoomId, 20);
+    assertThat(r.attendance().totalEntered()).isEqualTo(...);
+    assertThat(r.silenceExit().approximate()).isTrue();
+    assertThat(r.silenceExit().totalExits())
+            .isEqualTo(r.attendance().totalExited());   // 불변식(§4.1)
+}
+
+@Test
+void djHistory_created_at_desc_페이지() {
+    Page<AdminDjHistoryItemResponse> page = service.getDjHistory(existingRoomId, PageRequest.of(0, 2));
+    assertThat(page.getContent()).isSortedAccordingTo(
+            Comparator.comparing(AdminDjHistoryItemResponse::playedAt).reversed());
+}
+```
+
+- [ ] **Step 2: 실패 확인** — Run → FAIL(서비스 없음).
+
+- [ ] **Step 3: 서비스 구현**
+
+```java
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminPartyroomAnalyticsQueryService {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+    private static final int MIN_DAYS = 1;
+    private static final int MAX_DAYS = 90;
+
+    private final PartyroomAggregatePort aggregatePort;
+    private final UserActivityLogAnalyticsRepository activityRepo;
+    private final MemberRepository memberRepository;
+
+    public PartyroomAnalyticsResponse getAnalytics(PartyroomId partyroomId, int days) {
+        if (days < MIN_DAYS || days > MAX_DAYS) {
+            throw new BadRequestException("ADM-PR-002", "days out of range (1..90): " + days);
+        }
+        requireRoom(partyroomId);                                   // 404 게이트(S2)
+
+        LocalDateTime now = LocalDateTime.now(SEOUL);
+        LocalDateTime from = now.minusDays(days);
+        long pid = partyroomId.getId();
+
+        // ② attendance
+        List<DailyAttendanceBucket> daily = activityRepo.findDailyAttendance(pid, from, now);
+        long totalEntered = daily.stream().mapToLong(DailyAttendanceBucket::entered).sum();
+        long totalExited  = daily.stream().mapToLong(DailyAttendanceBucket::exited).sum();
+        long unique = activityRepo.countUniqueVisitors(pid, from, now);
+        AttendanceAnalytics attendance =
+                new AttendanceAnalytics(totalEntered, totalExited, unique, daily);
+
+        // ③ silence-exit
+        long fromMs = ms(from), nowMs = ms(now);
+        List<PlaybackInterval> intervals = aggregatePort
+                .findPlaybackForInterval(partyroomId, from, now).stream()
+                .filter(p -> p.getEndTime() != null)   // endTime 은 Long(nullable) — 언박싱 NPE 방어(레거시/엣지 row)
+                .map(p -> new PlaybackInterval(ms(p.getCreatedAt()), p.getEndTime()))
+                .toList();
+        List<Long> exits = activityRepo.findExitOccurredAt(pid, from, now).stream()
+                .map(this::ms).toList();
+        SilenceExitCalculator.Result s =
+                SilenceExitCalculator.compute(intervals, exits, fromMs, nowMs);
+        var silence = new PartyroomAnalyticsResponse.SilenceExit(
+                true, s.totalExits(), s.exitsDuringSilence(),
+                s.silenceExitRatio(), s.totalSilenceMinutes());
+
+        return new PartyroomAnalyticsResponse(days, attendance, silence);
+    }
+
+    public Page<AdminDjHistoryItemResponse> getDjHistory(PartyroomId partyroomId, Pageable pageable) {
+        requireRoom(partyroomId);
+        Page<PlaybackData> page = aggregatePort.findPlaybackHistory(partyroomId, pageable);
+        // 닉네임/아바타 enrichment (detail() 전략 재사용). 빈 페이지면 findAllByUserAccountIdIn([]) 도 안전 → 별도 분기 불필요.
+        List<Long> userIds = page.getContent().stream()
+                .map(p -> p.getUserId().getUid()).distinct().toList();
+        Map<Long, MemberData> byId = userIds.isEmpty() ? Map.of()
+                : memberRepository.findAllByUserAccountIdIn(userIds).stream()
+                        .collect(Collectors.toMap(MemberData::getUserAccountId, m -> m, (a, b) -> a));
+        return page.map(p -> {
+            MemberData m = byId.get(p.getUserId().getUid());
+            return new AdminDjHistoryItemResponse(
+                    p.getId(), p.getName(), p.getUserId().getUid(),
+                    nickname(m), avatarUri(m), p.getThumbnailImage(), p.getCreatedAt());
+        });
+    }
+
+    private void requireRoom(PartyroomId id) {
+        aggregatePort.findPartyroomById(id.getId())
+                .orElseThrow(() -> ExceptionCreator.create(PartyroomException.NOT_FOUND_ROOM));
+    }
+    private long ms(LocalDateTime t) { return t.atZone(SEOUL).toInstant().toEpochMilli(); }
+    private static String nickname(MemberData m) {
+        return (m == null || m.getProfileData() == null) ? null : m.getProfileData().getNicknameValue();
+    }
+    private static String avatarUri(MemberData m) {
+        if (m == null || m.getProfileData() == null || m.getProfileData().getAvatarSetting() == null) {
+            return null;
+        }
+        return m.getProfileData().getAvatarSetting().getAvatarIconUriValue();  // 미설정 시 "" 반환(null 아님)
+    }
+}
+```
+> 시그니처 확인됨: 아바타 URI = `profileData.getAvatarSetting().getAvatarIconUriValue()` (`AvatarSetting.java` — 미설정 시 빈 문자열 반환). `PlaybackData.getUserId()`는 `UserId` VO → `.getUid()`. `getCreatedAt()`은 `BaseEntity` 제공.
+> `BadRequestException`은 `com.pfplaybackend.api.common.exception.http.BadRequestException`(컨트롤러에서 이미 사용). `ExceptionCreator`/`PartyroomException.NOT_FOUND_ROOM`은 detail()과 동일.
+
+- [ ] **Step 4: 통과 확인** — Run: `./gradlew :app:test --tests '*AdminPartyroomAnalyticsQueryServiceIT'` → PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git commit -am "feat: 파티룸 행동분석 조합 서비스(analytics/dj-history)"
+```
+
+---
+
+## Chunk 6: 컨트롤러 엔드포인트 + 회귀 게이트
+
+### Task 8: AdminPartyroomQueryController 엔드포인트 2개
+
+**Files:**
+- Modify: `.../administration/adapter/in/web/AdminPartyroomQueryController.java`
+- Test: `.../administration/adapter/in/web/AdminPartyroomAnalyticsControllerTest.java`
+
+- [ ] **Step 1: 실패 테스트(MockMvc — 기존 컨트롤러 테스트 패턴)**
+
+```java
+@Test
+void analytics_비어드민_403() { /* @adminAuth false → 403 */ }
+
+@Test
+void analytics_200_스키마() {
+    // service mock → JSON 경로 검증: $.data.attendance, $.data.silenceExit.approximate=true
+}
+
+@Test
+void djHistory_size_200_초과_clamp() {
+    // size=500 요청 → service 에 size=200 으로 전달됐는지(Pageable captor)
+}
+
+@Test
+void analytics_없는방_404() { /* service 가 NOT_FOUND_ROOM → GlobalExceptionHandler 404 */ }
+
+@Test
+void analytics_days_범위밖_400() {
+    // service mock 이 BadRequestException("ADM-PR-002") 던지도록 stub → HTTP 400 계약 고정(스펙 §4.1)
+    // GET .../analytics?days=0 → status().isBadRequest()
+    // GET .../analytics?days=91 → status().isBadRequest()
+}
+```
+> days 범위 400은 서비스가 던지므로 컨트롤러 테스트는 service mock 이 `BadRequestException` 던질 때 **HTTP 400 상태코드**가 나오는지만 검증(경계값 실제 판정은 Task 7 서비스 IT가 담당). 이로써 스펙 §4.1 "400 reject" 계약이 상태코드 레벨에서 잠긴다.
+
+- [ ] **Step 2: 실패 확인** — Run → FAIL(엔드포인트 없음).
+
+- [ ] **Step 3: 엔드포인트 추가**
+
+`AdminPartyroomQueryController`에 필드 주입 추가(`private final AdminPartyroomAnalyticsQueryService analyticsService;`) 후:
+```java
+@Operation(summary = "B-3 룸 행동분석 (입퇴장 집계 + 무음이탈 근사)")
+@PreAuthorize("@adminAuth.isAdmin()")
+@GetMapping("/{partyroomId}/analytics")
+public ResponseEntity<ApiCommonResponse<PartyroomAnalyticsResponse>> analytics(
+        @PathVariable Long partyroomId,
+        @RequestParam(defaultValue = "20") int days) {
+    return ResponseEntity.ok(ApiCommonResponse.success(
+            analyticsService.getAnalytics(new PartyroomId(partyroomId), days)));
+}
+
+@Operation(summary = "B-4 룸 디제잉 이력 (페이지네이션)")
+@PreAuthorize("@adminAuth.isAdmin()")
+@GetMapping("/{partyroomId}/dj-history")
+public ResponseEntity<ApiCommonResponse<Page<AdminDjHistoryItemResponse>>> djHistory(
+        @PathVariable Long partyroomId,
+        @PageableDefault(size = 20) Pageable pageable) {
+    // size 만 200 캡(기존 list 패턴). 정렬은 리포지토리가 created_at DESC 로 고정(§9)하므로 Sort 는 전달 무의미.
+    Pageable bounded = pageable.getPageSize() > MAX_PAGE_SIZE
+            ? PageRequest.of(pageable.getPageNumber(), MAX_PAGE_SIZE)
+            : pageable;
+    return ResponseEntity.ok(ApiCommonResponse.success(
+            analyticsService.getDjHistory(new PartyroomId(partyroomId), bounded)));
+}
+```
+> `MAX_PAGE_SIZE=200` 상수는 컨트롤러에 이미 존재(재사용). days 범위검증은 서비스가 `BadRequestException`(400) 던짐 → 기존 매핑.
+
+- [ ] **Step 4: 통과 확인** — Run: `./gradlew :app:test --tests '*AdminPartyroomAnalyticsControllerTest'` → PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git commit -am "feat: 어드민 파티룸 analytics/dj-history 엔드포인트"
+```
+
+### Task 9: 전체 회귀 + 부팅 게이트 + ArchUnit
+
+- [ ] **Step 1: 모듈 전체 테스트**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test`
+Expected: 신규 포함 전체 GREEN. 특히 `CrossContextDependencyTest`/ArchUnit(administration↔party 경계) 통과 — playback 접근이 `PartyroomAggregatePort` 경유인지 확인.
+
+- [ ] **Step 2: 로컬 docker 풀부팅(fresh DB) 게이트**
+
+`./gradlew :app:bootJar` 후 `-p pfplay-local --env-file .env.local` 컨테이너 기동 → V34 적용 + validate 통과 + 앱 부팅 성공(`reference_local_boot_gate_jpql_startup_bugs`).
+
+- [ ] **Step 3: 라이브 스모크(어드민 인증)**
+
+로컬 부팅 상태에서 admin 세션으로 `GET /api/v1/admin/partyrooms/{id}/analytics?days=20` 및 `/dj-history` 200 확인. (어드민은 별도 브라우저/쿠키 — `reference_admin_login_shared_cookie_half_identity`.)
+
+- [ ] **Step 4: 최종 커밋(있으면)**
+
+```bash
+git commit -am "test: 행동분석 회귀/부팅 게이트 반영"
+```
+
+---
+
+## 실행 후 확인 체크리스트
+- [ ] `days` 범위 400, 없는 방 404, size 200 clamp 동작.
+- [ ] `silenceExit.approximate=true` 상시, `totalExits==attendance.totalExited` 불변식.
+- [ ] daily 버킷 KST 달력일 asc, 발생일만.
+- [ ] Flyway 슬롯 머지 직전 재확정(`uniq -d`).
+- [ ] 어드민 SPA UI는 **후속 슬라이스**(본 플랜 밖).

--- a/docs/superpowers/specs/2026-07-09-admin-partyroom-behavior-analytics-design.md
+++ b/docs/superpowers/specs/2026-07-09-admin-partyroom-behavior-analytics-design.md
@@ -1,0 +1,215 @@
+# 어드민 파티룸 행동분석 (Behavior Analytics) — 백엔드 설계
+
+- 작성일: 2026-07-09
+- 범위: **플랫폼 백엔드 only** (어드민 SPA UI는 후속 슬라이스)
+- BC: `administration` (Party 데이터는 `PartyroomAggregatePort` 경유)
+- 상태: Draft → 스펙 리뷰 대기
+
+## 1. 배경 & 목표
+
+어드민 콘솔에서 **특정 파티룸을 골라 상세로 들어가** 고객 행동을 진단하는 기능. 이미 프론트→Amplitude로 집계·퍼널 분석이 있으나, 그것은 **서비스 전체 aggregate**다. 본 기능은 성격이 다르다:
+
+- **운영/포렌식 드릴다운**: "이 방 하나가 어떻게 굴러갔나"를 파고든다.
+- Amplitude가 답하지 못하는 것: 서버 영속 데이터 기반의 방별 사실(fact) 조회.
+
+핵심 가설(사용자 제기): **"사람들이 파티룸을 나가는 이유가 노래가 활성화되지 않아서(무음)일 것"** — 이를 서버 데이터로 검증한다.
+
+## 2. 스코프
+
+| # | 기능 | 상태 |
+|---|------|------|
+| ① | 파티룸+호스트 목록, 최근 개설순 | **이미 구현됨** — `GET /api/v1/admin/partyrooms`가 `sort=createdAt DESC` 기본 + host 필터/닉네임 노출. **본 스펙 제외** |
+| ② | 최근 N일 입장/퇴장 집계 + 일자별 추이 | 신규 |
+| ③ | "무음 이탈" 가설 지표 (근사) | 신규 |
+| ④ | 디제잉 이력 페이지네이션 | 신규 |
+
+Non-goals (명시적 제외):
+- 개별 입장/퇴장 이벤트 raw 나열(드릴다운) — 데이터 폭발 회피. 필요 시 후속.
+- 리액션/채팅 밀도 — **서버 미영속**(Amplitude 전용). 본 기능으로 불가.
+- playback 활성화 구간의 **정확한** FSM 이력 — 전용 로깅 없음. ③은 근사만.
+- 어드민 SPA 화면.
+
+## 3. 데이터 소스 (기존 스키마, 신규 저장 없음)
+
+| 소스 | 용도 | 근거 |
+|------|------|------|
+| `user_activity_log` (V10, append-only) | ② 입퇴장, ③ 퇴장 시각 | `event_type IN (PARTYROOM_ENTERED, PARTYROOM_EXITED)`, `partyroom_id`, `occurred_at`. administration BC 소유 |
+| `playback` (V1) | ③ 활성구간, ④ DJ 이력 | `user_id`(DJ), `name`(트랙명), `created_at`(시작), `end_time`(예정종료 epoch ms), `thumbnail_image`, `partyroom_id`. Party BC |
+| `member`/`profile` | ④ DJ 닉네임/아바타 | 기존 `detail()`의 `memberRepository.findAllByUserAccountIdIn` 재사용 |
+
+> **주의 — 인덱스 현황(§7)**: `user_activity_log`는 `partyroom_id` 인덱스가 **없다**. `playback`은 단일컬럼 `playback_partyroom_id_IDX (partyroom_id)`가 **이미 존재**(V1)하나 `created_at` 정렬을 커버하지 못해 복합으로 대체한다.
+
+## 4. API 설계
+
+기존 `AdminPartyroomQueryController` 계열에 추가. 모든 엔드포인트 `@PreAuthorize("@adminAuth.isAdmin()")`, `ApiCommonResponse<T>` 래핑.
+
+### 4.1 `GET /api/v1/admin/partyrooms/{partyroomId}/analytics` — ②+③
+
+Query param: `days` (기본 20, **1~90 범위 밖은 400** `ADM-PR-002` reject — 파티션 스캔 방어).
+
+윈도우: `[now - days, now)`. 모든 시각 계산은 `Asia/Seoul` 고정 zone(§5.0). `daily` 버킷의 날짜는 **KST 달력일**(`date(occurred_at)`은 벽시계 그대로라 KST일과 일치; UTC 변환 삽입 금지).
+
+```jsonc
+{
+  "windowDays": 20,
+  "attendance": {                       // ② — user_activity_log
+    "totalEntered": 128,
+    "totalExited": 121,
+    "uniqueVisitors": 47,               // 윈도우 내 PARTYROOM_ENTERED 의 distinct user_account_id
+    "daily": [                          // 발생한 날만, KST 달력일 asc (윈도우는 자정 미정렬 → days=90이면 최대 91일 걸침)
+      { "date": "2026-06-20", "entered": 12, "exited": 9 }
+    ]
+  },
+  "silenceExit": {                      // ③ — playback 근사 (§5)
+    "approximate": true,               // 항상 true — 근사 지표임을 명시(오독 방지)
+    "totalExits": 121,                 // == attendance.totalExited (같은 윈도우·같은 이벤트원). 항상 동일
+    "exitsDuringSilence": 51,
+    "silenceExitRatio": 0.42,          // 소수 2자리 HALF_UP. totalExits=0 → null
+    "totalSilenceMinutes": 137
+  }
+}
+```
+
+- **404(S2)**: 집계 전 서비스가 `PartyroomAggregatePort.findPartyroomById`로 존재를 먼저 검증. 없으면 `NOT_FOUND_ROOM` → `GlobalExceptionHandler` 404. (검증 없으면 없는 방도 빈 200이 나오므로 필수.)
+- `uniqueVisitors`: 윈도우 내 **ENTERED 이벤트 기준** distinct. 윈도우 이전 입장해 윈도우 안에서 EXITED만 있는 유저는 **제외**.
+- `daily`는 이벤트 0인 날을 채우지 않음(발생한 날만) — 프론트에서 축 렌더(§9 확정).
+
+### 4.2 `GET /api/v1/admin/partyrooms/{partyroomId}/dj-history` — ④
+
+Query: 표준 `Pageable` (`page`, `size`; `size`는 기존 컨트롤러처럼 **200 초과 시 200으로 clamp**, reject 아님). 정렬 **`created_at DESC` 고정**(클라 sort param 무시 — §9 확정). 404 동작은 §4.1과 동일(집계 전 파티룸 존재 검증).
+
+```jsonc
+// Page<AdminDjHistoryItemResponse>
+{
+  "content": [
+    {
+      "playbackId": 90123,
+      "trackName": "...",
+      "djUserAccountId": 55,
+      "djNickname": "...",         // null-tolerant (탈퇴/프로필 미완)
+      "avatarIconUri": "...",
+      "thumbnailImage": "...",
+      "playedAt": "2026-07-09T14:02:11"   // created_at
+    }
+  ],
+  "pageable": { ... }, "totalElements": 340, ...
+}
+```
+
+## 5. ③ 무음 이탈 알고리즘 (근사)
+
+### 5.0 시간축 통일 (C1 — 반드시 선결)
+세 시각의 타입이 다르다: `occurred_at`·`created_at`은 오프셋 없는 **벽시계**(`LocalDateTime`/`DATETIME`), `end_time`은 **절대 epoch millis**(`bigint`), `now`도 벽시계. 유일하게 올바른 다리는 고정 zone `Asia/Seoul`(한국은 DST 없음, +09:00 고정)이다. **모든 시각을 epoch millis(`long`)로 통일**해 구간 연산을 수행한다:
+
+```
+static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");   // JVM 기본 TZ에 의존하지 않음(CI/테스트 TZ 무관)
+long ms(LocalDateTime t) = t.atZone(SEOUL).toInstant().toEpochMilli();
+// end_time 은 이미 epoch millis 이므로 그대로 사용.
+```
+③의 순수함수 단위테스트 입력도 이 결정에 맞춰 `long`(epoch millis)로 고정한다.
+
+### 5.1 활성구간(음악 재생 중) 집합 생성
+입력: partyroom의 playback 행 — **정렬 `created_at ASC`**, 아래 두 부분을 합친 것.
+- (a) 윈도우 내 트랙: `created_at ∈ [from, now)`.
+- (b) **straddle 트랙(S1)**: `created_at < from` 중 **가장 최신 1건**. 이 트랙이 `from` 이후까지 재생 중이었을 수 있으므로 반드시 포함한다(누락 시 윈도우 초반이 무음으로 오분류되어 silence 비율이 부풀려짐).
+
+각 트랙 → 반열림 구간 `[startMs, endMs)`:
+- `startMs = max(ms(created_at), fromMs)` — straddle 트랙 시작을 `from`으로 클램프.
+- `rawEnd  = min(end_time, next.created_at_ms)` — 스킵으로 실제 종료가 앞당겨진 경우 다음 트랙 시작으로 클램프(예정종료 과대추정 완화). 다음 트랙이 없으면 `end_time`.
+- `endMs   = min(rawEnd, nowMs)` — **윈도우 끝(now) 클램프(C2)**. 진행 중 트랙의 예정 `end_time`이 미래여도 union이 윈도우를 넘지 않게 한다.
+- `startMs >= endMs`면 버림(빈 구간).
+
+겹치거나 인접한 구간은 병합 → 정규화된 disjoint 구간 집합 `intervals`(각 `[start, end)`).
+
+### 5.2 퇴장 분류
+각 `PARTYROOM_EXITED`의 `exitMs = ms(occurred_at)`가 **어떤 `[start, end)`에도 포함되지 않으면 무음 중 이탈**.
+- 경계 규약(S3): **half-open `[start, end)`** — `exitMs == start`는 음악 중, `exitMs == end`는 무음. (병합 규약과 일관.)
+- 정렬된 `intervals`에 대해 이진탐색 O(log n).
+
+### 5.3 집계
+- `totalExits` = 윈도우 내 EXITED 수.
+- `exitsDuringSilence` = 위 무음 분류 수.
+- `silenceExitRatio` = `exitsDuringSilence / totalExits`, **소수 2자리 반올림(HALF_UP)**. `totalExits == 0` → `null`.
+- `totalSilenceMinutes` = `(nowMs − fromMs) − Σ(intervals 길이)`, 분 단위 반올림. 5.1의 now/from 클램프로 union ⊆ 윈도우가 보장되어 **음수 불가**.
+
+### 5.4 명시적 한계 (응답 문서/코드 주석에 남김)
+- `end_time`은 **예정** 종료 → 스킵 시 과대추정 가능(연속 트랙이면 §5.1 `rawEnd` 클램프로 상쇄, 마지막 트랙만 잔여 오차).
+- 리액션/채팅으로 인한 "체감 활성"은 못 봄 — 오직 **트랙 재생 여부** 기준.
+- EXIT은 presence grace(pending_exit) 이후 시각이라 실제 이탈과 수 초~수십 초 오차 가능.
+- **재입장/중복**: 같은 유저가 여러 번 입퇴장하면 각 EXIT을 독립 카운트(uniqueVisitors와 별개).
+- 결론: **정밀 지표가 아니라 가설의 방향성 신호**. 응답에 `approximate: true` 플래그를 노출한다(§9 확정).
+
+## 6. 구현 배치 (헥사고날, 기존 패턴 미러링)
+
+```
+administration/adapter/in/web/
+  AdminPartyroomQueryController            (기존 확장 — analytics, dj-history 엔드포인트 추가)
+administration/application/service/
+  AdminPartyroomAnalyticsQueryService      (신규; read-only. 조회부하를 detail 서비스와 분리)
+administration/application/dto/
+  AttendanceAnalytics, SilenceExitAnalytics, DailyAttendanceBucket   (신규)
+administration/adapter/out/persistence/
+  UserActivityLogAnalyticsRepository(Custom/Impl)  (신규; QueryDSL, BC 내부)
+party/domain/port/PartyroomAggregatePort   (메서드 추가)
+  + findPlaybackForInterval(PartyroomId, LocalDateTime from, LocalDateTime now): List<PlaybackData>
+      // ③ — created_at ∈ [from, now) 전부 + created_at < from 중 최신 1건(straddle, S1). created_at ASC.
+  + findPlaybackHistory(PartyroomId, Pageable): Page<PlaybackData>          // ④
+party/adapter/out/persistence/...          (위 포트 구현; QueryDSL)
+```
+
+- **파티룸 존재 검증 먼저(S2)**: 두 엔드포인트 모두 서비스 진입 시 `aggregatePort.findPartyroomById`로 404 판정 후 집계 진행.
+- **BC 경계**: ②는 administration이 자기 소유 `user_activity_log`를 직접 질의. ③④의 `playback`은 반드시 `PartyroomAggregatePort` 경유(ArchUnit Task 18 규칙 유지). ④의 닉네임/아바타 enrichment는 administration 측 `memberRepository`로 수행(기존 `detail()`과 동일 전략).
+- 집계/구간연산은 **서비스 계층**에서(순수 함수로 분리해 단위테스트 용이 — §5는 `long` 입력 순수함수). 리포지토리는 raw row만 반환.
+- ②의 집계(GROUP BY date)는 DB에서 수행(QueryDSL `date()` 그룹핑, KST 벽시계) vs 앱에서 수행 — **DB 그룹핑 권장**(전송량 축소). uniqueVisitors는 ENTERED 필터 후 `countDistinct(user_account_id)`.
+
+## 7. 성능 & 마이그레이션 (신규 인덱스)
+
+20일 윈도우는 `occurred_at`/`created_at` 파티션·범위로 좁혀지나, 바쁜 방/시기엔 전체 입퇴장·재생 스캔 부담. 신규 마이그레이션으로 범위/정렬 최적화 인덱스 추가:
+
+```sql
+-- V<next>: admin behavior-analytics range/sort indexes
+-- user_activity_log: partyroom_id 인덱스 신규(기존 부재).
+ALTER TABLE user_activity_log
+  ADD INDEX idx_ual_partyroom_event_time (partyroom_id, event_type, occurred_at DESC);
+-- playback: 기존 단일컬럼 playback_partyroom_id_IDX(V1)를 복합으로 대체(신규가 완전 상위집합 → 중복 제거).
+ALTER TABLE playback
+  ADD INDEX idx_playback_partyroom_time (partyroom_id, created_at DESC);
+DROP INDEX playback_partyroom_id_IDX ON playback;
+```
+
+> 엔티티 `PlaybackData`의 `@Index(name="playback_partyroom_id_IDX", ...)`도 신규 복합 인덱스로 **동시 교체**해야 한다(미교체 시 Hibernate `ddl-auto=validate`/부팅 게이트에서 스키마 drift로 실패). 마이그레이션 DROP과 엔티티 애노테이션을 한 커밋에 묶는다.
+
+- **컬럼 순서(S4)**: `user_activity_log`는 `(partyroom_id, event_type, occurred_at)`. 등가 필터(`partyroom_id`, `event_type IN/=`)를 앞에, 범위/정렬(`occurred_at`)을 뒤에 둔다. ②는 `event_type IN (ENTERED,EXITED)` + GROUP BY date, ③은 `event_type = EXITED` — **둘 다 이 하나의 인덱스로 커버**. (단순 `(partyroom_id, occurred_at)`은 event_type을 잔여 필터로 남겨 ②의 선택도가 떨어짐.)
+- **쓰기 비용 저울질(S4)**: `user_activity_log`는 append-only **핫 라이트 경로**라 인덱스 1개 추가는 매 INSERT에 소폭 비용. 그러나 (a) 어드민 조회의 스캔 폭발 방어 이득이 크고, (b) 인덱스 선두가 write 분산되는 `partyroom_id`라 hot-spot 삽입은 아님 → **추가 채택**. 향후 write 병목 관측 시 재검토.
+- `user_activity_log`는 파티셔닝 테이블 → 인덱스는 각 파티션에 로컬 생성(정상).
+- **Flyway 슬롯 확정 규칙**: V32/V33은 **미머지** `feature/vdj-bot-model-overhaul`가 점유. 본 슬라이스 머지 직전에 `origin/develop` HEAD와 인플라이트 마이그레이션 PR을 대조해 **충돌 없는 다음 슬롯**을 확정(`uniq -d` 사전 스캔). 문서상 잠정 `V34`로 표기하되 확정 아님.
+- `playback` 인덱스는 인덱스 포함 승인 결정의 자연스러운 확장 — ③④가 같은 `partyroom_id` 접근이므로 동반 추가.
+
+## 8. 테스트 전략
+
+기존 IT 패턴(`UserActivityLogListener*IT`, `AdminPartyroomQueryServiceTest`, `*RepositoryImplIT`) 미러링.
+
+- **② 집계**: activity_log 시드(입장 N·퇴장 M, 여러 날짜·유저) → totals·uniqueVisitors·일자버킷 검증. 윈도우 경계(`now-days` 포함/`now` 제외) 케이스.
+- **③ 구간분류 (순수함수 단위테스트 우선; 입력 `long` epoch millis)**:
+  - 음악 중 퇴장 / 무음 중 퇴장 / 트랙 없음(전부 무음) / 스킵 클램프(`rawEnd`).
+  - **경계(S3)**: `exitMs == start` → 음악 중, `exitMs == end` → 무음(half-open).
+  - **now 클램프(C2)**: 진행 중 트랙의 `end_time`이 윈도우 끝(now)보다 미래 → `endMs=now`, `totalSilenceMinutes` 음수 아님.
+  - **straddle(S1)**: `from` 이전 시작해 `from` 이후까지 재생 중인 트랙 → 윈도우 초반 EXIT이 음악 중으로 분류.
+  - **TZ(C1)**: `Asia/Seoul` 변환이 CI TZ와 무관하게 동일 결과(테스트 JVM TZ를 UTC로 강제해도 통과).
+  - `totalExits=0` → ratio null.
+- **④ 페이지네이션**: `created_at DESC` 순서, size 캡, 탈퇴 유저 닉네임 null-tolerant, 빈 페이지.
+- **인증**: 비-admin 403(기존 `@adminAuth` 테스트 패턴).
+- **부팅 게이트**: 신규 QueryDSL `@Query`/마이그레이션은 로컬 docker 풀부팅(fresh DB)로 검증(JPQL/Flyway 오류는 부팅에서만 잡힘).
+
+## 9. 결정 사항 (스펙 리뷰에서 확정, 2026-07-09)
+
+1. `daily` 0인 날 **안 채움**(발생한 날만) — YAGNI, 프론트 축 렌더.
+2. `silenceExit.approximate: true` **노출** — 근사 지표 오독 방지, 저비용 정직성.
+3. ④ 정렬 **`created_at DESC` 고정** — 화이트리스트 정렬은 후속 YAGNI.
+4. 컨트롤러는 **기존 `AdminPartyroomQueryController` 확장**(같은 리소스 하위 경로라 응집적). `@adminAuth`·`ApiCommonResponse` 일관 유지. (서비스는 조회부하 분리 위해 `AdminPartyroomAnalyticsQueryService` 신규.)
+5. `playback` 인덱스 **동반 추가**(§7, ③④ 동일 접근 경로).
+
+## 10. 후속 슬라이스 (본 스펙 밖)
+- 어드민 SPA 화면(카드·일자별 차트·이력 테이블·무음이탈 배지).
+- ③ 정밀화 옵션: `PLAYBACK_ACTIVATED/DEACTIVATED` 전용 로깅(전용 테이블 or user_activity_log 핸들러 추가) — 소급 데이터 없음, 오늘부터 축적. 파킹된 *재생 세션 명시 FSM*·*아웃박스* 설계와 연결.
+- 개별 입퇴장 raw 타임라인 드릴다운.

--- a/docs/superpowers/specs/2026-07-09-admin-partyroom-behavior-analytics-design.md
+++ b/docs/superpowers/specs/2026-07-09-admin-partyroom-behavior-analytics-design.md
@@ -177,7 +177,7 @@ ALTER TABLE playback
 DROP INDEX playback_partyroom_id_IDX ON playback;
 ```
 
-> 엔티티 `PlaybackData`의 `@Index(name="playback_partyroom_id_IDX", ...)`도 신규 복합 인덱스로 **동시 교체**해야 한다(미교체 시 Hibernate `ddl-auto=validate`/부팅 게이트에서 스키마 drift로 실패). 마이그레이션 DROP과 엔티티 애노테이션을 한 커밋에 묶는다.
+> 엔티티 `PlaybackData`의 `@Index(name="playback_partyroom_id_IDX", ...)`도 신규 복합 인덱스로 **동시 교체**한다. (주의: Hibernate `validate`는 테이블/컬럼/타입만 검증하고 secondary index는 검증하지 않으므로 미교체가 부팅을 깨진 않는다 — 부팅 게이트에 의존하지 말 것. 다만 `create-drop` 테스트 컨텍스트의 생성 DDL 정합을 위해 애노테이션 동기화는 위생 요건.) 마이그레이션 DROP과 엔티티 애노테이션을 한 커밋에 묶는다.
 
 - **컬럼 순서(S4)**: `user_activity_log`는 `(partyroom_id, event_type, occurred_at)`. 등가 필터(`partyroom_id`, `event_type IN/=`)를 앞에, 범위/정렬(`occurred_at`)을 뒤에 둔다. ②는 `event_type IN (ENTERED,EXITED)` + GROUP BY date, ③은 `event_type = EXITED` — **둘 다 이 하나의 인덱스로 커버**. (단순 `(partyroom_id, occurred_at)`은 event_type을 잔여 필터로 남겨 ②의 선택도가 떨어짐.)
 - **쓰기 비용 저울질(S4)**: `user_activity_log`는 append-only **핫 라이트 경로**라 인덱스 1개 추가는 매 INSERT에 소폭 비용. 그러나 (a) 어드민 조회의 스캔 폭발 방어 이득이 크고, (b) 인덱스 선두가 write 분산되는 `partyroom_id`라 hot-spot 삽입은 아님 → **추가 채택**. 향후 write 병목 관측 시 재검토.


### PR DESCRIPTION
## 개요
어드민 방별 행동분석 드릴다운 백엔드(analytics/dj-history 엔드포인트) + Flyway V34.

Closes #324

## 주요 변경
- 파티룸 analytics 엔드포인트(입퇴장 집계·무음이탈 근사·방별 지표)
- dj-history(디제잉 이력) — avatarIconUri member 부재 시 null→"" 계약 일치
- 조합 서비스 cross-BC javadoc 정확화
- Flyway **V34**(`admin_analytics_indexes`) — develop V33 다음 연속

## 검증
- 로컬 **FULL 유닛+IT 그린(0 실패)**
- fresh DB Flyway **V1→V34 validate** + 클린 부팅(`Successfully validated 34 migrations`, `now at version v34`, Started 62.7s)
- develop(vdj virtualcrew 리네임 + #319 IT 하네스 + #320 flaky fix) 위로 **리베이스 충돌 0·컴파일 정합**

## 비고
- 어드민 분석 UI는 별도 후속(본 PR은 백엔드 한정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)