### PR TITLE
feat(playlist): 신규 가입자 기본 플레이리스트 — DJ 온보딩 생성 단계 제거 (#329)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/bootstrap/adapter/PlaylistSetupAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/bootstrap/adapter/PlaylistSetupAdapter.java
@@ -16,4 +16,9 @@ public class PlaylistSetupAdapter implements PlaylistSetupPort {
     public void createDefaultPlaylist(UserId userId) {
         playlistCommandService.createDefaultPlaylist(userId);
     }
+
+    @Override
+    public void createDefaultDjPlaylist(UserId userId) {
+        playlistCommandService.createDefaultDjPlaylist(userId);
+    }
 }

--- a/app/src/test/java/com/pfplaybackend/api/playlist/DefaultDjPlaylistIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/playlist/DefaultDjPlaylistIT.java
@@ -1,0 +1,124 @@
+package com.pfplaybackend.api.playlist;
+
+import com.pfplaybackend.api.avatar.domain.entity.data.AvatarBodyResourceData;
+import com.pfplaybackend.api.avatar.domain.entity.data.AvatarFaceResourceData;
+import com.pfplaybackend.api.avatar.adapter.out.persistence.AvatarBodyResourceRepository;
+import com.pfplaybackend.api.avatar.adapter.out.persistence.AvatarFaceResourceRepository;
+import com.pfplaybackend.api.avatar.domain.enums.ObtainmentType;
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.aspect.context.AuthContext;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.enums.AuthorityTier;
+import com.pfplaybackend.api.common.exception.http.ConflictException;
+import com.pfplaybackend.api.playlist.application.service.PlaylistCommandService;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
+import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
+import com.pfplaybackend.api.playlist.domain.port.PlaylistAggregatePort;
+import com.pfplaybackend.api.user.application.service.initialize.TemporaryUserInitializeService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 신규 가입자 기본 DJ 플레이리스트(#329) — 가입 세트·AM 상한·삭제 후 재생성 IT.
+ *
+ * <p>진입점은 게스트→회원 전환 경로({@link TemporaryUserInitializeService#addAssociateMember})를
+ * 대표로 사용한다(플랜 확정 — MemberSignService 의 OAuth 경로는 배선 검증이 유닛으로 이미 충분).
+ */
+@Transactional
+class DefaultDjPlaylistIT extends AbstractIntegrationTest {
+
+    // AdminProfileService/UserAvatarQueryService 가 기본 아바타를 구성하는 데 필요한 최소 카탈로그.
+    // Flyway V3가 아바타를 시드하지만 DatabaseCleaner 격리로 메서드 간 truncate될 수 있어 조건부 재시드한다.
+    private static final String DEFAULT_BODY_URI =
+            "https://firebasestorage.googleapis.com/v0/b/pfplay-firebase.appspot.com/o/ava_basic%2Fava_basic_001.png?alt=media";
+    private static final String FACE_URI = "https://cdn.test/ava_face_basic_001.png";
+    private static final String FACE_ICON_URI = "https://cdn.test/ava_icon_face_basic_001.png";
+
+    @Autowired private TemporaryUserInitializeService temporaryUserInitializeService;
+    @Autowired private PlaylistAggregatePort aggregatePort;
+    @Autowired private PlaylistCommandService playlistCommandService;
+    @Autowired private AvatarBodyResourceRepository avatarBodyResourceRepository;
+    @Autowired private AvatarFaceResourceRepository avatarFaceResourceRepository;
+
+    @BeforeEach
+    void seedDefaultAvatarCatalog() {
+        if (avatarBodyResourceRepository.findOneAvatarResourceByResourceUri(DEFAULT_BODY_URI) == null) {
+            AvatarBodyResourceData body = AvatarBodyResourceData.draft(
+                    "ava_body_basic_001", DEFAULT_BODY_URI,
+                    null,
+                    ObtainmentType.BASIC, 0, true, true, 60, 41, null);
+            avatarBodyResourceRepository.save(body);
+        }
+        if (avatarFaceResourceRepository.findOneAvatarResourceByResourceUri(FACE_URI) == null) {
+            AvatarFaceResourceData face = AvatarFaceResourceData.draft(
+                    "ava_face_basic_001_pub", FACE_URI, FACE_ICON_URI, null);
+            face.publish(null);
+            avatarFaceResourceRepository.save(face);
+        }
+    }
+
+    @AfterEach
+    void clearAuthContext() {
+        ThreadLocalContext.clearContext();
+    }
+
+    private UserId initializeNewMemberFixture() {
+        UserId userId = new UserId();
+        temporaryUserInitializeService.addAssociateMember(userId, "member-" + userId.getUid() + "@test.local");
+        return userId;
+    }
+
+    private void setAuthContext(UserId userId, AuthorityTier tier) {
+        ThreadLocalContext.setContext(new AuthContext(userId, tier));
+    }
+
+    @Test
+    @DisplayName("가입 초기화 — GRABLIST 1 + '내 플레이리스트'(PLAYLIST) 1 이 생성된다")
+    void signupInitialization_createsGrablistAndDefaultDjPlaylist() {
+        UserId userId = initializeNewMemberFixture();
+        flushAndClear();
+
+        List<PlaylistData> grab = aggregatePort.findPlaylistsByOwnerAndType(userId, PlaylistType.GRABLIST);
+        List<PlaylistData> normal = aggregatePort.findPlaylistsByOwnerAndType(userId, PlaylistType.PLAYLIST);
+        assertThat(grab).hasSize(1);
+        assertThat(normal).hasSize(1);
+        assertThat(normal.get(0).getName()).isEqualTo("내 플레이리스트");
+    }
+
+    @Test
+    @DisplayName("AM 유저(기본 플리 보유)가 추가 생성 시도 → PLL-002 EXCEEDED_PLAYLIST_LIMIT")
+    void amUserWithDefaultPlaylist_cannotCreateAnother() {
+        UserId userId = initializeNewMemberFixture();
+        flushAndClear();
+        setAuthContext(userId, AuthorityTier.AM);
+
+        assertThatThrownBy(() -> playlistCommandService.createPlaylist("두번째"))
+                .isInstanceOf(ConflictException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "PLL-002");
+    }
+
+    @Test
+    @DisplayName("기본 플리 삭제 후엔 다시 1개 생성 가능 — 락아웃 없음")
+    void afterDeletingDefault_amUserCanCreateAgain() {
+        UserId userId = initializeNewMemberFixture();
+        flushAndClear();
+        setAuthContext(userId, AuthorityTier.AM);
+
+        Long defaultId = aggregatePort.findPlaylistsByOwnerAndType(userId, PlaylistType.PLAYLIST)
+                .get(0).getId();
+        playlistCommandService.deletePlaylist(List.of(defaultId));
+
+        PlaylistData recreated = playlistCommandService.createPlaylist("직접 만든 플리");
+        assertThat(recreated.getType()).isEqualTo(PlaylistType.PLAYLIST);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualUserPoolServiceIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualUserPoolServiceIT.java
@@ -12,6 +12,9 @@ import com.pfplaybackend.api.party.adapter.out.persistence.CrewRepository;
 import com.pfplaybackend.api.party.domain.entity.data.CrewData;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
+import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
+import com.pfplaybackend.api.playlist.domain.port.PlaylistAggregatePort;
 import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
 import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
 import com.pfplaybackend.api.virtualcrew.application.service.VirtualUserPoolService;
@@ -46,6 +49,7 @@ class VirtualUserPoolServiceIT extends AbstractIntegrationTest {
     @Autowired private AdminUserService adminUserService;
     @Autowired private AvatarBodyResourceRepository avatarBodyResourceRepository;
     @Autowired private AvatarFaceResourceRepository avatarFaceResourceRepository;
+    @Autowired private PlaylistAggregatePort aggregatePort;
 
     @BeforeEach
     void seedCatalog() {
@@ -165,5 +169,15 @@ class VirtualUserPoolServiceIT extends AbstractIntegrationTest {
                     .as("bot %s user_profile row count (provision 후 정확히 1개)", id.getUid())
                     .isEqualTo(1L);
         }
+    }
+
+    @Test
+    @DisplayName("봇 provision — PLAYLIST 타입이 정확히 1개(봇 전용)여야 한다 (#329 기본 플리 이중 생성 회귀 방지)")
+    void provision_botHasExactlyOnePlaylistTypePlaylist() {
+        List<UserId> bots = poolService.provision(1);
+        flushAndClear();
+
+        List<PlaylistData> playlists = aggregatePort.findPlaylistsByOwnerAndType(bots.get(0), PlaylistType.PLAYLIST);
+        assertThat(playlists).hasSize(1); // 두 번째 PLAYLIST가 생기면 playlistIdOf 단건 조회 파손
     }
 }

--- a/docs/superpowers/plans/2026-07-11-default-dj-playlist.md
+++ b/docs/superpowers/plans/2026-07-11-default-dj-playlist.md
@@ -1,0 +1,235 @@
+# 신규 가입자 기본 플레이리스트 구현 플랜 (#329)
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 신규 가입자에게 가입 시 GRABLIST와 함께 PLAYLIST 타입 기본 플리("내 플레이리스트")를 자동 생성해 DJ 온보딩의 "플레이리스트 생성" 단계를 제거한다. 백엔드 단독, 스키마/정책/웹 무변경.
+
+**Architecture:** `PlaylistCommandService.createDefaultDjPlaylist` 신설(기존 GRABLIST 생성과 동일 패턴 — 정책 우회, order 1) → `PlaylistSetupPort`/`PlaylistSetupAdapter` 확장 → 사람 가입 경로 2곳(`MemberSignService.initializeNewMember`, `TemporaryUserInitializeService.addAssociateMember`)에서 기존 `createDefaultPlaylist` 다음 줄에 호출. 봇/가상멤버 경로(`AdminUserService.createVirtualMember`)는 단건 조회(`playlistIdOf`) 보호를 위해 의도적 제외.
+
+**Tech Stack:** Spring Boot 3(Java 21), JUnit5/Mockito, Testcontainers IT(AbstractIntegrationTest·패턴A)
+
+**Spec:** `docs/superpowers/specs/2026-07-11-default-dj-playlist-design.md`
+**Branch:** `feat/default-dj-playlist-329` (origin/develop 분기, 스펙 커밋 `af888905` 존재)
+**Working dir:** `C:\Users\Eisen\Desktop\Labs\[projects] pfplay\pfplay-platform`
+**빌드:** gradle은 항상 `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7"` prefix.
+
+**확인된 기존 코드 사실 (재검증 불필요):**
+- `PlaylistCommandService.createDefaultPlaylist`(라인 29-33): `PlaylistData.create(0, "그랩한 곡", PlaylistType.GRABLIST, userId)` + `aggregatePort.savePlaylist(playlist)`, `@Transactional`, 정책 미호출.
+- `PlaylistSetupPort`(user BC, 메서드 1개) / `PlaylistSetupAdapter`(`app/.../bootstrap/adapter/`, `PlaylistCommandService` 위임).
+- 호출 지점: `MemberSignService.java:126`(step 4 주석 아래) / `TemporaryUserInitializeService.java:113`(orElseGet 신규 멤버 분기 안).
+- 기존 유닛 테스트 verify 지점: `MemberSignServiceTest` 라인 84·113(never)·145·169·191(never) / `TemporaryUserInitializeServiceTest:85`. `AdminUserServiceTest:91`은 adminPlaylistPort라 무관(무변경).
+- `PlaylistCommandServiceTest`: `@ExtendWith(MockitoExtension)` + `@Mock PlaylistAggregatePort` + `ThreadLocalContext.setContext(mock AuthContext)` 패턴, `@AfterEach` clear.
+- 봇 IT: `app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualUserPoolServiceIT.java` 기존재 — provision 검증 확장 적소.
+- `PlaylistCreationPolicy.enforce(tier, count)`: AM=1, PLAYLIST 타입만 카운트, 초과 시 `ConflictException`(PLL-002).
+
+---
+
+## Chunk 1: 구현 (TDD)
+
+### Task 1: `createDefaultDjPlaylist` 서비스 메서드
+
+**Files:**
+- Modify: `playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/PlaylistCommandService.java`
+- Test(Modify): `playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/PlaylistCommandServiceTest.java`
+
+- [ ] **Step 1: 실패하는 테스트 추가** (기존 테스트 클래스에 — 파일의 기존 픽스처/패턴 재사용):
+
+```java
+    @Test
+    @DisplayName("createDefaultDjPlaylist — PLAYLIST 타입 '내 플레이리스트'(order 1)를 정책 검사 없이 저장한다")
+    void createDefaultDjPlaylist_savesPlaylistTypeWithFixedName() {
+        playlistCommandService.createDefaultDjPlaylist(userId);
+
+        ArgumentCaptor<PlaylistData> captor = ArgumentCaptor.forClass(PlaylistData.class);
+        verify(aggregatePort).savePlaylist(captor.capture());
+        PlaylistData saved = captor.getValue();
+        assertThat(saved.getType()).isEqualTo(PlaylistType.PLAYLIST);
+        assertThat(saved.getName()).isEqualTo("내 플레이리스트");
+        assertThat(saved.getOrderNumber()).isEqualTo(1);
+        assertThat(saved.getOwnerId()).isEqualTo(userId);
+        // 정책 우회: findPlaylistsByOwnerAndType(상한 카운트용 조회)가 호출되지 않아야 한다
+        verify(aggregatePort, never()).findPlaylistsByOwnerAndType(any(), any());
+    }
+```
+
+(`ArgumentCaptor` import 추가. ✅리뷰 확정: `PlaylistData.create(Integer, String, PlaylistType, UserId)` / getter는 `getName()`·`getOrderNumber()`(Integer)·`getType()`·`getOwnerId()` — 위 코드 그대로 유효.)
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :playlist:test --tests "com.pfplaybackend.api.playlist.application.service.PlaylistCommandServiceTest"`
+Expected: 컴파일 실패 — `createDefaultDjPlaylist` 미존재.
+
+- [ ] **Step 3: 구현** — `createDefaultPlaylist` 바로 아래에 추가:
+
+```java
+    /**
+     * 신규 가입자 온보딩용 기본 DJ 플레이리스트(#329).
+     * GRABLIST 생성({@link #createDefaultPlaylist})과 동일하게 시스템 생성이라 생성 상한 정책을 거치지
+     * 않는다(가입 시점 1회). AM 상한(1)은 이 플리가 소모하며, 유저는 rename/삭제가 자유롭고 삭제 시
+     * 슬롯이 해제된다(정책은 현존 행 수 기준).
+     *
+     * <p>⚠️ 호출처는 <b>사람 가입 경로 한정</b>(MemberSignService·TemporaryUserInitializeService).
+     * 봇/가상 멤버({@code AdminUserService.createVirtualMember} 경유 — 데모 멤버 포함)에는 배선하지
+     * 않는다: 봇은 provision 이 자체 PLAYLIST 를 만들며, 송팩 적용이
+     * {@code findByOwnerIdAndType(PLAYLIST)} 단건 조회에 의존하므로 두 번째 PLAYLIST 는 이를 파손한다.
+     */
+    @Transactional
+    public void createDefaultDjPlaylist(UserId userId) {
+        PlaylistData playlist = PlaylistData.create(1, "내 플레이리스트", PlaylistType.PLAYLIST, userId);
+        aggregatePort.savePlaylist(playlist);
+    }
+```
+
+- [ ] **Step 4: 통과 확인** — Step 2 명령 재실행, 클래스 전체 PASS(기존+신규).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/PlaylistCommandService.java playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/PlaylistCommandServiceTest.java
+git commit -m "feat(playlist): 기본 DJ 플레이리스트 생성 메서드 — 정책 우회·봇 경로 제외 명문화 (#329)"
+```
+
+### Task 2: 포트/어댑터 확장 + 소셜 가입 배선
+
+**Files:**
+- Modify: `user/src/main/java/com/pfplaybackend/api/user/application/port/out/PlaylistSetupPort.java`
+- Modify: `app/src/main/java/com/pfplaybackend/api/bootstrap/adapter/PlaylistSetupAdapter.java`
+- Modify: `user/src/main/java/com/pfplaybackend/api/user/application/service/MemberSignService.java`
+- Test(Modify): `user/src/test/java/com/pfplaybackend/api/user/application/service/MemberSignServiceTest.java`
+
+- [ ] **Step 1: 실패하는 테스트 갱신** — `MemberSignServiceTest`의 verify 지점 5곳을 짝으로 확장:
+  - 라인 84: `verify(playlistSetupPort).createDefaultPlaylist(savedAccount.getUserId());` 다음 줄에 `verify(playlistSetupPort).createDefaultDjPlaylist(savedAccount.getUserId());`
+  - 라인 145·169: 동일 패턴으로 각각 추가.
+  - 라인 113·191(never 케이스): `verify(playlistSetupPort, never()).createDefaultDjPlaylist(any(UserId.class));` 추가.
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `JAVA_HOME=... ./gradlew :user:test --tests "com.pfplaybackend.api.user.application.service.MemberSignServiceTest"`
+Expected: 컴파일 실패 — 포트에 메서드 없음.
+
+- [ ] **Step 3: 구현**
+  - `PlaylistSetupPort`: `void createDefaultDjPlaylist(UserId userId);` 추가 (javadoc: 신규 가입자 온보딩용 기본 PLAYLIST — 사람 가입 경로 전용).
+  - `PlaylistSetupAdapter`: `@Override public void createDefaultDjPlaylist(UserId userId) { playlistCommandService.createDefaultDjPlaylist(userId); }`
+  - `MemberSignService.java:126` 다음 줄: `playlistSetupPort.createDefaultDjPlaylist(userAccount.getUserId());` (step 4 주석을 "default playlists" 복수로 갱신).
+
+- [ ] **Step 4: 통과 확인** — Step 2 명령 + `JAVA_HOME=... ./gradlew :app:compileJava` PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add user/src/main/java/com/pfplaybackend/api/user/application/port/out/PlaylistSetupPort.java app/src/main/java/com/pfplaybackend/api/bootstrap/adapter/PlaylistSetupAdapter.java user/src/main/java/com/pfplaybackend/api/user/application/service/MemberSignService.java user/src/test/java/com/pfplaybackend/api/user/application/service/MemberSignServiceTest.java
+git commit -m "feat(user): 소셜 가입 시 기본 DJ 플레이리스트 생성 배선 (#329)"
+```
+
+### Task 3: 게스트→회원 전환 배선
+
+**Files:**
+- Modify: `user/src/main/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeService.java`
+- Test(Modify): `user/src/test/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeServiceTest.java`
+
+- [ ] **Step 1: 실패하는 테스트 갱신** — `:85`의 `verify(playlistSetupPort).createDefaultPlaylist(any(UserId.class));` 다음 줄에 `verify(playlistSetupPort).createDefaultDjPlaylist(any(UserId.class));` 추가. (✅리뷰 확정: 그 파일에 기존-멤버 재진입 테스트 없음 — never() 짝 불필요.)
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `JAVA_HOME=... ./gradlew :user:test --tests "com.pfplaybackend.api.user.application.service.initialize.TemporaryUserInitializeServiceTest"`
+Expected: FAIL — 신규 verify 미충족.
+
+- [ ] **Step 3: 구현** — `TemporaryUserInitializeService.java:113` 다음 줄에 `playlistSetupPort.createDefaultDjPlaylist(userId);`
+
+- [ ] **Step 4: 통과 확인** — Step 2 명령 PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add user/src/main/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeService.java user/src/test/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeServiceTest.java
+git commit -m "feat(user): 게스트→회원 전환 시 기본 DJ 플레이리스트 생성 배선 (#329)"
+```
+
+### Task 4: IT 4건 — 가입 세트·봇 회귀·AM 상한·삭제 재생성
+
+**Files:**
+- Create: `app/src/test/java/com/pfplaybackend/api/playlist/DefaultDjPlaylistIT.java`
+- Modify: `app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualUserPoolServiceIT.java`
+
+- [ ] **Step 1: 기존 IT 픽스처 파악** — `VirtualUserPoolServiceIT` 읽고 provision 픽스처(mock/시드) 재사용 방식 확인. `AbstractIntegrationTest`의 `flushAndClear()`·`ThreadLocalContext` 관례는 `VirtualCrewAdminServiceIT` 참조. `TemporaryUserInitializeService.addAssociateMember`(또는 실제 public 진입 메서드 시그니처)를 확인해 가입 IT 진입점으로 사용 — MemberSignService 경로는 OAuth 의존이 무거우면 게스트→회원 경로로 가입 초기화를 대표 검증(두 경로 모두 유닛으로 배선 검증됨).
+
+- [ ] **Step 2: 실패하는 IT 작성** (개념 코드 — Step 1 확인분으로 시그니처 조정):
+
+`DefaultDjPlaylistIT` (신규, `@Transactional`, AbstractIntegrationTest):
+
+```java
+    @Test
+    @DisplayName("가입 초기화 — GRABLIST 1 + '내 플레이리스트'(PLAYLIST) 1 이 생성된다")
+    void signupInitialization_createsGrablistAndDefaultDjPlaylist() {
+        UserId userId = initializeNewMemberFixture(); // ✅확정: temporaryUserInitializeService.addAssociateMember(UserId, String email) → MemberData (user BC @Service, app IT에서 주입 가능)
+        flushAndClear();
+
+        List<PlaylistData> grab = aggregatePort.findPlaylistsByOwnerAndType(userId, PlaylistType.GRABLIST);
+        List<PlaylistData> normal = aggregatePort.findPlaylistsByOwnerAndType(userId, PlaylistType.PLAYLIST);
+        assertThat(grab).hasSize(1);
+        assertThat(normal).hasSize(1);
+        assertThat(normal.get(0).getName()).isEqualTo("내 플레이리스트");
+    }
+
+    @Test
+    @DisplayName("AM 유저(기본 플리 보유)가 추가 생성 시도 → PLL-002 EXCEEDED_PLAYLIST_LIMIT")
+    void amUserWithDefaultPlaylist_cannotCreateAnother() {
+        UserId userId = initializeNewMemberFixture();
+        setAuthContext(userId, AuthorityTier.AM); // ThreadLocalContext 세팅 헬퍼
+        assertThatThrownBy(() -> playlistCommandService.createPlaylist("두번째"))
+                .isInstanceOf(ConflictException.class);
+    }
+
+    @Test
+    @DisplayName("기본 플리 삭제 후엔 다시 1개 생성 가능 — 락아웃 없음")
+    void afterDeletingDefault_amUserCanCreateAgain() {
+        UserId userId = initializeNewMemberFixture();
+        setAuthContext(userId, AuthorityTier.AM);
+        Long defaultId = /* PLAYLIST 타입 단건 조회로 id 획득 */;
+        playlistCommandService.deletePlaylist(List.of(defaultId));
+        PlaylistData recreated = playlistCommandService.createPlaylist("직접 만든 플리");
+        assertThat(recreated.getType()).isEqualTo(PlaylistType.PLAYLIST);
+    }
+```
+
+`VirtualUserPoolServiceIT`에 추가:
+
+```java
+    @Test
+    @DisplayName("봇 provision — PLAYLIST 타입이 정확히 1개(봇 전용)여야 한다 (#329 기본 플리 이중 생성 회귀 방지)")
+    void provision_botHasExactlyOnePlaylistTypePlaylist() {
+        List<UserId> bots = poolService.provision(1);
+        flushAndClear();
+        List<PlaylistData> playlists = aggregatePort.findPlaylistsByOwnerAndType(bots.get(0), PlaylistType.PLAYLIST);
+        assertThat(playlists).hasSize(1); // 두 번째 PLAYLIST가 생기면 playlistIdOf 단건 조회 파손
+    }
+```
+
+(✅리뷰 확정 조회 수단: `PlaylistAggregatePort.findPlaylistsByOwnerAndType(UserId, PlaylistType)` → List — 이것을 사용. ⚠️`PlaylistRepository.findByOwnerIdAndType`는 **단건 반환**이라 2행이면 예외 — hasSize 단언용으로 금지. AuthContext 헬퍼 선례: `new AuthContext(userId, AuthorityTier.AM)` + `ThreadLocalContext.setContext`(CreateGeneralPartyRoomInvariantIntegrationTest:127 패턴). Task 2 verify 삽입은 라인번호가 밀리므로 인용된 verify 문 기준으로 앵커.)
+
+- [ ] **Step 3: 실패/통과 확인** — 신규 IT 실행:
+
+Run: `JAVA_HOME=... ./gradlew :app:integrationTest --tests "com.pfplaybackend.api.playlist.DefaultDjPlaylistIT" --tests "com.pfplaybackend.api.virtualcrew.VirtualUserPoolServiceIT"`
+Expected: 전부 PASS (Tasks 1-3 구현이 선행돼 있으므로 그린이 정상 — 봇 테스트는 "지금도 1개"를 고정하는 회귀 가드).
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add app/src/test/java/com/pfplaybackend/api/playlist/DefaultDjPlaylistIT.java app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualUserPoolServiceIT.java
+git commit -m "test(playlist): 가입 기본 플리 세트·봇 단일 PLAYLIST 회귀·AM 상한·삭제 재생성 IT (#329)"
+```
+
+## Chunk 2: 검증 게이트 + PR
+
+### Task 5: 전량 회귀 + 부팅 게이트 + 라이브 확인
+
+- [ ] **Step 1: 전량 유닛** — `JAVA_HOME=... ./gradlew test`(전 모듈: app·user·playlist 등) → GREEN.
+- [ ] **Step 2: 전량 IT** — `JAVA_HOME=... ./gradlew :app:integrationTest` → GREEN (선재 플래키 #320 1건만 빨간 경우 재실행 판정).
+- [ ] **Step 3: fresh DB 부팅 게이트** — `./gradlew :app:bootJar -x test` → `docker compose -f docker-compose.local.yml -p pfplay-local down -v` → `--env-file .env.local up -d --build` → "Started Application" + `/v3/api-docs` 200 + 로그 ERROR 0.
+- [ ] **Step 4: 라이브 확인** — 게스트 sign(`POST /api/v1/users/guests/sign`) → 회원 전환/신규 가입 경로(로컬 dev 경로, `EasyUserManagementController`는 !prod 노출) 후. 참고(리뷰): 부팅 시드 temp 유저(`addTemporaryUsers`)도 기본 플리를 받게 됨 — 의도된 부수효과. 플리 목록 조회로 "내 플레이리스트" 존재 확인. DB 직접 확인도 병행: `SELECT name,type FROM playlist WHERE user_id=<신규 userId>` → GRABLIST+PLAYLIST 각 1행.
+- [ ] **Step 5: 웹 dj-register e2e 회귀** — pfplay-web을 `development` 브랜치로 체크아웃 후 로컬 풀스택 e2e: `E2E_BASE_URL="http://localhost:3000" E2E_API_BASE="http://localhost:8080/api/" npx playwright test --project=e2e-b` + `--project=mobile e2e/mobile/dj-register.spec.ts` (next dev 기동·예열 절차는 기존 메모리 준수). 기존 `createPlaylistWithTracks` 헬퍼 플로우가 기본 플리 존재로 깨지지 않는지 확인(추가 플리가 있어도 이름 기반 셀렉터라 무영향 예상 — 깨지면 원인 보고). 완료 후 web 브랜치 원복.
+
+### Task 6: PR
+
+- [ ] **Step 1: 커밋 정리** — Task별 4~5커밋이 논리단위면 유지(과분할 시 통합, 파괴적 rebase 전 사용자 확인).
+- [ ] **Step 2: push + PR** — base `develop`, 제목 `feat(playlist): 신규 가입자 기본 플레이리스트 — DJ 온보딩 생성 단계 제거 (#329)`, 본문 한글(스펙 링크·확정 결정 4개·검증 증거·봇 제외 근거). CI 그린 확인. 머지=사용자 게이트.

--- a/docs/superpowers/specs/2026-07-11-default-dj-playlist-design.md
+++ b/docs/superpowers/specs/2026-07-11-default-dj-playlist-design.md
@@ -1,0 +1,83 @@
+# 신규 가입자 기본 플레이리스트 — 설계 (#329)
+
+## 배경 (재검증으로 정정된 문제 정의)
+
+DJ 등록에는 "곡이 담긴 플레이리스트"가 필요하다. 원래 프레이밍은 "플리가 없어 생성 단계가 강요된다"였으나, 재검증 결과(2026-07-11):
+
+- 가입 시 GRABLIST("그랩한 곡")가 항상 자동 생성되므로 회원의 플리 목록은 절대 0개가 아니다. 실제 게이트는 **"곡 있는 플리 없음"**이다 — 데스크탑 셀렉터의 `musicCount>0` 필터(`use-select-playlist.hook.tsx:95`)와 백엔드 `DjEnqueueSpecification`의 `EMPTY_PLAYLIST`(DJ-003) 거부.
+- 따라서 이 기능이 제거하는 마찰은 정확히 **"플레이리스트 생성"이라는 조작 단계 하나**다. 곡 추가는 본질적으로 사용자 몫(취향)으로 남는다. 신규 유저는 DJ 등록 진입 시 플리가 이미 있으므로 **곡 추가부터 시작**하게 된다 — 모바일은 빈 플리 카드 "+곡 추가" CTA 기존재, 데스크탑 드로어도 플리 존재 시 생성 없이 곡 추가만 남는다. **웹 코드 무변경.**
+
+## 사용자 확정 결정 (2026-07-11)
+
+1. **신규 가입자만**: 가입 시 GRABLIST + **PLAYLIST 타입 기본 플리 각 1개**. 기존 유저 데이터 무변경(백필 없음) — 기존 유저는 혜택 없음(트레이드오프 수용).
+2. **AM=1 상한 유지, 기본 플리 카운트 포함**: 정책·스키마 무변경. 신규 AM은 기본 플리 rename(`PATCH /api/v1/playlists/{id}` 기존재)으로 기존 AM(직접 1개 생성)과 실질 동등.
+3. **기본 플리 이름 = "내 플레이리스트"** (서버 하드코딩 한국어 — GRABLIST "그랩한 곡" 선례와 동일, 유저 rename 가능).
+4. **삭제 허용** (아래 삭제 시맨틱).
+5. **GRABLIST 디제잉 = 의도된 제품 동작** (사용자 확인 2026-07-11): DJ enqueue가 플리 타입을 검사하지 않는 것은 정상이며, 그랩곡 보유 유저는 GRABLIST로 바로 디제잉 가능. 본 건에서 어떤 타입 가드도 추가하지 않는다.
+
+## 목표 / 성공 기준
+
+- 신규 가입 직후 회원의 플리 상태 = GRABLIST + "내 플레이리스트" 정확히 각 1개.
+- 신규 유저의 DJ 등록 플로우에서 "플레이리스트 생성" 단계가 사라지고 곡 추가부터 시작.
+- 기존 유저·봇·기존 API 동작 회귀 0.
+
+## 비목표 (YAGNI)
+
+- 기존 유저 백필. `is_auto_created` 플래그. 곡 자동 채움. 삭제/rename 가드 추가. GRABLIST 관련 일체 변경. 웹 코드 변경. TEMP 플리 생성(quick-dj #3 소관 — 아래 정합 절).
+
+## 설계 (백엔드 국소 — 스키마/마이그레이션/정책 무변경)
+
+### ① `PlaylistCommandService.createDefaultDjPlaylist(userId)` 신설
+
+```java
+public void createDefaultDjPlaylist(UserId userId) {
+    PlaylistData playlist = PlaylistData.create(1, "내 플레이리스트", PlaylistType.PLAYLIST, userId);
+    aggregatePort.savePlaylist(playlist);  // 기존 createDefaultPlaylist(라인 29-33)와 동일 저장 경로
+}
+```
+
+- 기존 `createDefaultPlaylist`(GRABLIST, order 0)와 동일 패턴: **정책 검사 우회**(가입 시점 시스템 생성이라 상한 무관), orderNumber 1(GRABLIST=0 다음).
+- orderNumber 참고: 기존 `createPlaylist`의 orderNumber 산정(`isEmpty ? 1 : size`)은 중복 order를 이미 허용하는 선재 quirk — 본 건은 그 동작을 바꾸지 않으며, 기본 플리(order 1) 이후 첫 수동 생성이 order 1을 재사용해도 기존과 동일한 수준의 무해한 중복이다.
+
+### ② `PlaylistSetupPort` 확장 + 사람 가입 경로 2곳 배선
+
+- `PlaylistSetupPort`에 `createDefaultDjPlaylist(UserId)` 추가, `PlaylistSetupAdapter`(bootstrap) 위임 구현.
+- 호출 지점 — 기존 `createDefaultPlaylist` 호출 **바로 다음 줄**:
+  - `MemberSignService.initializeNewMember` (`MemberSignService.java:126` 다음) — 소셜 가입.
+  - `TemporaryUserInitializeService` (`:113` 다음) — 게스트→회원 전환(신규 멤버 생성 `orElseGet` 내부라 기존 회원 재진입 없음 — 중복 생성 위험 없음 확인).
+
+### ③ 봇/가상 멤버 경로 의도적 제외 (핵심 가드)
+
+`AdminUserService.createVirtualMember`(→`adminPlaylistPort.createDefaultPlaylist`)는 **배선하지 않는다.**
+
+- 근거: 봇은 `VirtualUserPoolService.provision`이 자체 PLAYLIST(`BOT_PLAYLIST_NAME`, order 1)를 직접 생성하며, 송팩 적용·DJ enqueue가 `playlistRepository.findByOwnerIdAndType(botUserId, PLAYLIST)` **단건 조회**(`playlistIdOf`)에 의존한다. 기본 플리를 추가하면 PLAYLIST 2개가 되어 이 조회가 파손된다.
+- `AdminPlaylistPort`/`AdminPlaylistAdapter`도 무변경. 제외 근거를 신설 메서드 javadoc에 명문화하고, **회귀 IT("봇 provision 후 PLAYLIST 정확히 1개")로 고정**한다.
+- 부수 효과(의도): `createVirtualMember`를 쓰는 데모/가상 멤버(`AdminPartyroomService`/`AdminDemoService`)도 기본 플리를 받지 않는다 — 실사용자 온보딩 전용 기능이므로 올바른 동작. javadoc에 한 줄 병기.
+
+### 삭제 시맨틱 (검토 완료 — 허용)
+
+- `deletePlaylist`는 소유권 검사만 하며 기본 플리는 무플래그 평범한 PLAYLIST 행 → 삭제 가능(의도).
+- **락아웃 없음**: `PlaylistCreationPolicy`는 현존 행 수 기준 카운트 — 삭제 후 AM도 다시 1개 직접 생성 가능.
+- **자동 재생성 없음**: 의도적 삭제 존중, 이후 구 플로우(직접 생성)로 자연 복귀. "기본 플리 존재"를 가정하는 코드가 백엔드·웹 어디에도 없음(웹 0-플리 분기도 존치).
+- 참고(선재, 본 건 무관·무악화): 삭제에 타입 가드가 없어 GRABLIST도 API로는 삭제 가능(웹 UI가 미노출로 방어) / DJ 등록 중 플리 삭제 가드 없음.
+
+### quick-dj(#3, 승인 스펙 2026-07-01)와의 정합
+
+- quick-dj의 숨김 `PlaylistType.TEMP` 플리는 그 스펙의 `findOrCreateTempPlaylist`가 **첫 사용 시 lazy 생성** — 기존·신규 유저 전원을 자동 커버하므로 **본 건에서 TEMP를 만들지 않는다**(가입 초기화 세트는 GRABLIST+기본 플리로 한정).
+- 접점 전수 검사(2026-07-11): PlaylistType(무추가 vs TEMP 추가·STRING 안전) / 상한(PLAYLIST만 카운트 → TEMP 자동 제외, 기본 플리는 포함) / 목록 노출(기본 플리 노출 vs TEMP 필터) / 봇(양쪽 다 제외) / `findByOwnerIdAndType` 단건 조회(봇 전용이라 사람의 PLAYLIST 복수 보유와 무관, TEMP 별개 타입) — **전부 무충돌.** 구현 순서 #2→#3 무방.
+
+## 오류 처리
+
+- 신설 메서드는 기존 `createDefaultPlaylist` **바로 다음 줄, 동일 트랜잭션 문맥**에서 실행 — 소셜 가입 경로(`getOrCreateMemberFor` @Transactional)는 실패 시 가입 전체 롤백. 게스트→회원 경로(`addAssociateMember`)는 선재적으로 비-@Transactional(호출별 독립 커밋)이나, 기존 GRABLIST 생성과 **정확히 동일한 시맨틱**을 공유하므로 신규 실패 모드 없음.
+
+## 테스트
+
+- **유닛**: `createDefaultDjPlaylist`(타입 PLAYLIST·이름 "내 플레이리스트"·order 1·정책 미호출). `MemberSignService`/`TemporaryUserInitializeService`가 두 생성 메서드를 각 1회 호출(기존 "createDefaultPlaylist 1회" 단언 테스트 갱신).
+- **IT**: ①가입 초기화 → GRABLIST 1 + PLAYLIST("내 플레이리스트") 1 단언 ②**봇 provision → PLAYLIST 타입 정확히 1개(BOT_PLAYLIST_NAME) 단언 — 이중 생성 회귀 방지 핵심** ③AM 유저(기본 플리 보유)가 `createPlaylist` 시도 → `PLL-002 EXCEEDED_PLAYLIST_LIMIT` ④기본 플리 삭제 후 `createPlaylist` → 성공(락아웃 없음).
+- **로컬 검증 게이트**: fresh DB docker 부팅(bootJar 선행) + 라이브 확인(신규 가입 경로 → 플리 목록에 "내 플레이리스트") + 웹 dj-register e2e 회귀(기존 `createPlaylistWithTracks` 헬퍼 플로우 무영향 확인).
+- 기존 전체 유닛/IT 회귀 그린.
+
+## 산출물 / 절차
+
+- 이슈: platform **#329**. 브랜치: `feat/default-dj-playlist-329`(origin/develop 분기). 웹/어드민 무변경 — 단일 레포 PR.
+- 커밋/PR 한글, dev 머지 전 로컬 풀스택 게이트, 머지=사용자 게이트.

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/PlaylistCommandService.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/PlaylistCommandService.java
@@ -32,6 +32,23 @@ public class PlaylistCommandService {
         aggregatePort.savePlaylist(playlist);
     }
 
+    /**
+     * 신규 가입자 온보딩용 기본 DJ 플레이리스트(#329).
+     * GRABLIST 생성({@link #createDefaultPlaylist})과 동일하게 시스템 생성이라 생성 상한 정책을 거치지
+     * 않는다(가입 시점 1회). AM 상한(1)은 이 플리가 소모하며, 유저는 rename/삭제가 자유롭고 삭제 시
+     * 슬롯이 해제된다(정책은 현존 행 수 기준).
+     *
+     * <p>⚠️ 호출처는 <b>사람 가입 경로 한정</b>(MemberSignService·TemporaryUserInitializeService).
+     * 봇/가상 멤버({@code AdminUserService.createVirtualMember} 경유 — 데모 멤버 포함)에는 배선하지
+     * 않는다: 봇은 provision 이 자체 PLAYLIST 를 만들며, 송팩 적용이
+     * {@code findByOwnerIdAndType(PLAYLIST)} 단건 조회에 의존하므로 두 번째 PLAYLIST 는 이를 파손한다.
+     */
+    @Transactional
+    public void createDefaultDjPlaylist(UserId userId) {
+        PlaylistData playlist = PlaylistData.create(1, "내 플레이리스트", PlaylistType.PLAYLIST, userId);
+        aggregatePort.savePlaylist(playlist);
+    }
+
     @Transactional
     public PlaylistData createPlaylist(String playlistName) {
         AuthContext authContext = ThreadLocalContext.getAuthContext();

--- a/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/PlaylistCommandServiceTest.java
+++ b/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/PlaylistCommandServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -50,6 +51,24 @@ class PlaylistCommandServiceTest {
     @AfterEach
     void tearDown() {
         ThreadLocalContext.clearContext();
+    }
+
+    // ========== createDefaultDjPlaylist ==========
+
+    @Test
+    @DisplayName("createDefaultDjPlaylist — PLAYLIST 타입 '내 플레이리스트'(order 1)를 정책 검사 없이 저장한다")
+    void createDefaultDjPlaylist_savesPlaylistTypeWithFixedName() {
+        playlistCommandService.createDefaultDjPlaylist(userId);
+
+        ArgumentCaptor<PlaylistData> captor = ArgumentCaptor.forClass(PlaylistData.class);
+        verify(aggregatePort).savePlaylist(captor.capture());
+        PlaylistData saved = captor.getValue();
+        assertThat(saved.getType()).isEqualTo(PlaylistType.PLAYLIST);
+        assertThat(saved.getName()).isEqualTo("내 플레이리스트");
+        assertThat(saved.getOrderNumber()).isEqualTo(1);
+        assertThat(saved.getOwnerId()).isEqualTo(userId);
+        // 정책 우회: findPlaylistsByOwnerAndType(상한 카운트용 조회)가 호출되지 않아야 한다
+        verify(aggregatePort, never()).findPlaylistsByOwnerAndType(any(), any());
     }
 
     // ========== createPlaylist ==========

--- a/user/src/main/java/com/pfplaybackend/api/user/application/port/out/PlaylistSetupPort.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/port/out/PlaylistSetupPort.java
@@ -4,4 +4,10 @@ import com.pfplaybackend.api.common.domain.value.UserId;
 
 public interface PlaylistSetupPort {
     void createDefaultPlaylist(UserId userId);
+
+    /**
+     * 신규 가입자 온보딩용 기본 PLAYLIST("내 플레이리스트") 생성 — 사람 가입 경로 전용(#329).
+     * 봇/가상 멤버 경로에는 배선하지 않는다.
+     */
+    void createDefaultDjPlaylist(UserId userId);
 }

--- a/user/src/main/java/com/pfplaybackend/api/user/application/service/MemberSignService.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/service/MemberSignService.java
@@ -122,8 +122,9 @@ public class MemberSignService {
         // 3. Persist Member (cascades the new ProfileData).
         MemberData savedMember = memberRepository.save(member);
 
-        // 4. Initialize default playlist (Party-context onboarding).
+        // 4. Initialize default playlists (Party-context onboarding): GRABLIST + PLAYLIST(#329).
         playlistSetupPort.createDefaultPlaylist(userAccount.getUserId());
+        playlistSetupPort.createDefaultDjPlaylist(userAccount.getUserId());
 
         // 5. Publish event for downstream listeners.
         applicationEventPublisher.publishEvent(

--- a/user/src/main/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeService.java
+++ b/user/src/main/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeService.java
@@ -111,6 +111,7 @@ public class TemporaryUserInitializeService {
                     userActivityCommandService.createUserActivities(userId);
 
                     playlistSetupPort.createDefaultPlaylist(userId);
+                    playlistSetupPort.createDefaultDjPlaylist(userId);
                     return memberData;
                 });
     }

--- a/user/src/test/java/com/pfplaybackend/api/user/application/service/MemberSignServiceTest.java
+++ b/user/src/test/java/com/pfplaybackend/api/user/application/service/MemberSignServiceTest.java
@@ -82,6 +82,7 @@ class MemberSignServiceTest {
         // Side-effects on the new-Member path (matches pre-V4 behavior).
         verify(userProfileCommandService).createProfileDataForMember(savedAccount.getUserId());
         verify(playlistSetupPort).createDefaultPlaylist(savedAccount.getUserId());
+        verify(playlistSetupPort).createDefaultDjPlaylist(savedAccount.getUserId());
         verify(applicationEventPublisher).publishEvent(any(MemberRegisteredEvent.class));
     }
 
@@ -111,6 +112,7 @@ class MemberSignServiceTest {
         // No new-Member side-effects when Member already exists.
         verify(userProfileCommandService, never()).createProfileDataForMember(any(UserId.class));
         verify(playlistSetupPort, never()).createDefaultPlaylist(any(UserId.class));
+        verify(playlistSetupPort, never()).createDefaultDjPlaylist(any(UserId.class));
         verify(applicationEventPublisher, never()).publishEvent(any(MemberRegisteredEvent.class));
     }
 
@@ -143,6 +145,7 @@ class MemberSignServiceTest {
         // so onboarding side-effects fire here too.
         verify(userProfileCommandService).createProfileDataForMember(existingAccount.getUserId());
         verify(playlistSetupPort).createDefaultPlaylist(existingAccount.getUserId());
+        verify(playlistSetupPort).createDefaultDjPlaylist(existingAccount.getUserId());
         verify(applicationEventPublisher).publishEvent(any(MemberRegisteredEvent.class));
     }
 
@@ -167,6 +170,7 @@ class MemberSignServiceTest {
         verify(memberRepository).save(any(MemberData.class));
         verify(userProfileCommandService).createProfileDataForMember(existingAccount.getUserId());
         verify(playlistSetupPort).createDefaultPlaylist(existingAccount.getUserId());
+        verify(playlistSetupPort).createDefaultDjPlaylist(existingAccount.getUserId());
         verify(applicationEventPublisher).publishEvent(any(MemberRegisteredEvent.class));
         // Critical: no recordLogin side effect on the UA.
         assertThat(existingAccount.getLastLoginAt()).isNull();
@@ -189,6 +193,7 @@ class MemberSignServiceTest {
         verify(memberRepository, never()).save(any(MemberData.class));
         verify(userProfileCommandService, never()).createProfileDataForMember(any(UserId.class));
         verify(playlistSetupPort, never()).createDefaultPlaylist(any(UserId.class));
+        verify(playlistSetupPort, never()).createDefaultDjPlaylist(any(UserId.class));
         verify(applicationEventPublisher, never()).publishEvent(any(MemberRegisteredEvent.class));
         // No recordLogin side effect.
         assertThat(existingAccount.getLastLoginAt()).isNull();

--- a/user/src/test/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeServiceTest.java
+++ b/user/src/test/java/com/pfplaybackend/api/user/application/service/initialize/TemporaryUserInitializeServiceTest.java
@@ -83,6 +83,7 @@ class TemporaryUserInitializeServiceTest {
         verify(memberRepository).save(any(MemberData.class));
         verify(userActivityCommandService).createUserActivities(any(UserId.class));
         verify(playlistSetupPort).createDefaultPlaylist(any(UserId.class));
+        verify(playlistSetupPort).createDefaultDjPlaylist(any(UserId.class));
     }
 
     @Test


### PR DESCRIPTION
Closes #329

## 개요 (2026-07 로드맵 #2)
신규 가입자에게 가입 시 GRABLIST와 함께 **PLAYLIST 타입 기본 플리("내 플레이리스트")**를 자동 생성한다. 재검증으로 정정된 문제 정의: 가입 시 GRABLIST가 항상 존재하므로 실제 게이트는 "곡 있는 플리 없음" — 이 기능은 그중 **생성 단계**를 제거해 신규 유저가 DJ 등록 진입 시 곡 추가부터 시작하게 한다. **백엔드 단독, 스키마/마이그레이션/정책/웹 전부 무변경.**

스펙/플랜: `docs/superpowers/specs/2026-07-11-default-dj-playlist-design.md` · `docs/superpowers/plans/2026-07-11-default-dj-playlist.md`

## 확정 결정 (2026-07-11)
- **신규 가입자만** (기존 유저 무변경·백필 없음)
- **AM=1 상한 유지, 기본 플리 카운트 포함** — 신규 AM은 rename으로 커스텀 동등성
- **삭제 허용** — 정책이 현존 행 기준이라 삭제 후 재생성 가능(락아웃 없음), 자동 재생성 없음
- **GRABLIST 디제잉=의도된 제품 동작** 명문화 (타입 가드 미추가)
- **quick-dj(#3) 정합**: TEMP 숨김 플리는 그쪽 스펙의 lazy 생성이 전원 커버 — 본 건 무관여

## 구현
- `PlaylistCommandService.createDefaultDjPlaylist` (order 1, 정책 우회 — GRABLIST 생성과 동일 패턴)
- `PlaylistSetupPort`/`PlaylistSetupAdapter` 확장, **사람 가입 경로 2곳만 배선** (소셜 가입 + 게스트→회원 전환)
- **봇/가상멤버 경로 의도적 제외** — 봇은 provision이 자체 PLAYLIST 생성, 추가 시 `findByOwnerIdAndType` 단건 조회(`playlistIdOf`·송팩 적용) 파손. javadoc 명문화 + 회귀 IT로 고정

## 검증
- 유닛 전 모듈 그린 (app 1342·user 146·playlist 78, 0실패) — verify 짝 5+1곳 갱신 포함
- **IT 전량 78클래스·308/0** (fresh 실행). 신규 IT 4건: 가입→GRABLIST+"내 플레이리스트" 각 1 / **봇 provision→PLAYLIST 정확히 1개(이중 생성 회귀 방지)** / AM 초과→PLL-002 errorCode 단언 / 삭제 후 재생성 가능
- **fresh DB docker 부팅 게이트** + **라이브 확인**: 부팅 시드 유저 전원 `GRABLIST(0)+내 플레이리스트(1)` DB 단언(이름 바이트 일치 확인)
- **웹 e2e 회귀** (development 브랜치, 로컬 풀스택): mobile dj-register 3 passed / e2e-b 단독 그린 — 배치 실행 실패 2회는 문서화된 dev-모드 다중클라 환경 플래키(실패 모드가 매회 상이·백엔드 에러 0·단독 그린 판정법 준수)

🤖 Generated with [Claude Code](https://claude.com/claude-code)