### PR TITLE
fix(virtualcrew): 봇 관리 어드민 응답의 TSID userId 문자열 직렬화 (#344)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/BotRosterItemResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/BotRosterItemResponse.java
@@ -2,12 +2,19 @@ package com.pfplaybackend.api.virtualcrew.adapter.in.web.payload;
 
 import com.pfplaybackend.api.virtualcrew.application.dto.BotRosterRow;
 
-/** 봇 로스터 1행(신원+현재 아바타+배치룸+매핑 페르소나) 응답. */
-public record BotRosterItemResponse(Long userId, String nickname, String avatarBodyUri, String avatarIconUri,
+/**
+ * 봇 로스터 1행(신원+현재 아바타+배치룸+매핑 페르소나) 응답.
+ *
+ * <p>{@code userId}(= user_account.user_id)는 TSID라 값이 2^53를 초과한다. JSON 숫자로 내보내면
+ * 어드민 프론트의 {@code JSON.parse}가 정밀도를 잃어(끝자리 반올림) 이후 mutation 요청에서
+ * 다른 봇을 가리키거나 404(ADM-004)를 낸다. web-facing {@code QueryMyInfoResponse.uid} 와 동일하게
+ * 문자열로 직렬화한다. 반면 {@code placementRoomId}·{@code personaId}는 IDENTITY(작은 값)라 Long 유지.
+ */
+public record BotRosterItemResponse(String userId, String nickname, String avatarBodyUri, String avatarIconUri,
                                     Long placementRoomId, String placementRoomTitle,
                                     Long personaId, String personaName) {
     public static BotRosterItemResponse from(BotRosterRow r) {
-        return new BotRosterItemResponse(r.userId(), r.nickname(), r.avatarBodyUri(), r.avatarIconUri(),
+        return new BotRosterItemResponse(String.valueOf(r.userId()), r.nickname(), r.avatarBodyUri(), r.avatarIconUri(),
                 r.placementPartyroomId(), r.placementPartyroomTitle(),
                 r.personaId(), r.personaName());
     }

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/DistributeBotAvatarResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/DistributeBotAvatarResponse.java
@@ -4,12 +4,16 @@ import com.pfplaybackend.api.virtualcrew.application.service.BotAvatarAssigner;
 
 import java.util.List;
 
-/** 봇 아바타 일괄 배분 결과 — 실제 적용된 (봇, 바디) 페어 목록. */
+/**
+ * 봇 아바타 일괄 배분 결과 — 실제 적용된 (봇, 바디) 페어 목록.
+ *
+ * <p>{@code userId}는 TSID라 JS 정밀도 손실을 피하려 문자열로 직렬화한다({@link BotRosterItemResponse} 참고).
+ */
 public record DistributeBotAvatarResponse(List<Assigned> assigned) {
-    public record Assigned(Long userId, String avatarBodyUri) {}
+    public record Assigned(String userId, String avatarBodyUri) {}
 
     public static DistributeBotAvatarResponse from(List<BotAvatarAssigner.Assigned> xs) {
         return new DistributeBotAvatarResponse(xs.stream()
-                .map(a -> new Assigned(a.userId(), a.avatarBodyUri())).toList());
+                .map(a -> new Assigned(String.valueOf(a.userId()), a.avatarBodyUri())).toList());
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/RemoveBotsResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/RemoveBotsResponse.java
@@ -4,10 +4,15 @@ import com.pfplaybackend.api.virtualcrew.application.service.VirtualCrewAdminSer
 
 import java.util.List;
 
-/** 봇 일괄 제거 결과 — 실제 탈퇴된 봇 수 + userId 목록(로스터에 없던 id 는 제외). */
-public record RemoveBotsResponse(int removed, List<Long> removedUserIds) {
+/**
+ * 봇 일괄 제거 결과 — 실제 탈퇴된 봇 수 + userId 목록(로스터에 없던 id 는 제외).
+ *
+ * <p>{@code removedUserIds}는 TSID라 JS 정밀도 손실을 피하려 문자열로 직렬화한다({@link BotRosterItemResponse} 참고).
+ */
+public record RemoveBotsResponse(int removed, List<String> removedUserIds) {
 
     public static RemoveBotsResponse from(VirtualCrewAdminService.BotRemovalResult result) {
-        return new RemoveBotsResponse(result.removed(), result.removedUserIds());
+        return new RemoveBotsResponse(result.removed(),
+                result.removedUserIds().stream().map(String::valueOf).toList());
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/virtualcrew/AdminVirtualCrewControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualcrew/AdminVirtualCrewControllerTest.java
@@ -572,12 +572,13 @@ class AdminVirtualCrewControllerTest {
     @Test
     @WithMockUser(roles = "ADMIN")
     void bots_admin_returns200WithBody() throws Exception {
+        // userId 는 TSID(2^53 초과) — JSON 문자열로 직렬화돼 어드민 프론트에서 정밀도 손실이 없어야 한다.
         given(botAvatarAdminService.roster())
                 .willReturn(List.of(new BotRosterRow(
-                        1L, "봇", "https://cdn/body.png", "https://cdn/icon.png", 7L, "룸", 3L, "DJ 챌린저")));
+                        864530440482800637L, "봇", "https://cdn/body.png", "https://cdn/icon.png", 7L, "룸", 3L, "DJ 챌린저")));
         mockMvc.perform(get("/api/v1/admin/virtual-crew/bots"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data[0].userId").value(1))
+                .andExpect(jsonPath("$.data[0].userId").value("864530440482800637"))
                 .andExpect(jsonPath("$.data[0].nickname").value("봇"))
                 .andExpect(jsonPath("$.data[0].avatarBodyUri").value("https://cdn/body.png"))
                 .andExpect(jsonPath("$.data[0].avatarIconUri").value("https://cdn/icon.png"))
@@ -631,9 +632,9 @@ class AdminVirtualCrewControllerTest {
                                 {"botIds":[1,2],"bodyUris":["https://cdn/a.png","https://cdn/b.png"]}
                                 """))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.assigned[0].userId").value(1))
+                .andExpect(jsonPath("$.data.assigned[0].userId").value("1"))
                 .andExpect(jsonPath("$.data.assigned[0].avatarBodyUri").value("https://cdn/a.png"))
-                .andExpect(jsonPath("$.data.assigned[1].userId").value(2));
+                .andExpect(jsonPath("$.data.assigned[1].userId").value("2"));
         verify(botAvatarAdminService).distribute(List.of(1L, 2L), List.of("https://cdn/a.png", "https://cdn/b.png"));
     }
 


### PR DESCRIPTION
## 문제
어드민 봇 닉네임 변경이 `ADM-004 회원을 찾을 수 없습니다 (404)`. stg·prod 양쪽, **배포 후 새로 만든 봇에서도** 재현. 닉네임뿐 아니라 아바타/페르소나/제거 등 봇 userId를 왕복하는 모든 봇 관리가 동일하게 깨짐.

## 원인
봇 `userId`(= `user_account.user_id`)는 TSID라 값이 2^53를 초과(실측 `864530440482800637`, 18자리). 생 `Long`으로 JSON 숫자 직렬화하면 어드민 프론트 `JSON.parse`가 정밀도를 잃어 끝자리가 뭉개지고(→ `...600`), 그 id로 mutation을 보내 `findByUserAccountId` 미스 → ADM-004. 실 회원 어드민은 `memberId`(IDENTITY)로 주소지정해 무관, 봇 엔드포인트만 user_account_id=TSID라 걸림.

## 변경
web-facing `QueryMyInfoResponse.uid`(이미 `String` + `getUid().toString()`) 관례대로 봇 userId를 노출하는 응답을 `Long`→`String`:
- `BotRosterItemResponse.userId`
- `DistributeBotAvatarResponse.Assigned.userId`
- `RemoveBotsResponse.removedUserIds`

요청 바디 `botIds`/`botUserIds`·경로변수 `{userId}`는 `Long` 유지(Jackson/Spring이 문자열→Long 무손실 coercion, 커스텀 Jackson 웹 설정 없음). 파티룸/페르소나 id는 IDENTITY라 무관.

## 검증
- `:app:test` (AdminVirtualCrewControllerTest, 문자열 단언 + 대형 TSID 회귀 가드) GREEN
- **로컬 풀스택 실측 왕복**: 실제 TSID 봇 생성 → 로스터가 `"userId":"864801359595238609"`(문자열) → 그 TSID로 닉네임 변경 **HTTP 204**(ADM-004 아님), 로스터 반영 확인. 한글 닉네임(UTF-8) 204도 확인.

프론트 짝: pfplay-admin#(별도 PR). 두 PR lockstep 머지 필요.

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)