### PR TITLE
feat(playlist): 트랙 조회에 재생 커서(NOW/NEXT) 노출 (#334)

### DIFF
--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/in/web/payload/response/QueryTrackListResponse.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/adapter/in/web/payload/response/QueryTrackListResponse.java
@@ -2,6 +2,7 @@ package com.pfplaybackend.api.playlist.adapter.in.web.payload.response;
 
 import com.pfplaybackend.api.common.dto.PaginationDto;
 import com.pfplaybackend.api.playlist.application.dto.PlaylistTrackDto;
+import com.pfplaybackend.api.playlist.application.dto.TrackListView;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
@@ -12,11 +13,16 @@ import java.util.List;
 @Builder
 public class QueryTrackListResponse {
     private List<PlaylistTrackDto> content;
+    // 재생 커서 — CurrentDJ에겐 NOW(지금 재생 중) 트랙. 커서 미설정 시 null.
+    // NEXT(다음 재생 곡)는 이 커서 + 현재 트랙 순서로부터 클라이언트가 파생한다.
+    private Long lastPlayedTrackId;
     private PaginationDto pagination;
 
-    public static QueryTrackListResponse from(Page<PlaylistTrackDto> page) {
+    public static QueryTrackListResponse from(TrackListView view) {
+        Page<PlaylistTrackDto> page = view.page();
         return QueryTrackListResponse.builder()
                 .content(page.getContent())
+                .lastPlayedTrackId(view.lastPlayedTrackId())
                 .pagination(new PaginationDto(
                         page.getNumber(),
                         page.getSize(),

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/dto/TrackListView.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/dto/TrackListView.java
@@ -1,0 +1,14 @@
+package com.pfplaybackend.api.playlist.application.dto;
+
+import org.springframework.data.domain.Page;
+
+/**
+ * 트랙 목록 조회 결과 + 재생 커서.
+ * lastPlayedTrackId(커서)는 CurrentDJ에겐 NOW(지금 재생 중) 트랙이다.
+ * NEXT(다음 재생 곡)는 커서 + 현재 트랙 순서로부터 클라이언트가 파생한다
+ * (낙관적 재정렬에도 refetch 없이 정확하도록).
+ */
+public record TrackListView(
+        Page<PlaylistTrackDto> page,
+        Long lastPlayedTrackId
+) {}

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackCommandService.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackCommandService.java
@@ -20,6 +20,7 @@ import com.pfplaybackend.api.playlist.domain.event.TrackAddedEvent;
 import com.pfplaybackend.api.playlist.domain.event.TrackRemovedEvent;
 import com.pfplaybackend.api.playlist.domain.exception.PlaylistException;
 import com.pfplaybackend.api.playlist.domain.exception.TrackException;
+import com.pfplaybackend.api.playlist.domain.policy.PlaybackCursorPolicy;
 import com.pfplaybackend.api.playlist.domain.port.PlaylistAggregatePort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -179,15 +180,8 @@ public class TrackCommandService {
                 .map(PlaylistData::getLastPlayedTrackId)
                 .orElse(null);
 
-        int start = 0; // 커서 null 또는 미발견 → top(0)부터
-        if (cursor != null) {
-            for (int i = 0; i < ordered.size(); i++) {
-                if (cursor.equals(ordered.get(i).trackId())) {
-                    start = i + 1; // 커서 "다음"부터
-                    break;
-                }
-            }
-        }
+        List<Long> orderedIds = ordered.stream().map(PlaylistTrackDto::trackId).toList();
+        int start = PlaybackCursorPolicy.startIndexAfterCursor(orderedIds, cursor);
 
         int n = ordered.size();
         List<PlaybackTrackDto> rotated = new ArrayList<>(n);

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackQueryService.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/application/service/TrackQueryService.java
@@ -5,7 +5,9 @@ import com.pfplaybackend.api.common.aspect.context.AuthContext;
 import com.pfplaybackend.api.common.domain.value.PlaylistId;
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
 import com.pfplaybackend.api.playlist.application.dto.PlaylistTrackDto;
+import com.pfplaybackend.api.playlist.application.dto.TrackListView;
 import com.pfplaybackend.api.playlist.application.port.out.PlaylistQueryPort;
+import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
 import com.pfplaybackend.api.playlist.domain.exception.PlaylistException;
 import com.pfplaybackend.api.playlist.domain.port.PlaylistAggregatePort;
 import lombok.RequiredArgsConstructor;
@@ -25,13 +27,17 @@ public class TrackQueryService {
     private final PlaylistQueryPort queryPort;
 
     @Transactional(readOnly = true)
-    public Page<PlaylistTrackDto> getTracks(Long playlistId, int pageNo, int pageSize) {
+    public TrackListView getTracks(Long playlistId, int pageNo, int pageSize) {
         AuthContext authContext = ThreadLocalContext.getAuthContext();
-        aggregatePort.findPlaylistByIdAndOwner(playlistId, authContext.getUserId())
+        PlaylistData playlist = aggregatePort.findPlaylistByIdAndOwner(playlistId, authContext.getUserId())
                 .orElseThrow(() -> ExceptionCreator.create(PlaylistException.NOT_FOUND_PLAYLIST));
 
+        PlaylistId pid = new PlaylistId(playlistId);
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.ASC, "orderNumber"));
-        return queryPort.getTracksWithPagination(new PlaylistId(playlistId), pageable);
+        Page<PlaylistTrackDto> page = queryPort.getTracksWithPagination(pid, pageable);
+
+        // 커서(NOW 앵커)만 노출. NEXT는 커서 + 현재 순서로부터 클라이언트가 파생한다.
+        return new TrackListView(page, playlist.getLastPlayedTrackId());
     }
 
     @Transactional(readOnly = true)

--- a/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/policy/PlaybackCursorPolicy.java
+++ b/playlist/src/main/java/com/pfplaybackend/api/playlist/domain/policy/PlaybackCursorPolicy.java
@@ -1,0 +1,26 @@
+package com.pfplaybackend.api.playlist.domain.policy;
+
+import java.util.List;
+
+/**
+ * 재생 커서(last_played_track_id)로부터 "다음에 재생할 위치"를 계산하는 순수 로직.
+ * 커서는 트랙 ID 참조이므로 재정렬에 안전하며, 정렬된 트랙 id 목록을 입력으로 받아
+ * 커서 다음 위치(순환)를 결정한다. 재생 시작(peekTracksFromCursor)이 이 로직을 사용한다.
+ * (조회 화면의 NEXT는 커서 + 현재 순서로부터 클라이언트가 파생한다.)
+ */
+public final class PlaybackCursorPolicy {
+
+    private PlaybackCursorPolicy() {}
+
+    /**
+     * 정렬된 트랙 id 목록에서 커서 "다음" 위치의 시작 인덱스(순환)를 반환한다.
+     * 커서가 null이거나 목록에서 찾지 못하면(삭제) 0(맨 앞). 빈 목록이면 0.
+     */
+    public static int startIndexAfterCursor(List<Long> orderedTrackIds, Long cursor) {
+        if (orderedTrackIds == null || orderedTrackIds.isEmpty()) return 0;
+        if (cursor == null) return 0;
+        int idx = orderedTrackIds.indexOf(cursor);
+        if (idx < 0) return 0;
+        return (idx + 1) % orderedTrackIds.size();
+    }
+}

--- a/playlist/src/test/java/com/pfplaybackend/api/playlist/adapter/in/web/TrackQueryControllerTest.java
+++ b/playlist/src/test/java/com/pfplaybackend/api/playlist/adapter/in/web/TrackQueryControllerTest.java
@@ -2,6 +2,7 @@ package com.pfplaybackend.api.playlist.adapter.in.web;
 
 import com.pfplaybackend.api.common.domain.value.Duration;
 import com.pfplaybackend.api.playlist.application.dto.PlaylistTrackDto;
+import com.pfplaybackend.api.playlist.application.dto.TrackListView;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
@@ -24,7 +25,7 @@ class TrackQueryControllerTest extends AbstractPlaylistWebMvcTest {
         Page<PlaylistTrackDto> page = new PageImpl<>(List.of(
                 new PlaylistTrackDto(1L, "abc123", "Test Track", 1, Duration.fromString("03:30"), "https://example.com/thumb.jpg")
         ));
-        when(trackQueryService.getTracks(1L, 0, 10)).thenReturn(page);
+        when(trackQueryService.getTracks(1L, 0, 10)).thenReturn(new TrackListView(page, null));
 
         // when & then
         mockMvc.perform(get("/api/v1/playlists/1/tracks")

--- a/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/TrackQueryServiceTest.java
+++ b/playlist/src/test/java/com/pfplaybackend/api/playlist/application/service/TrackQueryServiceTest.java
@@ -7,6 +7,7 @@ import com.pfplaybackend.api.common.domain.value.PlaylistId;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.exception.http.NotFoundException;
 import com.pfplaybackend.api.playlist.application.dto.PlaylistTrackDto;
+import com.pfplaybackend.api.playlist.application.dto.TrackListView;
 import com.pfplaybackend.api.playlist.application.port.out.PlaylistQueryPort;
 import com.pfplaybackend.api.playlist.domain.entity.data.PlaylistData;
 import com.pfplaybackend.api.playlist.domain.enums.PlaylistType;
@@ -71,11 +72,13 @@ class TrackQueryServiceTest {
         when(queryPort.getTracksWithPagination(eq(new PlaylistId(playlistId)), any(Pageable.class))).thenReturn(expectedPage);
 
         // when
-        Page<PlaylistTrackDto> result = trackQueryService.getTracks(playlistId, 0, 10);
+        TrackListView result = trackQueryService.getTracks(playlistId, 0, 10);
 
         // then
-        assertThat(result.getContent()).hasSize(2);
-        assertThat(result.getContent().get(0).name()).isEqualTo("Song A");
+        assertThat(result.page().getContent()).hasSize(2);
+        assertThat(result.page().getContent().get(0).name()).isEqualTo("Song A");
+        // 커서 미설정(builder에 없음) → NOW 앵커 없음. NEXT는 클라이언트가 파생.
+        assertThat(result.lastPlayedTrackId()).isNull();
         verify(aggregatePort).findPlaylistByIdAndOwner(playlistId, userId);
         verify(queryPort).getTracksWithPagination(eq(new PlaylistId(playlistId)), any(Pageable.class));
     }

--- a/playlist/src/test/java/com/pfplaybackend/api/playlist/domain/policy/PlaybackCursorPolicyTest.java
+++ b/playlist/src/test/java/com/pfplaybackend/api/playlist/domain/policy/PlaybackCursorPolicyTest.java
@@ -1,0 +1,54 @@
+package com.pfplaybackend.api.playlist.domain.policy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlaybackCursorPolicyTest {
+
+    @Test
+    @DisplayName("startIndexAfterCursor — 커서가 중간에 있으면 바로 다음 인덱스")
+    void startFromMiddle() {
+        List<Long> ordered = List.of(10L, 20L, 30L, 40L);
+        assertThat(PlaybackCursorPolicy.startIndexAfterCursor(ordered, 20L)).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("startIndexAfterCursor — 커서가 마지막이면 wrap 하여 0")
+    void startWrapsFromLast() {
+        List<Long> ordered = List.of(10L, 20L, 30L);
+        assertThat(PlaybackCursorPolicy.startIndexAfterCursor(ordered, 30L)).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("startIndexAfterCursor — 커서가 null이면 0(맨 앞)")
+    void startFromNullCursor() {
+        List<Long> ordered = List.of(10L, 20L, 30L);
+        assertThat(PlaybackCursorPolicy.startIndexAfterCursor(ordered, null)).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("startIndexAfterCursor — 커서가 목록에 없으면(삭제) 0(맨 앞)")
+    void startFromDeletedCursor() {
+        List<Long> ordered = List.of(10L, 20L, 30L);
+        assertThat(PlaybackCursorPolicy.startIndexAfterCursor(ordered, 999L)).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("startIndexAfterCursor — 단일 트랙이면 커서가 그 트랙이어도 wrap 하여 0")
+    void startSingleTrackWrapsToItself() {
+        List<Long> ordered = List.of(10L);
+        assertThat(PlaybackCursorPolicy.startIndexAfterCursor(ordered, 10L)).isEqualTo(0);
+        assertThat(PlaybackCursorPolicy.startIndexAfterCursor(ordered, null)).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("startIndexAfterCursor — 빈 목록이면 0")
+    void startEmpty() {
+        assertThat(PlaybackCursorPolicy.startIndexAfterCursor(List.of(), 10L)).isEqualTo(0);
+        assertThat(PlaybackCursorPolicy.startIndexAfterCursor(List.of(), null)).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
## 개요
Closes #334

플레이리스트 트랙 목록 조회 응답에 **재생 커서(`lastPlayedTrackId`)** 를 노출한다. 프론트는 이 커서로 NOW/NEXT 배지를 그린다(웹 PR: pfplay/pfplay-web#453).

## 변경
- `QueryTrackListResponse`에 `lastPlayedTrackId`(nullable) 추가. CurrentDJ에겐 NOW(지금 재생 중) 앵커.
- `TrackQueryService.getTracks` → `TrackListView(page, lastPlayedTrackId)` 반환. 소유권 검증용으로 이미 로드하던 `PlaylistData`에서 커서를 획득(추가 쿼리 없음).
- 커서 다음 위치(wrap) 계산을 **`PlaybackCursorPolicy`** 순수 헬퍼로 추출하여 기존 `peekTracksFromCursor`와 공유(중복 제거, 동작 보존).

## 설계 노트
- **NEXT는 백엔드가 계산하지 않는다.** 프론트가 커서 + 현재(낙관적 재정렬 반영) 트랙 순서로부터 파생한다. 트랙 재정렬 mutation은 의도적으로 invalidate하지 않으므로(플리커 방지), 서버가 nextTrackId를 내리면 재정렬 직후 stale가 된다. 커서만 노출하고 NEXT 파생을 클라로 두면 단일 소스 + refetch 없이 정확.
- 커서는 트랙 **ID 참조**라 재정렬에 안전(인덱스 아님).

## 테스트
- `PlaybackCursorPolicyTest`: 커서 중간/마지막(wrap)/null/삭제/단일곡/빈목록.
- `TrackQueryServiceTest`·`TrackQueryControllerTest`: 새 계약 반영.
- `:playlist:test` 전량 GREEN. 로컬 docker compose 부팅 정상(Started Application, 기동 오류 없음).
- 마이그레이션/`@Query` JPQL 변경 없음(querydsl·record만).
