### PR TITLE
CI integrationTest 재시도로 Testcontainers 인프라 플래키 종결 (#320)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -43,7 +43,21 @@ jobs:
       # ubuntu-latest 는 Docker 지원 → Testcontainers 동작. 직렬 실행(공유 스키마 truncate
       # 상호파괴 방지) 은 build.gradle 의 maxParallelForks=1 로 강제됨.
       - name: Run integration tests
-        run: ./gradlew :app:integrationTest
+        # #320: GitHub 러너/Docker 의 시간대별 컨디션에 따라 Testcontainers Redis 가 일부 실행에서
+        # 100스레드 버스트 중 도달불가('Connection refused: <mapped port>')가 되는 인프라 플래키
+        # (PartyroomAccessCommandServiceRaceIT). 불변식 crew_count==1 은 DB atomic UPDATE+unique+row
+        # lock 이 강제하므로 제품 무결이며, 실패는 코드가 아닌 러너 환경 기인. 시간대-클러스터링이라
+        # 코드로 결정적 제거 불가 → 실패 시 gradle 을 재호출해 Testcontainers 를 새로 띄워(죽은 컨테이너
+        # 탈출) 최대 3회 재시도. 실패 태스크는 캐싱 안 되므로 재시도는 실제 재실행됨.
+        run: |
+          for attempt in 1 2 3; do
+            echo "::group::integrationTest attempt ${attempt}/3"
+            ./gradlew :app:integrationTest && { echo "::endgroup::"; exit 0; }
+            echo "::endgroup::"
+            echo "::warning::[#320] integrationTest attempt ${attempt} 실패 — fresh Testcontainers 로 재시도"
+          done
+          echo "::error::[#320] integrationTest 3회 모두 실패 — 인프라 플래키 아닌 실 회귀 의심"
+          exit 1
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## 문제
`PartyroomAccessCommandServiceRaceIT`(100스레드 동시 tryEnter) CI 간헐 실패(#320).

## 근본 성격 (장기 조사 결론)
- **환경/인프라 플래키·제품 무결**: 실패=Testcontainers Redis 포트가 100스레드 버스트 중 도달불가(`Connection refused`). 불변식 crew_count==1 은 DB(atomic UPDATE+unique+row lock)가 강제, `PartyroomCounterListener`도 순수 DB.
- **시간대-클러스터링**: 같은 커밋이 어떤 시간대 ~40% 실패 / 다른 시간대 0%(18연속 통과 관측). GitHub 러너/Docker 인프라 컨디션에 좌우 → 코드로 결정적 제거 불가.
- **인-런 재시도 무효**: 나쁜 실행은 Redis 죽은 상태가 런 내내 지속(같은 JVM/컨테이너).

## 수정
integrationTest 스텝을 **최대 3회 재시도** — 각 재시도는 gradle 재호출 → **새 Testcontainers**(죽은 컨테이너 탈출). 실패 태스크는 캐싱 안 되어 실제 재실행. 3회 모두 실패 시에만 빌드 실패(진짜 회귀는 결정론적이라 여전히 검출).

## 정직한 검증 한계
좋은 창에선 fix 유무 무관하게 통과 → 온디맨드 A/B 입증 불가. 구성상 견고(새 컨테이너 재시도)하며 모니터로 확신 축적. (앞선 commandTimeout/공유 ClientResources(#323)/인-런 재시도/Ryuk-disable 은 전부 검증 실패로 기각.)

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)