### PR TITLE
feat(virtualcrew): 재배치(replace) — 송팩 변경 자동 반영 + 명시적 엔드포인트 (#327)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/AdminVirtualCrewController.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/AdminVirtualCrewController.java
@@ -271,6 +271,15 @@ public class AdminVirtualCrewController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "룸 재배치(replace)", description = "봇 전원 회수 후 현재 config·송팩 기준 재배치 — 송팩 교체/곡 구성 변경 반영용")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualCrew()")
+    @PostMapping("/partyrooms/{partyroomId}/virtual-crew/replace")
+    public ResponseEntity<Void> replace(@PathVariable("partyroomId") Long partyroomId) {
+        adminService.replace(new PartyroomId(partyroomId));
+        return ResponseEntity.noContent().build();
+    }
+
     @Operation(summary = "룸 가상 DJ live 상태 조회")
     @SecurityRequirement(name = "cookieAuth")
     @PreAuthorize("@adminAuth.canManageVirtualCrew()")

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/AdminVirtualCrewController.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/AdminVirtualCrewController.java
@@ -292,7 +292,7 @@ public class AdminVirtualCrewController {
 
     // ── 일괄 ──
 
-    @Operation(summary = "여러 룸 config 일괄 적용", description = "체크박스 일괄 — MANAGED 는 각각 reconcile")
+    @Operation(summary = "여러 룸 config 일괄 적용", description = "체크박스 일괄 — MANAGED 는 각각 reconcile(송팩 변경 시 replace — 방 전체 봇 교체), OFF 는 각각 drain")
     @SecurityRequirement(name = "cookieAuth")
     @PreAuthorize("@adminAuth.canManageVirtualCrew()")
     @PutMapping("/virtual-crew/bulk")

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/port/VirtualCrewOrchestrator.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/port/VirtualCrewOrchestrator.java
@@ -26,4 +26,13 @@ public interface VirtualCrewOrchestrator {
      * 분산 락으로 reconcile 과 직렬화된다.
      */
     void drainRoom(PartyroomId partyroomId);
+
+    /**
+     * 재배치(replace) — 룸의 모든 봇을 회수(drain)한 뒤 현재 config·송팩 기준으로 즉시 재배치한다.
+     *
+     * <p>용도: 송팩 교체/곡 구성 변경 반영, djBotCount 변경 후 트랙 파티션 재분배, 자기갱신 드리프트 리셋.
+     * 봇은 배치 시점 송팩 스냅샷을 재생하므로({@code SongPackApplier}), 팩 변경은 회수→재배치로만 전파된다.
+     * 분산 락 1회로 회수·재배치 사이 개입 창을 봉쇄한다.
+     */
+    void replaceRoom(PartyroomId partyroomId);
 }

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualCrewAdminService.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualCrewAdminService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * 어드민 가상 DJ 운영 서비스 — config 적용/drain + 단건/일괄 reconcile + live status 조회.
@@ -74,11 +75,12 @@ public class VirtualCrewAdminService {
 
     // ── per-room config ──
 
-    /** 단일 룸 config 적용 후 MANAGED 면 reconcile, OFF 면 drain 을 같은 트랜잭션에서 트리거. */
+    /** 단일 룸 config 적용 후 MANAGED 면 reconcile(송팩 변경 시 replace), OFF 면 drain 을 같은 트랜잭션에서 트리거. */
     @Transactional
     public void applyConfig(PartyroomId partyroomId, VirtualCrewStatus status, Integer targetCount,
                             Integer djBotCount, Long songPackId) {
         PartyroomVirtualCrewConfigData cfg = loadOrCreate(partyroomId);
+        Long previousSongPackId = cfg.getSongPackId();
         applyStatus(cfg, status, targetCount, djBotCount, songPackId);
         // saveAndFlush: reconcile/drain 의 봇 명령 경로가 영속성 컨텍스트를 clear 할 수 있어,
         // config 변경을 즉시 DB 에 확정한 뒤 reconcile(자기 config 재조회)/drain 을 트리거한다.
@@ -87,7 +89,13 @@ public class VirtualCrewAdminService {
                 partyroomId.getId(), status, targetCount, djBotCount, songPackId);
 
         if (status == VirtualCrewStatus.MANAGED) {
-            orchestrator.reconcileRoom(partyroomId);
+            if (!Objects.equals(previousSongPackId, songPackId)) {
+                // 송팩 변경 — 봇은 배치 시점 스냅샷을 재생하므로 reconcile(카운트 수렴)만으로는
+                // 기존 봇이 옛 팩을 계속 튼다(무음 no-op). 회수→재배치로 새 팩 스냅샷을 강제한다.
+                orchestrator.replaceRoom(partyroomId);
+            } else {
+                orchestrator.reconcileRoom(partyroomId);
+            }
         } else if (status == VirtualCrewStatus.OFF) {
             orchestrator.drainRoom(partyroomId);
         }
@@ -120,6 +128,16 @@ public class VirtualCrewAdminService {
     public void revive(PartyroomId partyroomId) {
         orchestrator.reconcileRoom(partyroomId);
         log.info("[VirtualCrewAdmin.revive] partyroomId={}", partyroomId.getId());
+    }
+
+    /**
+     * 재배치 — 봇 전원 회수 후 현재 config·송팩 기준으로 즉시 재배치. config 미변경(MANAGED 유지).
+     * 용도: 송팩 곡 구성 편집 반영, djBotCount 변경 후 파티션 재분배, 자기갱신 드리프트 리셋.
+     */
+    @Transactional
+    public void replace(PartyroomId partyroomId) {
+        orchestrator.replaceRoom(partyroomId);
+        log.info("[VirtualCrewAdmin.replace] partyroomId={}", partyroomId.getId());
     }
 
     // ── bulk ──

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualCrewAdminService.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualCrewAdminService.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * 어드민 가상 DJ 운영 서비스 — config 적용/drain + 단건/일괄 reconcile + live status 조회.
+ * 어드민 가상 DJ 운영 서비스 — config 적용/drain + 단건/일괄 reconcile·replace + live status 조회.
  *
  * <p>config 전환은 도메인 메서드({@link PartyroomVirtualCrewConfigData#applyManaged}/{@code turnOff})를
  * 통해서만 수행하고, 봇 투입/제거는 모두 {@link VirtualCrewOrchestrator}(봇 신원 path A)에 위임한다.
@@ -143,7 +143,8 @@ public class VirtualCrewAdminService {
     // ── bulk ──
 
     /**
-     * 여러 룸에 같은 config 를 적용(체크박스 일괄). MANAGED 는 각각 reconcile, OFF 는 각각 drain.
+     * 여러 룸에 같은 config 를 적용(체크박스 일괄). MANAGED 는 각각 reconcile(송팩 변경 시
+     * replace — 방 전체 봇 교체), OFF 는 각각 drain.
      *
      * <p>per-room 트랜잭션 격리: {@code self} 프록시를 통해 룸마다 {@link #applyConfig} 의
      * {@code @Transactional} 경계를 독립적으로 적용한다. 한 룸의 reconcile/drain 예외가 다른 룸의

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualCrewOrchestratorImpl.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualCrewOrchestratorImpl.java
@@ -55,4 +55,28 @@ public class VirtualCrewOrchestratorImpl implements VirtualCrewOrchestrator {
             return null;
         });
     }
+
+    /**
+     * {@link #reconcileRoom} 과 동일한 per-call(룸 단위) {@code @Transactional} 경계.
+     *
+     * <p><b>락 합성 금지:</b> {@link DistributedLockExecutor} 는 비재진입(점유 중이면 무음 skip)이므로
+     * 락이 걸린 {@code drainRoom}/{@code reconcileRoom} 을 이어 부르지 않고, 락 1회 안에서
+     * 언락 프리미티브({@code drainResources}→{@code placeToTarget})를 직접 호출한다.
+     *
+     * <p><b>복구 모델:</b> place 단계 예외 시 — {@code /replace} 엔드포인트 경로는 config 무변경(MANAGED
+     * 유지)이라 revive 재시도로 복구, applyConfig 자동 replace 경로는 같은 트랜잭션이라 송팩 변경까지
+     * 롤백(기존 reconcile 실패 시맨틱과 동일).
+     *
+     * <p>⚠️ 락 TTL 대비 임계구간이 drain+place 로 길어진다 — placeToTarget 단독도 초과 가능한
+     * 선재 리스크 클래스로, 본 변경에서 확장하지 않는다.
+     */
+    @Override
+    @Transactional
+    public void replaceRoom(PartyroomId partyroomId) {
+        lock.performTaskWithLock("virtualcrew:" + partyroomId.getId(), () -> {
+            botPlacementService.drainResources(partyroomId);
+            botPlacementService.placeToTarget(partyroomId);
+            return null;
+        });
+    }
 }

--- a/app/src/test/java/com/pfplaybackend/api/virtualcrew/AdminVirtualCrewControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualcrew/AdminVirtualCrewControllerTest.java
@@ -322,6 +322,28 @@ class AdminVirtualCrewControllerTest {
 
     @Test
     @WithMockUser(roles = "ADMIN")
+    void replace_admin_returns204() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/partyrooms/7/virtual-crew/replace").with(csrf()))
+                .andExpect(status().isNoContent());
+        verify(adminService).replace(new PartyroomId(7L));
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    void replace_member_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/partyrooms/7/virtual-crew/replace").with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void replace_missingCsrf_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/partyrooms/7/virtual-crew/replace"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
     void liveStatus_admin_returns200() throws Exception {
         given(adminService.liveStatus(new PartyroomId(7L)))
                 .willReturn(new VirtualCrewAdminService.LiveStatus(VirtualCrewStatus.MANAGED, 2, 1, 5L, 2));

--- a/app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewAdminServiceIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewAdminServiceIT.java
@@ -285,11 +285,16 @@ class VirtualCrewAdminServiceIT extends AbstractIntegrationTest {
         adminService.applyConfig(new PartyroomId(roomId), VirtualCrewStatus.MANAGED, 2, 2, packId);
         flushAndClear();
         List<UserId> before = activeBotUserIds(roomId);
+        Set<Long> trackIdsBefore = activeBotPlaylistTrackIds(roomId);
+        assertThat(trackIdsBefore).isNotEmpty();
 
         adminService.applyConfig(new PartyroomId(roomId), VirtualCrewStatus.MANAGED, 3, 2, packId);
         flushAndClear();
 
-        assertThat(activeBotUserIds(roomId)).containsAll(before); // 기존 봇 그대로 + 리스너 1 추가
+        assertThat(activeBotUserIds(roomId)).hasSize(3).containsAll(before); // 기존 봇 그대로 + 리스너 1 추가
+        // 판별력 핵심: idle 봇 선택이 결정적(oldest-first)이라 userId 단언만으론 replace 로 흘러도 통과할 수 있다.
+        // replace 였다면 re-copy 로 Track row 가 재생성돼 PK 가 바뀌고, reconcile 이면 기존 row 그대로다.
+        assertThat(activeBotPlaylistTrackIds(roomId)).containsAll(trackIdsBefore);
     }
 
     @Test
@@ -359,6 +364,23 @@ class VirtualCrewAdminServiceIT extends AbstractIntegrationTest {
     /** 룸의 활성 봇 crew userId 목록(역할 무관). */
     private List<UserId> activeBotUserIds(long roomId) {
         return botPoolQueryRepository.findActiveBotCrewUserIdsByJoinedDesc(new PartyroomId(roomId));
+    }
+
+    /**
+     * 룸의 활성 봇 crew 전원의 개인 플레이리스트 Track row PK(id) 집합.
+     * replace(re-copy) 는 Track row 를 재생성해 PK 를 바꾸고, reconcile 은 기존 row 를 보존한다 —
+     * count-only 경로가 reconcile 로 흘렀는지 판별하는 지문(fingerprint)으로 쓴다.
+     */
+    private Set<Long> activeBotPlaylistTrackIds(long roomId) {
+        List<UserId> bots = botPoolQueryRepository.findActiveBotCrewUserIdsByJoinedDesc(new PartyroomId(roomId));
+        Set<Long> trackIds = new HashSet<>();
+        for (UserId bot : bots) {
+            Long playlistId = poolService.playlistIdOf(bot);
+            for (TrackData track : trackRepository.findAllByPlaylistId(new PlaylistId(playlistId))) {
+                trackIds.add(track.getId());
+            }
+        }
+        return trackIds;
     }
 
     private long activeBotDjCount(long roomId) {

--- a/app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewAdminServiceIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewAdminServiceIT.java
@@ -5,6 +5,7 @@ import com.pfplaybackend.api.avatar.domain.entity.data.AvatarBodyResourceData;
 import com.pfplaybackend.api.avatar.domain.enums.ObtainmentType;
 import com.pfplaybackend.api.common.AbstractIntegrationTest;
 import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomRepository;
 import com.pfplaybackend.api.party.application.port.out.UserProfileQueryPort;
@@ -15,7 +16,10 @@ import com.pfplaybackend.api.party.domain.enums.StageType;
 import com.pfplaybackend.api.party.domain.value.LinkDomain;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.TrackRepository;
+import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
 import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
+import com.pfplaybackend.api.virtualcrew.adapter.out.persistence.BotPoolQueryRepository;
 import com.pfplaybackend.api.virtualcrew.adapter.out.persistence.PartyroomVirtualCrewConfigRepository;
 import com.pfplaybackend.api.virtualcrew.adapter.out.persistence.VirtualSongPackRepository;
 import com.pfplaybackend.api.virtualcrew.adapter.out.persistence.VirtualSongPackTrackRepository;
@@ -34,8 +38,10 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.pfplaybackend.api.common.exception.http.BadRequestException;
 
@@ -64,6 +70,8 @@ class VirtualCrewAdminServiceIT extends AbstractIntegrationTest {
     @Autowired private VirtualSongPackRepository packRepository;
     @Autowired private VirtualSongPackTrackRepository packTrackRepository;
     @Autowired private AvatarBodyResourceRepository avatarBodyResourceRepository;
+    @Autowired private BotPoolQueryRepository botPoolQueryRepository;
+    @Autowired private TrackRepository trackRepository;
 
     @MockBean private UserProfileQueryPort userProfileQueryPort;
 
@@ -245,6 +253,67 @@ class VirtualCrewAdminServiceIT extends AbstractIntegrationTest {
         assertThat(configRepository.findByPartyroomId(roomId)).isEmpty();
     }
 
+    @Test
+    @DisplayName("applyConfig 송팩 교체 — 기존 배치 봇이 새 팩 스냅샷으로 재복사된다 (무음 no-op 회귀 방지)")
+    void applyConfig_packSwap_rebuildsBotSnapshots() {
+        long roomId = seedRoom(5);
+        Long packA = seedSongPackWith("vidA", "vidB");
+        Long packB = seedSongPackWith("vidC", "vidD");
+        poolService.provision(4);
+        flushAndClear();
+
+        adminService.applyConfig(new PartyroomId(roomId), VirtualCrewStatus.MANAGED, 2, 2, packA);
+        flushAndClear();
+        assertThat(activeBotPlaylistLinkIds(roomId)).containsExactlyInAnyOrder("vidA", "vidB");
+
+        // 카운트 동일 + 송팩만 교체 → 종전엔 무음 no-op, 이제 replace 로 새 팩 반영
+        adminService.applyConfig(new PartyroomId(roomId), VirtualCrewStatus.MANAGED, 2, 2, packB);
+        flushAndClear();
+
+        assertThat(activeBotDjCount(roomId)).isEqualTo(2);
+        assertThat(activeBotPlaylistLinkIds(roomId)).containsExactlyInAnyOrder("vidC", "vidD");
+    }
+
+    @Test
+    @DisplayName("applyConfig 카운트만 변경 — 기존 봇 유지(전원 교체 아님), 추가분만 투입")
+    void applyConfig_countOnly_keepsExistingBots() {
+        long roomId = seedRoom(5);
+        Long packId = seedSongPackWith("vidA", "vidB");
+        poolService.provision(4);
+        flushAndClear();
+
+        adminService.applyConfig(new PartyroomId(roomId), VirtualCrewStatus.MANAGED, 2, 2, packId);
+        flushAndClear();
+        List<UserId> before = activeBotUserIds(roomId);
+
+        adminService.applyConfig(new PartyroomId(roomId), VirtualCrewStatus.MANAGED, 3, 2, packId);
+        flushAndClear();
+
+        assertThat(activeBotUserIds(roomId)).containsAll(before); // 기존 봇 그대로 + 리스너 1 추가
+    }
+
+    @Test
+    @DisplayName("replace() — 송팩 곡 구성 편집이 재배치로 반영된다")
+    void replace_appliesEditedPackContents() {
+        long roomId = seedRoom(5);
+        Long packId = seedSongPackWith("vidA", "vidB");
+        poolService.provision(4);
+        flushAndClear();
+
+        adminService.applyConfig(new PartyroomId(roomId), VirtualCrewStatus.MANAGED, 2, 2, packId);
+        flushAndClear();
+
+        // 팩 내용 편집(트랙 추가) — 기존 봇에는 미반영 상태
+        packTrackRepository.save(VirtualSongPackTrackData.create(packId, 3, "vidE", "Song vidE", "2:30", null));
+        flushAndClear();
+
+        adminService.replace(new PartyroomId(roomId));
+        flushAndClear();
+
+        assertThat(activeBotDjCount(roomId)).isEqualTo(2);
+        assertThat(activeBotPlaylistLinkIds(roomId)).contains("vidE"); // 2봇 청크 분배에 vidE 포함
+    }
+
     // ── fixtures (mirror VirtualCrewOrchestratorIT) ──
 
     private long seedRoom(int playbackTimeLimitMinutes) {
@@ -265,6 +334,31 @@ class VirtualCrewAdminServiceIT extends AbstractIntegrationTest {
         packTrackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 1, "vidA", "Song A", "2:00", null));
         packTrackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 2, "vidB", "Song B", "3:00", null));
         return pack.getId();
+    }
+
+    private Long seedSongPackWith(String vid1, String vid2) {
+        VirtualSongPackData pack = packRepository.save(VirtualSongPackData.create("Pack-" + System.nanoTime(), "IT"));
+        packTrackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 1, vid1, "Song " + vid1, "2:00", null));
+        packTrackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 2, vid2, "Song " + vid2, "3:00", null));
+        return pack.getId();
+    }
+
+    /** 룸의 활성 봇 crew 전원의 개인 플레이리스트 트랙 linkId 합집합(청크 분배라 개별 봇 단위로 나뉘어질 수 있음). */
+    private Set<String> activeBotPlaylistLinkIds(long roomId) {
+        List<UserId> bots = botPoolQueryRepository.findActiveBotCrewUserIdsByJoinedDesc(new PartyroomId(roomId));
+        Set<String> linkIds = new HashSet<>();
+        for (UserId bot : bots) {
+            Long playlistId = poolService.playlistIdOf(bot);
+            for (TrackData track : trackRepository.findAllByPlaylistId(new PlaylistId(playlistId))) {
+                linkIds.add(track.getLinkId());
+            }
+        }
+        return linkIds;
+    }
+
+    /** 룸의 활성 봇 crew userId 목록(역할 무관). */
+    private List<UserId> activeBotUserIds(long roomId) {
+        return botPoolQueryRepository.findActiveBotCrewUserIdsByJoinedDesc(new PartyroomId(roomId));
     }
 
     private long activeBotDjCount(long roomId) {

--- a/app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewAdminServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewAdminServiceTest.java
@@ -1,0 +1,113 @@
+package com.pfplaybackend.api.virtualcrew;
+
+import com.pfplaybackend.api.party.application.service.PartyroomQueryService;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.virtualcrew.adapter.out.persistence.BotPoolQueryRepository;
+import com.pfplaybackend.api.virtualcrew.adapter.out.persistence.PartyroomVirtualCrewConfigRepository;
+import com.pfplaybackend.api.virtualcrew.application.port.VirtualCrewOrchestrator;
+import com.pfplaybackend.api.virtualcrew.application.service.ActiveDjSnapshotService;
+import com.pfplaybackend.api.virtualcrew.application.service.SongPackApplier;
+import com.pfplaybackend.api.virtualcrew.application.service.VirtualCrewAdminService;
+import com.pfplaybackend.api.virtualcrew.application.service.VirtualUserPoolService;
+import com.pfplaybackend.api.virtualcrew.domain.entity.data.PartyroomVirtualCrewConfigData;
+import com.pfplaybackend.api.virtualcrew.domain.enums.VirtualCrewStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/** applyConfig 트리거 분기 — 송팩 변경=replaceRoom / 팩 동일=reconcileRoom / OFF=drainRoom. */
+@ExtendWith(MockitoExtension.class)
+class VirtualCrewAdminServiceTest {
+
+    @Mock private PartyroomVirtualCrewConfigRepository configRepository;
+    @Mock private VirtualCrewOrchestrator orchestrator;
+    @Mock private ActiveDjSnapshotService activeDjSnapshotService;
+    @Mock private VirtualUserPoolService poolService;
+    @Mock private BotPoolQueryRepository botPoolQueryRepository;
+    @Mock private PartyroomQueryService partyroomQueryService;
+    @Mock private SongPackApplier songPackApplier;
+
+    private VirtualCrewAdminService service;
+
+    private static final PartyroomId ROOM = new PartyroomId(7L);
+
+    @BeforeEach
+    void setUp() {
+        service = new VirtualCrewAdminService(configRepository, orchestrator, activeDjSnapshotService,
+                poolService, botPoolQueryRepository, partyroomQueryService, songPackApplier);
+        // applyStatus 의 송팩 검증 게이트 통과 스텁 (songPackId != null 케이스)
+        PartyroomData room = mock(PartyroomData.class, RETURNS_DEEP_STUBS);
+        lenient().when(room.getPlaybackTimeLimit().getMinutes()).thenReturn(5);
+        lenient().when(partyroomQueryService.getPartyroomById(any())).thenReturn(room);
+        lenient().when(songPackApplier.countPlayableTracks(anyLong(), anyInt())).thenReturn(10);
+        lenient().when(configRepository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private void givenExistingConfig(VirtualCrewStatus status, Integer target, Integer djBot, Long packId) {
+        PartyroomVirtualCrewConfigData cfg = PartyroomVirtualCrewConfigData.create(ROOM.getId());
+        if (status == VirtualCrewStatus.MANAGED) {
+            cfg.applyManaged(target, djBot, packId);
+        }
+        when(configRepository.findByPartyroomId(ROOM.getId())).thenReturn(Optional.of(cfg));
+    }
+
+    @Test
+    @DisplayName("MANAGED 적용 + 송팩 변경 → replaceRoom (reconcile 아님)")
+    void managed_packChanged_triggersReplace() {
+        givenExistingConfig(VirtualCrewStatus.MANAGED, 3, 2, 100L);
+        service.applyConfig(ROOM, VirtualCrewStatus.MANAGED, 3, 2, 200L);
+        verify(orchestrator).replaceRoom(ROOM);
+        verify(orchestrator, never()).reconcileRoom(any());
+    }
+
+    @Test
+    @DisplayName("MANAGED 적용 + 송팩 동일(카운트만 변경) → reconcileRoom (봇 전원 교체 아님)")
+    void managed_samePack_triggersReconcile() {
+        givenExistingConfig(VirtualCrewStatus.MANAGED, 3, 2, 100L);
+        service.applyConfig(ROOM, VirtualCrewStatus.MANAGED, 5, 2, 100L);
+        verify(orchestrator).reconcileRoom(ROOM);
+        verify(orchestrator, never()).replaceRoom(any());
+    }
+
+    @Test
+    @DisplayName("신규 config(prev pack=null)에 송팩 지정 → replaceRoom (drain은 무해 no-op)")
+    void newConfig_withPack_triggersReplace() {
+        when(configRepository.findByPartyroomId(ROOM.getId())).thenReturn(Optional.empty());
+        service.applyConfig(ROOM, VirtualCrewStatus.MANAGED, 3, 2, 100L);
+        verify(orchestrator).replaceRoom(ROOM);
+    }
+
+    @Test
+    @DisplayName("MANAGED 적용 + 송팩 null화 → replaceRoom (place는 게이트 skip → 봇 회수 의미)")
+    void managed_packNulled_triggersReplace() {
+        givenExistingConfig(VirtualCrewStatus.MANAGED, 3, 2, 100L);
+        service.applyConfig(ROOM, VirtualCrewStatus.MANAGED, 3, 2, null);
+        verify(orchestrator).replaceRoom(ROOM);
+    }
+
+    @Test
+    @DisplayName("OFF 적용 → drainRoom (기존 동작 불변)")
+    void off_triggersDrain() {
+        givenExistingConfig(VirtualCrewStatus.MANAGED, 3, 2, 100L);
+        service.applyConfig(ROOM, VirtualCrewStatus.OFF, null, null, null);
+        verify(orchestrator).drainRoom(ROOM);
+        verify(orchestrator, never()).replaceRoom(any());
+        verify(orchestrator, never()).reconcileRoom(any());
+    }
+
+    @Test
+    @DisplayName("replace() — orchestrator.replaceRoom 위임")
+    void replace_delegates() {
+        service.replace(ROOM);
+        verify(orchestrator).replaceRoom(ROOM);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewOrchestratorImplTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewOrchestratorImplTest.java
@@ -1,0 +1,42 @@
+package com.pfplaybackend.api.virtualcrew;
+
+import com.pfplaybackend.api.party.application.service.lock.DistributedLockExecutor;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.virtualcrew.application.service.BotPlacementService;
+import com.pfplaybackend.api.virtualcrew.application.service.VirtualCrewOrchestratorImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/** replaceRoom — 락 1회 안에서 drain→place 순차(언락 프리미티브 직접 호출) 검증. */
+@ExtendWith(MockitoExtension.class)
+class VirtualCrewOrchestratorImplTest {
+
+    @Mock private DistributedLockExecutor lock;
+    @Mock private BotPlacementService botPlacementService;
+    @InjectMocks private VirtualCrewOrchestratorImpl orchestrator;
+
+    @Test
+    @DisplayName("replaceRoom — 룸 락 1회 획득 안에서 drainResources → placeToTarget 순서로 호출한다")
+    void replaceRoom_drainThenPlace_underSingleLock() {
+        PartyroomId roomId = new PartyroomId(7L);
+        // ⚠️ performTaskWithLock 는 void 반환(Supplier<Void> 파라미터) — when(...)은 컴파일 불가, doAnswer 필수
+        doAnswer(inv -> ((java.util.function.Supplier<?>) inv.getArgument(1)).get())
+                .when(lock).performTaskWithLock(eq("virtualcrew:7"), any());
+
+        orchestrator.replaceRoom(roomId);
+
+        verify(lock, times(1)).performTaskWithLock(eq("virtualcrew:7"), any());
+        InOrder inOrder = inOrder(botPlacementService);
+        inOrder.verify(botPlacementService).drainResources(roomId);
+        inOrder.verify(botPlacementService).placeToTarget(roomId);
+        verifyNoMoreInteractions(botPlacementService);
+    }
+}

--- a/docs/superpowers/plans/2026-07-11-virtual-crew-replace.md
+++ b/docs/superpowers/plans/2026-07-11-virtual-crew-replace.md
@@ -1,0 +1,604 @@
+# 가상 크루 재배치(replace) 구현 플랜 (platform #327 / admin #26)
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 송팩 변경 시 자동 drain→place + 명시적 `/replace` 엔드포인트(platform) + 어드민 콘솔 「재배치」 버튼(admin)으로, "송팩 교체/편집이 기존 배치 봇에 반영 안 되는 무음 no-op"을 제거한다.
+
+**Architecture:** `VirtualCrewOrchestrator`에 `replaceRoom`(룸 분산락 1회 안에서 언락 프리미티브 `drainResources`→`placeToTarget` 직접 호출) 추가. `VirtualCrewAdminService.applyConfig`는 MANAGED 적용 시 `previousSongPackId != songPackId`면 `replaceRoom`, 아니면 기존 `reconcileRoom`. 컨트롤러에 `POST .../replace` 추가. admin은 기존 revive/drain-resources 3종 세트(api fn + mutation hook + 카드 버튼) 패턴 복제 + 확인 다이얼로그.
+
+**Tech Stack:** Spring Boot 3(Java 21) + JUnit5/Mockito/Testcontainers IT(패턴A) / React+Vite+TanStack Query+msw+vitest
+
+**Spec:** `docs/superpowers/specs/2026-07-11-virtual-crew-replace-design.md` (platform 레포, 커밋됨)
+**Branches:** platform `feat/virtual-crew-replace-327` / admin `feat/virtual-crew-replace-button-26` (둘 다 origin/develop 분기, 생성됨)
+**Working dirs:** `C:\Users\Eisen\Desktop\Labs\[projects] pfplay\pfplay-platform` / `...\pfplay-admin`
+**빌드 주의:** platform gradle은 항상 `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7"` prefix 필수.
+
+**확인된 기존 코드 사실 (재검증 불필요):**
+- `VirtualCrewOrchestratorImpl` = `DistributedLockExecutor lock` + `BotPlacementService` 2필드, `reconcileRoom`/`drainRoom` 모두 `@Transactional` + `lock.performTaskWithLock("virtualcrew:" + partyroomId.getId(), () -> { ...; return null; })`.
+- `DistributedLockExecutor`는 **비재진입**(SETNX 1회 시도, 점유 중이면 warn 후 no-op) — replaceRoom 내부에서 락 잡힌 `drainRoom`/`reconcileRoom` 합성 금지, 언락 프리미티브 직접 호출.
+- `VirtualCrewAdminService.applyConfig`(라인 78-94): `loadOrCreate` → `applyStatus`(검증 포함) → `saveAndFlush` → `if (MANAGED) reconcileRoom / else if (OFF) drainRoom`.
+- 컨트롤러 기존 액션 형태: `@Operation` + `@SecurityRequirement(name="cookieAuth")` + `@PreAuthorize("@adminAuth.canManageVirtualCrew()")` + `ResponseEntity.noContent().build()` (drain/drain-resources/revive 동일).
+- IT 하네스: `VirtualCrewAdminServiceIT`(@Transactional, AbstractIntegrationTest) — `seedRoom(분)`·`seedSongPack()`(vidA/vidB 2트랙)·`activeBotDjCount(roomId)`·`poolService.provision(n)`·`flushAndClear()` 헬퍼 기존재. `VirtualCrewOrchestratorIT`에 `TrackRepository`로 linkId 단언 선례.
+- admin: `virtual-crew-room-api.ts`(base fn들), `use-revive-virtual-crew.ts`(mutation+invalidate 2키+`mutationSuccessToast`), 훅 테스트 `__tests__/use-revive-virtual-crew.test.tsx`(msw+renderHook), 카드 `virtual-crew-config-card.tsx`(버튼 4개 flex, `isLive = live.status === "MANAGED"` 게이트, drain confirm Dialog 선례), 카드 테스트 `ui/__tests__/virtual-crew-config-card.test.tsx` 기존재.
+
+---
+
+## Chunk 1: platform — replaceRoom + applyConfig 분기 + 엔드포인트
+
+### Task 1: `VirtualCrewOrchestrator.replaceRoom` (TDD)
+
+**Files:**
+- Test(Create): `app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewOrchestratorImplTest.java`
+- Modify: `app/src/main/java/com/pfplaybackend/api/virtualcrew/application/port/VirtualCrewOrchestrator.java`
+- Modify: `app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualCrewOrchestratorImpl.java`
+
+- [ ] **Step 1: `DistributedLockExecutor.performTaskWithLock` 시그니처 확인** (`app/src/main/java/com/pfplaybackend/api/party/application/service/lock/DistributedLockExecutor.java`) — **`public void performTaskWithLock(String lockSuffix, Supplier<Void> action)` (void 반환)로 확인됨.** void라서 `when(...)` 스텁은 컴파일 불가 — 아래 테스트처럼 `doAnswer(...).when(lock)...` 형태를 쓴다.
+
+- [ ] **Step 2: 실패하는 유닛 테스트 작성** (개념 코드 — Step 1 확인한 타입으로 조정):
+
+```java
+package com.pfplaybackend.api.virtualcrew;
+
+import com.pfplaybackend.api.party.application.service.lock.DistributedLockExecutor;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.virtualcrew.application.service.BotPlacementService;
+import com.pfplaybackend.api.virtualcrew.application.service.VirtualCrewOrchestratorImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/** replaceRoom — 락 1회 안에서 drain→place 순차(언락 프리미티브 직접 호출) 검증. */
+@ExtendWith(MockitoExtension.class)
+class VirtualCrewOrchestratorImplTest {
+
+    @Mock private DistributedLockExecutor lock;
+    @Mock private BotPlacementService botPlacementService;
+    @InjectMocks private VirtualCrewOrchestratorImpl orchestrator;
+
+    @Test
+    @DisplayName("replaceRoom — 룸 락 1회 획득 안에서 drainResources → placeToTarget 순서로 호출한다")
+    void replaceRoom_drainThenPlace_underSingleLock() {
+        PartyroomId roomId = new PartyroomId(7L);
+        // ⚠️ performTaskWithLock 는 void 반환(Supplier<Void> 파라미터) — when(...)은 컴파일 불가, doAnswer 필수
+        doAnswer(inv -> ((java.util.function.Supplier<?>) inv.getArgument(1)).get())
+                .when(lock).performTaskWithLock(eq("virtualcrew:7"), any());
+
+        orchestrator.replaceRoom(roomId);
+
+        verify(lock, times(1)).performTaskWithLock(eq("virtualcrew:7"), any());
+        InOrder inOrder = inOrder(botPlacementService);
+        inOrder.verify(botPlacementService).drainResources(roomId);
+        inOrder.verify(botPlacementService).placeToTarget(roomId);
+        verifyNoMoreInteractions(botPlacementService);
+    }
+}
+```
+
+주의: 락 키 문자열은 기존 구현이 `"virtualcrew:" + partyroomId.getId()`이므로 `PartyroomId(7L)` → `"virtualcrew:7"`. `PartyroomId.getId()` 반환형이 Long이면 그대로 성립. `BotPlacementService.drainResources/placeToTarget`의 파라미터 타입(PartyroomId vs Long)도 실제 시그니처로 맞출 것.
+
+- [ ] **Step 3: 실패 확인**
+
+Run: `cd "C:\Users\Eisen\Desktop\Labs\[projects] pfplay\pfplay-platform" && JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.virtualcrew.VirtualCrewOrchestratorImplTest"`
+Expected: 컴파일 실패 — `replaceRoom` 미존재.
+
+- [ ] **Step 4: 포트 + 구현 추가**
+
+`VirtualCrewOrchestrator.java`에 추가:
+
+```java
+    /**
+     * 재배치(replace) — 룸의 모든 봇을 회수(drain)한 뒤 현재 config·송팩 기준으로 즉시 재배치한다.
+     *
+     * <p>용도: 송팩 교체/곡 구성 변경 반영, djBotCount 변경 후 트랙 파티션 재분배, 자기갱신 드리프트 리셋.
+     * 봇은 배치 시점 송팩 스냅샷을 재생하므로({@code SongPackApplier}), 팩 변경은 회수→재배치로만 전파된다.
+     * 분산 락 1회로 회수·재배치 사이 개입 창을 봉쇄한다.
+     */
+    void replaceRoom(PartyroomId partyroomId);
+```
+
+`VirtualCrewOrchestratorImpl.java`에 추가 (기존 두 메서드 아래):
+
+```java
+    /**
+     * {@link #reconcileRoom} 과 동일한 per-call(룸 단위) {@code @Transactional} 경계.
+     *
+     * <p><b>락 합성 금지:</b> {@link DistributedLockExecutor} 는 비재진입(점유 중이면 무음 skip)이므로
+     * 락이 걸린 {@code drainRoom}/{@code reconcileRoom} 을 이어 부르지 않고, 락 1회 안에서
+     * 언락 프리미티브({@code drainResources}→{@code placeToTarget})를 직접 호출한다.
+     *
+     * <p><b>복구 모델:</b> place 단계 예외 시 — {@code /replace} 엔드포인트 경로는 config 무변경(MANAGED
+     * 유지)이라 revive 재시도로 복구, applyConfig 자동 replace 경로는 같은 트랜잭션이라 송팩 변경까지
+     * 롤백(기존 reconcile 실패 시맨틱과 동일).
+     *
+     * <p>⚠️ 락 TTL 대비 임계구간이 drain+place 로 길어진다 — placeToTarget 단독도 초과 가능한
+     * 선재 리스크 클래스로, 본 변경에서 확장하지 않는다.
+     */
+    @Override
+    @Transactional
+    public void replaceRoom(PartyroomId partyroomId) {
+        lock.performTaskWithLock("virtualcrew:" + partyroomId.getId(), () -> {
+            botPlacementService.drainResources(partyroomId);
+            botPlacementService.placeToTarget(partyroomId);
+            return null;
+        });
+    }
+```
+
+- [ ] **Step 5: 통과 확인** — Step 3 명령 재실행, PASS.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/virtualcrew/application/port/VirtualCrewOrchestrator.java app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualCrewOrchestratorImpl.java app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewOrchestratorImplTest.java
+git commit -m "feat(virtualcrew): replaceRoom — 룸 락 1회 안 drain→place 재배치 프리미티브 (#327)"
+```
+
+### Task 2: `applyConfig` 송팩 변경 분기 + `replace()` 서비스 (TDD)
+
+**Files:**
+- Test(Create): `app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewAdminServiceTest.java`
+- Modify: `app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualCrewAdminService.java`
+
+- [ ] **Step 1: 실패하는 유닛 테스트 작성** — 트리거 분기 선택만 mock으로 검증(무거운 IT는 Task 4). `applyStatus`가 MANAGED+songPackId!=null이면 `partyroomQueryService.getPartyroomById`(PlaybackTimeLimit 필요)와 `songPackApplier.countPlayableTracks`를 호출하므로 스텁 필요 — `PartyroomData`는 mock으로 `getPlaybackTimeLimit()`이 `PlaybackTimeLimit`을 반환하게(중첩 mock 또는 실제 enum/VO 사용, 실제 타입 확인 후 조정):
+
+```java
+package com.pfplaybackend.api.virtualcrew;
+
+import com.pfplaybackend.api.party.application.service.PartyroomQueryService;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.virtualcrew.adapter.out.persistence.BotPoolQueryRepository;
+import com.pfplaybackend.api.virtualcrew.adapter.out.persistence.PartyroomVirtualCrewConfigRepository;
+import com.pfplaybackend.api.virtualcrew.application.port.VirtualCrewOrchestrator;
+import com.pfplaybackend.api.virtualcrew.application.service.ActiveDjSnapshotService;
+import com.pfplaybackend.api.virtualcrew.application.service.SongPackApplier;
+import com.pfplaybackend.api.virtualcrew.application.service.VirtualCrewAdminService;
+import com.pfplaybackend.api.virtualcrew.application.service.VirtualUserPoolService;
+import com.pfplaybackend.api.virtualcrew.domain.entity.data.PartyroomVirtualCrewConfigData;
+import com.pfplaybackend.api.virtualcrew.domain.enums.VirtualCrewStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/** applyConfig 트리거 분기 — 송팩 변경=replaceRoom / 팩 동일=reconcileRoom / OFF=drainRoom. */
+@ExtendWith(MockitoExtension.class)
+class VirtualCrewAdminServiceTest {
+
+    @Mock private PartyroomVirtualCrewConfigRepository configRepository;
+    @Mock private VirtualCrewOrchestrator orchestrator;
+    @Mock private ActiveDjSnapshotService activeDjSnapshotService;
+    @Mock private VirtualUserPoolService poolService;
+    @Mock private BotPoolQueryRepository botPoolQueryRepository;
+    @Mock private PartyroomQueryService partyroomQueryService;
+    @Mock private SongPackApplier songPackApplier;
+
+    private VirtualCrewAdminService service;
+
+    private static final PartyroomId ROOM = new PartyroomId(7L);
+
+    @BeforeEach
+    void setUp() {
+        service = new VirtualCrewAdminService(configRepository, orchestrator, activeDjSnapshotService,
+                poolService, botPoolQueryRepository, partyroomQueryService, songPackApplier);
+        // applyStatus 의 송팩 검증 게이트 통과 스텁 (songPackId != null 케이스)
+        PartyroomData room = mock(PartyroomData.class, RETURNS_DEEP_STUBS);
+        lenient().when(room.getPlaybackTimeLimit().getMinutes()).thenReturn(5);
+        lenient().when(partyroomQueryService.getPartyroomById(any())).thenReturn(room);
+        lenient().when(songPackApplier.countPlayableTracks(anyLong(), anyInt())).thenReturn(10);
+        lenient().when(configRepository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private void givenExistingConfig(VirtualCrewStatus status, Integer target, Integer djBot, Long packId) {
+        PartyroomVirtualCrewConfigData cfg = PartyroomVirtualCrewConfigData.create(ROOM.getId());
+        if (status == VirtualCrewStatus.MANAGED) {
+            cfg.applyManaged(target, djBot, packId);
+        }
+        when(configRepository.findByPartyroomId(ROOM.getId())).thenReturn(Optional.of(cfg));
+    }
+
+    @Test
+    @DisplayName("MANAGED 적용 + 송팩 변경 → replaceRoom (reconcile 아님)")
+    void managed_packChanged_triggersReplace() {
+        givenExistingConfig(VirtualCrewStatus.MANAGED, 3, 2, 100L);
+        service.applyConfig(ROOM, VirtualCrewStatus.MANAGED, 3, 2, 200L);
+        verify(orchestrator).replaceRoom(ROOM);
+        verify(orchestrator, never()).reconcileRoom(any());
+    }
+
+    @Test
+    @DisplayName("MANAGED 적용 + 송팩 동일(카운트만 변경) → reconcileRoom (봇 전원 교체 아님)")
+    void managed_samePack_triggersReconcile() {
+        givenExistingConfig(VirtualCrewStatus.MANAGED, 3, 2, 100L);
+        service.applyConfig(ROOM, VirtualCrewStatus.MANAGED, 5, 2, 100L);
+        verify(orchestrator).reconcileRoom(ROOM);
+        verify(orchestrator, never()).replaceRoom(any());
+    }
+
+    @Test
+    @DisplayName("신규 config(prev pack=null)에 송팩 지정 → replaceRoom (drain은 무해 no-op)")
+    void newConfig_withPack_triggersReplace() {
+        when(configRepository.findByPartyroomId(ROOM.getId())).thenReturn(Optional.empty());
+        service.applyConfig(ROOM, VirtualCrewStatus.MANAGED, 3, 2, 100L);
+        verify(orchestrator).replaceRoom(ROOM);
+    }
+
+    @Test
+    @DisplayName("MANAGED 적용 + 송팩 null화 → replaceRoom (place는 게이트 skip → 봇 회수 의미)")
+    void managed_packNulled_triggersReplace() {
+        givenExistingConfig(VirtualCrewStatus.MANAGED, 3, 2, 100L);
+        service.applyConfig(ROOM, VirtualCrewStatus.MANAGED, 3, 2, null);
+        verify(orchestrator).replaceRoom(ROOM);
+    }
+
+    @Test
+    @DisplayName("OFF 적용 → drainRoom (기존 동작 불변)")
+    void off_triggersDrain() {
+        givenExistingConfig(VirtualCrewStatus.MANAGED, 3, 2, 100L);
+        service.applyConfig(ROOM, VirtualCrewStatus.OFF, null, null, null);
+        verify(orchestrator).drainRoom(ROOM);
+        verify(orchestrator, never()).replaceRoom(any());
+        verify(orchestrator, never()).reconcileRoom(any());
+    }
+
+    @Test
+    @DisplayName("replace() — orchestrator.replaceRoom 위임")
+    void replace_delegates() {
+        service.replace(ROOM);
+        verify(orchestrator).replaceRoom(ROOM);
+    }
+}
+```
+
+주의: `VirtualCrewAdminService`는 `@RequiredArgsConstructor` — 생성자 파라미터 순서는 필드 선언 순서(configRepository, orchestrator, activeDjSnapshotService, poolService, botPoolQueryRepository, partyroomQueryService, songPackApplier)와 일치해야 함. self 프록시 필드는 setter 주입이라 생성자 무관. `PartyroomVirtualCrewConfigData.create/applyManaged` 접근이 테스트에서 가능하지 않으면(가시성) `givenExistingConfig`를 mock 기반(`when(cfg.getSongPackId())...`)으로 전환.
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.virtualcrew.VirtualCrewAdminServiceTest"`
+Expected: 컴파일 실패 — `replace` 미존재 (분기 테스트는 replaceRoom 미호출로 실패).
+
+- [ ] **Step 3: 구현** — `VirtualCrewAdminService.applyConfig` 트리거 분기 교체 + `replace` 추가:
+
+applyConfig 수정 (기존 라인 78-94 범위):
+
+```java
+    /** 단일 룸 config 적용 후 MANAGED 면 reconcile(송팩 변경 시 replace), OFF 면 drain 을 같은 트랜잭션에서 트리거. */
+    @Transactional
+    public void applyConfig(PartyroomId partyroomId, VirtualCrewStatus status, Integer targetCount,
+                            Integer djBotCount, Long songPackId) {
+        PartyroomVirtualCrewConfigData cfg = loadOrCreate(partyroomId);
+        Long previousSongPackId = cfg.getSongPackId();
+        applyStatus(cfg, status, targetCount, djBotCount, songPackId);
+        // saveAndFlush: reconcile/drain 의 봇 명령 경로가 영속성 컨텍스트를 clear 할 수 있어,
+        // config 변경을 즉시 DB 에 확정한 뒤 reconcile(자기 config 재조회)/drain 을 트리거한다.
+        configRepository.saveAndFlush(cfg);
+        log.info("[VirtualCrewAdmin.applyConfig] partyroomId={} status={} target={} djBotCount={} songPackId={}",
+                partyroomId.getId(), status, targetCount, djBotCount, songPackId);
+
+        if (status == VirtualCrewStatus.MANAGED) {
+            if (!Objects.equals(previousSongPackId, songPackId)) {
+                // 송팩 변경 — 봇은 배치 시점 스냅샷을 재생하므로 reconcile(카운트 수렴)만으로는
+                // 기존 봇이 옛 팩을 계속 튼다(무음 no-op). 회수→재배치로 새 팩 스냅샷을 강제한다.
+                orchestrator.replaceRoom(partyroomId);
+            } else {
+                orchestrator.reconcileRoom(partyroomId);
+            }
+        } else if (status == VirtualCrewStatus.OFF) {
+            orchestrator.drainRoom(partyroomId);
+        }
+    }
+```
+
+(import `java.util.Objects` 추가.)
+
+`revive` 아래에 추가:
+
+```java
+    /**
+     * 재배치 — 봇 전원 회수 후 현재 config·송팩 기준으로 즉시 재배치. config 미변경(MANAGED 유지).
+     * 용도: 송팩 곡 구성 편집 반영, djBotCount 변경 후 파티션 재분배, 자기갱신 드리프트 리셋.
+     */
+    @Transactional
+    public void replace(PartyroomId partyroomId) {
+        orchestrator.replaceRoom(partyroomId);
+        log.info("[VirtualCrewAdmin.replace] partyroomId={}", partyroomId.getId());
+    }
+```
+
+- [ ] **Step 4: 통과 확인** — Step 2 명령 재실행, PASS (7 tests).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualCrewAdminService.java app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewAdminServiceTest.java
+git commit -m "feat(virtualcrew): applyConfig 송팩 변경 시 자동 재배치 + replace 서비스 (#327)"
+```
+
+### Task 3: `/replace` 엔드포인트
+
+**Files:**
+- Modify: `app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/AdminVirtualCrewController.java` (revive 메서드 바로 아래)
+
+- [ ] **Step 1: 엔드포인트 추가** (기존 revive와 동일 형태):
+
+```java
+    @Operation(summary = "룸 재배치(replace)", description = "봇 전원 회수 후 현재 config·송팩 기준 재배치 — 송팩 교체/곡 구성 변경 반영용")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualCrew()")
+    @PostMapping("/partyrooms/{partyroomId}/virtual-crew/replace")
+    public ResponseEntity<Void> replace(@PathVariable("partyroomId") Long partyroomId) {
+        adminService.replace(new PartyroomId(partyroomId));
+        return ResponseEntity.noContent().build();
+    }
+```
+
+- [ ] **Step 2: 컨트롤러 테스트 추가** — `app/src/test/.../AdminVirtualCrewControllerTest.java`의 기존 revive 3종 세트(`revive_admin_returns204` / `revive_member_returns403` / `revive_missingCsrf_returns403`, 라인 303~319 부근)를 그대로 미러해 `replace_admin_returns204` / `replace_member_returns403` / `replace_missingCsrf_returns403` 추가 (URL만 `/replace`, 서비스 verify는 `adminService.replace(...)`). **fail-first**: 엔드포인트 추가 전 테스트 먼저 작성해 404/컴파일 실패 확인 후 Step 1 구현 순서로 진행해도 좋다(권장).
+
+- [ ] **Step 3: 테스트 통과 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "*AdminVirtualCrewControllerTest"`
+Expected: PASS (기존 + 신규 3)
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/AdminVirtualCrewController.java app/src/test/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/AdminVirtualCrewControllerTest.java
+git commit -m "feat(virtualcrew): POST /partyrooms/{id}/virtual-crew/replace 엔드포인트 (#327)"
+```
+(⚠️ 컨트롤러 테스트 파일 실제 경로는 기존 파일 위치를 따를 것 — `find app/src/test -name "AdminVirtualCrewControllerTest.java"`)
+
+### Task 4: 기능 IT — 무음 no-op 회귀 방지 핵심 단언 (TDD)
+
+**Files:**
+- Modify: `app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewAdminServiceIT.java`
+
+- [ ] **Step 1: 기존 IT 픽스처 파악** — `VirtualCrewOrchestratorIT`에서 봇 플레이리스트 트랙(linkId) 단언에 쓰는 리포지토리/헬퍼(`TrackRepository`, `VirtualUserPoolService.playlistIdOf` 또는 동등물)를 확인해 그대로 재사용한다. 활성 봇 userId 조회는 `BotPoolQueryRepository.findActiveBotCrewUserIdsByJoinedDesc` 사용(OrchestratorIT 선례 확인).
+
+- [ ] **Step 2: 실패하는 IT 3건 추가** (개념 코드 — 픽스처 시그니처는 Step 1 확인분으로 조정):
+
+```java
+    private Long seedSongPackWith(String vid1, String vid2) {
+        VirtualSongPackData pack = packRepository.save(VirtualSongPackData.create("Pack-" + System.nanoTime(), "IT"));
+        packTrackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 1, vid1, "Song " + vid1, "2:00", null));
+        packTrackRepository.save(VirtualSongPackTrackData.create(pack.getId(), 2, vid2, "Song " + vid2, "3:00", null));
+        return pack.getId();
+    }
+
+    /** 룸의 활성 봇 전원의 개인 플레이리스트 트랙 linkId 집합. */
+    private Set<String> activeBotPlaylistLinkIds(long roomId) { /* Step 1 픽스처로 구현 */ }
+
+    @Test
+    @DisplayName("applyConfig 송팩 교체 — 기존 배치 봇이 새 팩 스냅샷으로 재복사된다 (무음 no-op 회귀 방지)")
+    void applyConfig_packSwap_rebuildsBotSnapshots() {
+        long roomId = seedRoom(5);
+        Long packA = seedSongPackWith("vidA", "vidB");
+        Long packB = seedSongPackWith("vidC", "vidD");
+        poolService.provision(4);
+        flushAndClear();
+
+        adminService.applyConfig(new PartyroomId(roomId), VirtualCrewStatus.MANAGED, 2, 2, packA);
+        flushAndClear();
+        assertThat(activeBotPlaylistLinkIds(roomId)).containsExactlyInAnyOrder("vidA", "vidB");
+
+        // 카운트 동일 + 송팩만 교체 → 종전엔 무음 no-op, 이제 replace 로 새 팩 반영
+        adminService.applyConfig(new PartyroomId(roomId), VirtualCrewStatus.MANAGED, 2, 2, packB);
+        flushAndClear();
+
+        assertThat(activeBotDjCount(roomId)).isEqualTo(2);
+        assertThat(activeBotPlaylistLinkIds(roomId)).containsExactlyInAnyOrder("vidC", "vidD");
+    }
+
+    @Test
+    @DisplayName("applyConfig 카운트만 변경 — 기존 봇 유지(전원 교체 아님), 추가분만 투입")
+    void applyConfig_countOnly_keepsExistingBots() {
+        long roomId = seedRoom(5);
+        Long packId = seedSongPackWith("vidA", "vidB");
+        poolService.provision(4);
+        flushAndClear();
+
+        adminService.applyConfig(new PartyroomId(roomId), VirtualCrewStatus.MANAGED, 2, 2, packId);
+        flushAndClear();
+        List<UserId> before = activeBotUserIds(roomId); // findActiveBotCrewUserIdsByJoinedDesc 반환형 = List<UserId> (value equals)
+
+        adminService.applyConfig(new PartyroomId(roomId), VirtualCrewStatus.MANAGED, 3, 2, packId);
+        flushAndClear();
+
+        assertThat(activeBotUserIds(roomId)).containsAll(before); // 기존 봇 그대로 + 리스너 1 추가
+    }
+
+    @Test
+    @DisplayName("replace() — 송팩 곡 구성 편집이 재배치로 반영된다")
+    void replace_appliesEditedPackContents() {
+        long roomId = seedRoom(5);
+        Long packId = seedSongPackWith("vidA", "vidB");
+        poolService.provision(4);
+        flushAndClear();
+
+        adminService.applyConfig(new PartyroomId(roomId), VirtualCrewStatus.MANAGED, 2, 2, packId);
+        flushAndClear();
+
+        // 팩 내용 편집(트랙 추가) — 기존 봇에는 미반영 상태
+        packTrackRepository.save(VirtualSongPackTrackData.create(packId, 3, "vidE", "Song vidE", "2:30", null));
+        flushAndClear();
+
+        adminService.replace(new PartyroomId(roomId));
+        flushAndClear();
+
+        assertThat(activeBotDjCount(roomId)).isEqualTo(2);
+        assertThat(activeBotPlaylistLinkIds(roomId)).contains("vidE"); // 2봇 청크 분배에 vidE 포함
+    }
+```
+
+주의: `activeBotPlaylistLinkIds`의 "청크 분배" 단언 — 2 DJ봇에 3트랙이면 TrackDistribution이 조각을 나누므로 **합집합**으로 단언(개별 봇 단위 아님). replace 후 배치되는 봇은 풀에서 다시 뽑히므로 이전과 다른 계정일 수 있음 — userId가 아니라 "활성 봇들의 플리 내용"으로 단언한다.
+
+- [ ] **Step 3: 실패 확인 (fail-first)** — Task 2 구현이 이미 들어갔으므로 순수 fail-first가 어려움. 대신 **핵심 단언의 가치 증명**: `applyConfig_packSwap_rebuildsBotSnapshots`에서 `replaceRoom` 분기를 잠시 `reconcileRoom`으로 되돌린 로컬 변경(미커밋)으로 테스트가 `vidA/vidB` 잔존으로 **실패함을 확인** 후 원복 — 이 테스트가 무음 no-op을 실제로 잡는다는 증거.
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:integrationTest --tests "com.pfplaybackend.api.virtualcrew.VirtualCrewAdminServiceIT"`
+
+- [ ] **Step 4: 원복 후 통과 확인** — 같은 명령, 전체 PASS (기존 IT 포함).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewAdminServiceIT.java
+git commit -m "test(virtualcrew): 송팩 교체/편집 재배치 반영 IT — 무음 no-op 회귀 방지 (#327)"
+```
+
+### Task 5: platform 회귀 (검증만)
+
+- [ ] **Step 1: 전체 유닛** — `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test` → GREEN (기존 ~1313 유지+신규).
+- [ ] **Step 2: virtualcrew 패키지 IT 전체** — `JAVA_HOME=... ./gradlew :app:integrationTest --tests "com.pfplaybackend.api.virtualcrew.*"` → GREEN. (전량 IT는 Chunk 3 게이트에서. ⚠️IT 중단 시 gradle worker 좀비가 output.bin 락 가능 — `reference_gradle_worker_zombie_locks_output_bin` 메모리 절차로 해제.)
+
+## Chunk 2: admin — 「재배치」 버튼
+
+### Task 6: api 함수 + 훅 (TDD)
+
+**Files (admin 레포 `C:\Users\Eisen\Desktop\Labs\[projects] pfplay\pfplay-admin`):**
+- Modify: `src/features/partyrooms/api/virtual-crew-room-api.ts`
+- Create: `src/features/partyrooms/api/use-replace-virtual-crew.ts`
+- Test(Create): `src/features/partyrooms/api/__tests__/use-replace-virtual-crew.test.tsx`
+
+- [ ] **Step 1: 실패하는 훅 테스트 작성** — `use-revive-virtual-crew.test.tsx`를 그대로 미러(엔드포인트 `/replace`, 토스트 문구 "재배치 완료"). 성공 시 invalidate 2키(`["virtual-crew","room",id]`, `["partyrooms"]`) + `toast.success("재배치 완료")`, 에러 시 invalidate 안 함 — 2케이스.
+
+- [ ] **Step 2: 실패 확인** — `yarn test:run src/features/partyrooms/api/__tests__/use-replace-virtual-crew.test.tsx` (⚠️ `yarn test`는 watch 모드 — 반드시 `test:run`) → 모듈 없음 FAIL.
+
+- [ ] **Step 3: 구현**
+
+`virtual-crew-room-api.ts` — 주석 블록에 `POST .../replace → 204 (봇 전원 회수 후 현재 config·송팩 기준 재배치)` 한 줄 추가 + 함수:
+
+```ts
+export async function replace(id: number): Promise<void> {
+  await http<void>(`${base(id)}/replace`, { method: "POST" })
+}
+```
+
+`use-replace-virtual-crew.ts` (use-revive 미러):
+
+```ts
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { replace } from "./virtual-crew-room-api"
+import { mutationSuccessToast, mutationErrorToast } from "@/shared/lib/mutation-toast"
+
+// 봇 전원 회수 후 현재 config·송팩 기준으로 재배치 — 송팩 교체/곡 구성 변경 반영용.
+export function useReplaceVirtualCrew(partyroomId: number) {
+  const qc = useQueryClient()
+  return useMutation<void, unknown, void>({
+    mutationFn: () => replace(partyroomId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["virtual-crew", "room", partyroomId] })
+      qc.invalidateQueries({ queryKey: ["partyrooms"] })
+      mutationSuccessToast("재배치 완료")
+    },
+    onError: mutationErrorToast,
+  })
+}
+```
+
+- [ ] **Step 4: 통과 확인** — Step 2 명령 재실행 PASS.
+- [ ] **Step 5: 커밋** — `git add` 3파일, `git commit -m "feat(virtual-crew): 재배치 api·훅 — replace 뮤테이션 (#26)"`
+
+### Task 7: 카드 버튼 + 확인 다이얼로그 (TDD)
+
+**Files:**
+- Modify: `src/features/partyrooms/ui/virtual-crew-config-card.tsx`
+- Test(Modify): `src/features/partyrooms/ui/__tests__/virtual-crew-config-card.test.tsx`
+
+- [ ] **Step 1: 기존 카드 테스트 파일을 읽고 패턴 파악** (렌더 셋업·msw·버튼 단언 방식) — 아래 테스트를 그 파일 컨벤션으로 작성.
+
+- [ ] **Step 2: 실패하는 테스트 추가** (행동 스펙):
+  1. MANAGED live 상태에서 「재배치」 버튼 렌더 + enabled, OFF면 disabled (기존 부활 버튼 게이트 테스트 미러).
+  2. 「재배치」 클릭 → 확인 다이얼로그 표시(제목 "봇 재배치"), 확인 클릭 → `POST .../replace` 호출(msw spy)·다이얼로그 닫힘. ⚠️버튼명 "재배치"가 카드 트리거/다이얼로그 확인 2곳 — 기존 drain confirm 테스트처럼 `within(dialog)`로 스코프.
+  3. 다이얼로그 취소 → 호출 없음.
+
+- [ ] **Step 3: 실패 확인** — `yarn test:run src/features/partyrooms/ui/__tests__/virtual-crew-config-card.test.tsx` → 신규 케이스 FAIL.
+
+- [ ] **Step 4: 구현** — 카드에 추가:
+- import `useReplaceVirtualCrew`, 훅: `const replaceMutation = useReplaceVirtualCrew(partyroomId)`, state: `const [replaceOpen, setReplaceOpen] = useState(false)`.
+- 버튼(부활과 리소스 회수 사이, outline·isLive 게이트 동일):
+
+```tsx
+          <Button
+            variant="outline"
+            onClick={() => setReplaceOpen(true)}
+            disabled={!isLive || replaceMutation.isPending}
+            title="봇 전원 회수 후 현재 설정·송팩 기준 재배치 — 송팩 교체/곡 편집 반영, DJ봇 수 변경 후 재분배, 드리프트 리셋"
+          >
+            {replaceMutation.isPending ? "재배치 중..." : "재배치"}
+          </Button>
+```
+
+- 다이얼로그(기존 drain Dialog 아래, **비파괴 톤** — confirm 버튼 default variant):
+
+```tsx
+      {/* replace = 봇 전원 교체 → 가벼운 confirm (drain 과 달리 비파괴: MANAGED 유지) */}
+      <Dialog open={replaceOpen} onOpenChange={setReplaceOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>봇 재배치</DialogTitle>
+            <DialogDescription>
+              이 파티룸의 가상 DJ 봇을 전부 회수한 뒤 현재 설정·송팩 기준으로
+              다시 배치합니다. 송팩 교체/곡 구성 변경을 반영하거나 트랙 분배를
+              다시 계산할 때 사용하세요. 운영(운영중) 상태는 유지됩니다.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setReplaceOpen(false)}
+              disabled={replaceMutation.isPending}
+            >
+              취소
+            </Button>
+            <Button
+              type="button"
+              disabled={replaceMutation.isPending}
+              onClick={() =>
+                replaceMutation.mutate(undefined, {
+                  onSuccess: () => setReplaceOpen(false),
+                })
+              }
+            >
+              {replaceMutation.isPending ? "재배치 중..." : "재배치"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+```
+
+- [ ] **Step 5: 통과 확인** — Step 3 명령 재실행 PASS + `yarn test:run` 전체 GREEN(기존 686+신규) + `yarn build`(tsc+vite) PASS.
+- [ ] **Step 6: 커밋** — `git commit -m "feat(virtual-crew): 파티룸 카드 재배치 버튼 + 확인 다이얼로그 (#26)"`
+
+## Chunk 3: 로컬 검증 게이트 + PR (lockstep)
+
+### Task 8: platform 전량 회귀 + 부팅 게이트 + 라이브 e2e
+
+- [ ] **Step 1: 전량 IT** — `JAVA_HOME=... ./gradlew :app:integrationTest` → GREEN. (플래키 #320 `PartyroomAccessCommandServiceRaceIT`는 선재 — 해당 1건만 빨간 경우 재실행으로 판정.)
+- [ ] **Step 2: fresh DB docker 부팅 게이트** — `JAVA_HOME=... ./gradlew :app:bootJar -x test` → `docker compose -f docker-compose.local.yml -p pfplay-local down -v` → `up -d --build` → "Started Application" + `/v3/api-docs` 200. (스키마 무변경이지만 부팅 게이트는 룰.)
+- [ ] **Step 3: 라이브 e2e** (로컬 admin 계정 `admin@pfplay.local`, POST `/api/v1/auth/admin/login`, Origin `http://localhost:3000` 헤더 필수):
+  1. 송팩 2개 생성(트랙 각 2) + 봇 풀 충원 + 방 1개에 packA로 MANAGED(2,2) 적용 → 배치 확인(live status).
+  2. **packB로 교체 적용** → live status·DB(`playlist.source_song_pack_id`/track linkId)로 **새 팩 반영 확인** (본 기능의 핵심 시나리오).
+  3. packB에 트랙 추가 → `POST .../replace` → 반영 확인.
+  4. 로그에 무음 skip/에러 없는지 확인.
+- [ ] **Step 4: push 전 커밋 정리** — Task별 커밋이 논리단위(4~5개)면 유지, 과분할 시 통합(파괴적 rebase 전 사용자 확인 룰).
+
+### Task 9: PR 생성 (lockstep)
+
+- [ ] **Step 1: platform PR** — base `develop`, 제목 `feat(virtualcrew): 재배치(replace) — 송팩 변경 자동 반영 + 명시적 엔드포인트 (#327)`, 본문 한글(스펙 링크·검증 증거·admin #26 lockstep 명시). CI 확인.
+- [ ] **Step 2: admin PR** — base `develop`, 제목 `feat(virtual-crew): 파티룸 재배치 원버튼 (#26)`, 본문에 **platform #327 머지·dev 배포 후 머지** 의존 명시.
+- [ ] **Step 3: 머지는 사용자 게이트** — platform 머지→Deploy to dev green→admin 머지 순서 보고.

--- a/docs/superpowers/specs/2026-07-11-virtual-crew-replace-design.md
+++ b/docs/superpowers/specs/2026-07-11-virtual-crew-replace-design.md
@@ -1,0 +1,84 @@
+# 가상 크루 재배치(replace) — 설계 (platform #327 / admin #26)
+
+## 배경 (운영 함정)
+
+가상 크루 봇 모델(2026-07-10 머지, spec `2026-07-08-virtual-dj-bot-model-overhaul-design.md`)은:
+
+- 배치 시점에 송팩을 **스냅샷 복사**한다 — `SongPackApplier.copyTracksToBot`이 봇 개인 플레이리스트를 전량 삭제 후 송팩 트랙을 값 복사. 봇은 송팩을 라이브로 읽지 않는다.
+- `BotPlacementService.placeToTarget`은 **카운트 수렴만** 한다 — 송팩 diff 감지 없음, 기존 봇 재청크 없음.
+
+따라서 어드민이 config에서 **songPackId만 교체하고 「적용」하면 무음 no-op**(카운트 불변 → add/remove 0 → `applyChunkToBot` 미호출)이며, 기존 봇은 옛 송팩 복사본을 계속 재생한다. **송팩 곡 구성 편집**도 기존 배치 봇에 전파되지 않는다. 현재 유일한 반영 수단은 수동 「리소스 회수」→「부활」 2단계다.
+
+## 사용자 확정 스코프 (2026-07-11)
+
+- **(a)** `applyConfig`에서 **songPackId 변경 감지 시에만** 자동 재배치. djBotCount 변경은 자동 재배치 **제외**(방 UX 출렁임 회피 — (b) 버튼으로 수동 커버).
+- **(b)** 재배치는 **백엔드 단일 엔드포인트**(동일 룸 락 안 drain→place) + 어드민 콘솔 원버튼.
+
+## 목표 / 성공 기준
+
+- 어드민이 송팩을 교체하고 「적용」하면 **추가 조작 없이** 기존 배치 봇들이 새 송팩 스냅샷으로 재생한다 (무음 no-op 소멸).
+- 「재배치」 버튼 1회로 회수→부활이 원자적(단일 락)으로 수행된다 — 송팩 내용 편집 반영·djBotCount 변경 후 파티션 재분배·자기갱신 드리프트 리셋 용도.
+- 기존 동작 회귀 0: 카운트만 변경 시 기존 수렴(전원 교체 없음), drain/drain-resources/revive/점검/부팅 경로 불변.
+
+## 비목표 (YAGNI)
+
+- djBotCount 변경 시 자동 재배치 (사용자 결정으로 제외).
+- 송팩 편집 화면에서 "사용 중 방 N개에 재배치" 프롬프트 (후속 아이디어로만 기록).
+- 부분 재배치(특정 봇만), 무중단 롤링 교체.
+- Flyway 마이그레이션 없음 (스키마 무변경).
+
+## 설계 — platform
+
+### ① `replaceRoom` 프리미티브 (orchestrator)
+
+- `VirtualCrewOrchestrator` 포트에 `replaceRoom(PartyroomId)` 추가.
+- `VirtualCrewOrchestratorImpl.replaceRoom`: 기존 두 메서드와 동일 패턴 — `@Transactional` + **룸 분산락 `virtualcrew:{roomId}` 1회 획득 안에서** `botPlacementService.drainResources(id)` → `botPlacementService.placeToTarget(id)` 순차 실행.
+  - 락 1회로 회수·부활 사이 타 어드민/이벤트 개입 창을 봉쇄. **내부는 언락 프리미티브(`drainResources`/`placeToTarget`)를 직접 호출** — 락 잡힌 `drainRoom`/`reconcileRoom`을 합성하면 비재진입 executor가 무음 skip하므로 금지.
+  - place 단계 예외 시 복구 모델: `/replace` 엔드포인트 경로는 config 무변경(MANAGED 유지)이라 「부활」 재시도로 복구. applyConfig 자동 replace 경로는 같은 트랜잭션이라 **팩 변경까지 롤백**(기존 reconcile 실패 시맨틱과 동일) — 두 경로의 차이를 주석에 명기.
+  - 트랜잭션 경계 주석은 기존 reconcileRoom 문서와 동일 논리로 기술. ⚠️락 TTL(10s) 대비 임계구간이 drain+place로 길어짐 — 기존 placeToTarget 단독도 초과 가능한 선재 리스크 클래스로, 플랜에 주석 한 줄로 기록(스코프 확장 없음).
+
+### ② (a) applyConfig 송팩 변경 감지
+
+`VirtualCrewAdminService.applyConfig`에서:
+
+1. `loadOrCreate` 직후, 변경 **전** 송팩 캡처: `previousSongPackId`.
+2. `applyStatus` + `saveAndFlush` (기존 그대로 — 검증 포함).
+3. 트리거 분기 (기존 `if (MANAGED) reconcile / else if (OFF) drain` 교체):
+   - `status == MANAGED && !Objects.equals(previousSongPackId, songPackId)` → **`orchestrator.replaceRoom`**
+   - `status == MANAGED` (팩 동일: 카운트만 변경 등) → 기존 `reconcileRoom`
+   - `status == OFF` → 기존 `drainRoom`
+- **previousStatus 조건은 두지 않는다** (스펙 리뷰 반영): "OFF였으면 이미 drain됐다"는 가정은 drain 부분실패(per-bot try/catch 삼킴)·락 경합 무음 skip 후 OFF 커밋 시나리오에서 깨질 수 있고, 그 경우 옛 스냅샷 봇이 잔존한 채 OFF→MANAGED(새 팩)가 reconcile로 빠져 함정이 재발한다. 조건 제거 비용은 활성봇 조회+clearRoom no-op 1회로 무시 가능 — **"MANAGED 적용에서 팩이 달라졌으면 무조건 replace"**가 더 단순하고 견고. 신규 config(prev=null)에 팩 지정도 replace 경로로 흐르며 drain이 무해 no-op.
+- null↔값 변경도 "변경"이다: 값→null이면 replace의 place 단계가 게이트(songPackId null → skip)에서 자연 no-op → **"송팩 제거=봇 회수"** 의미가 일관되게 성립.
+- `applyBulk`는 per-room `self.applyConfig` 경유라 자동 적용(변경 없음).
+
+### ③ (b) 명시적 재배치 엔드포인트
+
+- `VirtualCrewAdminService.replace(PartyroomId)`: `orchestrator.replaceRoom` 위임 + info 로그 (기존 `revive`/`drainResources`와 동일 형태, `@Transactional`).
+- `AdminVirtualCrewController`: `POST /api/v1/admin/partyrooms/{id}/virtual-crew/replace` — 가드 `@adminAuth.canManageVirtualCrew()`, 응답 형태는 기존 drain-resources/revive와 동일.
+- **상태 검증은 두지 않는다**(기존 revive와 동일 컨벤션): OFF 방에 호출 시 drain은 잔존 봇 정리, place는 게이트 skip — 안전 no-op. MANAGED 게이트는 어드민 UI 버튼 활성화 조건으로만.
+
+## 설계 — admin (lockstep 후행)
+
+- `features/partyrooms/api/virtual-crew-room-api.ts`에 `replaceVirtualCrew(partyroomId)` 추가 (`POST .../replace`).
+- 훅 `use-replace-virtual-crew.ts` — 기존 `use-revive-virtual-crew`/`use-drain-resources-virtual-crew` 패턴(뮤테이션 + live status invalidate + 토스트).
+- `virtual-crew-config-card.tsx`: 「재배치」 버튼 추가 — 부활·리소스 회수 옆, `live.status === 'MANAGED'` 게이트 동일. **가벼운 확인 다이얼로그 1회**(봇 전원이 퇴장 후 현재 설정·송팩 기준으로 재입장한다는 안내 — drain의 파괴적 빨간 톤 아님, 상태 보존됨). 버튼 부근 헬프 텍스트: 용도 3가지(송팩 내용 편집 반영 / DJ봇 수 변경 후 재분배 / 드리프트 리셋).
+- 라벨은 기존 콘솔 표기 관행(한국어 라벨) 준수: 「재배치」.
+
+## 오류 처리
+
+- replace 중 drain 단계 실패: 룸별 per-bot try/catch(기존 drainResources 내부)로 봇 단위 격리 — 이후 place가 잔존 봇을 카운트에 포함해 수렴하므로 부분 실패도 다음 replace/revive로 수습 가능.
+- place 단계 실패(풀 고갈 등): 기존과 동일 best-effort + `INSUFFICIENT_IDLE_BOTS` 로그, 예외 아님.
+- applyConfig의 자동 replace에서 예외 발생 시: 같은 트랜잭션이므로 config 저장까지 롤백 — 기존 reconcile 실패 시맨틱과 동일(변경 없음), applyBulk에선 per-room 격리로 다른 방 계속 진행.
+- **락 경합 무음 skip** (기존 컨벤션 계승): `DistributedLockExecutor`는 락 점유 중이면 warn 로그 후 no-op — 자동 replace/`/replace`가 이 경우 실행되지 않은 채 2xx가 반환될 수 있다(기존 reconcile/drain과 동일). 운영 가이드: 반영이 안 보이면 「재배치」 재클릭. 별도 재시도 로직은 도입하지 않음(기존 컨벤션 유지, YAGNI).
+
+## 테스트
+
+- **유닛**: `VirtualCrewOrchestratorImpl.replaceRoom` — 락 1회 획득·drain→place 순서(언락 프리미티브 직접 호출). `VirtualCrewAdminService.applyConfig` 분기 — (MANAGED 적용, 팩 변경)→replaceRoom / (MANAGED 적용, 팩 동일·카운트만)→reconcileRoom / (신규 config에 팩 지정)→replaceRoom / (팩 null화)→replaceRoom / OFF→drainRoom. `replace()` 위임.
+- **기능 IT** (기존 orchestrator IT 하네스 재사용, 패턴A admin 시드): 봇 배치된 방에서 다른 송팩으로 applyConfig → **봇 플레이리스트가 새 팩 스냅샷으로 재복사됨을 단언**(트랙 linkId 비교 — 무음 no-op 회귀 방지의 핵심). 명시적 `/replace` 호출 동등 단언. 카운트만 변경 시 기존 봇 유지(전원 교체 아님) 단언.
+- **admin**: api/훅/버튼 테스트(확인 다이얼로그→호출→invalidate) + build(tsc+vite). 기존 686 테스트 회귀 그린.
+- **로컬 검증 게이트**: platform fresh DB docker 부팅(bootJar 선행) + 라이브 e2e(admin HTTP로 배치→송팩 교체 적용→새 팩 반영 확인→재배치 엔드포인트 확인). 기존 전체 유닛/IT 회귀 그린.
+
+## 산출물 / 절차
+
+- 이슈: platform **#327** / admin **#26**. 브랜치: `feat/virtual-crew-replace-327`(platform, origin/develop 분기) / `feat/virtual-crew-replace-button-26`(admin, origin/develop 분기).
+- **lockstep 머지 순서**: platform #327 → dev 배포 green → admin #26. 커밋/PR 한글, 머지=사용자 게이트.


### PR DESCRIPTION
Closes #327

## 개요
가상 크루 봇은 배치 시점에 송팩을 **스냅샷 복사**하고 `placeToTarget`은 카운트 수렴만 하므로, 어드민이 **송팩만 교체하고 「적용」하면 무음 no-op**(기존 봇이 옛 팩을 계속 재생)이었다. 본 PR은:

1. **`replaceRoom` 프리미티브** — 룸 분산락 **1회** 안에서 언락 프리미티브 `drainResources`→`placeToTarget` 직접 호출 (비재진입 executor라 락 잡힌 메서드 합성 금지 — javadoc 명문화)
2. **applyConfig 자동 재배치** — MANAGED 적용에서 `songPackId` 변경 감지(null↔값 포함) 시 reconcile 대신 replace. 카운트만 변경은 기존 수렴 유지(봇 전원 교체 없음). previousStatus 조건은 두지 않음(drain 부분실패 후 OFF→MANAGED 코너 견고성 — 스펙 리뷰 반영). `applyBulk`는 per-room 경유로 자동 적용.
3. **`POST /partyrooms/{id}/virtual-crew/replace`** — 송팩 **내용** 편집 반영·djBotCount 변경 후 파티션 재분배·자기갱신 드리프트 리셋용 (어드민 콘솔 버튼은 admin pfplay/pfplay-admin#26).

스펙/플랜: `docs/superpowers/specs/2026-07-11-virtual-crew-replace-design.md` · `docs/superpowers/plans/2026-07-11-virtual-crew-replace.md`

## 검증
- **유닛 전량 1342/0** (신규: orchestrator 락1회·순서 / applyConfig 분기 6케이스 / 컨트롤러 3종 미러)
- **IT 전량 77클래스·304/0** (fresh 실행 확인). 신규 IT 3건 — 핵심: **송팩 교체 적용 후 봇 플리 linkId가 새 팩으로 재복사됨 단언**. fail-first 증명: 분기를 reconcile로 되돌리면 `vidA/vidB` 잔존으로 실제 실패(무음 no-op 재현) 확인 후 원복. count-only 테스트는 Track row PK 지문으로 replace/reconcile 판별력 확보.
- **fresh DB docker 부팅 게이트** 통과(스키마 무변경, 에러 0)
- **라이브 e2e** (실 admin HTTP + DB 단언): 배치→송팩 교체 「적용」만으로 새 팩 반영 ★ / 팩 편집→`/replace` 반영 ★ / 락 무음 skip·에러 0 — ALL PASS

## 운영 노트
- 송팩 변경 적용/재배치는 **방의 봇 전원이 퇴장 후 재입장**(의도된 동작). bulk로 송팩 변경 시 선택한 모든 방에서 발생.
- **lockstep**: 본 PR 머지·dev 배포 green 후 admin pfplay/pfplay-admin#26 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)