### PR TITLE
feat(virtualcrew): 봇 VCREW 접두어 + 봇 제거(탈퇴) + 닉네임 변경 (#337)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/admin/application/service/AdminUserService.java
+++ b/app/src/main/java/com/pfplaybackend/api/admin/application/service/AdminUserService.java
@@ -3,6 +3,7 @@ package com.pfplaybackend.api.admin.application.service;
 import com.pfplaybackend.api.admin.application.port.out.AdminMemberPort;
 import com.pfplaybackend.api.admin.application.port.out.AdminPlaylistPort;
 import com.pfplaybackend.api.admin.domain.exception.AdminException;
+import com.pfplaybackend.api.administration.application.service.AdminMemberWithdrawCommandService;
 import com.pfplaybackend.api.common.config.security.enums.ProviderType;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
@@ -37,6 +38,7 @@ public class AdminUserService {
     private final AdminProfileService adminProfileService;
     private final AdminPlaylistPort adminPlaylistPort;
     private final UserAccountRepository userAccountRepository;
+    private final AdminMemberWithdrawCommandService adminMemberWithdrawCommandService;
 
     /**
      * Create virtual member with auto-generated profile and FM authority
@@ -173,6 +175,31 @@ public class AdminUserService {
         adminMemberPort.deleteMemberById(userId.getUid());
 
         log.info("Virtual member deleted: userId={}", userId.getUid());
+    }
+
+    /**
+     * 가상 회원을 탈퇴(soft-delete)한다 — 물리 삭제 대신 {@code withdrawn_at} 세팅 + 이메일 PII 비식별화.
+     *
+     * <p>가상 크루 봇 제거의 진입점. 봇 계정은 crew/dj/playlist/activity 등 여러 테이블이 참조하므로
+     * 물리 삭제는 orphan/FK 위험이 크다. 대신 실회원과 동일한 검증된 탈퇴 경로
+     * ({@link AdminMemberWithdrawCommandService#withdraw})를 재사용한다 — idempotent(재호출 무해),
+     * adminId 기록, {@code UserAccountWithdrawnEvent} 발행을 모두 승계한다. 모든 봇 풀 조회가
+     * {@code withdrawn_at IS NULL} 로 필터하므로 탈퇴 즉시 풀·로스터·배치 대상에서 사라진다.
+     *
+     * @param userId 가상 회원(봇)의 user_account_id
+     */
+    @Transactional
+    public void withdrawVirtualMember(UserId userId) {
+        // 1. 회원 조회(user_account_id) — 없으면 MEMBER_NOT_FOUND.
+        MemberData member = findMemberByUserId(userId);
+
+        // 2. LOCAL provider(가상 회원)인지 검증 — 실 소셜 회원 오탈퇴 방지.
+        requireLocalProviderForVirtualMemberOp(member, AdminException.NON_VIRTUAL_MEMBER_DELETE);
+
+        // 3. 검증된 탈퇴 명령에 위임(member_id 기준). idempotent — 이미 탈퇴면 no-op.
+        adminMemberWithdrawCommandService.withdraw(member.getMemberId());
+
+        log.info("Virtual member withdrawn (soft-delete): userId={}", userId.getUid());
     }
 
     /**

--- a/app/src/main/java/com/pfplaybackend/api/admin/application/service/AdminUserService.java
+++ b/app/src/main/java/com/pfplaybackend/api/admin/application/service/AdminUserService.java
@@ -8,9 +8,11 @@ import com.pfplaybackend.api.common.config.security.enums.ProviderType;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
 import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserProfileRepository;
 import com.pfplaybackend.api.user.domain.entity.data.MemberData;
 import com.pfplaybackend.api.user.domain.entity.data.ProfileData;
 import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
+import com.pfplaybackend.api.user.domain.value.Nickname;
 import com.pfplaybackend.api.avatar.domain.value.AvatarBodyUri;
 import com.pfplaybackend.api.avatar.domain.value.AvatarFaceUri;
 import com.pfplaybackend.api.user.domain.value.WalletAddress;
@@ -38,6 +40,7 @@ public class AdminUserService {
     private final AdminProfileService adminProfileService;
     private final AdminPlaylistPort adminPlaylistPort;
     private final UserAccountRepository userAccountRepository;
+    private final UserProfileRepository userProfileRepository;
     private final AdminMemberWithdrawCommandService adminMemberWithdrawCommandService;
 
     /**
@@ -200,6 +203,41 @@ public class AdminUserService {
         adminMemberWithdrawCommandService.withdraw(member.getMemberId());
 
         log.info("Virtual member withdrawn (soft-delete): userId={}", userId.getUid());
+    }
+
+    /**
+     * 가상 회원(봇)의 닉네임을 변경한다. 봇의 닉네임은 파티룸에서 그대로 노출되므로, 운영자가
+     * 사람처럼 보이는 이름으로 덮어쓸 수 있게 한다.
+     *
+     * <p>{@link Nickname} 도메인 규칙(비블랭크·20자 이하, charset 무제한 — 한글/공백 허용)을 따르고,
+     * {@code uk_user_profile_nickname} UNIQUE 제약을 사전 검사({@code existsByNicknameAndUserIdNot},
+     * self 제외)로 확인해 충돌 시 409({@link AdminException#DUPLICATE_NICKNAME})를 던진다.
+     * 프로필은 기존 행을 in-place mutate({@link ProfileData#updateNickname}) — 아바타 변경과 동일하게
+     * cascade 더블 인서트(uk 위반)를 피한다.
+     *
+     * @param userId   가상 회원(봇)의 user_account_id
+     * @param nickname 새 닉네임
+     */
+    @Transactional
+    public void updateVirtualMemberNickname(UserId userId, String nickname) {
+        // 1. 회원 조회 + LOCAL(가상) 검증.
+        MemberData member = findMemberByUserId(userId);
+        requireLocalProviderForVirtualMemberOp(member, AdminException.NON_VIRTUAL_MEMBER_NICKNAME_UPDATE);
+
+        // 2. 도메인 규칙 검증(비블랭크·20자 이하). 페이로드에서도 @NotBlank/@Size 로 400 선차단하지만
+        //    도메인 불변식을 최종 방어선으로 다시 태운다.
+        Nickname requested = new Nickname(nickname);
+
+        // 3. 닉네임 UNIQUE 사전 검사(self 제외) — 재저장(동일 닉) 은 허용, 타인 중복은 409.
+        if (userProfileRepository.existsByNicknameAndUserIdNot(requested, userId)) {
+            throw ExceptionCreator.create(AdminException.DUPLICATE_NICKNAME);
+        }
+
+        // 4. 기존 프로필 행 in-place 수정 후 저장(cascade UPDATE).
+        member.getProfileData().updateNickname(nickname);
+        adminMemberPort.saveMember(member);
+
+        log.info("Virtual member nickname updated: userId={}, nickname={}", userId.getUid(), nickname);
     }
 
     /**

--- a/app/src/main/java/com/pfplaybackend/api/admin/domain/exception/AdminException.java
+++ b/app/src/main/java/com/pfplaybackend/api/admin/domain/exception/AdminException.java
@@ -17,7 +17,9 @@ public enum AdminException implements DomainException {
     REACTION_SIMULATION_FAILED("ADM-009", "리액션 시뮬레이션에 실패했습니다", ErrorType.BAD_REQUEST),
     AVATAR_RESOURCES_NOT_INITIALIZED("ADM-010", "아바타 리소스가 초기화되지 않았습니다", ErrorType.BAD_REQUEST),
     MAIN_STAGE_NOT_FOUND("ADM-011", "메인 스테이지를 찾을 수 없습니다", ErrorType.NOT_FOUND),
-    NO_CREW_MEMBERS("ADM-012", "파티룸에 크루가 없습니다", ErrorType.NOT_FOUND);
+    NO_CREW_MEMBERS("ADM-012", "파티룸에 크루가 없습니다", ErrorType.NOT_FOUND),
+    NON_VIRTUAL_MEMBER_NICKNAME_UPDATE("ADM-013", "가상 회원이 아닌 사용자의 닉네임을 수정할 수 없습니다", ErrorType.FORBIDDEN),
+    DUPLICATE_NICKNAME("ADM-014", "이미 사용 중인 닉네임입니다", ErrorType.CONFLICT);
 
     private final String errorCode;
     private final String message;

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/AdminVirtualCrewController.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/AdminVirtualCrewController.java
@@ -21,6 +21,8 @@ import com.pfplaybackend.api.virtualcrew.adapter.in.web.payload.DistributeBotAva
 import com.pfplaybackend.api.virtualcrew.adapter.in.web.payload.DistributeBotAvatarResponse;
 import com.pfplaybackend.api.virtualcrew.adapter.in.web.payload.PoolSummaryResponse;
 import com.pfplaybackend.api.virtualcrew.adapter.in.web.payload.ProvisionPoolRequest;
+import com.pfplaybackend.api.virtualcrew.adapter.in.web.payload.RemoveBotsRequest;
+import com.pfplaybackend.api.virtualcrew.adapter.in.web.payload.RemoveBotsResponse;
 import com.pfplaybackend.api.virtualcrew.adapter.in.web.payload.RenameSongPackRequest;
 import com.pfplaybackend.api.virtualcrew.adapter.in.web.payload.SetBotAvatarRequest;
 import com.pfplaybackend.api.virtualcrew.adapter.in.web.payload.SongPackDetailResponse;
@@ -342,6 +344,16 @@ public class AdminVirtualCrewController {
             @Valid @RequestBody DistributeBotAvatarRequest req) {
         List<BotAvatarAssigner.Assigned> assigned = botAvatarAdminService.distribute(req.botIds(), req.bodyUris());
         return ResponseEntity.ok(ApiCommonResponse.success(DistributeBotAvatarResponse.from(assigned)));
+    }
+
+    @Operation(summary = "봇 일괄 제거(탈퇴)", description = "선택 봇들을 풀에서 제거(soft-delete). 배치된 봇이 포함되면 409(먼저 리소스 회수/재배치)")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualCrew()")
+    @PostMapping("/virtual-crew/bots/remove")
+    public ResponseEntity<ApiCommonResponse<RemoveBotsResponse>> removeBots(
+            @Valid @RequestBody RemoveBotsRequest req) {
+        return ResponseEntity.ok(ApiCommonResponse.success(
+                RemoveBotsResponse.from(adminService.removeBots(req.botUserIds()))));
     }
 
     // ── 봇↔페르소나 매핑 (P3) ──

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/AdminVirtualCrewController.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/AdminVirtualCrewController.java
@@ -23,6 +23,7 @@ import com.pfplaybackend.api.virtualcrew.adapter.in.web.payload.PoolSummaryRespo
 import com.pfplaybackend.api.virtualcrew.adapter.in.web.payload.ProvisionPoolRequest;
 import com.pfplaybackend.api.virtualcrew.adapter.in.web.payload.RemoveBotsRequest;
 import com.pfplaybackend.api.virtualcrew.adapter.in.web.payload.RemoveBotsResponse;
+import com.pfplaybackend.api.virtualcrew.adapter.in.web.payload.RenameBotRequest;
 import com.pfplaybackend.api.virtualcrew.adapter.in.web.payload.RenameSongPackRequest;
 import com.pfplaybackend.api.virtualcrew.adapter.in.web.payload.SetBotAvatarRequest;
 import com.pfplaybackend.api.virtualcrew.adapter.in.web.payload.SongPackDetailResponse;
@@ -333,6 +334,16 @@ public class AdminVirtualCrewController {
     public ResponseEntity<Void> setBotAvatar(@PathVariable("userId") Long userId,
                                              @Valid @RequestBody SetBotAvatarRequest req) {
         botAvatarAdminService.setIndividual(new UserId(userId), req.avatarBodyUri());
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "봇 닉네임 변경", description = "파티룸 노출명 교체. 비블랭크·20자 이하, 닉네임 중복 시 409")
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("@adminAuth.canManageVirtualCrew()")
+    @PutMapping("/virtual-crew/bots/{userId}/nickname")
+    public ResponseEntity<Void> renameBot(@PathVariable("userId") Long userId,
+                                          @Valid @RequestBody RenameBotRequest req) {
+        adminService.renameBot(userId, req.nickname());
         return ResponseEntity.noContent().build();
     }
 

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/RemoveBotsRequest.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/RemoveBotsRequest.java
@@ -1,0 +1,9 @@
+package com.pfplaybackend.api.virtualcrew.adapter.in.web.payload;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+/** 봇 일괄 제거(탈퇴 soft-delete) 요청 — 선택 봇들({@code botUserIds})을 풀에서 제거. */
+public record RemoveBotsRequest(
+        @NotEmpty List<Long> botUserIds) {}

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/RemoveBotsResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/RemoveBotsResponse.java
@@ -1,0 +1,13 @@
+package com.pfplaybackend.api.virtualcrew.adapter.in.web.payload;
+
+import com.pfplaybackend.api.virtualcrew.application.service.VirtualCrewAdminService;
+
+import java.util.List;
+
+/** 봇 일괄 제거 결과 — 실제 탈퇴된 봇 수 + userId 목록(로스터에 없던 id 는 제외). */
+public record RemoveBotsResponse(int removed, List<Long> removedUserIds) {
+
+    public static RemoveBotsResponse from(VirtualCrewAdminService.BotRemovalResult result) {
+        return new RemoveBotsResponse(result.removed(), result.removedUserIds());
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/RenameBotRequest.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/RenameBotRequest.java
@@ -1,0 +1,8 @@
+package com.pfplaybackend.api.virtualcrew.adapter.in.web.payload;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/** 봇 닉네임 변경 요청 — 파티룸 노출명. 비블랭크 + 20자 이하(Nickname 도메인 규칙). */
+public record RenameBotRequest(
+        @NotBlank @Size(max = 20) String nickname) {}

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/out/persistence/BotPoolQueryRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/out/persistence/BotPoolQueryRepository.java
@@ -6,6 +6,7 @@ import com.pfplaybackend.api.virtualcrew.application.dto.BotCandidate;
 import com.pfplaybackend.api.virtualcrew.application.dto.BotRosterRow;
 import com.pfplaybackend.api.virtualcrew.application.dto.PoolPlacementRow;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -53,6 +54,15 @@ public interface BotPoolQueryRepository {
      * 입력이 null/빈 리스트면 빈 리스트를 반환한다.
      */
     List<Long> filterBotUserIds(List<Long> candidateUserIds);
+
+    /**
+     * 후보 봇 중 현재 활성 crew 로 배치된 봇의 userId 부분집합을 반환한다({@link #findIdleBotUserIds} 와 대칭).
+     *
+     * <p>배치 판정을 {@code 활성 crew EXISTS} 로만 한다 — 파티룸 행 존재/제목 조인에 의존하지 않는다.
+     * 따라서 파티룸이 지워졌지만 활성 crew row 가 남은 orphan 상황에서도 배치로 본다(제거 시 방 잔류창 방지).
+     * 봇(is_dummy=true, withdrawn_at IS NULL)으로 한정한다. 입력이 null/빈 컬렉션이면 빈 리스트.
+     */
+    List<Long> filterPlacedBotUserIds(Collection<Long> botUserIds);
 
     /**
      * 주어진 파티룸 안에서 채팅 응답 후보가 될 수 있는 페르소나 봇 목록을 반환한다.

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/out/persistence/impl/BotPoolQueryRepositoryImpl.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/out/persistence/impl/BotPoolQueryRepositoryImpl.java
@@ -14,6 +14,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -73,6 +74,28 @@ public class BotPoolQueryRepositoryImpl implements BotPoolQueryRepository {
                         userAccountData.userId.uid.in(candidateUserIds),
                         userAccountData.isDummy.isTrue(),
                         userAccountData.withdrawnAt.isNull())
+                .fetch();
+    }
+
+    @Override
+    public List<Long> filterPlacedBotUserIds(Collection<Long> botUserIds) {
+        if (botUserIds == null || botUserIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return queryFactory
+                .select(userAccountData.userId.uid)
+                .from(userAccountData)
+                .where(
+                        userAccountData.userId.uid.in(botUserIds),
+                        userAccountData.isDummy.isTrue(),
+                        userAccountData.withdrawnAt.isNull(),
+                        // 활성 crew EXISTS — findIdleBotUserIds 의 NOT EXISTS 와 대칭. 파티룸 조인 없이
+                        // crew 만으로 판정하므로 orphan 파티룸이어도 배치로 잡는다.
+                        JPAExpressions.selectOne()
+                                .from(crewData)
+                                .where(crewData.userId.uid.eq(userAccountData.userId.uid)
+                                        .and(crewData.isActive.isTrue()))
+                                .exists())
                 .fetch();
     }
 

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/out/provision/VirtualMemberProvisionAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/out/provision/VirtualMemberProvisionAdapter.java
@@ -1,6 +1,7 @@
 package com.pfplaybackend.api.virtualcrew.adapter.out.provision;
 
 import com.pfplaybackend.api.admin.application.service.AdminUserService;
+import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.user.domain.entity.data.MemberData;
 import com.pfplaybackend.api.virtualcrew.application.port.VirtualMemberProvisionPort;
 import lombok.RequiredArgsConstructor;
@@ -21,5 +22,10 @@ public class VirtualMemberProvisionAdapter implements VirtualMemberProvisionPort
     @Override
     public MemberData createVirtualMember(String nickname) {
         return adminUserService.createVirtualMember(nickname, null, null);
+    }
+
+    @Override
+    public void withdrawVirtualMember(Long botUserId) {
+        adminUserService.withdrawVirtualMember(new UserId(botUserId));
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/out/provision/VirtualMemberProvisionAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/out/provision/VirtualMemberProvisionAdapter.java
@@ -28,4 +28,9 @@ public class VirtualMemberProvisionAdapter implements VirtualMemberProvisionPort
     public void withdrawVirtualMember(Long botUserId) {
         adminUserService.withdrawVirtualMember(new UserId(botUserId));
     }
+
+    @Override
+    public void updateVirtualMemberNickname(Long botUserId, String nickname) {
+        adminUserService.updateVirtualMemberNickname(new UserId(botUserId), nickname);
+    }
 }

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/port/VirtualMemberProvisionPort.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/port/VirtualMemberProvisionPort.java
@@ -25,4 +25,13 @@ public interface VirtualMemberProvisionPort {
      * @param botUserId 봇의 user_account_id
      */
     void withdrawVirtualMember(Long botUserId);
+
+    /**
+     * 봇(가상 멤버)의 닉네임을 변경한다(파티룸 노출명 교체). 비블랭크·20자 이하 + 닉네임 UNIQUE 를
+     * 검증하며, 충돌 시 예외를 던진다.
+     *
+     * @param botUserId 봇의 user_account_id
+     * @param nickname  새 닉네임
+     */
+    void updateVirtualMemberNickname(Long botUserId, String nickname);
 }

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/port/VirtualMemberProvisionPort.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/port/VirtualMemberProvisionPort.java
@@ -17,4 +17,12 @@ public interface VirtualMemberProvisionPort {
      * (FM 승격 + 프로필·기본 아바타 + activity 행 + GRABLIST 포함).
      */
     MemberData createVirtualMember(String nickname);
+
+    /**
+     * 봇(가상 멤버)을 탈퇴(soft-delete)한다 — 실회원과 동일한 검증된 탈퇴 경로 재사용.
+     * idempotent(이미 탈퇴면 no-op). 탈퇴 즉시 봇 풀·로스터·배치 대상 조회에서 제외된다.
+     *
+     * @param botUserId 봇의 user_account_id
+     */
+    void withdrawVirtualMember(Long botUserId);
 }

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualCrewAdminService.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualCrewAdminService.java
@@ -1,5 +1,6 @@
 package com.pfplaybackend.api.virtualcrew.application.service;
 
+import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.exception.ExceptionCreator;
 import com.pfplaybackend.api.party.application.service.PartyroomQueryService;
 import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 
@@ -61,6 +63,42 @@ public class VirtualCrewAdminService {
     public void provisionPool(int count) {
         poolService.provision(count);
     }
+
+    /**
+     * 선택 봇들을 풀에서 제거(탈퇴 soft-delete)한다 — provision 의 역연산(로스터 다중 선택 삭제).
+     *
+     * <p><b>유휴 전용 가드:</b> 요청 봇 중 하나라도 현재 방에 배치돼 있으면 전체를 거부한다
+     * ({@link VirtualCrewException#BOT_PLACED_CANNOT_REMOVE}). 배치된 봇을 탈퇴시키면 다음 reconcile
+     * 까지 방에 남는 창(window)이 생기므로, 먼저 해당 방을 리소스 회수/재배치하도록 강제한다.
+     * 부분 제거 대신 all-or-nothing 으로 혼선을 막는다.
+     *
+     * <p>로스터에 없는 id(비-봇/미존재/이미 탈퇴)는 멱등적으로 스킵한다. 반환값은 실제 탈퇴된 봇 목록.
+     */
+    @Transactional
+    public BotRemovalResult removeBots(List<Long> botUserIds) {
+        if (botUserIds == null || botUserIds.isEmpty()) {
+            return new BotRemovalResult(0, List.of());
+        }
+        // 중복 제거 후 실제 봇(is_dummy·non-withdrawn)만 남긴다 — 비봇/미존재/이미 탈퇴 id 는 멱등 스킵.
+        List<Long> validBots = botPoolQueryRepository.filterBotUserIds(
+                new ArrayList<>(new LinkedHashSet<>(botUserIds)));
+        if (validBots.isEmpty()) {
+            return new BotRemovalResult(0, List.of());
+        }
+        // 활성 crew 로 배치된 봇이 하나라도 있으면 전체 거부(먼저 리소스 회수/재배치). 파티룸 행 존재가
+        // 아니라 활성 crew 존재(권위 신호)로 판정 — orphan 방 잔류 봇도 배치로 본다. all-or-nothing.
+        if (!botPoolQueryRepository.filterPlacedBotUserIds(validBots).isEmpty()) {
+            throw ExceptionCreator.create(VirtualCrewException.BOT_PLACED_CANNOT_REMOVE);
+        }
+        for (Long id : validBots) {
+            poolService.withdrawBot(new UserId(id));
+        }
+        log.info("[VirtualCrewAdmin.removeBots] requested={} removed={}", botUserIds.size(), validBots.size());
+        return new BotRemovalResult(validBots.size(), validBots);
+    }
+
+    /** 봇 제거 결과 — 실제 탈퇴된 봇 수 + userId 목록(로스터에 없던 id 는 제외). */
+    public record BotRemovalResult(int removed, List<Long> removedUserIds) {}
 
     /** 봇 풀 전체 요약 — 전체/idle 수 + 파티룸별 배치 현황. */
     @Transactional(readOnly = true)

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualCrewAdminService.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualCrewAdminService.java
@@ -100,6 +100,13 @@ public class VirtualCrewAdminService {
     /** 봇 제거 결과 — 실제 탈퇴된 봇 수 + userId 목록(로스터에 없던 id 는 제외). */
     public record BotRemovalResult(int removed, List<Long> removedUserIds) {}
 
+    /** 봇 닉네임 변경(파티룸 노출명 교체) — 검증·UNIQUE 는 pool→provision→admin 경로에서 수행. */
+    @Transactional
+    public void renameBot(Long botUserId, String nickname) {
+        poolService.renameBot(new UserId(botUserId), nickname);
+        log.info("[VirtualCrewAdmin.renameBot] botUserId={} nickname={}", botUserId, nickname);
+    }
+
     /** 봇 풀 전체 요약 — 전체/idle 수 + 파티룸별 배치 현황. */
     @Transactional(readOnly = true)
     public PoolSummary poolSummary() {

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualUserPoolService.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualUserPoolService.java
@@ -79,6 +79,19 @@ public class VirtualUserPoolService {
     }
 
     /**
+     * 봇 1명을 풀에서 탈퇴(soft-delete)시킨다 — {@code provision} 의 역연산.
+     *
+     * <p>물리 삭제(playlist/track/activity/crew 등 다수 테이블 정리 + orphan/FK 위험) 대신 실회원과
+     * 동일한 검증된 탈퇴 경로({@link VirtualMemberProvisionPort#withdrawVirtualMember})를 재사용한다.
+     * 모든 봇 풀 조회가 {@code withdrawn_at IS NULL} 로 필터하므로 탈퇴 즉시 풀·로스터·idle 후보에서 사라진다.
+     * 배치 여부 가드(placed 봇 거부)는 상위 오케스트레이션({@code VirtualCrewAdminService.removeBots})이 담당한다.
+     */
+    @Transactional
+    public void withdrawBot(UserId botUserId) {
+        virtualMemberProvisionPort.withdrawVirtualMember(botUserId.getUid());
+    }
+
+    /**
      * 봇의 DJ 용 {@link PlaylistType#PLAYLIST} playlist id 를 반환한다(Chunk 4 enqueueDj 에서 사용).
      */
     @Transactional(readOnly = true)
@@ -91,6 +104,6 @@ public class VirtualUserPoolService {
     }
 
     private String generateBotNickname() {
-        return "DJ_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        return "VCREW_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualUserPoolService.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/application/service/VirtualUserPoolService.java
@@ -92,6 +92,14 @@ public class VirtualUserPoolService {
     }
 
     /**
+     * 봇 닉네임을 변경한다(파티룸 노출명 교체). 검증·UNIQUE 는 provision seam 너머(admin) 에서 수행한다.
+     */
+    @Transactional
+    public void renameBot(UserId botUserId, String nickname) {
+        virtualMemberProvisionPort.updateVirtualMemberNickname(botUserId.getUid(), nickname);
+    }
+
+    /**
      * 봇의 DJ 용 {@link PlaylistType#PLAYLIST} playlist id 를 반환한다(Chunk 4 enqueueDj 에서 사용).
      */
     @Transactional(readOnly = true)

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/domain/exception/VirtualCrewException.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/domain/exception/VirtualCrewException.java
@@ -20,7 +20,8 @@ public enum VirtualCrewException implements DomainException {
     PERSONA_INACTIVE("VCREW-011", "비활성 페르소나는 새로 매핑할 수 없습니다.", ErrorType.BAD_REQUEST),
     PERSONA_IN_USE("VCREW-012", "봇에 매핑된 페르소나는 삭제할 수 없습니다. 먼저 매핑을 해제하세요.", ErrorType.CONFLICT),
     CHAT_CONFIG_INVALID("VCREW-013", "채팅 설정 값이 유효하지 않습니다.", ErrorType.BAD_REQUEST),
-    DJ_COUNT_EXCEEDS_TRACKS("VCREW-014", "djBotCount 가 필터 통과 트랙 수를 초과합니다", ErrorType.BAD_REQUEST);
+    DJ_COUNT_EXCEEDS_TRACKS("VCREW-014", "djBotCount 가 필터 통과 트랙 수를 초과합니다", ErrorType.BAD_REQUEST),
+    BOT_PLACED_CANNOT_REMOVE("VCREW-015", "배치된 봇은 제거할 수 없습니다. 먼저 해당 방을 리소스 회수/재배치하세요", ErrorType.CONFLICT);
 
     private final String errorCode;
     private final String message;

--- a/app/src/main/resources/db/migration/V37__rename_bot_nickname_prefix_dj_to_vcrew.sql
+++ b/app/src/main/resources/db/migration/V37__rename_bot_nickname_prefix_dj_to_vcrew.sql
@@ -1,0 +1,12 @@
+-- V37: 가상 크루 봇 닉네임 접두어 DJ_ → VCREW_ (기존 봇만).
+--
+-- 신규 봇은 VirtualUserPoolService.generateBotNickname 에서 이미 VCREW_ 로 생성한다(코드 변경).
+-- 이 마이그레이션은 기존에 생성된 봇들의 닉네임을 함께 맞춘다.
+--
+-- 스코프: 봇 닉네임 생성식 = "DJ_" + UUID 12 소문자 hex. 정확히 그 패턴만 치환하여
+--         실사용자의 "DJ_..." 닉네임(예: DJ_Master) 오염을 방지한다.
+-- 길이: "DJ_"(3) + hex(12) = 15 → "VCREW_"(6) + hex(12) = 18 ≤ user_profile.nickname VARCHAR(20).
+-- UNIQUE(uk_user_profile_nickname): hex 접미가 고유하고 VCREW_ 접두는 신규라 충돌 없음.
+UPDATE user_profile
+SET nickname = CONCAT('VCREW_', SUBSTRING(nickname, 4))
+WHERE nickname REGEXP '^DJ_[0-9a-f]{12}$';

--- a/app/src/test/java/com/pfplaybackend/api/admin/application/service/AdminUserServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/admin/application/service/AdminUserServiceTest.java
@@ -5,9 +5,11 @@ import com.pfplaybackend.api.admin.application.port.out.AdminPlaylistPort;
 import com.pfplaybackend.api.common.config.security.enums.ProviderType;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.common.enums.AuthorityTier;
+import com.pfplaybackend.api.common.exception.http.ConflictException;
 import com.pfplaybackend.api.common.exception.http.ForbiddenException;
 import com.pfplaybackend.api.common.exception.http.NotFoundException;
 import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserProfileRepository;
 import com.pfplaybackend.api.user.domain.entity.data.MemberData;
 import com.pfplaybackend.api.user.domain.entity.data.ProfileData;
 import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
@@ -43,6 +45,9 @@ class AdminUserServiceTest {
 
     @Mock
     private UserAccountRepository userAccountRepository;
+
+    @Mock
+    private UserProfileRepository userProfileRepository;
 
     @InjectMocks
     private AdminUserService adminUserService;
@@ -210,5 +215,61 @@ class AdminUserServiceTest {
         // when & then
         assertThatThrownBy(() -> adminUserService.getVirtualMember(userId))
                 .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("updateVirtualMemberNickname — 가상 회원 닉네임이 in-place 로 변경되고 저장된다")
+    void updateVirtualMemberNicknameSuccess() {
+        // given
+        UserId userId = new UserId(401L);
+        MemberData virtualMember = createMemberFor(userId.getUid());
+        UserAccountData localAccount = createLocalAccount(userId);
+
+        when(adminMemberPort.findMemberByUserAccountId(userId.getUid())).thenReturn(Optional.of(virtualMember));
+        when(userAccountRepository.findById(userId)).thenReturn(Optional.of(localAccount));
+        when(userProfileRepository.existsByNicknameAndUserIdNot(new Nickname("루나"), userId)).thenReturn(false);
+        when(adminMemberPort.saveMember(any(MemberData.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        // when
+        adminUserService.updateVirtualMemberNickname(userId, "루나");
+
+        // then — 기존 프로필 행이 새 닉네임으로 mutate + 저장
+        assertThat(virtualMember.getProfileData().getNicknameValue()).isEqualTo("루나");
+        verify(adminMemberPort).saveMember(virtualMember);
+    }
+
+    @Test
+    @DisplayName("updateVirtualMemberNickname — 비가상(GOOGLE) 회원은 ForbiddenException")
+    void updateVirtualMemberNicknameNonVirtualThrows() {
+        // given
+        UserId userId = new UserId(402L);
+        MemberData googleMember = createMemberFor(userId.getUid());
+        UserAccountData googleAccount = createGoogleAccount(userId);
+
+        when(adminMemberPort.findMemberByUserAccountId(userId.getUid())).thenReturn(Optional.of(googleMember));
+        when(userAccountRepository.findById(userId)).thenReturn(Optional.of(googleAccount));
+
+        // when & then
+        assertThatThrownBy(() -> adminUserService.updateVirtualMemberNickname(userId, "루나"))
+                .isInstanceOf(ForbiddenException.class);
+        verify(adminMemberPort, never()).saveMember(any());
+    }
+
+    @Test
+    @DisplayName("updateVirtualMemberNickname — 닉네임 중복(타인) 시 ConflictException")
+    void updateVirtualMemberNicknameDuplicateThrows() {
+        // given
+        UserId userId = new UserId(403L);
+        MemberData virtualMember = createMemberFor(userId.getUid());
+        UserAccountData localAccount = createLocalAccount(userId);
+
+        when(adminMemberPort.findMemberByUserAccountId(userId.getUid())).thenReturn(Optional.of(virtualMember));
+        when(userAccountRepository.findById(userId)).thenReturn(Optional.of(localAccount));
+        when(userProfileRepository.existsByNicknameAndUserIdNot(new Nickname("중복닉"), userId)).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> adminUserService.updateVirtualMemberNickname(userId, "중복닉"))
+                .isInstanceOf(ConflictException.class);
+        verify(adminMemberPort, never()).saveMember(any());
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewAdminServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewAdminServiceTest.java
@@ -3,6 +3,7 @@ package com.pfplaybackend.api.virtualcrew;
 import com.pfplaybackend.api.party.application.service.PartyroomQueryService;
 import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
 import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.virtualcrew.adapter.out.persistence.BotPoolQueryRepository;
 import com.pfplaybackend.api.virtualcrew.adapter.out.persistence.PartyroomVirtualCrewConfigRepository;
 import com.pfplaybackend.api.virtualcrew.application.port.VirtualCrewOrchestrator;
@@ -12,6 +13,7 @@ import com.pfplaybackend.api.virtualcrew.application.service.VirtualCrewAdminSer
 import com.pfplaybackend.api.virtualcrew.application.service.VirtualUserPoolService;
 import com.pfplaybackend.api.virtualcrew.domain.entity.data.PartyroomVirtualCrewConfigData;
 import com.pfplaybackend.api.virtualcrew.domain.enums.VirtualCrewStatus;
+import com.pfplaybackend.api.virtualcrew.domain.exception.VirtualCrewException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,8 +21,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -109,5 +114,71 @@ class VirtualCrewAdminServiceTest {
     void replace_delegates() {
         service.replace(ROOM);
         verify(orchestrator).replaceRoom(ROOM);
+    }
+
+    // ── removeBots (봇 일괄 제거 = 탈퇴 soft-delete) ──
+
+    @Test
+    @DisplayName("removeBots — 유효 봇 전원 withdrawBot 위임 + 결과 반환")
+    void removeBots_idle_withdrawsEach() {
+        when(botPoolQueryRepository.filterBotUserIds(anyList())).thenReturn(List.of(1L, 2L));
+        when(botPoolQueryRepository.filterPlacedBotUserIds(anyCollection())).thenReturn(List.of());
+
+        VirtualCrewAdminService.BotRemovalResult result = service.removeBots(List.of(1L, 2L));
+
+        verify(poolService).withdrawBot(new UserId(1L));
+        verify(poolService).withdrawBot(new UserId(2L));
+        assertThat(result.removed()).isEqualTo(2);
+        assertThat(result.removedUserIds()).containsExactly(1L, 2L);
+    }
+
+    @Test
+    @DisplayName("removeBots — 활성 crew 배치 봇 포함 시 409(BOT_PLACED_CANNOT_REMOVE), 전체 거부(withdraw 0건)")
+    void removeBots_placed_rejectsAll() {
+        when(botPoolQueryRepository.filterBotUserIds(anyList())).thenReturn(List.of(1L, 2L));
+        when(botPoolQueryRepository.filterPlacedBotUserIds(anyCollection())).thenReturn(List.of(2L));
+
+        assertThatThrownBy(() -> service.removeBots(List.of(1L, 2L)))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining(VirtualCrewException.BOT_PLACED_CANNOT_REMOVE.getMessage());
+
+        verify(poolService, never()).withdrawBot(any());
+    }
+
+    @Test
+    @DisplayName("removeBots — 비봇/미존재/이미탈퇴 id 는 filterBotUserIds 가 걸러 멱등 스킵")
+    void removeBots_unknownId_skipped() {
+        when(botPoolQueryRepository.filterBotUserIds(anyList())).thenReturn(List.of(1L));
+        when(botPoolQueryRepository.filterPlacedBotUserIds(anyCollection())).thenReturn(List.of());
+
+        VirtualCrewAdminService.BotRemovalResult result = service.removeBots(List.of(1L, 999L));
+
+        verify(poolService).withdrawBot(new UserId(1L));
+        verify(poolService, never()).withdrawBot(new UserId(999L));
+        assertThat(result.removed()).isEqualTo(1);
+        assertThat(result.removedUserIds()).containsExactly(1L);
+    }
+
+    @Test
+    @DisplayName("removeBots — 빈 목록은 no-op(repo 조회조차 안 함)")
+    void removeBots_empty_noop() {
+        VirtualCrewAdminService.BotRemovalResult result = service.removeBots(List.of());
+
+        assertThat(result.removed()).isZero();
+        verify(botPoolQueryRepository, never()).filterBotUserIds(anyList());
+        verify(botPoolQueryRepository, never()).filterPlacedBotUserIds(anyCollection());
+        verify(poolService, never()).withdrawBot(any());
+    }
+
+    @Test
+    @DisplayName("removeBots — 유효 봇이 하나도 없으면 no-op(withdraw 0건)")
+    void removeBots_noValidBots_noop() {
+        when(botPoolQueryRepository.filterBotUserIds(anyList())).thenReturn(List.of());
+
+        VirtualCrewAdminService.BotRemovalResult result = service.removeBots(List.of(999L));
+
+        assertThat(result.removed()).isZero();
+        verify(botPoolQueryRepository, never()).filterPlacedBotUserIds(anyCollection());
+        verify(poolService, never()).withdrawBot(any());
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewBotRemovalIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualCrewBotRemovalIT.java
@@ -1,0 +1,148 @@
+package com.pfplaybackend.api.virtualcrew;
+
+import com.pfplaybackend.api.administration.application.AdminContext;
+import com.pfplaybackend.api.avatar.adapter.out.persistence.AvatarBodyResourceRepository;
+import com.pfplaybackend.api.avatar.adapter.out.persistence.AvatarFaceResourceRepository;
+import com.pfplaybackend.api.avatar.domain.entity.data.AvatarBodyResourceData;
+import com.pfplaybackend.api.avatar.domain.entity.data.AvatarFaceResourceData;
+import com.pfplaybackend.api.avatar.domain.enums.ObtainmentType;
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.adapter.out.persistence.CrewRepository;
+import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.enums.GradeType;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
+import com.pfplaybackend.api.virtualcrew.adapter.out.persistence.BotPoolQueryRepository;
+import com.pfplaybackend.api.virtualcrew.application.service.VirtualCrewAdminService;
+import com.pfplaybackend.api.virtualcrew.application.service.VirtualUserPoolService;
+import com.pfplaybackend.api.virtualcrew.domain.exception.VirtualCrewException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * 봇 제거(탈퇴 soft-delete) 전체 체인 IT — {@link VirtualCrewAdminService#removeBots} →
+ * {@link VirtualUserPoolService#withdrawBot} → provision 어댑터 → {@code AdminUserService.withdrawVirtualMember}
+ * → {@code AdminMemberWithdrawCommandService.withdraw} → {@code UserAccountData.withdraw}.
+ *
+ * <p>검증: (1) idle 봇 탈퇴 시 {@code withdrawn_at} 세팅 + 풀/로스터/idle 조회에서 즉시 제외,
+ * (2) 배치(활성 crew)된 봇이 섞이면 {@link VirtualCrewException#BOT_PLACED_CANNOT_REMOVE} 로 전체 거부.
+ *
+ * <p>{@code AdminContext} 는 실 SecurityContext 대신 mock — withdraw 는 auth principal 을 요구하므로
+ * (AdminMemberWithdrawCommandServiceIT 와 동일 패턴). AFTER_COMMIT audit 리스너는 @Transactional
+ * 롤백으로 안 뛰지만, 여기 관심사는 봇 풀 상태이므로 무관하다.
+ */
+@Transactional
+class VirtualCrewBotRemovalIT extends AbstractIntegrationTest {
+
+    private static final String DEFAULT_BODY_URI =
+            "https://firebasestorage.googleapis.com/v0/b/pfplay-firebase.appspot.com/o/ava_basic%2Fava_basic_001.png?alt=media";
+    private static final String COMBINABLE_BODY_URI = "https://cdn.test/ava_body_basic_001.png";
+    private static final String STANDALONE_BODY_URI = "https://cdn.test/ava_body_basic_002.png";
+    private static final String STANDALONE_ICON_URI = "https://cdn.test/ava_icon_body_basic_002.png";
+    private static final String FACE_URI = "https://cdn.test/ava_face_basic_001.png";
+    private static final String FACE_ICON_URI = "https://cdn.test/ava_icon_face_basic_001.png";
+
+    @Autowired private VirtualUserPoolService poolService;
+    @Autowired private VirtualCrewAdminService adminService;
+    @Autowired private UserAccountRepository userAccountRepository;
+    @Autowired private CrewRepository crewRepository;
+    @Autowired private BotPoolQueryRepository botPoolQueryRepository;
+    @Autowired private AvatarBodyResourceRepository avatarBodyResourceRepository;
+    @Autowired private AvatarFaceResourceRepository avatarFaceResourceRepository;
+
+    @MockBean private AdminContext adminContext;
+
+    @BeforeEach
+    void setUp() {
+        if (avatarBodyResourceRepository.findOneAvatarResourceByResourceUri(DEFAULT_BODY_URI) == null) {
+            avatarBodyResourceRepository.save(AvatarBodyResourceData.draft(
+                    "ava_body_basic_001", DEFAULT_BODY_URI, null,
+                    ObtainmentType.BASIC, 0, true, true, 60, 41, null));
+        }
+        seedPublishedBody("ava_body_basic_001_pub", COMBINABLE_BODY_URI, null, true, 60, 41);
+        seedPublishedBody("ava_body_basic_002_pub", STANDALONE_BODY_URI, STANDALONE_ICON_URI, false, 0, 0);
+        seedPublishedFace("ava_face_basic_001_pub", FACE_URI, FACE_ICON_URI);
+
+        given(adminContext.currentAdministratorId()).willReturn(1L);
+    }
+
+    private void seedPublishedBody(String name, String uri, String iconUri, boolean combinable, int px, int py) {
+        if (avatarBodyResourceRepository.findOneAvatarResourceByResourceUri(uri) != null) {
+            return;
+        }
+        AvatarBodyResourceData body = AvatarBodyResourceData.draft(
+                name, uri, iconUri, ObtainmentType.BASIC, 0, combinable, false, px, py, null);
+        body.publish(null);
+        avatarBodyResourceRepository.save(body);
+    }
+
+    private void seedPublishedFace(String name, String uri, String iconUri) {
+        if (avatarFaceResourceRepository.findOneAvatarResourceByResourceUri(uri) != null) {
+            return;
+        }
+        AvatarFaceResourceData face = AvatarFaceResourceData.draft(name, uri, iconUri, null);
+        face.publish(null);
+        avatarFaceResourceRepository.save(face);
+    }
+
+    @Test
+    @DisplayName("idle 봇 removeBots → withdrawn_at 세팅 + 풀/로스터/idle 조회에서 제외")
+    void removeIdleBot_softDeletesAndDisappearsFromPool() {
+        List<UserId> bots = poolService.provision(2);
+        flushAndClear();
+        UserId target = bots.get(0);
+        UserId keep = bots.get(1);
+        long beforeCount = botPoolQueryRepository.countBots();
+
+        VirtualCrewAdminService.BotRemovalResult result = adminService.removeBots(List.of(target.getUid()));
+        flushAndClear();
+
+        assertThat(result.removed()).isEqualTo(1);
+        assertThat(result.removedUserIds()).containsExactly(target.getUid());
+
+        // withdrawn_at 세팅됨
+        UserAccountData account = userAccountRepository.findById(target).orElseThrow();
+        assertThat(account.isWithdrawn()).isTrue();
+
+        // 풀 카운트 1 감소, 로스터/idle 후보에서 제외
+        assertThat(botPoolQueryRepository.countBots()).isEqualTo(beforeCount - 1);
+        assertThat(botPoolQueryRepository.findRoster())
+                .extracting(row -> row.userId())
+                .doesNotContain(target.getUid())
+                .contains(keep.getUid());
+        assertThat(poolService.findIdleBots(10)).doesNotContain(target).contains(keep);
+    }
+
+    @Test
+    @DisplayName("배치(활성 crew)된 봇 포함 → BOT_PLACED_CANNOT_REMOVE, 전체 거부(탈퇴 0건)")
+    void removePlacedBot_rejectsAll() {
+        List<UserId> bots = poolService.provision(2);
+        flushAndClear();
+        UserId idle = bots.get(0);
+        UserId placed = bots.get(1);
+        // placed 봇을 임의 방의 활성 crew 로 만든다.
+        crewRepository.save(CrewData.create(new PartyroomId(1234L), placed, GradeType.LISTENER, null));
+        flushAndClear();
+
+        assertThatThrownBy(() -> adminService.removeBots(List.of(idle.getUid(), placed.getUid())))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining(VirtualCrewException.BOT_PLACED_CANNOT_REMOVE.getMessage());
+
+        // 전체 거부 — idle 봇도 탈퇴되지 않았다(all-or-nothing). removeBots 는 write 전에 던지므로
+        // rollback-only 마킹 없이 아래 read 가 안전하다.
+        assertThat(userAccountRepository.findById(idle).orElseThrow().isWithdrawn()).isFalse();
+        assertThat(userAccountRepository.findById(placed).orElseThrow().isWithdrawn()).isFalse();
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualUserPoolServiceIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualcrew/VirtualUserPoolServiceIT.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Transactional
 class VirtualUserPoolServiceIT extends AbstractIntegrationTest {
@@ -169,6 +170,34 @@ class VirtualUserPoolServiceIT extends AbstractIntegrationTest {
                     .as("bot %s user_profile row count (provision 후 정확히 1개)", id.getUid())
                     .isEqualTo(1L);
         }
+    }
+
+    @Test
+    @DisplayName("renameBot — 봇 닉네임이 실DB user_profile 에서 변경된다")
+    void renameBot_updatesNicknameInDb() {
+        UserId bot = poolService.provision(1).get(0);
+        flushAndClear();
+
+        poolService.renameBot(bot, "루나");
+        flushAndClear();
+
+        String nickname = adminUserService.getVirtualMember(bot)
+                .getProfileData().getNicknameValue();
+        assertThat(nickname).isEqualTo("루나");
+    }
+
+    @Test
+    @DisplayName("renameBot — 다른 봇이 이미 쓰는 닉네임으로 변경 시 ConflictException(UNIQUE)")
+    void renameBot_duplicateNickname_throws() {
+        List<UserId> bots = poolService.provision(2);
+        flushAndClear();
+        UserId a = bots.get(0);
+        UserId b = bots.get(1);
+        poolService.renameBot(b, "디제이민수");
+        flushAndClear();
+
+        assertThatThrownBy(() -> poolService.renameBot(a, "디제이민수"))
+                .isInstanceOf(com.pfplaybackend.api.common.exception.http.ConflictException.class);
     }
 
     @Test


### PR DESCRIPTION
Closes #337

## 요약
가상 크루 봇 운영 3종: (1) 식별자 접두어 `DJ_`→`VCREW_`, (2) 봇 제거(탈퇴 soft-delete), (3) 봇 닉네임 변경(파티룸 노출명).

## 변경
### 1) 접두어 DJ_ → VCREW_
- 신규: `VirtualUserPoolService.generateBotNickname`. 기존: **Flyway V37**(`^DJ_[0-9a-f]{12}$` 정밀 치환, 실사용자 미오염).

### 2) 봇 제거 = 탈퇴 soft-delete
- `AdminUserService.withdrawVirtualMember` → `AdminMemberWithdrawCommandService.withdraw` 재사용(idempotent·adminId·이벤트 승계).
- `VirtualCrewAdminService.removeBots`: `filterBotUserIds`(유효 봇) + `filterPlacedBotUserIds`(**활성 crew EXISTS**, 파티룸 조인 무관)로 배치봇 all-or-nothing 거부(409). `POST /virtual-crew/bots/remove`.

### 3) 봇 닉네임 변경
- `AdminUserService.updateVirtualMemberNickname`: 가상+LOCAL 검증 → `Nickname` 도메인 규칙(비블랭크·20자, **charset 무제한=한글/공백 허용**) → `existsByNicknameAndUserIdNot`(self 제외) 중복검사 409(`DUPLICATE_NICKNAME`) → `ProfileData.updateNickname` in-place. `PUT /virtual-crew/bots/{userId}/nickname`.
- 참고: 탈퇴 봇의 닉네임은 UNIQUE 상 계속 예약됨(실회원 탈퇴와 동일 기존 동작, 별도 스코프).

seam: 세 연산 모두 `VirtualMemberProvisionPort/Adapter`(virtualcrew→admin 유일 경계, ArchUnit GREEN) 경유.

## 검증
- 유닛 `VirtualCrewAdminServiceTest`(removeBots 5) + `AdminUserServiceTest`(nickname 성공/비가상 403/중복 409).
- IT `VirtualCrewBotRemovalIT`(전체 탈퇴 체인+배치 거부) + `VirtualUserPoolServiceIT`(rename 실DB 변경/중복 409) + `BotPoolQueryRepositoryImplIT`.
- **로컬 풀부팅**: Flyway V37 실DB 적용 + 컨텍스트 로딩(신규 cross-BC 의존).
- **라이브 e2e**(실행 스택 :8080, 실 admin 인증): provision 201 → VCREW_ 확인 → 닉네임 변경 204(ASCII·한글 저장 확인) → 중복 409(ADM-014) → blank 400 → remove 200 → 로스터 소멸.

어드민 lockstep: pfplay-admin #32(제거+닉네임 UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)