### PR TITLE
feat: Quick-DJ — 곡 즉석 선택 one-shot DJ 대기열 등록 (#331)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandController.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandController.java
@@ -4,13 +4,18 @@ import com.pfplaybackend.api.common.ApiCommonResponse;
 import com.pfplaybackend.api.common.config.swagger.ApiErrorCodes;
 import com.pfplaybackend.api.common.domain.value.PlaylistId;
 import com.pfplaybackend.api.party.adapter.in.web.payload.request.dj.ChangePlaylistRequest;
+import com.pfplaybackend.api.party.adapter.in.web.payload.request.dj.QuickDjRequest;
 import com.pfplaybackend.api.party.adapter.in.web.payload.request.dj.RegisterDjRequest;
 import com.pfplaybackend.api.party.adapter.in.web.payload.response.CreateDjResponse;
+import com.pfplaybackend.api.party.adapter.in.web.payload.response.QuickDjResponse;
 import com.pfplaybackend.api.party.application.service.DjCommandService;
+import com.pfplaybackend.api.party.application.service.QuickDjService;
+import com.pfplaybackend.api.party.domain.entity.data.DjData;
 import com.pfplaybackend.api.party.domain.exception.DjException;
 import com.pfplaybackend.api.party.domain.exception.GradeException;
 import com.pfplaybackend.api.party.domain.value.DjId;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.playlist.application.dto.command.AddTrackCommand;
 import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -33,6 +38,7 @@ import org.springframework.web.bind.annotation.*;
 public class DjCommandController {
 
     private final DjCommandService djCommandService;
+    private final QuickDjService quickDjService;
 
     @Operation(summary = "DJ 등록", description = "파티룸의 DJ 큐에 등록합니다. 플레이리스트를 선택하여 등록하며, MEMBER 권한이 필요합니다.")
     @ApiResponse(responseCode = "201", description = "DJ 등록 성공")
@@ -46,6 +52,22 @@ public class DjCommandController {
         Long djId = djCommandService.enqueueDj(new PartyroomId(partyroomId), new PlaylistId(request.getPlaylistId()));
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiCommonResponse.success(new CreateDjResponse(djId)));
+    }
+
+    @Operation(summary = "Quick-DJ 등록",
+            description = "검색한 곡 하나로 즉시 DJ 큐에 one-shot 등록합니다. 1회 재생 후 자동으로 대기열에서 이탈하며, MEMBER 권한이 필요합니다.")
+    @ApiResponse(responseCode = "201", description = "Quick-DJ 등록 성공")
+    @SecurityRequirement(name = "cookieAuth")
+    @ApiErrorCodes({DjException.class})
+    @PostMapping("/{partyroomId}/dj-queue/quick")
+    @PreAuthorize("hasRole('MEMBER')")
+    public ResponseEntity<ApiCommonResponse<QuickDjResponse>> quickEnqueueDj(
+            @Parameter(description = "파티룸 ID") @PathVariable Long partyroomId,
+            @Valid @RequestBody QuickDjRequest request) {
+        DjData dj = quickDjService.quickEnqueue(new PartyroomId(partyroomId),
+                new AddTrackCommand(request.getName(), request.getLinkId(), request.getDuration(), request.getThumbnailImage()));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiCommonResponse.success(new QuickDjResponse(dj.getId(), dj.getOrderNumber())));
     }
 
     @Operation(summary = "본인 DJ 해제", description = "본인을 DJ 큐에서 해제합니다. 현재 재생 중인 DJ인 경우 재생이 중단됩니다.")

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/payload/request/dj/QuickDjRequest.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/payload/request/dj/QuickDjRequest.java
@@ -1,0 +1,31 @@
+package com.pfplaybackend.api.party.adapter.in.web.payload.request.dj;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "Quick-DJ 등록 요청 — 검색 결과에서 선택한 곡 하나")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class QuickDjRequest {
+    @NotBlank(message = "name is required.")
+    @Schema(description = "곡 이름", example = "BLACKPINK - 'Shut Down' M/V", requiredMode = Schema.RequiredMode.REQUIRED, type = "string")
+    private String name;
+
+    @NotBlank(message = "linkId is required.")
+    @Schema(description = "곡 링크 id", example = "POe9SOEKotk", requiredMode = Schema.RequiredMode.REQUIRED, type = "string")
+    private String linkId;
+
+    @NotBlank(message = "duration is required.")
+    @Pattern(regexp = "^\\d+:\\d{2}(:\\d{2})?$", message = "duration must be m:ss or h:mm:ss.")
+    @Schema(description = "곡 재생 시간", example = "03:01", requiredMode = Schema.RequiredMode.REQUIRED, type = "string")
+    private String duration;
+
+    @NotBlank(message = "thumbnailImage is required.")
+    @Schema(description = "곡 썸네일 이미지", example = "https://i.ytimg.com/vi/POe9SOEKotk/mqdefault.jpg", requiredMode = Schema.RequiredMode.REQUIRED, type = "string")
+    private String thumbnailImage;
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/payload/response/QuickDjResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/payload/response/QuickDjResponse.java
@@ -1,0 +1,9 @@
+package com.pfplaybackend.api.party.adapter.in.web.payload.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Quick-DJ 등록 응답")
+public record QuickDjResponse(
+        @Schema(description = "생성된 DJ ID") Long djId,
+        @Schema(description = "내 대기열 순번(1-base)") int orderNumber
+) {}

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/PlaylistCommandAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/PlaylistCommandAdapter.java
@@ -6,7 +6,9 @@ import com.pfplaybackend.api.party.application.port.out.AddedTrackInfo;
 import com.pfplaybackend.api.party.application.port.out.PlaylistCommandPort;
 import com.pfplaybackend.api.playlist.application.dto.GrabbedTrackDto;
 import com.pfplaybackend.api.playlist.application.dto.PlaybackTrackDto;
+import com.pfplaybackend.api.playlist.application.dto.command.AddTrackCommand;
 import com.pfplaybackend.api.playlist.application.service.GrabTrackService;
+import com.pfplaybackend.api.playlist.application.service.TempPlaylistService;
 import com.pfplaybackend.api.playlist.application.service.TrackCommandService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +21,7 @@ public class PlaylistCommandAdapter implements PlaylistCommandPort {
 
     private final GrabTrackService grabTrackService;
     private final TrackCommandService trackCommandService;
+    private final TempPlaylistService tempPlaylistService;
 
     @Override
     public AddedTrackInfo grabTrack(UserId userId, String linkId) {
@@ -34,5 +37,10 @@ public class PlaylistCommandAdapter implements PlaylistCommandPort {
     @Override
     public void advancePlaybackCursor(PlaylistId playlistId, Long trackId) {
         trackCommandService.advancePlaybackCursor(playlistId.getId(), trackId);
+    }
+
+    @Override
+    public Long prepareOneShotPlaylist(UserId userId, AddTrackCommand command) {
+        return tempPlaylistService.prepareOneShotPlaylist(userId, command);
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/port/out/PlaylistCommandPort.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/port/out/PlaylistCommandPort.java
@@ -3,9 +3,12 @@ package com.pfplaybackend.api.party.application.port.out;
 import com.pfplaybackend.api.common.domain.value.PlaylistId;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.playlist.application.dto.PlaybackTrackDto;
+import com.pfplaybackend.api.playlist.application.dto.command.AddTrackCommand;
 
 public interface PlaylistCommandPort {
     AddedTrackInfo grabTrack(UserId userId, String linkId);
     java.util.List<PlaybackTrackDto> peekTracksFromCursor(PlaylistId playlistId);
     void advancePlaybackCursor(PlaylistId playlistId, Long trackId);
+    /** Quick-DJ(#331) — per-user TEMP 플리를 리셋 후 선택 곡 1개를 담아 그 id 를 반환한다. */
+    Long prepareOneShotPlaylist(UserId userId, AddTrackCommand command);
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java
@@ -9,6 +9,7 @@ import com.pfplaybackend.api.party.application.port.out.PlaybackControlPort;
 import com.pfplaybackend.api.party.application.port.out.PlaylistQueryPort;
 import com.pfplaybackend.api.party.domain.entity.data.*;
 import com.pfplaybackend.api.party.domain.enums.DjChangeType;
+import com.pfplaybackend.api.party.domain.enums.DjKind;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
 import com.pfplaybackend.api.party.domain.event.DjQueueChangedEvent;
 import com.pfplaybackend.api.party.domain.exception.DjException;
@@ -42,6 +43,11 @@ public class DjCommandService {
 
     @Transactional
     public Long enqueueDj(PartyroomId partyroomId, PlaylistId playlistId)  {
+        return enqueueDj(partyroomId, playlistId, DjKind.NORMAL).getId();
+    }
+
+    @Transactional
+    public DjData enqueueDj(PartyroomId partyroomId, PlaylistId playlistId, DjKind kind)  {
         AuthContext authContext = ThreadLocalContext.getAuthContext();
         log.info("[enqueueDj] ENTER - requestId={}, partyroomId={}, userId={}, playlistId={}",
                 RequestIdInterceptor.current(), partyroomId.getId(), authContext.getUserId().getUid(), playlistId.getId());
@@ -74,7 +80,7 @@ public class DjCommandService {
         int nextOrder = queuedDjs.size() + 1;
 
         // Create and save DJ
-        DjData dj = DjData.create(partyroom.getPartyroomId(), playlistId, crewId, nextOrder);
+        DjData dj = DjData.create(partyroom.getPartyroomId(), playlistId, crewId, nextOrder, kind);
         DjData saved = aggregatePort.saveDj(dj);
         log.info("[enqueueDj] SAVED - requestId={}, partyroomId={}, crewId={}, djId={}, orderNumber={}",
                 RequestIdInterceptor.current(), partyroomId.getId(), crew.getId(), saved.getId(), nextOrder);
@@ -89,7 +95,7 @@ public class DjCommandService {
         if (isPostActivationProcessingRequired) {
             playbackControlPort.startPlayback(partyroom);
         }
-        return saved.getId();
+        return saved;
     }
 
     @Transactional

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java
@@ -13,6 +13,7 @@ import com.pfplaybackend.api.party.application.port.out.PlaylistCommandPort;
 import com.pfplaybackend.api.party.application.port.out.UserActivityPort;
 import com.pfplaybackend.api.party.domain.entity.data.*;
 import com.pfplaybackend.api.party.domain.enums.DjChangeType;
+import com.pfplaybackend.api.party.domain.enums.DjKind;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
 import com.pfplaybackend.api.party.domain.event.DjQueueChangedEvent;
 import com.pfplaybackend.api.party.domain.event.PlaybackStartedEvent;
@@ -89,25 +90,52 @@ public class PlaybackCommandService implements PlaybackControlPort {
 
     private void tryProceed(PartyroomId partyroomId) {
         PartyroomData partyroom = partyroomQueryService.getPartyroomById(partyroomId);
+        boolean oneShotRetired = retireOutgoingOneShot(partyroomId);
         List<DjData> queuedDjs = aggregatePort.findDjsOrdered(partyroomId);
-        log.debug("[tryProceed] partyroomId={}, queueSize={}", partyroomId.getId(), queuedDjs.size());
+        log.debug("[tryProceed] partyroomId={}, queueSize={}, oneShotRetired={}",
+                partyroomId.getId(), queuedDjs.size(), oneShotRetired);
 
         if(!queuedDjs.isEmpty()) {
-            doStart(partyroom);
+            // ONE_SHOT 제거로 이미 큐가 전진했으면 중복 회전 금지(spec §3-3)
+            doStart(partyroom, !oneShotRetired);
         }else{
             log.info("[tryProceed] EMPTY_QUEUE_DEACTIVATE - partyroomId={}", partyroomId.getId());
             deactivateAndNotify(partyroom);
         }
     }
 
-    @Override
-    public void startPlayback(PartyroomData partyroom) {
-        doStart(partyroom);
+    /**
+     * 방금 재생을 끝낸(outgoing) DJ 가 ONE_SHOT 이면 회전 대신 큐에서 제거한다.
+     * 제거 기준은 위치(order-1)가 아닌 정체(currentDjCrewId) — doStart 의 선두 회전은
+     * 최초 활성화·dequeue-후-skip 경로에서도 진입하므로 위치 기준은 미재생 엔트리를 삭제한다(spec §3-3).
+     * currentDjCrewId 는 deactivate 에서만 클리어되므로 완료/스킵 시점엔 방금 끝난 DJ 를 가리킨다.
+     */
+    private boolean retireOutgoingOneShot(PartyroomId partyroomId) {
+        PartyroomPlaybackData playbackState = aggregatePort.findPlaybackState(partyroomId);
+        CrewId outgoingCrewId = playbackState.getCurrentDjCrewId();
+        if (outgoingCrewId == null) return false;
+        return aggregatePort.findDj(partyroomId, outgoingCrewId)
+                .filter(dj -> dj.getKind() == DjKind.ONE_SHOT)
+                .map(dj -> {
+                    partyroomAggregateService.removeDjFromQueue(partyroomId, outgoingCrewId);
+                    eventPublisher.publishEvent(new DjQueueChangedEvent(partyroomId, DjChangeType.ONE_SHOT_COMPLETED, outgoingCrewId));
+                    log.info("[tryProceed] ONE_SHOT_COMPLETED - partyroomId={}, crewId={}",
+                            partyroomId.getId(), outgoingCrewId.getId());
+                    return true;
+                })
+                .orElse(false);
     }
 
-    private void doStart(PartyroomData partyroom) {
+    @Override
+    public void startPlayback(PartyroomData partyroom) {
+        doStart(partyroom, true);
+    }
+
+    private void doStart(PartyroomData partyroom, boolean rotate) {
         long partyroomIdValue = partyroom.getPartyroomId().getId();
-        List<DjData> rotatedDjs = partyroomAggregateService.rotateDjQueue(partyroom.getPartyroomId());
+        List<DjData> rotatedDjs = rotate
+                ? partyroomAggregateService.rotateDjQueue(partyroom.getPartyroomId())
+                : aggregatePort.findDjsOrdered(partyroom.getPartyroomId());
         int limitMin = partyroom.getPlaybackTimeLimit().getMinutes();
         log.debug("[doStart] ENTER - partyroomId={}, queueSize={}, limitMin={}",
                 partyroomIdValue, rotatedDjs.size(), limitMin);

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/QuickDjService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/QuickDjService.java
@@ -1,0 +1,55 @@
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.adapter.in.web.RequestIdInterceptor;
+import com.pfplaybackend.api.common.aspect.context.AuthContext;
+import com.pfplaybackend.api.common.domain.value.Duration;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.exception.ExceptionCreator;
+import com.pfplaybackend.api.party.application.port.out.PlaylistCommandPort;
+import com.pfplaybackend.api.party.domain.entity.data.DjData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.enums.DjKind;
+import com.pfplaybackend.api.party.domain.exception.DjException;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.playlist.application.dto.command.AddTrackCommand;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Quick-DJ(#331) — 곡 즉석 선택 → one-shot DJ 큐 등록 오케스트레이션.
+ * 시간한도 사전검증(결정7/B) → TEMP 플리 준비(리셋+삽입) → ONE_SHOT enqueue 를
+ * 1 트랜잭션으로 묶어, 실패 시 TEMP 에 곡만 남는 중간상태를 남기지 않는다(spec §3-2).
+ * 양자택일(이미 큐 등록 시 거부)은 enqueue 내부의 ALREADY_REGISTERED 가드가 그대로 보장한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QuickDjService {
+
+    private final PartyroomQueryService partyroomQueryService;
+    private final PlaylistCommandPort playlistCommandPort;
+    private final DjCommandService djCommandService;
+
+    @Transactional
+    public DjData quickEnqueue(PartyroomId partyroomId, AddTrackCommand command) {
+        AuthContext authContext = ThreadLocalContext.getAuthContext();
+        UserId userId = authContext.getUserId();
+        log.info("[quickEnqueue] ENTER - requestId={}, partyroomId={}, userId={}, linkId={}",
+                RequestIdInterceptor.current(), partyroomId.getId(), userId.getUid(), command.linkId());
+
+        PartyroomData partyroom = partyroomQueryService.getPartyroomById(partyroomId);
+        partyroomQueryService.getCrewOrThrow(partyroomId, userId);
+
+        Duration duration = Duration.fromString(command.duration());
+        if (partyroom.getPlaybackTimeLimit().exceedsDuration(duration)) {
+            throw ExceptionCreator.create(DjException.TRACK_EXCEEDS_TIME_LIMIT);
+        }
+
+        Long tempPlaylistId = playlistCommandPort.prepareOneShotPlaylist(userId, command);
+        return djCommandService.enqueueDj(partyroomId, new PlaylistId(tempPlaylistId), DjKind.ONE_SHOT);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/DjData.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/DjData.java
@@ -2,6 +2,7 @@ package com.pfplaybackend.api.party.domain.entity.data;
 
 import com.pfplaybackend.api.common.domain.value.PlaylistId;
 import com.pfplaybackend.api.common.entity.BaseEntity;
+import com.pfplaybackend.api.party.domain.enums.DjKind;
 import com.pfplaybackend.api.party.domain.value.CrewId;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import jakarta.persistence.*;
@@ -9,6 +10,8 @@ import lombok.Builder;
 import lombok.Getter;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -42,18 +45,24 @@ public class DjData extends BaseEntity {
 
     private int orderNumber;
 
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @Column(length = 20, nullable = false)
+    private DjKind kind;
+
     // 데이터 엔티티 생성자
     protected DjData() {
     }
 
     @Builder
     public DjData(Long id, PartyroomId partyroomId, CrewId crewId, PlaylistId playlistId, int orderNumber,
-                  LocalDateTime createdAt, LocalDateTime updatedAt) {
+                  DjKind kind, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.partyroomId = partyroomId;
         this.crewId = crewId;
         this.playlistId = playlistId;
         this.orderNumber = orderNumber;
+        this.kind = kind;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -61,11 +70,16 @@ public class DjData extends BaseEntity {
     // ── Business Methods ──
 
     public static DjData create(PartyroomId partyroomId, PlaylistId playlistId, CrewId crewId, int orderNumber) {
+        return create(partyroomId, playlistId, crewId, orderNumber, DjKind.NORMAL);
+    }
+
+    public static DjData create(PartyroomId partyroomId, PlaylistId playlistId, CrewId crewId, int orderNumber, DjKind kind) {
         return DjData.builder()
                 .partyroomId(partyroomId)
                 .playlistId(playlistId)
                 .crewId(crewId)
                 .orderNumber(orderNumber)
+                .kind(kind)
                 .build();
     }
 

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/enums/DjChangeType.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/enums/DjChangeType.java
@@ -6,5 +6,7 @@ public enum DjChangeType {
     DEQUEUE_ADMIN,
     DEQUEUE_EXIT,
     ROTATE,
-    DEACTIVATE
+    DEACTIVATE,
+    /** Quick-DJ(#331) — ONE_SHOT 엔트리가 1회 재생을 마치고 자연 이탈 */
+    ONE_SHOT_COMPLETED
 }

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/enums/DjKind.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/enums/DjKind.java
@@ -1,0 +1,11 @@
+package com.pfplaybackend.api.party.domain.enums;
+
+/**
+ * DJ 큐 엔트리 종류.
+ * NORMAL — 플레이리스트 기반 상시 회전 엔트리(기존 동작).
+ * ONE_SHOT — Quick-DJ 로 등록된 1회 재생 엔트리. 재생 완료/스킵 시 큐에서 자동 이탈한다(spec §3-3).
+ */
+public enum DjKind {
+    NORMAL,
+    ONE_SHOT
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/exception/DjException.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/exception/DjException.java
@@ -11,7 +11,8 @@ public enum DjException implements DomainException {
     EMPTY_PLAYLIST("DJ-003", "빈 플레이리스트로 등록할 수 없습니다", ErrorType.FORBIDDEN),
     NOT_FOUND_DJ("DJ-004", "DJ 대기열에서 해당 DJ를 찾을 수 없습니다", ErrorType.NOT_FOUND),
     NOT_OWNED_PLAYLIST("DJ-005", "본인 소유 플레이리스트가 아닙니다", ErrorType.FORBIDDEN),
-    CURRENT_DJ_CANNOT_CHANGE_PLAYLIST("DJ-006", "재생 중 DJ는 플레이리스트를 변경할 수 없습니다", ErrorType.CONFLICT);
+    CURRENT_DJ_CANNOT_CHANGE_PLAYLIST("DJ-006", "재생 중 DJ는 플레이리스트를 변경할 수 없습니다", ErrorType.CONFLICT),
+    TRACK_EXCEEDS_TIME_LIMIT("DJ-007", "곡 길이가 방의 재생 시간 한도를 초과합니다", ErrorType.BAD_REQUEST);
 
     private final String errorCode;
     private final String message;

--- a/app/src/main/resources/db/migration/V35__add_dj_kind_for_quick_dj.sql
+++ b/app/src/main/resources/db/migration/V35__add_dj_kind_for_quick_dj.sql
@@ -1,0 +1,3 @@
+-- V35: Quick-DJ(#331) — dj.kind 추가 (NORMAL/ONE_SHOT), 기존 행 NORMAL 백필
+ALTER TABLE dj
+    ADD COLUMN kind VARCHAR(20) NOT NULL DEFAULT 'NORMAL' COMMENT 'DJ 큐 엔트리 종류 (NORMAL/ONE_SHOT)' AFTER playlist_id;

--- a/app/src/main/resources/db/migration/V36__add_temp_playlist_type.sql
+++ b/app/src/main/resources/db/migration/V36__add_temp_playlist_type.sql
@@ -1,0 +1,4 @@
+-- V36: Quick-DJ(#331) — playlist.type ENUM 에 'TEMP' 추가 (one-shot 곡 저장용 숨김 플리)
+-- 기존 값('GRABLIST','PLAYLIST') 뒤에 append — 저장값/인덱스 영향 없음 (V32 MODIFY ENUM 패턴 계승)
+ALTER TABLE playlist
+    MODIFY COLUMN type ENUM('GRABLIST','PLAYLIST','TEMP') COMMENT '플레이리스트 타입';

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/AbstractPartyCommandWebMvcTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/AbstractPartyCommandWebMvcTest.java
@@ -34,6 +34,7 @@ abstract class AbstractPartyCommandWebMvcTest {
 
     @Autowired protected MockMvc mockMvc;
     @MockBean protected DjCommandService djCommandService;
+    @MockBean protected QuickDjService quickDjService;
     @MockBean protected CrewPenaltyCommandService crewPenaltyCommandService;
     @MockBean protected CrewBlockCommandService crewBlockCommandService;
     @MockBean protected CrewGradeCommandService crewGradeCommandService;

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandControllerTest.java
@@ -5,10 +5,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
+import com.pfplaybackend.api.party.domain.entity.data.DjData;
 import com.pfplaybackend.api.party.domain.exception.DjException;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
@@ -152,6 +154,81 @@ class DjCommandControllerTest extends AbstractPartyCommandWebMvcTest {
                         .content("{\"playlistId\": 99}"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.errorCode").value("DJ-003"));
+    }
+
+    // ───────────────────────── Quick-DJ (#331) ─────────────────────────
+
+    private String quickBody(String name, String duration) {
+        return """
+                {
+                    "name": "%s",
+                    "linkId": "POe9SOEKotk",
+                    "duration": "%s",
+                    "thumbnailImage": "https://i.ytimg.com/vi/POe9SOEKotk/mqdefault.jpg"
+                }
+                """.formatted(name, duration);
+    }
+
+    @Test
+    @DisplayName("quickEnqueueDj — 201 Created + djId/orderNumber 반환")
+    void quickEnqueueDjReturns201WithDjIdAndOrderNumber() throws Exception {
+        DjData dj = mock(DjData.class);
+        when(dj.getId()).thenReturn(77L);
+        when(dj.getOrderNumber()).thenReturn(2);
+        when(quickDjService.quickEnqueue(any(), any())).thenReturn(dj);
+
+        mockMvc.perform(post("/api/v1/partyrooms/1/dj-queue/quick")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(quickBody("BLACKPINK - 'Shut Down' M/V", "3:01")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.djId").value(77))
+                .andExpect(jsonPath("$.data.orderNumber").value(2));
+    }
+
+    @Test
+    @DisplayName("quickEnqueueDj — duration \"abc\" (형식 전체 불일치) → 400")
+    void quickEnqueueDjInvalidDurationReturns400() throws Exception {
+        mockMvc.perform(post("/api/v1/partyrooms/1/dj-queue/quick")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(quickBody("곡", "abc")))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("quickEnqueueDj — duration \"3:xx\" (비숫자 세그먼트) → 400")
+    void quickEnqueueDjNonNumericSegmentDurationReturns400() throws Exception {
+        mockMvc.perform(post("/api/v1/partyrooms/1/dj-queue/quick")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(quickBody("곡", "3:xx")))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("quickEnqueueDj — duration \"1:02:03:04\" (세그먼트 수 초과) → 400")
+    void quickEnqueueDjTooManySegmentsDurationReturns400() throws Exception {
+        mockMvc.perform(post("/api/v1/partyrooms/1/dj-queue/quick")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(quickBody("곡", "1:02:03:04")))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("quickEnqueueDj — name \"\" → 400")
+    void quickEnqueueDjBlankNameReturns400() throws Exception {
+        mockMvc.perform(post("/api/v1/partyrooms/1/dj-queue/quick")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(quickBody("", "3:01")))
+                .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandControllerTest.java
@@ -221,6 +221,21 @@ class DjCommandControllerTest extends AbstractPartyCommandWebMvcTest {
     }
 
     @Test
+    @DisplayName("quickEnqueueDj — DJ-007 TRACK_EXCEEDS_TIME_LIMIT → 400")
+    void quickEnqueueDjTrackExceedsTimeLimitReturns400() throws Exception {
+        doThrow(ExceptionCreator.create(DjException.TRACK_EXCEEDS_TIME_LIMIT))
+                .when(quickDjService).quickEnqueue(any(), any());
+
+        mockMvc.perform(post("/api/v1/partyrooms/1/dj-queue/quick")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(quickBody("곡", "3:01")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("DJ-007"));
+    }
+
+    @Test
     @DisplayName("quickEnqueueDj — name \"\" → 400")
     void quickEnqueueDjBlankNameReturns400() throws Exception {
         mockMvc.perform(post("/api/v1/partyrooms/1/dj-queue/quick")

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceTest.java
@@ -10,6 +10,7 @@ import com.pfplaybackend.api.common.exception.http.ForbiddenException;
 import com.pfplaybackend.api.party.application.port.out.PlaybackControlPort;
 import com.pfplaybackend.api.party.application.port.out.PlaylistQueryPort;
 import com.pfplaybackend.api.party.domain.entity.data.*;
+import com.pfplaybackend.api.party.domain.enums.DjKind;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
 import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
 import com.pfplaybackend.api.party.domain.service.PartyroomAggregateService;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -163,6 +165,66 @@ class DjCommandServiceTest {
 
         // then
         verify(playbackControlPort).startPlayback(partyroom);
+    }
+
+    @Test
+    @DisplayName("enqueueDj(kind) — ONE_SHOT 지정 시 kind 가 저장된다")
+    void enqueueDjPersistsOneShotKind() {
+        // given — 기존 enqueueDj happy 테스트와 동일 스텁 구성
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(partyroomId.getId()).partyroomId(partyroomId).build();
+        PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+        DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+        CrewData crew = CrewData.builder()
+                .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+        when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+        when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+        when(aggregatePort.isDjRegistered(partyroomId, new CrewId(1L))).thenReturn(false);
+        when(playlistQueryPort.isOwnedBy(playlistId.getId(), userId.getUid())).thenReturn(true);
+        when(playlistQueryPort.isEmptyPlaylist(playlistId.getId())).thenReturn(false);
+        when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(Collections.emptyList());
+        when(aggregatePort.saveDj(any(DjData.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        // when
+        djCommandService.enqueueDj(partyroomId, playlistId, DjKind.ONE_SHOT);
+
+        // then
+        ArgumentCaptor<DjData> captor = ArgumentCaptor.forClass(DjData.class);
+        verify(aggregatePort).saveDj(captor.capture());
+        assertThat(captor.getValue().getKind()).isEqualTo(DjKind.ONE_SHOT);
+    }
+
+    @Test
+    @DisplayName("enqueueDj(2-arg) — 기존 경로는 NORMAL 유지(회귀)")
+    void enqueueDjDefaultsToNormalKind() {
+        // given — 동일 스텁
+        PartyroomData partyroom = PartyroomData.builder()
+                .id(partyroomId.getId()).partyroomId(partyroomId).build();
+        PartyroomPlaybackData playbackState = PartyroomPlaybackData.createFor(partyroomId);
+        DjQueueData djQueue = DjQueueData.createFor(partyroomId);
+        CrewData crew = CrewData.builder()
+                .id(1L).partyroomId(partyroomId).userId(userId).gradeType(GradeType.CLUBBER).build();
+
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroom);
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(playbackState);
+        when(aggregatePort.findDjQueueState(partyroomId)).thenReturn(djQueue);
+        when(partyroomQueryService.getCrewOrThrow(partyroomId, userId)).thenReturn(crew);
+        when(aggregatePort.isDjRegistered(partyroomId, new CrewId(1L))).thenReturn(false);
+        when(playlistQueryPort.isOwnedBy(playlistId.getId(), userId.getUid())).thenReturn(true);
+        when(playlistQueryPort.isEmptyPlaylist(playlistId.getId())).thenReturn(false);
+        when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(Collections.emptyList());
+        when(aggregatePort.saveDj(any(DjData.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        // when
+        djCommandService.enqueueDj(partyroomId, playlistId);
+
+        // then
+        ArgumentCaptor<DjData> captor = ArgumentCaptor.forClass(DjData.class);
+        verify(aggregatePort).saveDj(captor.capture());
+        assertThat(captor.getValue().getKind()).isEqualTo(DjKind.NORMAL);
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackCommandServiceTest.java
@@ -17,6 +17,7 @@ import com.pfplaybackend.api.party.application.port.out.PlaylistCommandPort;
 import com.pfplaybackend.api.party.application.port.out.UserActivityPort;
 import com.pfplaybackend.api.party.domain.entity.data.*;
 import com.pfplaybackend.api.party.domain.enums.DjChangeType;
+import com.pfplaybackend.api.party.domain.enums.DjKind;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
 import com.pfplaybackend.api.party.domain.event.DjQueueChangedEvent;
 import com.pfplaybackend.api.party.domain.event.PlaybackStartedEvent;
@@ -78,6 +79,9 @@ class PlaybackCommandServiceTest {
         lenient().when(authContext.getUserId()).thenReturn(userId);
         lenient().when(authContext.getAuthorityTier()).thenReturn(AuthorityTier.FM);
         ThreadLocalContext.setContext(authContext);
+        // Quick-DJ(#331) — currentDjCrewId=null 인 기본 상태(rotate 경로 보존)
+        lenient().when(aggregatePort.findPlaybackState(any(PartyroomId.class)))
+                .thenAnswer(inv -> PartyroomPlaybackData.createFor(inv.getArgument(0)));
     }
 
     @AfterEach
@@ -479,6 +483,102 @@ class PlaybackCommandServiceTest {
         verify(playlistCommandPort, never()).advancePlaybackCursor(eq(pl1), anyLong());
         verify(partyroomAggregateService, times(1)).rotateDjQueue(partyroomId);
         verify(partyroomAggregateService, never()).deactivatePlayback(any(PartyroomId.class));
+    }
+
+    // ── Quick-DJ(#331) — outgoing ONE_SHOT 이탈 분기 ──
+    // 제거 기준은 위치(order-1)가 아닌 정체(currentDjCrewId). 분기는 tryProceed 에만 존재하고
+    // startPlayback(최초 활성화)·doStart 내부에는 제거 로직이 없어야 한다(spec §3-3).
+
+    private PartyroomData partyroomFixture() {
+        return PartyroomData.builder().id(partyroomId.getId()).partyroomId(partyroomId)
+                .playbackTimeLimit(PlaybackTimeLimit.ofMinutes(10)).build();
+    }
+
+    private PartyroomPlaybackData activatedPlaybackState(CrewId currentDjCrewId) {
+        PartyroomPlaybackData state = PartyroomPlaybackData.createFor(partyroomId);
+        state.activate(new PlaybackId(77L), currentDjCrewId);
+        return state;
+    }
+
+    @Test
+    @DisplayName("complete — outgoing ONE_SHOT 은 회전 대신 제거되고 ONE_SHOT_COMPLETED 가 발행된다")
+    void completeRetiresOutgoingOneShotInsteadOfRotating() {
+        CrewId outgoing = new CrewId(31L);
+        DjData oneShot = DjData.create(partyroomId, new PlaylistId(2L), outgoing, 1, DjKind.ONE_SHOT);
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroomFixture());
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(activatedPlaybackState(outgoing));
+        when(aggregatePort.findDj(partyroomId, outgoing)).thenReturn(Optional.of(oneShot));
+        when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(List.of()); // 제거 후 빈 큐
+
+        playbackCommandService.complete(partyroomId, userId);
+
+        verify(partyroomAggregateService).removeDjFromQueue(partyroomId, outgoing);
+        verify(partyroomAggregateService, never()).rotateDjQueue(any());
+        ArgumentCaptor<Object> events = ArgumentCaptor.forClass(Object.class);
+        verify(eventPublisher, atLeastOnce()).publishEvent(events.capture());
+        assertThat(events.getAllValues().stream()
+                .filter(e -> e instanceof DjQueueChangedEvent)
+                .map(e -> ((DjQueueChangedEvent) e).getChangeType()))
+                .contains(DjChangeType.ONE_SHOT_COMPLETED);
+    }
+
+    @Test
+    @DisplayName("complete — outgoing NORMAL 은 기존 회전 경로 그대로(제거 없음)")
+    void completeRotatesForNormalOutgoing() {
+        CrewId outgoing = new CrewId(32L);
+        DjData normal = DjData.create(partyroomId, new PlaylistId(2L), outgoing, 1);
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroomFixture());
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(activatedPlaybackState(outgoing));
+        when(aggregatePort.findDj(partyroomId, outgoing)).thenReturn(Optional.of(normal));
+        when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(List.of(normal));
+        when(partyroomAggregateService.rotateDjQueue(partyroomId)).thenReturn(List.of(normal));
+        // doStart 진입 후 재생가능 트랙 없음 → deactivate 로 수렴해도 본 검증엔 무관
+        when(aggregatePort.findCrewById(anyLong())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> playbackCommandService.complete(partyroomId, userId))
+                .isInstanceOf(NoSuchElementException.class); // findCrewById orElseThrow — 기존 doStart 거동
+        verify(partyroomAggregateService).rotateDjQueue(partyroomId);
+        verify(partyroomAggregateService, never()).removeDjFromQueue(any(), any());
+    }
+
+    @Test
+    @DisplayName("complete — outgoing 이 큐에 없으면(dequeue-후-skip) 제거 분기 미실행, 회전 경로")
+    void completeSkipsRetireWhenOutgoingAlreadyDequeued() {
+        CrewId outgoing = new CrewId(33L);
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroomFixture());
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(activatedPlaybackState(outgoing));
+        when(aggregatePort.findDj(partyroomId, outgoing)).thenReturn(Optional.empty());
+        when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(List.of());
+
+        playbackCommandService.complete(partyroomId, userId);
+
+        verify(partyroomAggregateService, never()).removeDjFromQueue(any(), any());
+        verify(partyroomAggregateService).deactivatePlayback(partyroomId); // 빈 큐 → 기존 deactivate
+    }
+
+    @Test
+    @DisplayName("complete — currentDjCrewId=null(비활성)이면 분기 미실행(기존 거동)")
+    void completeNullOutgoingKeepsLegacyPath() {
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroomFixture());
+        when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(List.of());
+
+        playbackCommandService.complete(partyroomId, userId);
+
+        verify(partyroomAggregateService, never()).removeDjFromQueue(any(), any());
+        verify(aggregatePort, never()).findDj(any(), any());
+    }
+
+    @Test
+    @DisplayName("startPlayback(최초 활성화) — tryProceed 미경유라 ONE_SHOT 이어도 제거되지 않는다(미재생 삭제 금지)")
+    void startPlaybackNeverRetiresOneShot() {
+        CrewId crewId = new CrewId(34L);
+        DjData oneShot = DjData.create(partyroomId, new PlaylistId(2L), crewId, 1, DjKind.ONE_SHOT);
+        when(partyroomAggregateService.rotateDjQueue(partyroomId)).thenReturn(List.of(oneShot));
+        when(aggregatePort.findCrewById(anyLong())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> playbackCommandService.startPlayback(partyroomFixture()))
+                .isInstanceOf(NoSuchElementException.class);
+        verify(partyroomAggregateService, never()).removeDjFromQueue(any(), any());
     }
 
     @Test

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/QuickDjOneShotIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/QuickDjOneShotIntegrationTest.java
@@ -1,0 +1,354 @@
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.aspect.context.AuthContext;
+import com.pfplaybackend.api.common.domain.value.Duration;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.enums.AuthorityTier;
+import com.pfplaybackend.api.common.exception.http.BadRequestException;
+import com.pfplaybackend.api.common.exception.http.ConflictException;
+import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.entity.data.DjData;
+import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
+import com.pfplaybackend.api.party.domain.enums.DjKind;
+import com.pfplaybackend.api.party.domain.enums.GradeType;
+import com.pfplaybackend.api.party.domain.enums.StageType;
+import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
+import com.pfplaybackend.api.party.domain.value.CrewId;
+import com.pfplaybackend.api.party.domain.value.LinkDomain;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.playlist.application.dto.command.AddTrackCommand;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
+import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
+import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
+import com.pfplaybackend.api.playlist.domain.port.PlaylistAggregatePort;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+
+/**
+ * Quick-DJ(#331) — one-shot 회전 트레이스 통합 잠금 (spec §5).
+ *
+ * <p>PlaylistQueryPort/PlaylistCommandPort 를 모킹하지 않고 실 빈으로 구동한다 —
+ * TEMP 플리 준비(prepareOneShotPlaylist)·소유/공백 검증(isOwnedBy/isEmptyPlaylist)·
+ * 재생 선곡(peekTracksFromCursor)까지 전부 실경로. 그래서 NORMAL DJ 는 실
+ * PLAYLIST+TRACK 시드가 필요하다.
+ *
+ * <p>재생 완료/스킵 시뮬레이션은 {@link PlaybackCommandService#complete}/{@code skipPlayback}
+ * 직접 호출. WS/Redis 릴레이는 단언하지 않고 DB 상태(DJ row·kind·order·playback state)만
+ * 단언한다. expiration task 는 Testcontainers Redis 로 스케줄되지만 단언 대상 아님.
+ *
+ * <p>(e-2)만 tx 밖에서 실행({@code NOT_SUPPORTED}) — 클래스 @Transactional 로는
+ * quickEnqueue 의 REQUIRED tx 가 테스트 tx 에 참여해 중간 롤백이 관측되지 않는다.
+ * 커밋된 시드/데이터 정리는 DatabaseCleaner 가 다음 테스트 전 자동 수행.
+ */
+@Transactional
+class QuickDjOneShotIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private QuickDjService quickDjService;
+    @Autowired
+    private DjCommandService djCommandService;
+    @Autowired
+    private PlaybackCommandService playbackCommandService;
+    @Autowired
+    private PartyroomAggregatePort aggregatePort;
+    @Autowired
+    private PlaylistAggregatePort playlistAggregatePort;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @AfterEach
+    void clearAuthContext() {
+        ThreadLocalContext.clearContext();
+    }
+
+    // ───────────────────────── 시드 헬퍼 ─────────────────────────
+
+    private PartyroomId persistFullActivePartyroom(UserId hostId, String linkSuffix, int limitMinutes) {
+        PartyroomData partyroom = PartyroomData.create(
+                "quick-dj IT 파티룸", "#331 잠금용",
+                LinkDomain.of("quickdj-" + linkSuffix),
+                PlaybackTimeLimit.ofMinutes(limitMinutes),
+                StageType.GENERAL, hostId);
+        entityManager.persist(partyroom);
+        entityManager.flush();
+        PartyroomId partyroomId = new PartyroomId(partyroom.getId());
+
+        entityManager.persist(PartyroomPlaybackData.createFor(partyroomId));
+        entityManager.persist(DjQueueData.createFor(partyroomId));
+        return partyroomId;
+    }
+
+    private CrewData persistActiveCrew(PartyroomId partyroomId, UserId userId) {
+        CrewData crew = CrewData.create(partyroomId, userId, GradeType.CLUBBER, null);
+        entityManager.persist(crew);
+        flushAndClear();
+        return crew;
+    }
+
+    private Long persistPlaylistWithTrack(UserId owner, String linkId, String duration) {
+        PlaylistData playlist = PlaylistData.create(1, "IT 플리", PlaylistType.PLAYLIST, owner);
+        entityManager.persist(playlist);
+        entityManager.flush();
+        TrackData track = TrackData.builder()
+                .playlistId(new PlaylistId(playlist.getId()))
+                .name("곡-" + linkId).linkId(linkId)
+                .duration(Duration.fromString(duration))
+                .orderNumber(1)
+                .thumbnailImage("https://i.ytimg.com/vi/" + linkId + "/mqdefault.jpg")
+                .build();
+        entityManager.persist(track);
+        flushAndClear();
+        return playlist.getId();
+    }
+
+    private void seedAuthContext(UserId userId) {
+        ThreadLocalContext.setContext(new AuthContext(userId, AuthorityTier.FM));
+    }
+
+    private AddTrackCommand song(String name, String linkId, String duration) {
+        return new AddTrackCommand(name, linkId, duration,
+                "https://i.ytimg.com/vi/" + linkId + "/mqdefault.jpg");
+    }
+
+    private PartyroomPlaybackData refetchPlaybackState(PartyroomId partyroomId) {
+        flushAndClear();
+        return aggregatePort.findPlaybackState(partyroomId);
+    }
+
+    // ───────────────────────── 시나리오 ─────────────────────────
+
+    @Test
+    @DisplayName("(a) 유일 ONE_SHOT 최초 활성화 — 재생됨 → 완료 시 제거 → deactivate (미재생 삭제 금지 회귀 잠금)")
+    void soleOneShotPlaysOnceThenRetiresAndDeactivates() {
+        UserId hostId = new UserId(9300L);
+        UserId userX = new UserId(9301L);
+        PartyroomId partyroomId = persistFullActivePartyroom(hostId, "a", 5);
+        long crewXId = persistActiveCrew(partyroomId, userX).getId();
+
+        // when — X quickEnqueue: 최초 활성화 경로 → 즉시 재생 시작(미재생 삭제 금지)
+        seedAuthContext(userX);
+        DjData saved = quickDjService.quickEnqueue(partyroomId, song("곡X", "qdj-a-x", "3:00"));
+
+        // then — DJ row 가 ONE_SHOT 으로 존재하고 X 가 재생 중
+        assertThat(saved.getKind()).isEqualTo(DjKind.ONE_SHOT);
+        flushAndClear();
+        Optional<DjData> row = aggregatePort.findDj(partyroomId, new CrewId(crewXId));
+        assertThat(row).isPresent();
+        assertThat(row.get().getKind()).isEqualTo(DjKind.ONE_SHOT);
+        PartyroomPlaybackData state = aggregatePort.findPlaybackState(partyroomId);
+        assertThat(state.isActivated()).isTrue();
+        assertThat(state.getCurrentDjCrewId()).isEqualTo(new CrewId(crewXId));
+
+        // when — 재생 완료
+        playbackCommandService.complete(partyroomId, userX);
+
+        // then — ONE_SHOT 제거 + 빈 큐 deactivate
+        flushAndClear();
+        assertThat(aggregatePort.findDj(partyroomId, new CrewId(crewXId))).isEmpty();
+        PartyroomPlaybackData after = aggregatePort.findPlaybackState(partyroomId);
+        assertThat(after.isActivated()).isFalse();
+        assertThat(after.getCurrentDjCrewId()).isNull();
+    }
+
+    @Test
+    @DisplayName("(b) 혼합 큐 [A(NORMAL,재생중), X(ONE_SHOT), B(NORMAL)] — X 는 1턴 후 소멸, A·B 라운드로빈 보존")
+    void mixedQueueOneShotVanishesAfterOneTurnRoundRobinPreserved() {
+        UserId hostId = new UserId(9310L);
+        UserId userA = new UserId(9311L);
+        UserId userX = new UserId(9312L);
+        UserId userB = new UserId(9313L);
+        PartyroomId partyroomId = persistFullActivePartyroom(hostId, "b", 5);
+        long crewAId = persistActiveCrew(partyroomId, userA).getId();
+        long crewXId = persistActiveCrew(partyroomId, userX).getId();
+        long crewBId = persistActiveCrew(partyroomId, userB).getId();
+        Long playlistA = persistPlaylistWithTrack(userA, "qdj-b-a", "2:00");
+        Long playlistB = persistPlaylistWithTrack(userB, "qdj-b-b", "2:00");
+
+        // given — A(NORMAL, 최초 활성화로 재생 중) → X(ONE_SHOT) → B(NORMAL)
+        seedAuthContext(userA);
+        djCommandService.enqueueDj(partyroomId, new PlaylistId(playlistA));
+        seedAuthContext(userX);
+        quickDjService.quickEnqueue(partyroomId, song("곡X", "qdj-b-x", "2:30"));
+        seedAuthContext(userB);
+        djCommandService.enqueueDj(partyroomId, new PlaylistId(playlistB));
+
+        assertThat(refetchPlaybackState(partyroomId).getCurrentDjCrewId()).isEqualTo(new CrewId(crewAId));
+
+        // when — complete ×1 → 회전으로 X 재생, A 는 tail
+        playbackCommandService.complete(partyroomId, userA);
+
+        assertThat(refetchPlaybackState(partyroomId).getCurrentDjCrewId()).isEqualTo(new CrewId(crewXId));
+        assertThat(aggregatePort.findDjsOrdered(partyroomId))
+                .extracting(dj -> dj.getCrewId().getId(), DjData::getOrderNumber, DjData::getKind)
+                .containsExactly(
+                        tuple(crewXId, 1, DjKind.ONE_SHOT),
+                        tuple(crewBId, 2, DjKind.NORMAL),
+                        tuple(crewAId, 3, DjKind.NORMAL));
+
+        // when — complete ×2 → X 는 제거(추가 회전 없이 큐 전진), B 재생
+        playbackCommandService.complete(partyroomId, userX);
+
+        assertThat(refetchPlaybackState(partyroomId).getCurrentDjCrewId()).isEqualTo(new CrewId(crewBId));
+        assertThat(aggregatePort.findDj(partyroomId, new CrewId(crewXId))).isEmpty();
+        assertThat(aggregatePort.findDjsOrdered(partyroomId))
+                .extracting(dj -> dj.getCrewId().getId(), DjData::getOrderNumber, DjData::getKind)
+                .containsExactly(
+                        tuple(crewBId, 1, DjKind.NORMAL),
+                        tuple(crewAId, 2, DjKind.NORMAL));
+
+        // when — complete ×3 → NORMAL 라운드로빈 복귀: A 재생
+        playbackCommandService.complete(partyroomId, userB);
+
+        assertThat(refetchPlaybackState(partyroomId).getCurrentDjCrewId()).isEqualTo(new CrewId(crewAId));
+        assertThat(aggregatePort.findDjsOrdered(partyroomId))
+                .extracting(dj -> dj.getCrewId().getId(), DjData::getOrderNumber, DjData::getKind)
+                .containsExactly(
+                        tuple(crewAId, 1, DjKind.NORMAL),
+                        tuple(crewBId, 2, DjKind.NORMAL));
+    }
+
+    @Test
+    @DisplayName("(c) 현재 DJ dequeue-후-skip — incoming ONE_SHOT 은 미삭제, 그대로 재생 시작")
+    void dequeueThenSkipDoesNotDeleteIncomingOneShot() {
+        UserId hostId = new UserId(9320L);
+        UserId userA = new UserId(9321L);
+        UserId userX = new UserId(9322L);
+        PartyroomId partyroomId = persistFullActivePartyroom(hostId, "c", 5);
+        long crewAId = persistActiveCrew(partyroomId, userA).getId();
+        long crewXId = persistActiveCrew(partyroomId, userX).getId();
+        Long playlistA = persistPlaylistWithTrack(userA, "qdj-c-a", "2:00");
+
+        // given — A(NORMAL) 재생 중 + X(ONE_SHOT) 대기
+        seedAuthContext(userA);
+        djCommandService.enqueueDj(partyroomId, new PlaylistId(playlistA));
+        seedAuthContext(userX);
+        quickDjService.quickEnqueue(partyroomId, song("곡X", "qdj-c-x", "2:30"));
+        assertThat(refetchPlaybackState(partyroomId).getCurrentDjCrewId()).isEqualTo(new CrewId(crewAId));
+
+        // when — 현재 DJ A 가 본인 dequeue → 내부 skip 경로 (outgoing 이 큐에 없는 quirk 경로)
+        seedAuthContext(userA);
+        djCommandService.dequeueDj(partyroomId);
+
+        // then — 미재생 ONE_SHOT X 는 삭제되지 않고 그대로 재생 시작
+        flushAndClear();
+        Optional<DjData> rowX = aggregatePort.findDj(partyroomId, new CrewId(crewXId));
+        assertThat(rowX).isPresent();
+        assertThat(rowX.get().getKind()).isEqualTo(DjKind.ONE_SHOT);
+        PartyroomPlaybackData state = aggregatePort.findPlaybackState(partyroomId);
+        assertThat(state.isActivated()).isTrue();
+        assertThat(state.getCurrentDjCrewId()).isEqualTo(new CrewId(crewXId));
+    }
+
+    @Test
+    @DisplayName("(d) 버튼 스킵 — 재생 중 ONE_SHOT 트랙 스킵 → 재등장 없이 제거, 다음 NORMAL 재생")
+    void skipDuringOneShotPlaybackRetiresIt() {
+        UserId hostId = new UserId(9330L);
+        UserId userX = new UserId(9331L);
+        UserId userB = new UserId(9332L);
+        PartyroomId partyroomId = persistFullActivePartyroom(hostId, "d", 5);
+        long crewXId = persistActiveCrew(partyroomId, userX).getId();
+        long crewBId = persistActiveCrew(partyroomId, userB).getId();
+        Long playlistB = persistPlaylistWithTrack(userB, "qdj-d-b", "2:00");
+
+        // given — X(ONE_SHOT) 최초 활성화로 재생 중 + B(NORMAL) 대기
+        seedAuthContext(userX);
+        quickDjService.quickEnqueue(partyroomId, song("곡X", "qdj-d-x", "2:30"));
+        seedAuthContext(userB);
+        djCommandService.enqueueDj(partyroomId, new PlaylistId(playlistB));
+        assertThat(refetchPlaybackState(partyroomId).getCurrentDjCrewId()).isEqualTo(new CrewId(crewXId));
+
+        // when — 스킵
+        playbackCommandService.skipPlayback(partyroomId);
+
+        // then — X 는 재등장 없이 제거, B 재생
+        flushAndClear();
+        assertThat(aggregatePort.findDj(partyroomId, new CrewId(crewXId))).isEmpty();
+        PartyroomPlaybackData state = aggregatePort.findPlaybackState(partyroomId);
+        assertThat(state.isActivated()).isTrue();
+        assertThat(state.getCurrentDjCrewId()).isEqualTo(new CrewId(crewBId));
+        assertThat(aggregatePort.findDjsOrdered(partyroomId))
+                .extracting(dj -> dj.getCrewId().getId(), DjData::getOrderNumber, DjData::getKind)
+                .containsExactly(tuple(crewBId, 1, DjKind.NORMAL));
+    }
+
+    @Test
+    @DisplayName("(e-1) 시간한도 사전거부 — limit=3분 방에 3:01 → DJ-007, DJ row 미생성 + TEMP 무변화")
+    void trackExceedingTimeLimitIsRejectedBeforeAnyWrite() {
+        UserId hostId = new UserId(9340L);
+        UserId userX = new UserId(9341L);
+        PartyroomId partyroomId = persistFullActivePartyroom(hostId, "e1", 3);
+        persistActiveCrew(partyroomId, userX);
+
+        // when & then — 사전거부(DJ-007 BAD_REQUEST)
+        seedAuthContext(userX);
+        assertThatThrownBy(() -> quickDjService.quickEnqueue(partyroomId, song("곡X", "qdj-e1-x", "3:01")))
+                .isInstanceOfSatisfying(BadRequestException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo("DJ-007"));
+
+        // then — write 이전 거부: DJ row 미생성, TEMP 플리 미생성, 재생 미활성화
+        flushAndClear();
+        assertThat(aggregatePort.findDjsOrdered(partyroomId)).isEmpty();
+        assertThat(playlistAggregatePort.findPlaylistsByOwnerAndType(userX, PlaylistType.TEMP)).isEmpty();
+        assertThat(aggregatePort.findPlaybackState(partyroomId).isActivated()).isFalse();
+    }
+
+    @Test
+    @DisplayName("(e-2) ALREADY_REGISTERED 양자택일 — DJ-001 거부 + TEMP 리셋/삽입까지 전체 롤백 (커밋 경계 관측)")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void alreadyRegisteredRejectionRollsBackTempPreparation() {
+        // 시드는 별도 tx 로 커밋 — 본 메서드는 tx 밖이라 quickEnqueue 의 REQUIRED tx 가
+        // 독립 커밋/롤백된다(중간상태 관측 가능). 정리는 DatabaseCleaner 위임.
+        TransactionTemplate txTemplate = new TransactionTemplate(transactionManager);
+        UserId hostId = new UserId(9350L);
+        UserId userX = new UserId(9351L);
+        record Seed(PartyroomId partyroomId, long crewXId) {}
+        Seed seed = txTemplate.execute(status -> {
+            PartyroomId partyroomId = persistFullActivePartyroom(hostId, "e2", 5);
+            long crewXId = persistActiveCrew(partyroomId, userX).getId();
+            return new Seed(partyroomId, crewXId);
+        });
+        PartyroomId partyroomId = seed.partyroomId();
+
+        // given — 곡A 로 quickEnqueue 성공(커밋됨): TEMP=곡A, DJ row 1개(ONE_SHOT)
+        seedAuthContext(userX);
+        quickDjService.quickEnqueue(partyroomId, song("곡A", "qdj-e2-a", "2:00"));
+
+        List<PlaylistData> tempsBefore = playlistAggregatePort.findPlaylistsByOwnerAndType(userX, PlaylistType.TEMP);
+        assertThat(tempsBefore).hasSize(1);
+        PlaylistId tempId = new PlaylistId(tempsBefore.get(0).getId());
+        assertThat(playlistAggregatePort.findTrackByPlaylistAndLink(tempId, "qdj-e2-a")).isPresent();
+
+        // when & then — 이미 큐에 등록된 상태에서 곡B 재시도 → DJ-001(CONFLICT)
+        assertThatThrownBy(() -> quickDjService.quickEnqueue(partyroomId, song("곡B", "qdj-e2-b", "2:00")))
+                .isInstanceOfSatisfying(ConflictException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo("DJ-001"));
+
+        // then — TEMP 리셋(곡A 삭제)+곡B 삽입이 실제로 롤백되어 곡A 그대로, DJ row 1개 유지
+        assertThat(playlistAggregatePort.findTrackByPlaylistAndLink(tempId, "qdj-e2-a")).isPresent();
+        assertThat(playlistAggregatePort.findTrackByPlaylistAndLink(tempId, "qdj-e2-b")).isEmpty();
+        assertThat(playlistAggregatePort.findPlaylistsByOwnerAndType(userX, PlaylistType.TEMP)).hasSize(1);
+        List<DjData> queue = aggregatePort.findDjsOrdered(partyroomId);
+        assertThat(queue)
+                .extracting(dj -> dj.getCrewId().getId(), DjData::getOrderNumber, DjData::getKind)
+                .containsExactly(tuple(seed.crewXId(), 1, DjKind.ONE_SHOT));
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/QuickDjServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/QuickDjServiceTest.java
@@ -1,0 +1,115 @@
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.aspect.context.AuthContext;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.exception.http.BadRequestException;
+import com.pfplaybackend.api.party.application.port.out.PlaylistCommandPort;
+import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.entity.data.DjData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.enums.DjKind;
+import com.pfplaybackend.api.party.domain.value.CrewId;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.playlist.application.dto.command.AddTrackCommand;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Quick-DJ(#331) 오케스트레이션 — 시간한도 사전검증(결정7/B)·TEMP 준비·ONE_SHOT enqueue.
+ */
+@ExtendWith(MockitoExtension.class)
+class QuickDjServiceTest {
+
+    @Mock PartyroomQueryService partyroomQueryService;
+    @Mock PlaylistCommandPort playlistCommandPort;
+    @Mock DjCommandService djCommandService;
+
+    @InjectMocks QuickDjService quickDjService;
+
+    private final UserId userId = new UserId(1L);
+    private final PartyroomId partyroomId = new PartyroomId(10L);
+
+    @BeforeEach
+    void setUp() {
+        AuthContext authContext = mock(AuthContext.class);
+        lenient().when(authContext.getUserId()).thenReturn(userId);
+        ThreadLocalContext.setContext(authContext);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ThreadLocalContext.clearContext();
+    }
+
+    private PartyroomData roomWithLimitMinutes(int minutes) {
+        return PartyroomData.builder().id(partyroomId.getId()).partyroomId(partyroomId)
+                .playbackTimeLimit(PlaybackTimeLimit.ofMinutes(minutes)).build();
+    }
+
+    private AddTrackCommand command(String duration) {
+        return new AddTrackCommand("곡A", "aaa111", duration, "https://i.ytimg.com/vi/aaa111/mqdefault.jpg");
+    }
+
+    @Test
+    @DisplayName("곡 duration > 방 한도 → DJ-007, write 미발생")
+    void rejectsTrackExceedingTimeLimit() {
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(roomWithLimitMinutes(3));
+        when(partyroomQueryService.getCrewOrThrow(eq(partyroomId), any())).thenReturn(mock(CrewData.class));
+
+        // ExceptionCreator 는 getMessage()에 errorCode 를 싣지 않는다 — 타입 + errorCode 필드로 단언
+        assertThatThrownBy(() -> quickDjService.quickEnqueue(partyroomId, command("3:01")))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "DJ-007");
+
+        verifyNoInteractions(playlistCommandPort);
+        verifyNoInteractions(djCommandService);
+    }
+
+    @Test
+    @DisplayName("happy — TEMP 준비 후 ONE_SHOT 으로 enqueue")
+    void happyPathPreparesTempAndEnqueuesOneShot() {
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(roomWithLimitMinutes(5));
+        when(partyroomQueryService.getCrewOrThrow(eq(partyroomId), any())).thenReturn(mock(CrewData.class));
+        when(playlistCommandPort.prepareOneShotPlaylist(eq(userId), any(AddTrackCommand.class))).thenReturn(42L);
+        DjData saved = DjData.create(partyroomId, new PlaylistId(42L), new CrewId(3L), 2, DjKind.ONE_SHOT);
+        when(djCommandService.enqueueDj(partyroomId, new PlaylistId(42L), DjKind.ONE_SHOT)).thenReturn(saved);
+
+        DjData result = quickDjService.quickEnqueue(partyroomId, command("3:45"));
+
+        assertThat(result.getKind()).isEqualTo(DjKind.ONE_SHOT);
+        assertThat(result.getOrderNumber()).isEqualTo(2);
+        InOrder inOrder = inOrder(playlistCommandPort, djCommandService);
+        inOrder.verify(playlistCommandPort).prepareOneShotPlaylist(eq(userId), any(AddTrackCommand.class));
+        inOrder.verify(djCommandService).enqueueDj(partyroomId, new PlaylistId(42L), DjKind.ONE_SHOT);
+    }
+
+    @Test
+    @DisplayName("무제한 방(limit=0) — 어떤 duration 도 통과")
+    void unlimitedRoomAcceptsAnyDuration() {
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(roomWithLimitMinutes(0));
+        when(partyroomQueryService.getCrewOrThrow(eq(partyroomId), any())).thenReturn(mock(CrewData.class));
+        when(playlistCommandPort.prepareOneShotPlaylist(eq(userId), any())).thenReturn(42L);
+        when(djCommandService.enqueueDj(eq(partyroomId), any(), eq(DjKind.ONE_SHOT)))
+                .thenReturn(DjData.create(partyroomId, new PlaylistId(42L), new CrewId(3L), 1, DjKind.ONE_SHOT));
+
+        quickDjService.quickEnqueue(partyroomId, command("2:10:00"));
+
+        verify(djCommandService).enqueueDj(eq(partyroomId), any(), eq(DjKind.ONE_SHOT));
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/domain/entity/data/DjDataTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/domain/entity/data/DjDataTest.java
@@ -1,6 +1,7 @@
 package com.pfplaybackend.api.party.domain.entity.data;
 
 import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.party.domain.enums.DjKind;
 import com.pfplaybackend.api.party.domain.value.CrewId;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import org.junit.jupiter.api.DisplayName;
@@ -57,5 +58,21 @@ class DjDataTest {
         assertThat(dj.getOrderNumber()).isEqualTo(3);
         assertThat(dj.getCrewId()).isEqualTo(new CrewId(20L));
         assertThat(dj.getPartyroomId()).isEqualTo(new PartyroomId(1L));
+    }
+
+    // ── Quick-DJ(#331) — DjKind ──
+
+    @Test
+    @DisplayName("create(4-arg) — kind 미지정 생성은 NORMAL")
+    void createDefaultsToNormal() {
+        DjData dj = DjData.create(new PartyroomId(1L), new PlaylistId(2L), new CrewId(3L), 1);
+        assertThat(dj.getKind()).isEqualTo(DjKind.NORMAL);
+    }
+
+    @Test
+    @DisplayName("create(5-arg) — ONE_SHOT 지정 생성")
+    void createWithOneShotKind() {
+        DjData dj = DjData.create(new PartyroomId(1L), new PlaylistId(2L), new CrewId(3L), 1, DjKind.ONE_SHOT);
+        assertThat(dj.getKind()).isEqualTo(DjKind.ONE_SHOT);
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/playlist/application/service/TempPlaylistServiceIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/playlist/application/service/TempPlaylistServiceIntegrationTest.java
@@ -1,0 +1,64 @@
+package com.pfplaybackend.api.playlist.application.service;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.playlist.application.dto.command.AddTrackCommand;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
+import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
+import com.pfplaybackend.api.playlist.domain.port.PlaylistAggregatePort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Quick-DJ(#331) — TEMP 플리 준비(find-or-create + 전곡 리셋 + 단건 삽입)(spec §3-2 step3~5).
+ * per-user 1개 재사용으로 행 증식이 없음을 잠근다(spec 결정6).
+ */
+@Transactional
+class TempPlaylistServiceIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private TempPlaylistService tempPlaylistService;
+    @Autowired
+    private PlaylistAggregatePort aggregatePort;
+
+    private AddTrackCommand track(String linkId, String name) {
+        return new AddTrackCommand(name, linkId, "3:45", "https://i.ytimg.com/vi/" + linkId + "/mqdefault.jpg");
+    }
+
+    @Test
+    @DisplayName("TEMP 미존재 → 생성 + 곡 1개 삽입")
+    void createsTempWhenAbsent() {
+        UserId owner = new UserId(9201L);
+
+        Long playlistId = tempPlaylistService.prepareOneShotPlaylist(owner, track("aaa111", "곡A"));
+        flushAndClear();
+
+        List<PlaylistData> temps = aggregatePort.findPlaylistsByOwnerAndType(owner, PlaylistType.TEMP);
+        assertThat(temps).hasSize(1);
+        assertThat(temps.get(0).getId()).isEqualTo(playlistId);
+        assertThat(aggregatePort.findTrackByPlaylistAndLink(new PlaylistId(playlistId), "aaa111")).isPresent();
+    }
+
+    @Test
+    @DisplayName("재호출 — 같은 TEMP 재사용(행 증식 없음), 이전 곡은 리셋되고 새 곡만 남는다")
+    void reusesAndResetsTemp() {
+        UserId owner = new UserId(9202L);
+
+        Long first = tempPlaylistService.prepareOneShotPlaylist(owner, track("aaa111", "곡A"));
+        flushAndClear();
+        Long second = tempPlaylistService.prepareOneShotPlaylist(owner, track("bbb222", "곡B"));
+        flushAndClear();
+
+        assertThat(second).isEqualTo(first);
+        assertThat(aggregatePort.findPlaylistsByOwnerAndType(owner, PlaylistType.TEMP)).hasSize(1);
+        assertThat(aggregatePort.findTrackByPlaylistAndLink(new PlaylistId(first), "aaa111")).isEmpty();
+        assertThat(aggregatePort.findTrackByPlaylistAndLink(new PlaylistId(first), "bbb222")).isPresent();
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/playlist/application/service/TempPlaylistServiceIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/playlist/application/service/TempPlaylistServiceIntegrationTest.java
@@ -61,4 +61,21 @@ class TempPlaylistServiceIntegrationTest extends AbstractIntegrationTest {
         assertThat(aggregatePort.findTrackByPlaylistAndLink(new PlaylistId(first), "aaa111")).isEmpty();
         assertThat(aggregatePort.findTrackByPlaylistAndLink(new PlaylistId(first), "bbb222")).isPresent();
     }
+
+    @Test
+    @DisplayName("동시 더블서밋 잔재(TEMP 2행) — 다음 호출이 1행만 남기고 자가치유(opportunistic dedup)")
+    void dedupsLeftoverDuplicateTemps() {
+        UserId owner = new UserId(9203L);
+        entityManager.persist(PlaylistData.create(0, "Quick-DJ", PlaylistType.TEMP, owner));
+        entityManager.persist(PlaylistData.create(0, "Quick-DJ", PlaylistType.TEMP, owner));
+        flushAndClear();
+
+        Long playlistId = tempPlaylistService.prepareOneShotPlaylist(owner, track("ccc333", "곡C"));
+        flushAndClear();
+
+        List<PlaylistData> temps = aggregatePort.findPlaylistsByOwnerAndType(owner, PlaylistType.TEMP);
+        assertThat(temps).hasSize(1);
+        assertThat(temps.get(0).getId()).isEqualTo(playlistId);
+        assertThat(aggregatePort.findTrackByPlaylistAndLink(new PlaylistId(playlistId), "ccc333")).isPresent();
+    }
 }

--- a/app/src/test/java/com/pfplaybackend/api/playlist/application/service/TempPlaylistVisibilityIntegrationTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/playlist/application/service/TempPlaylistVisibilityIntegrationTest.java
@@ -1,0 +1,57 @@
+package com.pfplaybackend.api.playlist.application.service;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.PlaylistRepository;
+import com.pfplaybackend.api.playlist.application.dto.PlaylistSummaryDto;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
+import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Quick-DJ(#331) — TEMP 플리는 사용자 목록/단건 조회에서 숨겨진다(spec §3-1a).
+ * GRABLIST/PLAYLIST 노출은 현행 유지(회귀 잠금).
+ */
+@Transactional
+class TempPlaylistVisibilityIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private PlaylistRepository playlistRepository;
+
+    @Test
+    @DisplayName("findAllByUserId — TEMP 제외, GRABLIST/PLAYLIST 는 노출")
+    void findAllExcludesTemp() {
+        UserId owner = new UserId(9101L);
+        entityManager.persist(PlaylistData.create(0, "그랩한 곡", PlaylistType.GRABLIST, owner));
+        entityManager.persist(PlaylistData.create(1, "내 플레이리스트", PlaylistType.PLAYLIST, owner));
+        entityManager.persist(PlaylistData.create(0, "Quick-DJ", PlaylistType.TEMP, owner));
+        flushAndClear();
+
+        List<PlaylistSummaryDto> result = playlistRepository.findAllByUserId(owner);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(PlaylistSummaryDto::type)
+                .containsExactlyInAnyOrder(PlaylistType.GRABLIST, PlaylistType.PLAYLIST);
+    }
+
+    @Test
+    @DisplayName("findByIdAndUserId — TEMP id 단건 조회도 새지 않는다(null)")
+    void findByIdExcludesTemp() {
+        UserId owner = new UserId(9102L);
+        PlaylistData temp = PlaylistData.create(0, "Quick-DJ", PlaylistType.TEMP, owner);
+        entityManager.persist(temp);
+        PlaylistData normal = PlaylistData.create(1, "내 플레이리스트", PlaylistType.PLAYLIST, owner);
+        entityManager.persist(normal);
+        flushAndClear();
+
+        assertThat(playlistRepository.findByIdAndUserId(temp.getId(), owner)).isNull();
+        assertThat(playlistRepository.findByIdAndUserId(normal.getId(), owner)).isNotNull();
+    }
+}

--- a/docs/superpowers/plans/2026-07-11-quick-dj-one-shot-queue.md
+++ b/docs/superpowers/plans/2026-07-11-quick-dj-one-shot-queue.md
@@ -6,7 +6,7 @@
 
 **Architecture:** 곡 저장은 신규 `PlaylistType.TEMP`(per-user 1개 재사용·조회 숨김), 큐 엔트리는 신규 `DjData.kind`(NORMAL/ONE_SHOT). ONE_SHOT 이탈은 위치(order-1)가 아닌 **outgoing DJ 정체**(`PartyroomPlaybackData.getCurrentDjCrewId()`) 기준으로 `tryProceed`에서 분기하고 `doStart`는 rotate 플래그를 받는다. NORMAL 라운드로빈·dequeue quirk·활성화 경로는 무변경.
 
-**Tech Stack:** Spring Boot 3 / JPA(Hibernate) / QueryDSL / Flyway(V35) / JUnit5+Mockito / Testcontainers MySQL+Redis IT 하네스(`AbstractIntegrationTest`, `@Tag("integration")`)
+**Tech Stack:** Spring Boot 3 / JPA(Hibernate) / QueryDSL / Flyway(V35+V36) / JUnit5+Mockito / Testcontainers MySQL+Redis IT 하네스(`AbstractIntegrationTest`, `@Tag("integration")`)
 
 **승인 스펙:** `docs/superpowers/specs/2026-07-01-quick-dj-one-shot-queue-design.md` (2패스 리뷰 승인 · 오픈결정 전부 확정 · 이슈 [#331](https://github.com/pfplay/pfplay-platform/issues/331))
 
@@ -16,7 +16,7 @@
 - `app` 모듈 = party 도메인(DJ큐·재생) + 컨트롤러. `playlist` 모듈 = 플레이리스트/트랙.
 - party→playlist 접근은 포트 경유: `app/.../party/application/port/out/PlaylistCommandPort.java` ← 구현 `app/.../party/adapter/out/external/PlaylistCommandAdapter.java`(playlist 모듈 서비스 직접 주입).
 - IT는 `app/src/test/...`에 위치, `AbstractIntegrationTest` 상속 시 `@Tag("integration")` 자동 부여 → `./gradlew integrationTest`로 실행(단일 fork, DatabaseCleaner truncate).
-- 마이그레이션: `app/src/main/resources/db/migration/` — 현재 최신 **V34** → 이 작업은 **V35** 슬롯 사용. IT 하네스는 Flyway 적용+`ddl-auto: validate`이므로 엔티티와 DDL이 어긋나면 IT 부팅에서 잡힌다.
+- 마이그레이션: `app/src/main/resources/db/migration/` — 현재 최신 **V34** → 이 작업은 **V35(dj.kind)+V36(playlist.type ENUM 확장)** 두 슬롯 사용. IT 하네스는 Flyway 적용+`ddl-auto: validate`이므로 엔티티와 DDL이 어긋나면 IT 부팅에서 잡힌다.
 
 ---
 
@@ -136,7 +136,7 @@ Expected: PASS
 - [ ] **Step 5: Flyway 슬롯 중복 사전스캔** (배치 머지 함정 회피)
 
 Run: `ls app/src/main/resources/db/migration/ | sed -E 's/^(V[0-9]+)__.*/\1/' | sort | uniq -d`
-Expected: 출력 없음 (V35 유일)
+Expected: 출력 없음 (V35/V36 둘 다 유일 확인 — 이 작업은 두 슬롯 사용)
 
 - [ ] **Step 6: 커밋**
 
@@ -153,6 +153,7 @@ git commit -m "feat(party): DjData.kind(NORMAL/ONE_SHOT) 도입 + Flyway V35 (#3
 **Files:**
 - Modify: `playlist/src/main/java/com/pfplaybackend/api/playlist/domain/enums/PlaylistType.java`
 - Modify: `playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/impl/PlaylistRepositoryImpl.java` (`findAllByUserId`, `findByIdAndUserId` 양쪽)
+- Create: `app/src/main/resources/db/migration/V36__add_temp_playlist_type.sql` — **V1 DDL 의 `playlist.type` 이 MySQL `ENUM('GRABLIST','PLAYLIST')` 라 Java enum append 만으로는 'TEMP' INSERT 가 strict mode 에서 실패** → `ALTER TABLE playlist MODIFY COLUMN type ENUM('GRABLIST','PLAYLIST','TEMP')` (V32 MODIFY ENUM 패턴 계승)
 - Test: `app/src/test/java/com/pfplaybackend/api/playlist/application/service/TempPlaylistVisibilityIntegrationTest.java` (신규 IT — QueryDSL이라 DB 필요)
 
 - [ ] **Step 1: 실패하는 IT 작성**

--- a/docs/superpowers/plans/2026-07-11-quick-dj-one-shot-queue.md
+++ b/docs/superpowers/plans/2026-07-11-quick-dj-one-shot-queue.md
@@ -1,0 +1,1190 @@
+# Quick-DJ One-shot Queue 구현 플랜
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 검색 모달에서 곡 하나를 선택하는 즉시 그 곡으로 DJ 대기열에 등록되고, 1회 재생 후 자동 이탈하는 병렬 빠른 경로(Quick-DJ)를 pfplay-platform 백엔드에 추가한다.
+
+**Architecture:** 곡 저장은 신규 `PlaylistType.TEMP`(per-user 1개 재사용·조회 숨김), 큐 엔트리는 신규 `DjData.kind`(NORMAL/ONE_SHOT). ONE_SHOT 이탈은 위치(order-1)가 아닌 **outgoing DJ 정체**(`PartyroomPlaybackData.getCurrentDjCrewId()`) 기준으로 `tryProceed`에서 분기하고 `doStart`는 rotate 플래그를 받는다. NORMAL 라운드로빈·dequeue quirk·활성화 경로는 무변경.
+
+**Tech Stack:** Spring Boot 3 / JPA(Hibernate) / QueryDSL / Flyway(V35) / JUnit5+Mockito / Testcontainers MySQL+Redis IT 하네스(`AbstractIntegrationTest`, `@Tag("integration")`)
+
+**승인 스펙:** `docs/superpowers/specs/2026-07-01-quick-dj-one-shot-queue-design.md` (2패스 리뷰 승인 · 오픈결정 전부 확정 · 이슈 [#331](https://github.com/pfplay/pfplay-platform/issues/331))
+
+**빌드 명령 공통:** 모든 gradlew 호출은 `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7"` prefix 필수 (Git Bash 기준 `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew ...`).
+
+**모듈 지형(사전 지식):**
+- `app` 모듈 = party 도메인(DJ큐·재생) + 컨트롤러. `playlist` 모듈 = 플레이리스트/트랙.
+- party→playlist 접근은 포트 경유: `app/.../party/application/port/out/PlaylistCommandPort.java` ← 구현 `app/.../party/adapter/out/external/PlaylistCommandAdapter.java`(playlist 모듈 서비스 직접 주입).
+- IT는 `app/src/test/...`에 위치, `AbstractIntegrationTest` 상속 시 `@Tag("integration")` 자동 부여 → `./gradlew integrationTest`로 실행(단일 fork, DatabaseCleaner truncate).
+- 마이그레이션: `app/src/main/resources/db/migration/` — 현재 최신 **V34** → 이 작업은 **V35** 슬롯 사용. IT 하네스는 Flyway 적용+`ddl-auto: validate`이므로 엔티티와 DDL이 어긋나면 IT 부팅에서 잡힌다.
+
+---
+
+## Chunk 1: 데이터 모델 (DjKind · TEMP 플리 · 준비 서비스)
+
+### Task 1: `DjKind` enum + `DjData.kind` + Flyway V35
+
+**Files:**
+- Create: `app/src/main/java/com/pfplaybackend/api/party/domain/enums/DjKind.java`
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/DjData.java`
+- Create: `app/src/main/resources/db/migration/V35__add_dj_kind_for_quick_dj.sql`
+- Test: `app/src/test/java/com/pfplaybackend/api/party/domain/entity/data/DjDataTest.java` (신규)
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+```java
+package com.pfplaybackend.api.party.domain.entity.data;
+
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.party.domain.enums.DjKind;
+import com.pfplaybackend.api.party.domain.value.CrewId;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DjDataTest {
+
+    @Test
+    @DisplayName("create(4-arg) — kind 미지정 생성은 NORMAL")
+    void createDefaultsToNormal() {
+        DjData dj = DjData.create(new PartyroomId(1L), new PlaylistId(2L), new CrewId(3L), 1);
+        assertThat(dj.getKind()).isEqualTo(DjKind.NORMAL);
+    }
+
+    @Test
+    @DisplayName("create(5-arg) — ONE_SHOT 지정 생성")
+    void createWithOneShotKind() {
+        DjData dj = DjData.create(new PartyroomId(1L), new PlaylistId(2L), new CrewId(3L), 1, DjKind.ONE_SHOT);
+        assertThat(dj.getKind()).isEqualTo(DjKind.ONE_SHOT);
+    }
+}
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.domain.entity.data.DjDataTest"`
+Expected: 컴파일 실패 (`DjKind` 미존재)
+
+- [ ] **Step 3: 구현**
+
+`DjKind.java` 신규:
+```java
+package com.pfplaybackend.api.party.domain.enums;
+
+/**
+ * DJ 큐 엔트리 종류.
+ * NORMAL — 플레이리스트 기반 상시 회전 엔트리(기존 동작).
+ * ONE_SHOT — Quick-DJ 로 등록된 1회 재생 엔트리. 재생 완료/스킵 시 큐에서 자동 이탈한다(spec §3-3).
+ */
+public enum DjKind {
+    NORMAL,
+    ONE_SHOT
+}
+```
+
+`DjData.java` 수정 — 필드 추가(orderNumber 아래), 빌더 생성자에 파라미터 추가, create 오버로드:
+```java
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private DjKind kind;
+```
+```java
+    @Builder
+    public DjData(Long id, PartyroomId partyroomId, CrewId crewId, PlaylistId playlistId, int orderNumber,
+                  DjKind kind, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.partyroomId = partyroomId;
+        this.crewId = crewId;
+        this.playlistId = playlistId;
+        this.orderNumber = orderNumber;
+        this.kind = kind;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+```
+```java
+    public static DjData create(PartyroomId partyroomId, PlaylistId playlistId, CrewId crewId, int orderNumber) {
+        return create(partyroomId, playlistId, crewId, orderNumber, DjKind.NORMAL);
+    }
+
+    public static DjData create(PartyroomId partyroomId, PlaylistId playlistId, CrewId crewId, int orderNumber, DjKind kind) {
+        return DjData.builder()
+                .partyroomId(partyroomId)
+                .playlistId(playlistId)
+                .crewId(crewId)
+                .orderNumber(orderNumber)
+                .kind(kind)
+                .build();
+    }
+```
+import 추가: `com.pfplaybackend.api.party.domain.enums.DjKind`.
+
+`V35__add_dj_kind_for_quick_dj.sql` 신규:
+```sql
+-- V35: Quick-DJ(#331) — dj.kind 추가 (NORMAL/ONE_SHOT), 기존 행 NORMAL 백필
+ALTER TABLE dj
+    ADD COLUMN kind VARCHAR(20) NOT NULL DEFAULT 'NORMAL' COMMENT 'DJ 큐 엔트리 종류 (NORMAL/ONE_SHOT)' AFTER playlist_id;
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.domain.entity.data.DjDataTest"`
+Expected: PASS
+
+- [ ] **Step 5: Flyway 슬롯 중복 사전스캔** (배치 머지 함정 회피)
+
+Run: `ls app/src/main/resources/db/migration/ | sed -E 's/^(V[0-9]+)__.*/\1/' | sort | uniq -d`
+Expected: 출력 없음 (V35 유일)
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/domain/enums/DjKind.java \
+        app/src/main/java/com/pfplaybackend/api/party/domain/entity/data/DjData.java \
+        app/src/main/resources/db/migration/V35__add_dj_kind_for_quick_dj.sql \
+        app/src/test/java/com/pfplaybackend/api/party/domain/entity/data/DjDataTest.java
+git commit -m "feat(party): DjData.kind(NORMAL/ONE_SHOT) 도입 + Flyway V35 (#331)"
+```
+
+### Task 2: `PlaylistType.TEMP` + 목록/단건 조회 숨김 필터
+
+**Files:**
+- Modify: `playlist/src/main/java/com/pfplaybackend/api/playlist/domain/enums/PlaylistType.java`
+- Modify: `playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/impl/PlaylistRepositoryImpl.java` (`findAllByUserId`, `findByIdAndUserId` 양쪽)
+- Test: `app/src/test/java/com/pfplaybackend/api/playlist/application/service/TempPlaylistVisibilityIntegrationTest.java` (신규 IT — QueryDSL이라 DB 필요)
+
+- [ ] **Step 1: 실패하는 IT 작성**
+
+`PlaylistRepository`(Spring Data + custom)를 autowire해 세 타입(PLAYLIST/GRABLIST/TEMP)의 플리를 시드하고 필터를 단언한다. 시드는 `entityManager.persist(PlaylistData.create(...))` + `flushAndClear()` 사용(`AbstractIntegrationTest` 제공). **주의: TEMP enum 값이 없어 처음엔 컴파일 실패 — 그것이 red.**
+
+```java
+package com.pfplaybackend.api.playlist.application.service;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.playlist.adapter.out.persistence.PlaylistRepository;
+import com.pfplaybackend.api.playlist.application.dto.PlaylistSummaryDto;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
+import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Quick-DJ(#331) — TEMP 플리는 사용자 목록/단건 조회에서 숨겨진다(spec §3-1a).
+ * GRABLIST/PLAYLIST 노출은 현행 유지(회귀 잠금).
+ */
+@Transactional
+class TempPlaylistVisibilityIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private PlaylistRepository playlistRepository;
+
+    @Test
+    @DisplayName("findAllByUserId — TEMP 제외, GRABLIST/PLAYLIST 는 노출")
+    void findAllExcludesTemp() {
+        UserId owner = new UserId(9101L);
+        entityManager.persist(PlaylistData.create(0, "그랩한 곡", PlaylistType.GRABLIST, owner));
+        entityManager.persist(PlaylistData.create(1, "내 플레이리스트", PlaylistType.PLAYLIST, owner));
+        entityManager.persist(PlaylistData.create(0, "Quick-DJ", PlaylistType.TEMP, owner));
+        flushAndClear();
+
+        List<PlaylistSummaryDto> result = playlistRepository.findAllByUserId(owner);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(PlaylistSummaryDto::type)
+                .containsExactlyInAnyOrder(PlaylistType.GRABLIST, PlaylistType.PLAYLIST);
+    }
+
+    @Test
+    @DisplayName("findByIdAndUserId — TEMP id 단건 조회도 새지 않는다(null)")
+    void findByIdExcludesTemp() {
+        UserId owner = new UserId(9102L);
+        PlaylistData temp = PlaylistData.create(0, "Quick-DJ", PlaylistType.TEMP, owner);
+        entityManager.persist(temp);
+        PlaylistData normal = PlaylistData.create(1, "내 플레이리스트", PlaylistType.PLAYLIST, owner);
+        entityManager.persist(normal);
+        flushAndClear();
+
+        assertThat(playlistRepository.findByIdAndUserId(temp.getId(), owner)).isNull();
+        assertThat(playlistRepository.findByIdAndUserId(normal.getId(), owner)).isNotNull();
+    }
+}
+```
+
+주의: `PlaylistSummaryDto`가 record가 아니면 `extracting("type")` 형태로 조정. `PlaylistRepository` 인터페이스 정확 경로는 `playlist/.../adapter/out/persistence/PlaylistRepository.java`(custom `PlaylistRepositoryCustom` 상속) — 컴파일 에러 시 실제 이름 확인.
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:integrationTest --tests "*TempPlaylistVisibilityIntegrationTest"`
+Expected: 컴파일 실패(TEMP 미존재)
+
+- [ ] **Step 3: 구현**
+
+`PlaylistType.java`:
+```java
+public enum PlaylistType {
+    GRABLIST,
+    PLAYLIST,
+    /** Quick-DJ(#331) one-shot 곡 저장용 per-user 숨김 플리 — 목록/단건 조회에서 제외된다. @Enumerated(STRING)이라 append 안전. */
+    TEMP
+}
+```
+
+`PlaylistRepositoryImpl.java` — 두 메서드의 `.where(...)`에 TEMP 제외 조건 추가:
+```java
+// findAllByUserId
+.where(qPlaylistData.ownerId.eq(ownerId)
+        .and(qPlaylistData.type.ne(PlaylistType.TEMP)))
+// findByIdAndUserId
+.where(qPlaylistData.id.eq(playlistId)
+        .and(qPlaylistData.ownerId.eq(ownerId))
+        .and(qPlaylistData.type.ne(PlaylistType.TEMP)))
+```
+import 추가: `com.pfplaybackend.api.playlist.domain.enums.PlaylistType`.
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:integrationTest --tests "*TempPlaylistVisibilityIntegrationTest"`
+Expected: PASS (2/2)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add playlist/src/main/java/com/pfplaybackend/api/playlist/domain/enums/PlaylistType.java \
+        playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/impl/PlaylistRepositoryImpl.java \
+        app/src/test/java/com/pfplaybackend/api/playlist/application/service/TempPlaylistVisibilityIntegrationTest.java
+git commit -m "feat(playlist): PlaylistType.TEMP 도입 + 목록/단건 조회 숨김 (#331)"
+```
+
+### Task 3: `TempPlaylistService.prepareOneShotPlaylist` (find-or-create + 리셋 + 삽입)
+
+**Files:**
+- Modify: `playlist/src/main/java/com/pfplaybackend/api/playlist/domain/port/PlaylistAggregatePort.java` — `void deleteAllTracksByPlaylist(Long playlistId);` 추가
+- Modify: PlaylistAggregatePort 구현체 (`playlist/.../adapter/out/persistence/` 아래 — `grep -rn "implements PlaylistAggregatePort" playlist/src/main`으로 위치 확인) — 기존 `TrackRepository.deleteAllByPlaylistIdValue(playlistId)`(이미 존재, `SongPackApplier:86`이 사용) 위임
+- Create: `playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TempPlaylistService.java`
+- Test: `app/src/test/java/com/pfplaybackend/api/playlist/application/service/TempPlaylistServiceIntegrationTest.java` (신규 IT)
+
+⚠️ 구현 전 확인: `TrackRepository.deleteAllByPlaylistIdValue`의 `@Modifying` 속성. `clearAutomatically=true`면 **미flush 영속성 컨텍스트 변경이 폐기**되는 함정이 있으므로(과거 사고 패턴), `prepareOneShotPlaylist` 안에서 삭제 → 삽입 순서를 지키고 삭제 전에 보류 중인 엔티티 변경이 없도록 서비스 구조를 유지한다(아래 구현이 그 순서).
+
+- [ ] **Step 1: 실패하는 IT 작성**
+
+```java
+package com.pfplaybackend.api.playlist.application.service;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.playlist.application.dto.command.AddTrackCommand;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
+import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
+import com.pfplaybackend.api.playlist.domain.port.PlaylistAggregatePort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Quick-DJ(#331) — TEMP 플리 준비(find-or-create + 전곡 리셋 + 단건 삽입)(spec §3-2 step3~5).
+ * per-user 1개 재사용으로 행 증식이 없음을 잠근다(spec 결정6).
+ */
+@Transactional
+class TempPlaylistServiceIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private TempPlaylistService tempPlaylistService;
+    @Autowired
+    private PlaylistAggregatePort aggregatePort;
+
+    private AddTrackCommand track(String linkId, String name) {
+        return new AddTrackCommand(name, linkId, "3:45", "https://i.ytimg.com/vi/" + linkId + "/mqdefault.jpg");
+    }
+
+    @Test
+    @DisplayName("TEMP 미존재 → 생성 + 곡 1개 삽입")
+    void createsTempWhenAbsent() {
+        UserId owner = new UserId(9201L);
+
+        Long playlistId = tempPlaylistService.prepareOneShotPlaylist(owner, track("aaa111", "곡A"));
+        flushAndClear();
+
+        List<PlaylistData> temps = aggregatePort.findPlaylistsByOwnerAndType(owner, PlaylistType.TEMP);
+        assertThat(temps).hasSize(1);
+        assertThat(temps.get(0).getId()).isEqualTo(playlistId);
+        assertThat(aggregatePort.findTrackByPlaylistAndLink(new PlaylistId(playlistId), "aaa111")).isPresent();
+    }
+
+    @Test
+    @DisplayName("재호출 — 같은 TEMP 재사용(행 증식 없음), 이전 곡은 리셋되고 새 곡만 남는다")
+    void reusesAndResetsTemp() {
+        UserId owner = new UserId(9202L);
+
+        Long first = tempPlaylistService.prepareOneShotPlaylist(owner, track("aaa111", "곡A"));
+        flushAndClear();
+        Long second = tempPlaylistService.prepareOneShotPlaylist(owner, track("bbb222", "곡B"));
+        flushAndClear();
+
+        assertThat(second).isEqualTo(first);
+        assertThat(aggregatePort.findPlaylistsByOwnerAndType(owner, PlaylistType.TEMP)).hasSize(1);
+        assertThat(aggregatePort.findTrackByPlaylistAndLink(new PlaylistId(first), "aaa111")).isEmpty();
+        assertThat(aggregatePort.findTrackByPlaylistAndLink(new PlaylistId(first), "bbb222")).isPresent();
+    }
+}
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:integrationTest --tests "*TempPlaylistServiceIntegrationTest"`
+Expected: 컴파일 실패(`TempPlaylistService` 미존재)
+
+- [ ] **Step 3: 구현**
+
+`PlaylistAggregatePort.java` — Track 섹션에 추가:
+```java
+    void deleteAllTracksByPlaylist(Long playlistId);
+```
+
+구현체(어댑터)에 위임 메서드 추가:
+```java
+    @Override
+    public void deleteAllTracksByPlaylist(Long playlistId) {
+        trackRepository.deleteAllByPlaylistIdValue(playlistId);
+    }
+```
+(구현체가 `trackRepository`를 이미 주입받는지 확인 — `saveTrack` 등 기존 위임과 동일 필드 사용.)
+
+`TempPlaylistService.java` 신규:
+```java
+package com.pfplaybackend.api.playlist.application.service;
+
+import com.pfplaybackend.api.common.domain.value.Duration;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.playlist.application.dto.command.AddTrackCommand;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
+import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
+import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
+import com.pfplaybackend.api.playlist.domain.port.PlaylistAggregatePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Quick-DJ(#331) one-shot 곡 저장용 TEMP 플리 준비.
+ * per-user 1개를 재사용하며 호출마다 리셋(전곡 삭제) 후 선택 곡 1개만 삽입한다(spec §3-2 step3~5, 결정6).
+ * 재생 커서(lastPlayedTrackId)는 리셋하지 않는다 — 가리키던 트랙이 삭제되면
+ * peekTracksFromCursor 가 자연 순서로 fall-back 하므로 무해(spec §4).
+ */
+@Service
+@RequiredArgsConstructor
+public class TempPlaylistService {
+
+    private final PlaylistAggregatePort aggregatePort;
+
+    @Transactional
+    public Long prepareOneShotPlaylist(UserId userId, AddTrackCommand command) {
+        PlaylistData temp = aggregatePort.findPlaylistsByOwnerAndType(userId, PlaylistType.TEMP).stream()
+                .findFirst()
+                .orElseGet(() -> aggregatePort.savePlaylist(
+                        PlaylistData.create(0, "Quick-DJ", PlaylistType.TEMP, userId)));
+
+        aggregatePort.deleteAllTracksByPlaylist(temp.getId());
+
+        TrackData track = TrackData.builder()
+                .playlistId(new PlaylistId(temp.getId()))
+                .name(command.name())
+                .linkId(command.linkId())
+                .duration(Duration.fromString(command.duration()))
+                .orderNumber(1)
+                .thumbnailImage(command.thumbnailImage())
+                .build();
+        aggregatePort.saveTrack(track);
+        return temp.getId();
+    }
+}
+```
+(참고: `TrackData` 빌더 필드명은 `TrackCommandService.insertTrack:77-84`와 동일 — 컴파일 에러 시 그쪽을 기준으로 맞춘다. `insertTrack`을 재사용하지 않는 이유: ThreadLocal 결합·HEAD 삽입 시프트·`TrackAddedEvent` 발행이 TEMP 의미와 안 맞음.)
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:integrationTest --tests "*TempPlaylistServiceIntegrationTest"`
+Expected: PASS (2/2)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add playlist/src/main/java/com/pfplaybackend/api/playlist/domain/port/PlaylistAggregatePort.java \
+        playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TempPlaylistService.java \
+        app/src/test/java/com/pfplaybackend/api/playlist/application/service/TempPlaylistServiceIntegrationTest.java
+# + 어댑터 구현체 파일
+git commit -m "feat(playlist): TEMP 플리 준비 서비스 — find-or-create·리셋·단건삽입 (#331)"
+```
+
+### Task 4: `enqueueDj` kind 오버로드
+
+**Files:**
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java:43-93`
+- Test: `app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceTest.java` (기존 파일에 추가)
+
+- [ ] **Step 1: 실패하는 테스트 작성** — 기존 `DjCommandServiceTest`의 enqueue 헬퍼/스텁 패턴을 그대로 따라, ONE_SHOT enqueue 시 저장되는 `DjData.kind`를 captor로 단언:
+
+```java
+    @Test
+    @DisplayName("enqueueDj(kind) — ONE_SHOT 지정 시 kind 가 저장된다")
+    void enqueueDjPersistsOneShotKind() {
+        // given — 기존 enqueueDj happy 테스트와 동일 스텁 구성(해당 파일 참조)
+        // when
+        djCommandService.enqueueDj(partyroomId, playlistId, DjKind.ONE_SHOT);
+        // then
+        ArgumentCaptor<DjData> captor = ArgumentCaptor.forClass(DjData.class);
+        verify(aggregatePort).saveDj(captor.capture());
+        assertThat(captor.getValue().getKind()).isEqualTo(DjKind.ONE_SHOT);
+    }
+
+    @Test
+    @DisplayName("enqueueDj(2-arg) — 기존 경로는 NORMAL 유지(회귀)")
+    void enqueueDjDefaultsToNormalKind() {
+        // given — 동일 스텁
+        // when
+        djCommandService.enqueueDj(partyroomId, playlistId);
+        // then
+        ArgumentCaptor<DjData> captor = ArgumentCaptor.forClass(DjData.class);
+        verify(aggregatePort).saveDj(captor.capture());
+        assertThat(captor.getValue().getKind()).isEqualTo(DjKind.NORMAL);
+    }
+```
+(given 스텁은 기존 테스트 파일의 enqueue happy path 구성을 복제 — partyroom·playbackState·djQueue·crew·isOwned=true·isEmptyPlaylist=false·`saveDj` returns 인자.)
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.application.service.DjCommandServiceTest"`
+Expected: 컴파일 실패(3-arg 오버로드 미존재)
+
+- [ ] **Step 3: 구현** — 기존 본문을 3-arg로 이동, `DjData.create(..., kind)` 사용, 반환을 `DjData`로. 2-arg는 위임:
+
+```java
+    @Transactional
+    public Long enqueueDj(PartyroomId partyroomId, PlaylistId playlistId) {
+        return enqueueDj(partyroomId, playlistId, DjKind.NORMAL).getId();
+    }
+
+    @Transactional
+    public DjData enqueueDj(PartyroomId partyroomId, PlaylistId playlistId, DjKind kind) {
+        // ... 기존 본문 그대로, 아래 두 줄만 변경 ...
+        DjData dj = DjData.create(partyroom.getPartyroomId(), playlistId, crewId, nextOrder, kind);
+        // ... 마지막: return saved;  (기존 return saved.getId() 대신)
+    }
+```
+import 추가: `DjKind`.
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.application.service.DjCommandServiceTest"`
+Expected: PASS (기존 테스트 포함 전체)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/application/service/DjCommandService.java \
+        app/src/test/java/com/pfplaybackend/api/party/application/service/DjCommandServiceTest.java
+git commit -m "feat(party): enqueueDj kind 오버로드 — ONE_SHOT 등록 경로 (#331)"
+```
+
+---
+
+## Chunk 2: One-shot 이탈 분기 + Quick-DJ 오케스트레이션 + API
+
+### Task 5: `tryProceed` outgoing-ONE_SHOT 제거 분기 + `doStart(rotate)` + `ONE_SHOT_COMPLETED`
+
+**핵심 불변식(spec §3-3, 초안 버그 재발 방지):** 제거 기준은 위치(order-1)가 아닌 **정체**. `doStart` 선두 회전은 최초 활성화·dequeue-후-skip에서도 진입하므로, order-1 기준 제거는 미재생 ONE_SHOT을 삭제한다. outgoing = `PartyroomPlaybackData.getCurrentDjCrewId()`(deactivate에서만 클리어)로 식별하고, 분기는 `tryProceed`(완료·스킵 경로 전용)에만 둔다.
+
+**Files:**
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/domain/enums/DjChangeType.java` — `ONE_SHOT_COMPLETED` 추가
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java:90-145`
+- Test: `app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackCommandServiceTest.java` (기존 파일에 추가)
+
+- [ ] **Step 1: 실패하는 테스트 작성** — 기존 `PlaybackCommandServiceTest` 하네스(Mockito, `@InjectMocks`)에 추가. **먼저 기존 setUp에 lenient 기본 스텁 1줄 추가**(신규 `findPlaybackState` 호출 때문에 기존 테스트가 NPE 나지 않도록):
+
+```java
+        // setUp() 마지막에 추가 — currentDjCrewId=null 인 기본 상태(rotate 경로 보존)
+        lenient().when(aggregatePort.findPlaybackState(any(PartyroomId.class)))
+                .thenAnswer(inv -> PartyroomPlaybackData.createFor(inv.getArgument(0)));
+```
+
+신규 테스트 5건:
+
+```java
+    // ── Quick-DJ(#331) — outgoing ONE_SHOT 이탈 분기 ──
+
+    private PartyroomData partyroomFixture() {
+        return PartyroomData.builder().id(partyroomId.getId()).partyroomId(partyroomId)
+                .playbackTimeLimit(PlaybackTimeLimit.ofMinutes(10)).build();
+    }
+
+    private PartyroomPlaybackData activatedPlaybackState(CrewId currentDjCrewId) {
+        PartyroomPlaybackData state = PartyroomPlaybackData.createFor(partyroomId);
+        state.activate(new PlaybackId(77L), currentDjCrewId);
+        return state;
+    }
+
+    @Test
+    @DisplayName("complete — outgoing ONE_SHOT 은 회전 대신 제거되고 ONE_SHOT_COMPLETED 가 발행된다")
+    void completeRetiresOutgoingOneShotInsteadOfRotating() {
+        CrewId outgoing = new CrewId(31L);
+        DjData oneShot = DjData.create(partyroomId, new PlaylistId(2L), outgoing, 1, DjKind.ONE_SHOT);
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroomFixture());
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(activatedPlaybackState(outgoing));
+        when(aggregatePort.findDj(partyroomId, outgoing)).thenReturn(Optional.of(oneShot));
+        when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(List.of()); // 제거 후 빈 큐
+
+        playbackCommandService.complete(partyroomId, userId);
+
+        verify(partyroomAggregateService).removeDjFromQueue(partyroomId, outgoing);
+        verify(partyroomAggregateService, never()).rotateDjQueue(any());
+        ArgumentCaptor<Object> events = ArgumentCaptor.forClass(Object.class);
+        verify(eventPublisher, atLeastOnce()).publishEvent(events.capture());
+        assertThat(events.getAllValues().stream()
+                .filter(e -> e instanceof DjQueueChangedEvent)
+                .map(e -> ((DjQueueChangedEvent) e).getChangeType()))
+                .contains(DjChangeType.ONE_SHOT_COMPLETED);
+    }
+
+    @Test
+    @DisplayName("complete — outgoing NORMAL 은 기존 회전 경로 그대로(제거 없음)")
+    void completeRotatesForNormalOutgoing() {
+        CrewId outgoing = new CrewId(32L);
+        DjData normal = DjData.create(partyroomId, new PlaylistId(2L), outgoing, 1);
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroomFixture());
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(activatedPlaybackState(outgoing));
+        when(aggregatePort.findDj(partyroomId, outgoing)).thenReturn(Optional.of(normal));
+        when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(List.of(normal));
+        when(partyroomAggregateService.rotateDjQueue(partyroomId)).thenReturn(List.of(normal));
+        // doStart 진입 후 재생가능 트랙 없음 → deactivate 로 수렴해도 본 검증엔 무관
+        when(aggregatePort.findCrewById(anyLong())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> playbackCommandService.complete(partyroomId, userId))
+                .isInstanceOf(NoSuchElementException.class); // findCrewById orElseThrow — 기존 doStart 거동
+        verify(partyroomAggregateService).rotateDjQueue(partyroomId);
+        verify(partyroomAggregateService, never()).removeDjFromQueue(any(), any());
+    }
+
+    @Test
+    @DisplayName("complete — outgoing 이 큐에 없으면(dequeue-후-skip) 제거 분기 미실행, 회전 경로")
+    void completeSkipsRetireWhenOutgoingAlreadyDequeued() {
+        CrewId outgoing = new CrewId(33L);
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroomFixture());
+        when(aggregatePort.findPlaybackState(partyroomId)).thenReturn(activatedPlaybackState(outgoing));
+        when(aggregatePort.findDj(partyroomId, outgoing)).thenReturn(Optional.empty());
+        when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(List.of());
+
+        playbackCommandService.complete(partyroomId, userId);
+
+        verify(partyroomAggregateService, never()).removeDjFromQueue(any(), any());
+        verify(partyroomAggregateService).deactivatePlayback(partyroomId); // 빈 큐 → 기존 deactivate
+    }
+
+    @Test
+    @DisplayName("complete — currentDjCrewId=null(비활성)이면 분기 미실행(기존 거동)")
+    void completeNullOutgoingKeepsLegacyPath() {
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(partyroomFixture());
+        when(aggregatePort.findDjsOrdered(partyroomId)).thenReturn(List.of());
+
+        playbackCommandService.complete(partyroomId, userId);
+
+        verify(partyroomAggregateService, never()).removeDjFromQueue(any(), any());
+        verify(aggregatePort, never()).findDj(any(), any());
+    }
+
+    @Test
+    @DisplayName("startPlayback(최초 활성화) — tryProceed 미경유라 ONE_SHOT 이어도 제거되지 않는다(미재생 삭제 금지)")
+    void startPlaybackNeverRetiresOneShot() {
+        CrewId crewId = new CrewId(34L);
+        DjData oneShot = DjData.create(partyroomId, new PlaylistId(2L), crewId, 1, DjKind.ONE_SHOT);
+        when(partyroomAggregateService.rotateDjQueue(partyroomId)).thenReturn(List.of(oneShot));
+        when(aggregatePort.findCrewById(anyLong())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> playbackCommandService.startPlayback(partyroomFixture()))
+                .isInstanceOf(NoSuchElementException.class);
+        verify(partyroomAggregateService, never()).removeDjFromQueue(any(), any());
+    }
+```
+(`DjQueueChangedEvent`의 changeType getter 이름은 실제 클래스 확인 — `@Getter`면 `getChangeType()`.)
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.application.service.PlaybackCommandServiceTest"`
+Expected: 신규 5건 FAIL 또는 컴파일 실패(`ONE_SHOT_COMPLETED` 미존재)
+
+- [ ] **Step 3: 구현**
+
+`DjChangeType.java`:
+```java
+public enum DjChangeType {
+    ENQUEUE,
+    DEQUEUE,
+    DEQUEUE_ADMIN,
+    DEQUEUE_EXIT,
+    ROTATE,
+    DEACTIVATE,
+    /** Quick-DJ(#331) — ONE_SHOT 엔트리가 1회 재생을 마치고 자연 이탈 */
+    ONE_SHOT_COMPLETED
+}
+```
+
+`PlaybackCommandService.java` — `tryProceed`/`doStart` 교체(기존 line 90-145):
+```java
+    private void tryProceed(PartyroomId partyroomId) {
+        PartyroomData partyroom = partyroomQueryService.getPartyroomById(partyroomId);
+        boolean oneShotRetired = retireOutgoingOneShot(partyroomId);
+        List<DjData> queuedDjs = aggregatePort.findDjsOrdered(partyroomId);
+        log.debug("[tryProceed] partyroomId={}, queueSize={}, oneShotRetired={}",
+                partyroomId.getId(), queuedDjs.size(), oneShotRetired);
+
+        if(!queuedDjs.isEmpty()) {
+            // ONE_SHOT 제거로 이미 큐가 전진했으면 중복 회전 금지(spec §3-3)
+            doStart(partyroom, !oneShotRetired);
+        }else{
+            log.info("[tryProceed] EMPTY_QUEUE_DEACTIVATE - partyroomId={}", partyroomId.getId());
+            deactivateAndNotify(partyroom);
+        }
+    }
+
+    /**
+     * 방금 재생을 끝낸(outgoing) DJ 가 ONE_SHOT 이면 회전 대신 큐에서 제거한다.
+     * 제거 기준은 위치(order-1)가 아닌 정체(currentDjCrewId) — doStart 의 선두 회전은
+     * 최초 활성화·dequeue-후-skip 경로에서도 진입하므로 위치 기준은 미재생 엔트리를 삭제한다(spec §3-3).
+     * currentDjCrewId 는 deactivate 에서만 클리어되므로 완료/스킵 시점엔 방금 끝난 DJ 를 가리킨다.
+     */
+    private boolean retireOutgoingOneShot(PartyroomId partyroomId) {
+        PartyroomPlaybackData playbackState = aggregatePort.findPlaybackState(partyroomId);
+        CrewId outgoingCrewId = playbackState.getCurrentDjCrewId();
+        if (outgoingCrewId == null) return false;
+        return aggregatePort.findDj(partyroomId, outgoingCrewId)
+                .filter(dj -> dj.getKind() == DjKind.ONE_SHOT)
+                .map(dj -> {
+                    partyroomAggregateService.removeDjFromQueue(partyroomId, outgoingCrewId);
+                    eventPublisher.publishEvent(new DjQueueChangedEvent(partyroomId, DjChangeType.ONE_SHOT_COMPLETED, outgoingCrewId));
+                    log.info("[tryProceed] ONE_SHOT_COMPLETED - partyroomId={}, crewId={}",
+                            partyroomId.getId(), outgoingCrewId.getId());
+                    return true;
+                })
+                .orElse(false);
+    }
+
+    @Override
+    public void startPlayback(PartyroomData partyroom) {
+        doStart(partyroom, true);
+    }
+
+    private void doStart(PartyroomData partyroom, boolean rotate) {
+        long partyroomIdValue = partyroom.getPartyroomId().getId();
+        List<DjData> rotatedDjs = rotate
+                ? partyroomAggregateService.rotateDjQueue(partyroom.getPartyroomId())
+                : aggregatePort.findDjsOrdered(partyroom.getPartyroomId());
+        // ... 이하 기존 본문 무변경 ...
+    }
+```
+import 추가: `DjKind`, `Optional`(이미 있음).
+
+`tryProceed`의 `null` 가드: 비활성 상태에서 `findPlaybackState`가 던지는지/null 반환인지는 기존 코드( `enqueueDj:49` )가 무조건 호출하는 걸로 보아 row 는 항상 존재 — `getCurrentDjCrewId()` null 체크로 충분.
+
+- [ ] **Step 4: 통과 확인 (신규 + 기존 회귀)**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.application.service.PlaybackCommandServiceTest"`
+Expected: PASS 전체(기존 테스트 포함 — 기존 것이 깨지면 setUp 기본 스텁부터 의심)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/domain/enums/DjChangeType.java \
+        app/src/main/java/com/pfplaybackend/api/party/application/service/PlaybackCommandService.java \
+        app/src/test/java/com/pfplaybackend/api/party/application/service/PlaybackCommandServiceTest.java
+git commit -m "feat(party): outgoing ONE_SHOT 이탈 분기 — 정체 기준 제거 + doStart(rotate) (#331)"
+```
+
+### Task 6: `QuickDjService` + `TRACK_EXCEEDS_TIME_LIMIT` + 포트 확장
+
+**Files:**
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/domain/exception/DjException.java` — `TRACK_EXCEEDS_TIME_LIMIT("DJ-007", ...)` 추가
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/application/port/out/PlaylistCommandPort.java` — `Long prepareOneShotPlaylist(UserId userId, AddTrackCommand command);` 추가
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/PlaylistCommandAdapter.java` — `TempPlaylistService` 주입·위임
+- Create: `app/src/main/java/com/pfplaybackend/api/party/application/service/QuickDjService.java`
+- Test: `app/src/test/java/com/pfplaybackend/api/party/application/service/QuickDjServiceTest.java` (신규)
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+```java
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.aspect.context.AuthContext;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.application.port.out.PlaylistCommandPort;
+import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.entity.data.DjData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.enums.DjKind;
+import com.pfplaybackend.api.party.domain.value.CrewId;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.playlist.application.dto.command.AddTrackCommand;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Quick-DJ(#331) 오케스트레이션 — 시간한도 사전검증(결정7/B)·TEMP 준비·ONE_SHOT enqueue.
+ */
+@ExtendWith(MockitoExtension.class)
+class QuickDjServiceTest {
+
+    @Mock PartyroomQueryService partyroomQueryService;
+    @Mock PlaylistCommandPort playlistCommandPort;
+    @Mock DjCommandService djCommandService;
+
+    @InjectMocks QuickDjService quickDjService;
+
+    private final UserId userId = new UserId(1L);
+    private final PartyroomId partyroomId = new PartyroomId(10L);
+
+    @BeforeEach
+    void setUp() {
+        AuthContext authContext = mock(AuthContext.class);
+        lenient().when(authContext.getUserId()).thenReturn(userId);
+        ThreadLocalContext.setContext(authContext);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ThreadLocalContext.clearContext();
+    }
+
+    private PartyroomData roomWithLimitMinutes(int minutes) {
+        return PartyroomData.builder().id(partyroomId.getId()).partyroomId(partyroomId)
+                .playbackTimeLimit(PlaybackTimeLimit.ofMinutes(minutes)).build();
+    }
+
+    private AddTrackCommand command(String duration) {
+        return new AddTrackCommand("곡A", "aaa111", duration, "https://i.ytimg.com/vi/aaa111/mqdefault.jpg");
+    }
+
+    @Test
+    @DisplayName("곡 duration > 방 한도 → DJ-007, write 미발생")
+    void rejectsTrackExceedingTimeLimit() {
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(roomWithLimitMinutes(3));
+        when(partyroomQueryService.getCrewOrThrow(eq(partyroomId), any())).thenReturn(mock(CrewData.class));
+
+        // ExceptionCreator 는 getMessage()에 errorCode 를 싣지 않는다 — 타입 + errorCode 필드로 단언
+        assertThatThrownBy(() -> quickDjService.quickEnqueue(partyroomId, command("3:01")))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "DJ-007");
+
+        verifyNoInteractions(playlistCommandPort);
+        verifyNoInteractions(djCommandService);
+    }
+
+    @Test
+    @DisplayName("happy — TEMP 준비 후 ONE_SHOT 으로 enqueue")
+    void happyPathPreparesTempAndEnqueuesOneShot() {
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(roomWithLimitMinutes(5));
+        when(partyroomQueryService.getCrewOrThrow(eq(partyroomId), any())).thenReturn(mock(CrewData.class));
+        when(playlistCommandPort.prepareOneShotPlaylist(eq(userId), any(AddTrackCommand.class))).thenReturn(42L);
+        DjData saved = DjData.create(partyroomId, new PlaylistId(42L), new CrewId(3L), 2, DjKind.ONE_SHOT);
+        when(djCommandService.enqueueDj(partyroomId, new PlaylistId(42L), DjKind.ONE_SHOT)).thenReturn(saved);
+
+        DjData result = quickDjService.quickEnqueue(partyroomId, command("3:45"));
+
+        assertThat(result.getKind()).isEqualTo(DjKind.ONE_SHOT);
+        assertThat(result.getOrderNumber()).isEqualTo(2);
+        InOrder inOrder = inOrder(playlistCommandPort, djCommandService);
+        inOrder.verify(playlistCommandPort).prepareOneShotPlaylist(eq(userId), any(AddTrackCommand.class));
+        inOrder.verify(djCommandService).enqueueDj(partyroomId, new PlaylistId(42L), DjKind.ONE_SHOT);
+    }
+
+    @Test
+    @DisplayName("무제한 방(limit=0) — 어떤 duration 도 통과")
+    void unlimitedRoomAcceptsAnyDuration() {
+        when(partyroomQueryService.getPartyroomById(partyroomId)).thenReturn(roomWithLimitMinutes(0));
+        when(partyroomQueryService.getCrewOrThrow(eq(partyroomId), any())).thenReturn(mock(CrewData.class));
+        when(playlistCommandPort.prepareOneShotPlaylist(eq(userId), any())).thenReturn(42L);
+        when(djCommandService.enqueueDj(eq(partyroomId), any(), eq(DjKind.ONE_SHOT)))
+                .thenReturn(DjData.create(partyroomId, new PlaylistId(42L), new CrewId(3L), 1, DjKind.ONE_SHOT));
+
+        quickDjService.quickEnqueue(partyroomId, command("2:10:00"));
+
+        verify(djCommandService).enqueueDj(eq(partyroomId), any(), eq(DjKind.ONE_SHOT));
+    }
+}
+```
+(import 추가: `org.mockito.InOrder`, `com.pfplaybackend.api.common.exception.http.BadRequestException`. `ExceptionCreator.create`는 `ErrorType.BAD_REQUEST` → `BadRequestException(errorCode, message)`를 만들고 errorCode 는 `@Getter` 필드다.)
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.application.service.QuickDjServiceTest"`
+Expected: 컴파일 실패(QuickDjService 미존재)
+
+- [ ] **Step 3: 구현**
+
+`DjException.java` — 추가:
+```java
+    TRACK_EXCEEDS_TIME_LIMIT("DJ-007", "곡 길이가 방의 재생 시간 한도를 초과합니다", ErrorType.BAD_REQUEST);
+```
+(`ErrorType.BAD_REQUEST` 존재 — `TrackException.INVALID_TRACK_ORDER`가 사용 중.)
+
+`PlaylistCommandPort.java` — 추가:
+```java
+    /** Quick-DJ(#331) — per-user TEMP 플리를 리셋 후 선택 곡 1개를 담아 그 id 를 반환한다. */
+    Long prepareOneShotPlaylist(UserId userId, com.pfplaybackend.api.playlist.application.dto.command.AddTrackCommand command);
+```
+(import 정리는 파일 스타일에 맞춰.)
+
+`PlaylistCommandAdapter.java` — `TempPlaylistService` 주입 + 위임:
+```java
+    @Override
+    public Long prepareOneShotPlaylist(UserId userId, AddTrackCommand command) {
+        return tempPlaylistService.prepareOneShotPlaylist(userId, command);
+    }
+```
+
+`QuickDjService.java` 신규:
+```java
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.adapter.in.web.RequestIdInterceptor;
+import com.pfplaybackend.api.common.aspect.context.AuthContext;
+import com.pfplaybackend.api.common.domain.value.Duration;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.exception.ExceptionCreator;
+import com.pfplaybackend.api.party.application.port.out.PlaylistCommandPort;
+import com.pfplaybackend.api.party.domain.entity.data.DjData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.enums.DjKind;
+import com.pfplaybackend.api.party.domain.exception.DjException;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.playlist.application.dto.command.AddTrackCommand;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Quick-DJ(#331) — 곡 즉석 선택 → one-shot DJ 큐 등록 오케스트레이션.
+ * 시간한도 사전검증(결정7/B) → TEMP 플리 준비(리셋+삽입) → ONE_SHOT enqueue 를
+ * 1 트랜잭션으로 묶어, 실패 시 TEMP 에 곡만 남는 중간상태를 남기지 않는다(spec §3-2).
+ * 양자택일(이미 큐 등록 시 거부)은 enqueue 내부의 ALREADY_REGISTERED 가드가 그대로 보장한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QuickDjService {
+
+    private final PartyroomQueryService partyroomQueryService;
+    private final PlaylistCommandPort playlistCommandPort;
+    private final DjCommandService djCommandService;
+
+    @Transactional
+    public DjData quickEnqueue(PartyroomId partyroomId, AddTrackCommand command) {
+        AuthContext authContext = ThreadLocalContext.getAuthContext();
+        UserId userId = authContext.getUserId();
+        log.info("[quickEnqueue] ENTER - requestId={}, partyroomId={}, userId={}, linkId={}",
+                RequestIdInterceptor.current(), partyroomId.getId(), userId.getUid(), command.linkId());
+
+        PartyroomData partyroom = partyroomQueryService.getPartyroomById(partyroomId);
+        partyroomQueryService.getCrewOrThrow(partyroomId, userId);
+
+        Duration duration = Duration.fromString(command.duration());
+        if (partyroom.getPlaybackTimeLimit().exceedsDuration(duration)) {
+            throw ExceptionCreator.create(DjException.TRACK_EXCEEDS_TIME_LIMIT);
+        }
+
+        Long tempPlaylistId = playlistCommandPort.prepareOneShotPlaylist(userId, command);
+        return djCommandService.enqueueDj(partyroomId, new PlaylistId(tempPlaylistId), DjKind.ONE_SHOT);
+    }
+}
+```
+(`getCrewOrThrow` 시그니처가 `(PartyroomId, UserId)`인지 확인 — `DjCommandService:55` 참조.)
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.application.service.QuickDjServiceTest"`
+Expected: PASS (3/3)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/domain/exception/DjException.java \
+        app/src/main/java/com/pfplaybackend/api/party/application/port/out/PlaylistCommandPort.java \
+        app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/PlaylistCommandAdapter.java \
+        app/src/main/java/com/pfplaybackend/api/party/application/service/QuickDjService.java \
+        app/src/test/java/com/pfplaybackend/api/party/application/service/QuickDjServiceTest.java
+git commit -m "feat(party): QuickDjService — 시간한도 사전검증·TEMP 준비·ONE_SHOT enqueue 1-tx (#331)"
+```
+
+### Task 7: Quick-DJ endpoint (`POST /{partyroomId}/dj-queue/quick`)
+
+**Files:**
+- Create: `app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/payload/request/dj/QuickDjRequest.java`
+- Create: `app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/payload/response/QuickDjResponse.java`
+- Modify: `app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandController.java`
+- Modify: `app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/AbstractPartyCommandWebMvcTest.java` — **필수**: 이 `@WebMvcTest` 베이스는 서비스 빈을 명시적 `@MockBean` 목록으로만 제공한다. `DjCommandController` 생성자에 `QuickDjService`가 추가되므로 `@MockBean protected QuickDjService quickDjService;`를 추가하지 않으면 이 베이스를 상속하는 **모든** 파티 컨트롤러 테스트가 컨텍스트 로드 실패로 전멸한다.
+- Test: `app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandControllerTest.java` (기존 파일에 추가 — 기존 슬라이스/모킹 하네스 그대로 따름)
+
+- [ ] **Step 1: 실패하는 테스트 작성** — 기존 `DjCommandControllerTest`의 enqueue 테스트(POST dj-queue, line 35·62)를 본떠 3건 추가:
+  1. happy: 유효 body → 201 + `djId`/`orderNumber` (QuickDjService mock이 `DjData.create(..., 2, ONE_SHOT)` 반환하도록 — id는 저장 전 null이므로 응답 단언은 orderNumber 중심 또는 mock DjData 사용)
+  2. `duration: "abc"` → 400 (@Pattern 위반)
+  3. `name: ""` → 400 (@NotBlank 위반)
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.adapter.in.web.DjCommandControllerTest"`
+Expected: 컴파일 실패(QuickDjRequest 미존재)
+
+- [ ] **Step 3: 구현**
+
+`QuickDjRequest.java` (`AddTrackRequest` 미러 + duration 형식 검증 — 검증 통과 시 `Duration.fromString` 파싱이 항상 성공):
+```java
+package com.pfplaybackend.api.party.adapter.in.web.payload.request.dj;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "Quick-DJ 등록 요청 — 검색 결과에서 선택한 곡 하나")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class QuickDjRequest {
+    @NotBlank(message = "name is required.")
+    @Schema(description = "곡 이름", example = "BLACKPINK - 'Shut Down' M/V", requiredMode = Schema.RequiredMode.REQUIRED, type = "string")
+    private String name;
+
+    @NotBlank(message = "linkId is required.")
+    @Schema(description = "곡 링크 id", example = "POe9SOEKotk", requiredMode = Schema.RequiredMode.REQUIRED, type = "string")
+    private String linkId;
+
+    @NotBlank(message = "duration is required.")
+    @Pattern(regexp = "^\\d+:\\d{2}(:\\d{2})?$", message = "duration must be m:ss or h:mm:ss.")
+    @Schema(description = "곡 재생 시간", example = "03:01", requiredMode = Schema.RequiredMode.REQUIRED, type = "string")
+    private String duration;
+
+    @NotBlank(message = "thumbnailImage is required.")
+    @Schema(description = "곡 썸네일 이미지", example = "https://i.ytimg.com/vi/POe9SOEKotk/mqdefault.jpg", requiredMode = Schema.RequiredMode.REQUIRED, type = "string")
+    private String thumbnailImage;
+}
+```
+
+`QuickDjResponse.java`:
+```java
+package com.pfplaybackend.api.party.adapter.in.web.payload.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Quick-DJ 등록 응답")
+public record QuickDjResponse(
+        @Schema(description = "생성된 DJ ID") Long djId,
+        @Schema(description = "내 대기열 순번(1-base)") int orderNumber
+) {}
+```
+
+`AbstractPartyCommandWebMvcTest.java` — 기존 `@MockBean` 목록에 추가:
+```java
+    @MockBean
+    protected QuickDjService quickDjService;
+```
+
+`DjCommandController.java` — 필드 `private final QuickDjService quickDjService;` 추가 + 메서드:
+```java
+    @Operation(summary = "Quick-DJ 등록",
+            description = "검색한 곡 하나로 즉시 DJ 큐에 one-shot 등록합니다. 1회 재생 후 자동으로 대기열에서 이탈하며, MEMBER 권한이 필요합니다.")
+    @ApiResponse(responseCode = "201", description = "Quick-DJ 등록 성공")
+    @SecurityRequirement(name = "cookieAuth")
+    @ApiErrorCodes({DjException.class})
+    @PostMapping("/{partyroomId}/dj-queue/quick")
+    @PreAuthorize("hasRole('MEMBER')")
+    public ResponseEntity<ApiCommonResponse<QuickDjResponse>> quickEnqueueDj(
+            @Parameter(description = "파티룸 ID") @PathVariable Long partyroomId,
+            @Valid @RequestBody QuickDjRequest request) {
+        DjData dj = quickDjService.quickEnqueue(new PartyroomId(partyroomId),
+                new AddTrackCommand(request.getName(), request.getLinkId(), request.getDuration(), request.getThumbnailImage()));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiCommonResponse.success(new QuickDjResponse(dj.getId(), dj.getOrderNumber())));
+    }
+```
+import 추가: `QuickDjService`, `QuickDjRequest`, `QuickDjResponse`, `DjData`, `AddTrackCommand`.
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "com.pfplaybackend.api.party.adapter.in.web.DjCommandControllerTest"`
+Expected: PASS (기존 포함 전체)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/ \
+        app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/DjCommandControllerTest.java
+git commit -m "feat(party): POST /dj-queue/quick — Quick-DJ 등록 endpoint (#331)"
+```
+
+### Task 8: 통합 테스트 — spec §5 트레이스 잠금
+
+**Files:**
+- Create: `app/src/test/java/com/pfplaybackend/api/party/application/service/QuickDjOneShotIntegrationTest.java`
+
+시드 헬퍼는 `DjCommandIntegrationTest`(partyroom+playback+dj_queue+crew 시드, `seedAuthContext`)를 본뜨되, **PlaylistQueryPort/PlaylistCommandPort를 모킹하지 않고 실 빈으로 구동**한다(재생 선곡 `peekTracksFromCursor`까지 실경로 — 그래서 PLAYLIST/TRACK 실데이터 시드 필요). 재생 시작·완료는 `DjCommandService.enqueueDj`/`QuickDjService.quickEnqueue` → `PlaybackCommandService.complete(partyroomId, userId)` 직접 호출로 시뮬레이션. WS/Redis 릴레이 단언은 하지 않고 **DB 상태(DJ row·kind·order·playback state)**만 단언한다.
+
+주의: `@Transactional` IT에서 expiration task 는 Redis 로 스케줄되지만(Testcontainers Redis) 단언 대상이 아님. `complete()`의 userId 인자는 점수 갱신용 — 아무 사용자나 무방.
+
+- [ ] **Step 1: 실패하는 IT 작성** — 시나리오 5건:
+
+```java
+    // (a) 유일 ONE_SHOT 최초 활성화 — 재생됨 → 완료 시 제거 → deactivate (미재생 삭제 금지 회귀 잠금)
+    //  quickEnqueue(user X) → DJ row kind=ONE_SHOT & playbackState.currentDjCrewId=X크루 & isActivated=true
+    //  complete() → X의 DJ row 부재 & isActivated=false
+    // (b) 혼합 큐 [A(NORMAL,재생중), X(ONE_SHOT), B(NORMAL)] — X는 1턴 후 소멸, A·B 라운드로빈 보존
+    //  A enqueue(실플리+트랙) → X quickEnqueue → B enqueue
+    //  complete()×1 → X 재생 중(currentDjCrewId=X크루), A는 tail
+    //  complete()×2 → X row 부재, B 재생 중, 큐=[B(1),A(2)] 유지
+    //  complete()×3 → A 재생 중 (라운드로빈 확인)
+    // (c) 현재 DJ dequeue-후-skip — incoming ONE_SHOT 미삭제
+    //  A(재생중)+X(ONE_SHOT 대기) → A dequeueDj → X의 DJ row 존재 & X 재생 시작
+    // (d) 버튼 스킵 — 재생 중 ONE_SHOT 트랙 스킵 → 재등장 없이 제거
+    //  X(ONE_SHOT) 단독 재생 중 + B(NORMAL) 대기 → skipPlayback → X row 부재, B 재생
+    // (e-1) TRACK_EXCEEDS_TIME_LIMIT 사전거부 — limit=3분 방에 duration "3:01" quickEnqueue
+    //  → DJ-007(BadRequestException, errorCode 필드 단언) & DJ row 미생성 & TEMP 무변화
+    //  (write 이전 사전거부라 @Transactional 테스트 tx 안에서도 관측 가능)
+    // (e-2) ALREADY_REGISTERED 양자택일 + 전체 롤백 — ⚠️ 클래스 @Transactional 로는 관측 불가:
+    //  quickEnqueue 의 REQUIRED tx 가 테스트 tx 에 참여해 중간 롤백이 일어나지 않고 rollback-only
+    //  마킹만 되므로, "TEMP 곡이 첫 곡 그대로" 단언이 뒤집힌다(곡B가 보임).
+    //  → 이 @Test 만 @Transactional(propagation = Propagation.NOT_SUPPORTED) 로 선언하고,
+    //    시드는 @Autowired TransactionTemplate 로 커밋(별도 tx), 정리는 DatabaseCleaner 에 위임.
+    //    시나리오: X quickEnqueue(곡A, 커밋됨) → 재-quickEnqueue(곡B) → DJ-001(ConflictException)
+    //    → 재조회: TEMP 트랙 = 곡A 그대로(곡B 리셋/삽입이 실제 롤백됨), DJ row 1개 유지.
+```
+
+각 시나리오는 독립 `@Test`로, 시드 사용자 id 대역을 분리(9300~). (e-2)를 제외한 테스트는 클래스 `@Transactional`, (e-2)만 메서드 레벨 `NOT_SUPPORTED` + `TransactionTemplate` 시드. 실플리 시드 헬퍼:
+```java
+    private Long persistPlaylistWithTrack(UserId owner, String linkId, String duration) {
+        PlaylistData playlist = PlaylistData.create(1, "IT 플리", PlaylistType.PLAYLIST, owner);
+        entityManager.persist(playlist);
+        entityManager.flush();
+        TrackData track = TrackData.builder()
+                .playlistId(new PlaylistId(playlist.getId()))
+                .name("곡-" + linkId).linkId(linkId)
+                .duration(Duration.fromString(duration))
+                .orderNumber(1)
+                .thumbnailImage("https://i.ytimg.com/vi/" + linkId + "/mqdefault.jpg")
+                .build();
+        entityManager.persist(track);
+        flushAndClear();
+        return playlist.getId();
+    }
+```
+enqueue/quickEnqueue 호출 전 `seedAuthContext(해당 user)` 전환. (b)의 큐 순서 단언은 `aggregatePort.findDjsOrdered(partyroomId)`의 (crewId, orderNumber, kind) 튜플로.
+
+⚠️ ONE_SHOT quickEnqueue 사용자도 실제 회원 UserId 시드가 필요한지 확인: `enqueueDj` 내부 `startPlaybackFor`가 `djCrew.getUserId()`를 쓰므로 CrewData 시드에 UserId만 있으면 충분(별도 user 테이블 FK 없음 — `DjCommandIntegrationTest`가 임의 UserId로 통과하는 것으로 확인됨).
+
+- [ ] **Step 2: 실행 및 green 확인** (이 태스크는 검증 잠금 성격 — 구현이 이미 끝났으므로 red 가 아니라 **전부 green 이어야 정상**. 하나라도 red면 Task 5/6 구현 버그이므로 구현을 수정 후 재실행)
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:integrationTest --tests "*QuickDjOneShotIntegrationTest"`
+Expected: PASS (6/6 — (a)(b)(c)(d)(e-1)(e-2))
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add app/src/test/java/com/pfplaybackend/api/party/application/service/QuickDjOneShotIntegrationTest.java
+git commit -m "test(party): Quick-DJ one-shot 회전 트레이스 IT — spec §5 (a)~(d)+파이프라인 잠금 (#331)"
+```
+
+---
+
+## Chunk 3: 전량 검증 + 부팅 게이트 + PR
+
+### Task 9: 전량 회귀 (유닛 + IT)
+
+- [ ] **Step 1: 유닛 전량**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew test`
+Expected: BUILD SUCCESSFUL, 실패 0 (기준선: 기존 ~1276+)
+
+- [ ] **Step 2: IT 전량**
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew integrationTest`
+Expected: BUILD SUCCESSFUL, 실패 0 (기준선: 기존 72클래스/282케이스 + 신규)
+주의: 로컬 IT 전량은 느릴 수 있음(DatabaseCleaner). 실패 시 gradle Worker 좀비의 output.bin 락 가능성 — 재시도 전 잔존 Test Executor JVM kill.
+
+- [ ] **Step 3: 실패 있으면 원인 수정 후 재실행** (플래키 의심 시에도 원인 규명 우선 — "재실행 그린"으로 넘어가지 않는다)
+
+### Task 10: 로컬 docker 풀부팅 게이트 (fresh DB · Flyway V35 · validate)
+
+- [ ] **Step 1: 최신 jar 빌드** (스테일 jar 함정 — Dockerfile 은 호스트 빌드 jar 를 COPY)
+
+Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:bootJar`
+
+- [ ] **Step 2: fresh DB 풀부팅** (volume 초기화로 V1→V35 전체 적용 + validate)
+
+```bash
+docker compose -p pfplay-local --env-file .env.local -f docker-compose.local.yml down -v
+docker compose -p pfplay-local --env-file .env.local -f docker-compose.local.yml up -d --build
+# 부팅 로그에서 Flyway "Successfully applied ... v35" + 앱 Started 확인 (-f + head 는 파이프 조기종료 위험)
+docker compose -p pfplay-local --env-file .env.local -f docker-compose.local.yml logs --tail 300 api | grep -E "flyway|Flyway|Started|ERROR"
+# Started 가 안 보이면 수 초 대기 후 재실행
+```
+Expected: Flyway V35 적용 성공, Hibernate validate 통과, 애플리케이션 정상 기동. JPQL/스키마 오류는 여기서만 잡히는 부류이므로 반드시 통과 확인.
+
+- [ ] **Step 3: 라이브 스모크(선택·권장)** — 로컬 스택에서 로그인 후 `POST /api/v1/partyrooms/{id}/dj-queue/quick` 1회 호출(swagger 또는 curl), 201 + DJ 큐 GET 에 ONE_SHOT 반영 확인. (admin 로그인 shared 쿠키 함정 — 회원 계정으로.)
+
+- [ ] **Step 4: 정리 후 커밋 통합 점검** — 논리단위 커밋 유지 확인(필요시 squash, 파괴적 rebase 전 사용자 확인), push:
+
+```bash
+git push -u origin feat/quick-dj-one-shot-queue
+```
+
+- [ ] **Step 5: PR 생성(한글, 이슈 연결)**
+
+```bash
+gh pr create --base develop --title "feat: Quick-DJ — 곡 즉석 선택 one-shot DJ 대기열 등록 (#331)" --body "..."
+```
+PR 본문: 배경(온보딩 이탈)·설계 요지(TEMP/DjKind/outgoing-정체 분기)·스펙 문서 링크·테스트 증거(유닛/IT/부팅 게이트)·웹 후속 이슈 예고. Closes #331.
+반드시 명시할 것 2건:
+1. **확정 API 계약** — 스펙 §3-2의 Body 어휘(`videoId/videoTitle/runningTime/...`, 200)와 달리 구현은 기존 `AddTrackRequest` 어휘(`name/linkId/duration/thumbnailImage`) + **201**로 확정(웹 후속 PR이 이 계약을 따르도록 PR 본문이 진실원천).
+2. **웹 "ONE_SHOT 큐 표식" 선결조건** — DJ 큐 GET 응답 DTO에 `kind` 미노출 상태. 표식 UI가 필요해지면 후속 백엔드 변경(조회 DTO에 kind 추가) 필요함을 기록.
+
+- [ ] **Step 6: CI 전체 그린 확인 후 사용자 보고** (dev 머지는 로컬 e2e 게이트 통과·사용자 승인 후 — web 연동 UI 가 없으므로 백엔드 단독 머지 여부는 보고 시 사용자 결정 사항으로 명시)
+
+---
+
+## 회귀 가드 요약 (리뷰어 체크리스트)
+
+1. **NORMAL 라운드로빈 무변경**: `rotateDjQueue`/`removeDjFromQueue` 로직 자체는 손대지 않는다. `doStart(rotate=true)` 경로는 기존과 바이트단위 동일 거동.
+2. **미재생 ONE_SHOT 삭제 금지**: 제거 분기는 `tryProceed`에만 존재. `startPlayback`(최초 활성화)·`doStart` 내부에는 제거 로직이 없다.
+3. **dequeue-후-skip quirk 보존**: outgoing 이 큐에 없으면(`findDj` empty) 분기 미실행 → 기존 rotate 경로.
+4. **TEMP 누출 금지**: 목록+단건 양쪽 필터. GRABLIST 노출은 현행 유지.
+5. **생성 상한 무영향**: `createPlaylist`는 PLAYLIST만 카운트 — TEMP 자동 제외(코드 무변경으로 보장).
+6. **웹 이벤트 호환**: `ONE_SHOT_COMPLETED`는 신규 타입 — 기존 web 이 unknown type 을 무시하는지 여부는 web 후속 PR에서 처리(백엔드는 발행만).

--- a/docs/superpowers/specs/2026-07-01-quick-dj-one-shot-queue-design.md
+++ b/docs/superpowers/specs/2026-07-01-quick-dj-one-shot-queue-design.md
@@ -1,0 +1,167 @@
+# Quick-DJ — 곡 즉석 선택 → One-shot DJ 대기열 등록 설계
+
+- 작성일: 2026-07-01
+- 대상 이슈: 미등록(신규 기능, 착수 시 pfplay-platform + pfplay-web 이슈 발행)
+- 대상 레포: pfplay-platform(playlist + party 모듈, backend) / pfplay-web(검색모달 UX, 별 PR)
+- 분류: 신규 기능(온보딩 이탈 완화) — 도메인 모델 확장(신규 PlaylistType·DjData.kind) + 신규 오케스트레이션 endpoint
+- 상태: **설계 파킹**(코드 미착수, 사용자 지시 시 plan → 구현)
+
+## 1. 배경 / 문제
+
+첫 사용자가 DJ가 되려면 모달이 **①플레이리스트 생성 → ②곡 등록 → ③플리 선택 → ④DJ 대기열 등록** 다단계를 강요 → 복잡해서 이탈. (검증된 pain, 관련 파킹 아이디어 = `default_playlist_dj_onboarding_idea`.)
+
+→ **검색 모달에서 곡을 검색·선택하는 즉시 그 곡과 함께 DJ 대기열에 등록되는 병렬 빠른 경로(Quick-DJ)** 추가.
+
+### 현행 코드 사실(2026-07-01 확인)
+
+- **DJ 큐 = 크루 1슬롯 모델.** `DjData` = {id, partyroomId, crewId, playlistId, orderNumber}, 엔트리 종류 필드 없음 (`app/.../party/domain/entity/data/DjData.java:26-43`).
+- **enqueue** `DjCommandService.enqueueDj(PartyroomId, PlaylistId)` (`app/.../party/application/service/DjCommandService.java:43-93`): `getCrewOrThrow`로 활성 크루 확인 → 가드 `isAlreadyRegistered`(crewId) · `isOwned` · `isEmptyPlaylist` → `DjEnqueueSpecification.validate` → `nextOrder = queuedDjs.size()+1`(맨 뒤) → `DjData.create(...)` 저장. 비활성 재생 시 playback 활성화·start.
+- **가드** `DjEnqueueSpecification`: `validateOpen`(QUEUE_CLOSED) · `NOT_OWNED_PLAYLIST` · `EMPTY_PLAYLIST` · `ALREADY_REGISTERED`. → **`ALREADY_REGISTERED`(crewId 기준)가 "1크루 1엔트리"를 이미 강제.**
+- **회전** `PartyroomAggregateService.rotateDjQueue`(`app/.../party/domain/service/PartyroomAggregateService.java:46-58`): head(order 1)→tail, 나머지 −1. **영구 라운드로빈, 재생 완료로 이탈하는 경로 없음.**
+- **회전 호출점** `PlaybackCommandService.doStart`(`app/.../party/application/service/PlaybackCommandService.java:108-145`)가 트랙 완료 시(complete→tryProceed→doStart) **맨 처음(line 110) `rotateDjQueue` 무조건 호출** → 그 다음 재생 가능한 새 head 선택(`peekTracksFromCursor`, line 122).
+- **제거** `PartyroomAggregateService.removeDjFromQueue(partyroomId, crewId)`(line 25-41): crewId의 모든 행 삭제 후 재번호. 호출점 = 자발 dequeue·관리자 dequeue·방 이탈(`handleDjQueueOnLeave`)뿐. **트랙 완료로는 호출 안 됨.**
+- **1곡 플리 재생 거동**: `peekTracksFromCursor`(`playlist/.../application/service/TrackCommandService.java:174-200`)가 커서 다음부터 wrap → n=1이면 **같은 곡 무한 반복**.
+- **플리 타입** `PlaylistType` = {GRABLIST, PLAYLIST} (`playlist/.../domain/enums/PlaylistType.java`).
+- **목록 조회** `PlaylistRepositoryImpl.findAllByUserId`(`playlist/.../adapter/out/persistence/impl/PlaylistRepositoryImpl.java:20-38`): WHERE = ownerId뿐, **타입 필터 없음**(GRABLIST 포함 전부 반환).
+- **생성 상한** `PlaylistCreationPolicy`(FM=10/AM=1)는 `createPlaylist`가 **`PlaylistType.PLAYLIST`만 카운트**(`PlaylistCommandService.java:39-42`)해 적용. `createDefaultPlaylist`(GRABLIST, line 30-33)는 정책 우회 = **per-user 시스템 플리 생성 선례.**
+
+## 2. 결정 (사용자 확정, 2026-07-01)
+
+1. **대상 = 모두를 위한 병렬 빠른 경로.** 단 **큐 등록은 양자택일** — 이미 큐에 등록된(NORMAL이든 ONE_SHOT이든) 크루는 Quick-DJ 불가. → 기존 `ALREADY_REGISTERED`(crewId)가 그대로 보장, **가드 변경 불필요.**
+2. **관심사 분리**: 곡 **저장 = TEMP 플리**(신규 타입) / 불변식 **#2 = ONE_SHOT 큐 엔트리**(신규 `DjData.kind`). #2를 플리 비우기/삭제로 흉내내지 않는다(1곡 무한반복 방지).
+3. **하나의 DJ 큐에 NORMAL·ONE_SHOT 혼합** 등록. 회전 경계에서 타입으로 분기.
+4. **ONE_SHOT 배치 = 맨 뒤 append**(기존 `nextOrder` 그대로). "빠른"은 *등록 과정*이 빠른 것. 우선순위 삽입은 out-of-scope(붐빔이 실 pain으로 확인되면 후속).
+5. **ONE_SHOT 이탈 트리거 = 재생 완료 + 스킵.** 방 이탈·전체 deactivate는 기존 경로가 이미 커버.
+6. **TEMP 플리 = per-user 1개 재사용**, Quick-DJ마다 리셋(이전 곡 비우고 새 곡 삽입). GRABLIST와 일관, 행 증식 없음. 리셋-중-재생 레이스는 양자택일이 원천 차단(재생 중엔 등록 상태 → 재-Quick-DJ 불가).
+7. **곡 duration 사전검증(옵션 B 확정, 2026-07-01)**: 선택 곡 재생시간이 방 `playbackTimeLimit` 초과면 **quick-enqueue 시점에 400 거부**. 단일 곡이라 duration을 미리 알 수 있으므로, "조용히 안 나오는 곡"(§4)을 등록 전에 차단.
+
+## 3. 설계
+
+### 3-1. 데이터 모델 변경
+
+**(a) `PlaylistType`에 `TEMP` 추가**
+```
+enum PlaylistType { GRABLIST, PLAYLIST, TEMP }
+```
+- **마이그레이션 안전 확정**: `PlaylistData.type`은 `@Enumerated(EnumType.STRING)` 매핑(`playlist/.../domain/entity/data/PlaylistData.java:45-46`). 문자열 저장이므로 **enum에 TEMP를 어디에 append하든 안전**(ordinal 재정렬·데이터 rewrite 위험 없음). 별도 Flyway 데이터 마이그레이션 불필요.
+- 목록/단건 조회 **양쪽**에 `type != TEMP` 필터 추가:
+  - `findAllByUserId`(`PlaylistRepositoryImpl.java:20-38`) — WHERE에 `type.ne(TEMP)`
+  - `findByIdAndUserId`(`PlaylistRepositoryImpl.java:40-61`) — 단건 fetch도 모든 타입 반환하므로 TEMP id가 새지 않게 동일 predicate 추가
+  - (GRABLIST는 현행대로 노출 유지, TEMP만 숨김.)
+- 생성 상한 = 이미 PLAYLIST만 카운트(`createPlaylist:39`) → TEMP 자동 제외(정책 변경 불필요).
+
+**(b) `DjData`에 `kind` 추가**
+```
+enum DjKind { NORMAL, ONE_SHOT }
+DjData { ..., @Enumerated(STRING) DjKind kind }   // 기본 NORMAL
+```
+- STRING 매핑으로 통일(ordinal 위험 회피). Flyway: `dj_data.kind` VARCHAR NOT NULL, 기존 행 default `'NORMAL'` 백필.
+- `DjData.create(...)`에 kind 파라미터 추가(또는 ONE_SHOT용 오버로드). 기존 호출부(NORMAL)는 기본값 유지.
+
+### 3-2. Quick-DJ 오케스트레이션 (신규, 1 트랜잭션)
+
+신규 application 서비스(예: `QuickDjService`) 또는 기존 서비스 확장:
+
+```
+quickEnqueue(partyroomId, VideoSelection):   // userId는 ThreadLocalContext.getAuthContext()에서 유도(기존 관례)
+  1. crew = getCrewOrThrow(partyroomId, userId)          // 활성 크루 확인(재사용)
+  2. partyroom = getPartyroomById(partyroomId)
+     if partyroom.playbackTimeLimit.exceedsDuration(VideoSelection.duration):
+         throw 400 TRACK_EXCEEDS_TIME_LIMIT               // 결정7(B) — 등록 전 사전거부
+  3. tempPlaylist = findOrCreateTempPlaylist(userId)     // TEMP 없으면 생성(createDefaultPlaylist 패턴)
+  4. resetTracks(tempPlaylist)                            // 기존 곡 전부 삭제 + 커서 초기화
+  5. insertTrack(tempPlaylist, VideoSelection)           // TrackCommandService 재사용
+  6. enqueueDj(partyroomId, tempPlaylist.id, ONE_SHOT)   // 기존 enqueue 경로 + kind
+```
+- duration 원천: `VideoSelection.runningTime`(검색결과 표시문자열, 예 "3:45")을 `Duration`으로 파싱 → `PartyroomData.getPlaybackTimeLimit().exceedsDuration(Duration)`(기존 `doStart:125`와 동일 비교기)로 검증. 파싱 실패/누락 시 400.
+- 3~6 단일 `@Transactional`. 실패 시 전체 롤백(TEMP에 곡만 남고 큐 미등록 방지). 검증(2)은 write 이전이라 조기 반환.
+- 5의 가드(`isAlreadyRegistered`)가 양자택일 자동 보장 → 이미 큐에 있으면 `ALREADY_REGISTERED`로 거부.
+- `isEmptyPlaylist` 통과(1곡). `isOwned` 통과(TEMP = 본인 소유).
+- **구체 서브태스크(리뷰 반영)**: 기존 `enqueueDj(PartyroomId, PlaylistId)`는 userId를 컨텍스트에서 유도하고 kind 파라미터가 없다 → `enqueueDj(PartyroomId, PlaylistId, DjKind)` 오버로드/확장(기본 NORMAL 유지). `getCrewOrThrow`가 step1과 `enqueueDj` 내부에서 **2회 해석**되나 무해(동일 결과) — 필요 시 내부 enqueue에 crew 전달하는 형태로 정리 가능(선택).
+
+**API 계약(확정)**
+```
+POST /api/v1/partyrooms/{partyroomId}/dj-queue/quick
+Auth: cookieAuth, hasRole('MEMBER')
+Body: { videoId, videoTitle, watchUrl, runningTime, thumbnailUrl }   // 검색결과 항목
+Success: 200 + 등록된 DJ 요약(웹이 등록 성공/내 순번 피드백에 사용)
+```
+Error: 기존 enqueue 에러(DJ-002 QUEUE_CLOSED / ALREADY_REGISTERED) 재사용 + 곡 payload 검증(400 INVALID_REQUEST) + **신규 400 TRACK_EXCEEDS_TIME_LIMIT**(결정7/B, 곡 duration > 방 한도).
+
+### 3-3. One-shot 이탈 (불변식 #2, 핵심 신규) — **outgoing 정체(identity) 기준**
+
+> ⚠️ 리뷰 반영(초안 폐기): "order-1이 ONE_SHOT이면 retire"는 **틀렸다.** `doStart`의 선두 `rotateDjQueue`(line 110)는 재생 완료·스킵뿐 아니라 **최초 활성화**(`startPlayback`→`doStart`)와 **현재 DJ dequeue-후-skip**에서도 진입하며, 그때 order-1은 *아직 재생 안 한* DJ다. order-1을 무조건 제거하면 **미재생 ONE_SHOT을 삭제**(최초 활성화 시 유일 ONE_SHOT이 재생도 못 하고 사라짐). 따라서 제거 기준은 **위치(order-1)가 아니라 "방금 재생을 끝낸 그 DJ"의 정체**여야 한다.
+
+**정체 원천**: 현재 재생 DJ는 `PartyroomPlaybackData`에 crewId로 기록된다(`PlaybackCommandService.startPlaybackFor:156` `playbackState.updatePlayback(playbackId, crewId)`). `aggregatePort.findPlaybackState(partyroomId)`로 outgoing DJ를 정확히 식별.
+
+**설계**: `doStart`의 선두 회전을 그대로 두되, **완료·스킵 경로(`tryProceed`)에서 회전 직전에 outgoing DJ가 ONE_SHOT이면 회전 대신 제거**로 분기. `doStart`는 회전 여부를 파라미터로 받는다.
+
+```
+tryProceed(partyroomId):
+    playbackState = findPlaybackState(partyroomId)
+    outgoingCrewId = playbackState.currentDjCrewId          // 방금 재생을 끝낸 DJ(없으면 null)
+    outgoingDj = queue에서 outgoingCrewId로 조회             // dequeue로 이미 빠졌으면 null
+    if outgoingDj != null && outgoingDj.kind == ONE_SHOT:
+        removeDjFromQueue(partyroomId, outgoingCrewId)      // 회전 대신 제거(1엔트리라 crewId 안전)
+        broadcast(DjQueueChangedEvent, ONE_SHOT_COMPLETED, outgoingCrewId)
+        doStart(partyroom, rotate=false)                   // 이미 큐를 전진시켰으므로 중복 회전 금지
+    else:
+        doStart(partyroom, rotate=true)                    // 기존 동작 그대로(NORMAL 회전·dequeue quirk·활성화)
+```
+
+**정확성 근거(트레이스)** — 기존 NORMAL 라운드로빈과 활성화를 **완전 보존**하면서 ONE_SHOT만 1회 후 이탈:
+- **최초 활성화**(유일 ONE_SHOT X): enqueue→`startPlayback`→`doStart(rotate=true)`. 이 경로는 `tryProceed`를 안 지나므로 제거 분기 미실행 → rotate는 n=1 no-op → X **재생됨**. X 완료 → `complete`→`tryProceed`: outgoing=X(ONE_SHOT, 큐 존재) → 제거 → `doStart(rotate=false)` → 큐 빔 → deactivate. ✅ (§4 엣지#1 충족)
+- **중간 ONE_SHOT** [A(NORMAL,재생), X(ONE_SHOT), B(NORMAL)]: A완료→outgoing=A(NORMAL)→`doStart(rotate=true)`: A→tail, X 재생. X완료→outgoing=X(ONE_SHOT)→제거→`doStart(rotate=false)`→B 재생. B완료→A→tail→A 재생. **A·B 라운드로빈 보존, X는 1회 후 소멸.** ✅
+- **현재 DJ dequeue-후-skip**: `dequeueDj`가 current를 먼저 `removeDjFromQueue` → `skipPlayback`→`tryProceed`: outgoing(=제거된 그 crew)은 큐에 없음 → 제거 분기 미실행 → `doStart(rotate=true)` = **기존 동작 그대로**(기존 quirk 포함 무변경). 들어오는 ONE_SHOT이 있어도 rotate는 tail 이동일 뿐 **삭제 아님** → 미재생 삭제 없음. ✅
+
+**변경 요약**: `doStart`에 `rotate` 플래그 추가(기존 호출부는 `true`) + `tryProceed`에 outgoing-ONE_SHOT 제거 분기. `rotateDjQueue`/`removeDjFromQueue`/기존 NORMAL 경로 로직 자체는 **무변경**.
+
+**확정 사실(2차 리뷰 검증)**:
+- outgoing 식별 = `PartyroomPlaybackData.getCurrentDjCrewId()`(클래스 `@Getter`, 필드 line 36). `updatePlayback(playbackId, crewId)`(line 70-73)로 세팅, **`deactivate()`에서만 클리어**되므로 완료→`tryProceed` 시점엔 방금 끝난 DJ를 정확히 가리킨다. (`isCurrentDj(CrewId)` 헬퍼도 있어 구현 시 택일 가능.)
+- 큐-내-존재 조회 = `aggregatePort.findDj(partyroomId, crewId)`(기존, `DjCommandService:154`). dequeue로 이미 빠진 outgoing은 null → 분기 미실행(가드).
+- **empty-queue 처리 보존**: 두 분기 모두 결국 `doStart`로 수렴하고 `doStart`가 빈 큐 시 fall-through로 `deactivateAndNotify`(line 144). 기존 `tryProceed`의 명시적 `EMPTY_QUEUE_DEACTIVATE` 로그(line 95-100)를 유지할지, `doStart`의 `DEACTIVATE_TRIGGERED`로 일원화할지는 plan에서 로그 정합만 결정(기능 동일).
+
+### 3-4. 브로드캐스트
+
+ONE_SHOT 재생-후-제거 시 웹 큐 갱신용 이벤트 필요.
+- **방식**: 기존 `DjQueueChangedEvent` 발행. `DjChangeType`에 **`ONE_SHOT_COMPLETED` 신규 추가** 권장(vs `DEQUEUE` 재사용) — 웹이 "1회 재생 종료로 자연 이탈"을 정상 dequeue와 구분해 표시할 수 있게. (재사용해도 기능은 되나 의미 소실.)
+- 기존 enqueue의 `ENQUEUE` 이벤트는 그대로.
+
+## 4. 엣지 케이스
+
+- **ONE_SHOT이 유일/첫 엔트리**: enqueue가 playback 활성화(`startPlayback`→`doStart(rotate=true)`, `tryProceed` 미경유) → **1회 재생됨** → 완료 시 `tryProceed`가 outgoing=ONE_SHOT 감지·제거 → 큐 빔 → deactivate. OK (§3-3 트레이스).
+- **재-Quick-DJ**: 이전 곡 종료·제거로 미등록 상태 → TEMP 리셋 후 재등록 가능. OK.
+- **ONE_SHOT 대기 중 방 이탈/추방**: `handleDjQueueOnLeave`가 crewId로 제거 → 기존 커버.
+- **버튼 스킵(본인/관리자)으로 ONE_SHOT의 트랙을 스킵**: 스킵 시점 outgoing=그 ONE_SHOT(현재 재생 중) → `tryProceed`가 제거 → 재등장 없음. OK(§3-3 outgoing 기준이라 완료·스킵 동일 처리).
+- **ONE_SHOT 곡이 방 재생시간 초과(playbackTimeLimit)** → **결정7(B)로 해소**: quick-enqueue 시점(§3-2 step2)에 400 `TRACK_EXCEEDS_TIME_LIMIT`로 사전거부 → 애초에 큐에 안 들어옴("조용히 안 나오는 곡" 방지). (미검증 시 발생하던 잔류 경로 = `doStart` per-DJ 스킵으로 current 못 됨 → 완료이벤트 없음 → 제거 트리거 없음.)
+- **TEMP 커서(`lastPlayedTrackId`)**: 1곡·리셋 반복이라 무해(다음 리셋 시 재초기화).
+
+## 5. 테스트 전략 (TDD)
+
+- 단위: `DjData.create(kind=ONE_SHOT)`; `tryProceed` outgoing 분기(outgoing=ONE_SHOT→제거+`rotate=false` / outgoing=NORMAL·null→`rotate=true`); TEMP 리셋+삽입.
+- 서비스: `quickEnqueue` 1트랜잭션(성공/롤백); `ALREADY_REGISTERED`로 양자택일 거부; `isEmptyPlaylist` 통과; **곡 duration > 방 한도면 400 `TRACK_EXCEEDS_TIME_LIMIT` + write 미발생(TEMP 리셋/삽입 안 됨)**(결정7).
+- IT(재현) — §3-3 트레이스를 그대로 테스트로:
+  - **(a) 유일 ONE_SHOT 최초 활성화**: enqueue→**재생됨**→완료 후 제거→deactivate. (초안 버그 회귀 방지 = 미재생 삭제 금지)
+  - **(b) 중간 ONE_SHOT 혼합 큐** [NORMAL, ONE_SHOT, NORMAL]: ONE_SHOT 1턴 후 제거, NORMAL 순환 보존.
+  - **(c) 현재 DJ dequeue-후-skip에 incoming ONE_SHOT**: 들어오는 ONE_SHOT이 **삭제되지 않음**(rotate=tail 이동일 뿐).
+  - **(d) 버튼 스킵으로 ONE_SHOT 트랙 스킵**: 재등장 없이 제거.
+- 회귀: NORMAL 라운드로빈 순서 무변경; 목록/단건 조회 TEMP 제외; GRABLIST 여전히 노출; 생성 상한 무영향.
+
+## 6. Out-of-scope
+
+- ONE_SHOT 우선순위/큐 점프(맨 뒤 append 고정).
+- 재생 중 DJ의 ONE_SHOT 전환/취소.
+- Quick-DJ 남용 방지(rate limit) — 필요 시 후속.
+- 웹 상세 UX(별 PR, pfplay-web): 검색모달 "이 곡으로 바로 DJ" CTA, ONE_SHOT 큐 표식, 등록 후 피드백.
+
+## 7. 재사용 vs 신규 요약
+
+| | 항목 |
+|---|---|
+| **재사용(그대로)** | enqueue 경로·`DjEnqueueSpecification`·`ALREADY_REGISTERED` 양자택일·재생/커서(`peekTracksFromCursor`)·`rotateDjQueue`/`removeDjFromQueue` 로직·방이탈/deactivate 경로·`TrackCommandService` 삽입·`createDefaultPlaylist` 패턴·생성상한(무변)·**NORMAL 라운드로빈 순서(무변)** |
+| **신규(국소)** | `PlaylistType.TEMP`+목록/단건 필터 · `DjData.kind`(STRING)+Flyway · **`tryProceed` outgoing-ONE_SHOT 제거 분기 + `doStart` rotate 플래그** · `enqueueDj` kind 오버로드 · `QuickDjService` 오케스트레이션 · `DjChangeType.ONE_SHOT_COMPLETED` · quick endpoint · 웹 UX |
+
+## 8. 오픈 결정 (전부 확정)
+
+- ~~ONE_SHOT 곡 duration > 방 `playbackTimeLimit`~~ → **결정7 (B) 확정(2026-07-01)**: quick-enqueue 사전검증·400 `TRACK_EXCEEDS_TIME_LIMIT`. (§2-7, §3-2, §4)
+- 나머지(enum STRING · outgoing-identity 메커니즘 · API 200+요약)도 확정. **남은 오픈 결정 없음 → planning-ready.**

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/PlaylistAggregateAdapter.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/PlaylistAggregateAdapter.java
@@ -103,6 +103,11 @@ public class PlaylistAggregateAdapter implements PlaylistAggregatePort, Playlist
         return trackRepository.existsByPlaylistId(playlistId);
     }
 
+    @Override
+    public void deleteAllTracksByPlaylist(Long playlistId) {
+        trackRepository.deleteAllByPlaylistIdValue(playlistId);
+    }
+
     // ===== Track Reordering =====
 
     @Override

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/impl/PlaylistRepositoryImpl.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/out/persistence/impl/PlaylistRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.pfplaybackend.api.playlist.adapter.out.persistence.custom.PlaylistRep
 import com.pfplaybackend.api.playlist.application.dto.PlaylistSummaryDto;
 import com.pfplaybackend.api.playlist.domain.entity.data.QPlaylistData;
 import com.pfplaybackend.api.playlist.domain.entity.data.QTrackData;
+import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +32,8 @@ public class PlaylistRepositoryImpl implements PlaylistRepositoryCustom {
                 )
                 .from(qPlaylistData)
                 .leftJoin(qTrackData).on(qPlaylistData.id.eq(qTrackData.playlistId.id))
-                .where(qPlaylistData.ownerId.eq(ownerId))
+                .where(qPlaylistData.ownerId.eq(ownerId)
+                        .and(qPlaylistData.type.ne(PlaylistType.TEMP)))
                 .groupBy(qPlaylistData.id)
                 .orderBy(qPlaylistData.type.desc(), qPlaylistData.orderNumber.asc())
                 .fetch();
@@ -54,6 +56,7 @@ public class PlaylistRepositoryImpl implements PlaylistRepositoryCustom {
                 .leftJoin(qTrackData).on(qPlaylistData.id.eq(qTrackData.playlistId.id))
                 .where(qPlaylistData.id.eq(playlistId)
                         .and(qPlaylistData.ownerId.eq(ownerId))
+                        .and(qPlaylistData.type.ne(PlaylistType.TEMP))
                 )
                 .groupBy(qPlaylistData.id)
                 .orderBy(qPlaylistData.type.desc(), qPlaylistData.orderNumber.asc())

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/PlaylistQueryService.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/PlaylistQueryService.java
@@ -35,9 +35,12 @@ public class PlaylistQueryService {
     }
 
     /**
-     * 소유권 검증 — 조회 숨김(TEMP 제외, V36)과는 별개 관심사라 view 쿼리가 아닌
-     * aggregate 포트의 원시 조회를 쓴다. Quick-DJ(#331)의 TEMP 플리도 본인 소유면 true —
-     * view 쿼리에 얹으면 ONE_SHOT enqueue 의 ownership 검증이 NOT_OWNED 로 오탐한다.
+     * 소유권 검증 — 조회 숨김(TEMP 제외 — PlaylistRepositoryImpl 필터)과는 별개 관심사라
+     * view 쿼리가 아닌 aggregate 포트의 원시 조회를 쓴다. Quick-DJ(#331)의 TEMP 플리도
+     * 본인 소유면 true — view 쿼리에 얹으면 ONE_SHOT enqueue 의 ownership 검증이
+     * NOT_OWNED 로 오탐한다.
+     * TEMP 는 소유권상 valid — ONE_SHOT 전용 강제는 별도 불변식이며 현재
+     * 미구현(TEMP id 비노출로 실질 도달 불가).
      */
     @Transactional(readOnly = true)
     public boolean isOwnedBy(Long playlistId, UserId userId) {

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/PlaylistQueryService.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/PlaylistQueryService.java
@@ -5,6 +5,7 @@ import com.pfplaybackend.api.common.aspect.context.AuthContext;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.playlist.application.dto.PlaylistSummaryDto;
 import com.pfplaybackend.api.playlist.application.port.out.PlaylistQueryPort;
+import com.pfplaybackend.api.playlist.domain.port.PlaylistAggregatePort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +20,7 @@ import java.util.List;
 public class PlaylistQueryService {
 
     private final PlaylistQueryPort queryPort;
+    private final PlaylistAggregatePort aggregatePort;
 
     @Transactional(readOnly = true)
     public List<PlaylistSummaryDto> getPlaylists() {
@@ -32,8 +34,13 @@ public class PlaylistQueryService {
         return queryPort.findByIdAndUserId(playlistId, authContext.getUserId());
     }
 
+    /**
+     * 소유권 검증 — 조회 숨김(TEMP 제외, V36)과는 별개 관심사라 view 쿼리가 아닌
+     * aggregate 포트의 원시 조회를 쓴다. Quick-DJ(#331)의 TEMP 플리도 본인 소유면 true —
+     * view 쿼리에 얹으면 ONE_SHOT enqueue 의 ownership 검증이 NOT_OWNED 로 오탐한다.
+     */
     @Transactional(readOnly = true)
     public boolean isOwnedBy(Long playlistId, UserId userId) {
-        return queryPort.findByIdAndUserId(playlistId, userId) != null;
+        return aggregatePort.findPlaylistByIdAndOwner(playlistId, userId).isPresent();
     }
 }

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TempPlaylistService.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TempPlaylistService.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 /**
  * Quick-DJ(#331) one-shot 곡 저장용 TEMP 플리 준비.
  * per-user 1개를 재사용하며 호출마다 리셋(전곡 삭제) 후 선택 곡 1개만 삽입한다(spec §3-2 step3~5, 결정6).
@@ -26,10 +28,23 @@ public class TempPlaylistService {
 
     @Transactional
     public Long prepareOneShotPlaylist(UserId userId, AddTrackCommand command) {
-        PlaylistData temp = aggregatePort.findPlaylistsByOwnerAndType(userId, PlaylistType.TEMP).stream()
+        List<PlaylistData> temps = aggregatePort.findPlaylistsByOwnerAndType(userId, PlaylistType.TEMP);
+        PlaylistData temp = temps.stream()
                 .findFirst()
                 .orElseGet(() -> aggregatePort.savePlaylist(
                         PlaylistData.create(0, "Quick-DJ", PlaylistType.TEMP, userId)));
+
+        // 같은 유저의 동시 더블서밋 시 find-or-create 는 read-then-write 레이스라 TEMP 가 2행 이상
+        // 생길 수 있다(per-user 유니크 제약 없음 — MySQL 은 partial index 불가). blast radius 는
+        // 숨김 행 고아화에 한정된다(TEMP 는 목록/단건 조회에서 제외되고, enqueue 는 isDjRegistered
+        // 가드가 큐 중복을 차단). 여기서 첫 행만 남기고 정리해 다음 호출이 자가치유한다(opportunistic dedup).
+        if (temps.size() > 1) {
+            List<Long> extraIds = temps.subList(1, temps.size()).stream()
+                    .map(PlaylistData::getId)
+                    .toList();
+            extraIds.forEach(aggregatePort::deleteAllTracksByPlaylist);
+            aggregatePort.deletePlaylistsByIds(extraIds);
+        }
 
         aggregatePort.deleteAllTracksByPlaylist(temp.getId());
 

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TempPlaylistService.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TempPlaylistService.java
@@ -1,0 +1,47 @@
+package com.pfplaybackend.api.playlist.application.service;
+
+import com.pfplaybackend.api.common.domain.value.Duration;
+import com.pfplaybackend.api.common.domain.value.PlaylistId;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.playlist.application.dto.command.AddTrackCommand;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
+import com.pfplaybackend.api.playlist.domain.entity.data.TrackData;
+import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
+import com.pfplaybackend.api.playlist.domain.port.PlaylistAggregatePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Quick-DJ(#331) one-shot 곡 저장용 TEMP 플리 준비.
+ * per-user 1개를 재사용하며 호출마다 리셋(전곡 삭제) 후 선택 곡 1개만 삽입한다(spec §3-2 step3~5, 결정6).
+ * 재생 커서(lastPlayedTrackId)는 리셋하지 않는다 — 가리키던 트랙이 삭제되면
+ * peekTracksFromCursor 가 자연 순서로 fall-back 하므로 무해(spec §4).
+ */
+@Service
+@RequiredArgsConstructor
+public class TempPlaylistService {
+
+    private final PlaylistAggregatePort aggregatePort;
+
+    @Transactional
+    public Long prepareOneShotPlaylist(UserId userId, AddTrackCommand command) {
+        PlaylistData temp = aggregatePort.findPlaylistsByOwnerAndType(userId, PlaylistType.TEMP).stream()
+                .findFirst()
+                .orElseGet(() -> aggregatePort.savePlaylist(
+                        PlaylistData.create(0, "Quick-DJ", PlaylistType.TEMP, userId)));
+
+        aggregatePort.deleteAllTracksByPlaylist(temp.getId());
+
+        TrackData track = TrackData.builder()
+                .playlistId(new PlaylistId(temp.getId()))
+                .name(command.name())
+                .linkId(command.linkId())
+                .duration(Duration.fromString(command.duration()))
+                .orderNumber(1)
+                .thumbnailImage(command.thumbnailImage())
+                .build();
+        aggregatePort.saveTrack(track);
+        return temp.getId();
+    }
+}

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/enums/PlaylistType.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/enums/PlaylistType.java
@@ -2,5 +2,7 @@ package com.pfplaybackend.api.playlist.domain.enums;
 
 public enum PlaylistType {
     GRABLIST,
-    PLAYLIST
+    PLAYLIST,
+    /** Quick-DJ(#331) one-shot 곡 저장용 per-user 숨김 플리 — 목록/단건 조회에서 제외된다. @Enumerated(STRING)이라 append 안전. */
+    TEMP
 }

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/port/PlaylistAggregatePort.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/port/PlaylistAggregatePort.java
@@ -29,6 +29,7 @@ public interface PlaylistAggregatePort {
     TrackData findFirstTrackByLink(String linkId);
     Optional<TrackData> findTrackByIdAndPlaylist(Long trackId, PlaylistId playlistId);
     boolean hasTracksByPlaylist(PlaylistId playlistId);
+    void deleteAllTracksByPlaylist(Long playlistId);
 
     // ===== Track Reordering (batch operations) =====
     void shiftAllOrdersDown(Long playlistId);

--- a/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/PlaylistQueryServiceTest.java
+++ b/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/PlaylistQueryServiceTest.java
@@ -5,7 +5,9 @@ import com.pfplaybackend.api.common.aspect.context.AuthContext;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.playlist.application.dto.PlaylistSummaryDto;
 import com.pfplaybackend.api.playlist.application.port.out.PlaylistQueryPort;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
 import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
+import com.pfplaybackend.api.playlist.domain.port.PlaylistAggregatePort;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -25,6 +28,7 @@ import static org.mockito.Mockito.*;
 class PlaylistQueryServiceTest {
 
     @Mock PlaylistQueryPort queryPort;
+    @Mock PlaylistAggregatePort aggregatePort;
     @InjectMocks PlaylistQueryService playlistQueryService;
 
     private UserId userId;
@@ -93,9 +97,9 @@ class PlaylistQueryServiceTest {
     @Test
     @DisplayName("isOwnedBy — playlist 가 본인 소유면 true")
     void isOwnedByReturnsTrueWhenOwned() {
-        // given
-        PlaylistSummaryDto owned = new PlaylistSummaryDto(99L, "My Playlist", 5, PlaylistType.PLAYLIST, 1L);
-        when(queryPort.findByIdAndUserId(99L, userId)).thenReturn(owned);
+        // given — 소유권 검증은 view 쿼리가 아닌 aggregate 원시 조회 기반
+        PlaylistData owned = PlaylistData.create(5, "My Playlist", PlaylistType.PLAYLIST, userId);
+        when(aggregatePort.findPlaylistByIdAndOwner(99L, userId)).thenReturn(Optional.of(owned));
 
         // when
         boolean result = playlistQueryService.isOwnedBy(99L, userId);
@@ -105,10 +109,24 @@ class PlaylistQueryServiceTest {
     }
 
     @Test
+    @DisplayName("isOwnedBy — 조회 숨김 대상인 TEMP 도 본인 소유면 true (Quick-DJ #331)")
+    void isOwnedByReturnsTrueForOwnTempPlaylist() {
+        // given — TEMP 는 목록/단건 view 에서 숨겨지지만 소유권 검증은 통과해야 한다
+        PlaylistData temp = PlaylistData.create(0, "Quick-DJ", PlaylistType.TEMP, userId);
+        when(aggregatePort.findPlaylistByIdAndOwner(77L, userId)).thenReturn(Optional.of(temp));
+
+        // when
+        boolean result = playlistQueryService.isOwnedBy(77L, userId);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
     @DisplayName("isOwnedBy — playlist 가 타인 소유거나 미존재면 false")
     void isOwnedByReturnsFalseWhenNotOwned() {
         // given
-        when(queryPort.findByIdAndUserId(99L, userId)).thenReturn(null);
+        when(aggregatePort.findPlaylistByIdAndOwner(99L, userId)).thenReturn(Optional.empty());
 
         // when
         boolean result = playlistQueryService.isOwnedBy(99L, userId);


### PR DESCRIPTION
## 배경
첫 사용자가 DJ가 되려면 플리 생성→곡 등록→플리 선택→대기열 등록 다단계를 거쳐야 해 이탈이 발생합니다. #329로 생성 단계는 제거됐지만, 곡을 즉석에서 골라 바로 대기열에 오르는 경로는 없었습니다. 검색한 곡 하나로 즉시 DJ 대기열에 등록되고 **1회 재생 후 자동 이탈**하는 병렬 빠른 경로(Quick-DJ)를 추가합니다.

- 이슈: #331 (Closes #331)
- 스펙: `docs/superpowers/specs/2026-07-01-quick-dj-one-shot-queue-design.md` (2패스 리뷰 승인)
- 플랜: `docs/superpowers/plans/2026-07-11-quick-dj-one-shot-queue.md`

## 설계 요지
- **곡 저장 = `PlaylistType.TEMP`**: per-user 1개 재사용(호출마다 리셋), 목록/단건 조회에서 숨김. 생성 상한 무영향(PLAYLIST만 카운트). 동시 더블서밋 레이스는 opportunistic dedup으로 자가치유.
- **큐 엔트리 = `DjData.kind`(NORMAL/ONE_SHOT, STRING)**: Flyway **V35**(dj.kind 백필) + **V36**(playlist.type MySQL ENUM에 'TEMP' 추가 — V1 DDL이 ENUM이라 필수).
- **ONE_SHOT 이탈 = 위치가 아닌 outgoing 정체 기준**: `tryProceed`에서 `getCurrentDjCrewId()`로 방금 재생을 끝낸 DJ를 식별해 ONE_SHOT이면 회전 대신 제거(`doStart(rotate)` 플래그). **NORMAL 라운드로빈·dequeue quirk·최초 활성화 경로 무변경** — order-1 기준 제거는 미재생 엔트리를 삭제하는 함정(스펙 §3-3)이라 배제.
- **사전검증(결정7/B)**: 곡 duration > 방 `playbackTimeLimit`이면 등록 전 400 `TRACK_EXCEEDS_TIME_LIMIT`(DJ-007).
- **1 트랜잭션**: 검증→TEMP 준비→ONE_SHOT enqueue. 실패 시 전체 롤백(IT로 실증). 양자택일은 기존 `ALREADY_REGISTERED` 가드가 그대로 보장.
- 브로드캐스트: `DjChangeType.ONE_SHOT_COMPLETED` 신규 발행(AFTER_COMMIT 릴레이, enum-agnostic이라 기존 소비자 무영향).

## ⚠️ 확정 API 계약 (웹 후속 PR의 진실원천)
스펙 §3-2 초안 어휘(videoId/videoTitle/runningTime, 200)와 달리 **기존 `AddTrackRequest` 어휘로 확정**:
```
POST /api/v1/partyrooms/{partyroomId}/dj-queue/quick   (MEMBER)
Body: { name, linkId, duration: "m:ss|h:mm:ss", thumbnailImage }
201: { djId, orderNumber }
에러: 400 INVALID(형식) / 400 DJ-007(시간한도) / 409 DJ-001(이미 등록) / 403 DJ-002(큐 닫힘)
```

## 계획 외 수정 (IT가 적발한 실버그)
`PlaylistQueryService.isOwnedBy`가 TEMP 숨김이 적용된 view 쿼리를 경유해 **본인 TEMP 플리 소유권을 DJ-005로 오탐** → 원시 조회(`findPlaylistByIdAndOwner`) 기반으로 분리. view 숨김은 무변경(가시성 IT 그린 유지). TEMP는 소유권상 valid — ONE_SHOT 전용 강제는 별도 불변식이며 현재 TEMP id 비노출로 실질 도달 불가(javadoc에 기록).

## 검증
- 유닛 전량: **:app 1360/0 · :playlist 79/0**
- IT 전량: **319/0** (신규 `QuickDjOneShotIntegrationTest` 6종 = 스펙 §5 트레이스 잠금: 유일 ONE_SHOT 활성화/혼합 큐 라운드로빈 보존/dequeue-후-skip 미삭제/스킵 제거/DJ-007 사전거부/ALREADY_REGISTERED **실 커밋-롤백 관측**(NOT_SUPPORTED+TransactionTemplate))
- 로컬 docker **fresh DB 풀부팅 게이트**: V1→V36 전체 적용 + Hibernate validate 통과 + Started(50s) + 신규 endpoint 라우팅 확인(401)
- Flyway 슬롯 중복 스캔: V35/V36 유일

## 후속 (비차단)
- 웹 UX 별도 이슈/PR: 검색모달 CTA·등록 피드백. **ONE_SHOT 큐 표식**이 필요하면 큐 GET DTO에 kind 노출 백엔드 후속 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)