### PR TITLE
chore(release): dev→stg 승격 — 봇 TSID userId 정밀도 픽스 (#345)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/BotRosterItemResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/BotRosterItemResponse.java
@@ -2,12 +2,19 @@ package com.pfplaybackend.api.virtualcrew.adapter.in.web.payload;
 
 import com.pfplaybackend.api.virtualcrew.application.dto.BotRosterRow;
 
-/** 봇 로스터 1행(신원+현재 아바타+배치룸+매핑 페르소나) 응답. */
-public record BotRosterItemResponse(Long userId, String nickname, String avatarBodyUri, String avatarIconUri,
+/**
+ * 봇 로스터 1행(신원+현재 아바타+배치룸+매핑 페르소나) 응답.
+ *
+ * <p>{@code userId}(= user_account.user_id)는 TSID라 값이 2^53를 초과한다. JSON 숫자로 내보내면
+ * 어드민 프론트의 {@code JSON.parse}가 정밀도를 잃어(끝자리 반올림) 이후 mutation 요청에서
+ * 다른 봇을 가리키거나 404(ADM-004)를 낸다. web-facing {@code QueryMyInfoResponse.uid} 와 동일하게
+ * 문자열로 직렬화한다. 반면 {@code placementRoomId}·{@code personaId}는 IDENTITY(작은 값)라 Long 유지.
+ */
+public record BotRosterItemResponse(String userId, String nickname, String avatarBodyUri, String avatarIconUri,
                                     Long placementRoomId, String placementRoomTitle,
                                     Long personaId, String personaName) {
     public static BotRosterItemResponse from(BotRosterRow r) {
-        return new BotRosterItemResponse(r.userId(), r.nickname(), r.avatarBodyUri(), r.avatarIconUri(),
+        return new BotRosterItemResponse(String.valueOf(r.userId()), r.nickname(), r.avatarBodyUri(), r.avatarIconUri(),
                 r.placementPartyroomId(), r.placementPartyroomTitle(),
                 r.personaId(), r.personaName());
     }

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/DistributeBotAvatarResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/DistributeBotAvatarResponse.java
@@ -4,12 +4,16 @@ import com.pfplaybackend.api.virtualcrew.application.service.BotAvatarAssigner;
 
 import java.util.List;
 
-/** 봇 아바타 일괄 배분 결과 — 실제 적용된 (봇, 바디) 페어 목록. */
+/**
+ * 봇 아바타 일괄 배분 결과 — 실제 적용된 (봇, 바디) 페어 목록.
+ *
+ * <p>{@code userId}는 TSID라 JS 정밀도 손실을 피하려 문자열로 직렬화한다({@link BotRosterItemResponse} 참고).
+ */
 public record DistributeBotAvatarResponse(List<Assigned> assigned) {
-    public record Assigned(Long userId, String avatarBodyUri) {}
+    public record Assigned(String userId, String avatarBodyUri) {}
 
     public static DistributeBotAvatarResponse from(List<BotAvatarAssigner.Assigned> xs) {
         return new DistributeBotAvatarResponse(xs.stream()
-                .map(a -> new Assigned(a.userId(), a.avatarBodyUri())).toList());
+                .map(a -> new Assigned(String.valueOf(a.userId()), a.avatarBodyUri())).toList());
     }
 }

--- a/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/RemoveBotsResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/virtualcrew/adapter/in/web/payload/RemoveBotsResponse.java
@@ -4,10 +4,15 @@ import com.pfplaybackend.api.virtualcrew.application.service.VirtualCrewAdminSer
 
 import java.util.List;
 
-/** 봇 일괄 제거 결과 — 실제 탈퇴된 봇 수 + userId 목록(로스터에 없던 id 는 제외). */
-public record RemoveBotsResponse(int removed, List<Long> removedUserIds) {
+/**
+ * 봇 일괄 제거 결과 — 실제 탈퇴된 봇 수 + userId 목록(로스터에 없던 id 는 제외).
+ *
+ * <p>{@code removedUserIds}는 TSID라 JS 정밀도 손실을 피하려 문자열로 직렬화한다({@link BotRosterItemResponse} 참고).
+ */
+public record RemoveBotsResponse(int removed, List<String> removedUserIds) {
 
     public static RemoveBotsResponse from(VirtualCrewAdminService.BotRemovalResult result) {
-        return new RemoveBotsResponse(result.removed(), result.removedUserIds());
+        return new RemoveBotsResponse(result.removed(),
+                result.removedUserIds().stream().map(String::valueOf).toList());
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/virtualcrew/AdminVirtualCrewControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/virtualcrew/AdminVirtualCrewControllerTest.java
@@ -572,12 +572,13 @@ class AdminVirtualCrewControllerTest {
     @Test
     @WithMockUser(roles = "ADMIN")
     void bots_admin_returns200WithBody() throws Exception {
+        // userId 는 TSID(2^53 초과) — JSON 문자열로 직렬화돼 어드민 프론트에서 정밀도 손실이 없어야 한다.
         given(botAvatarAdminService.roster())
                 .willReturn(List.of(new BotRosterRow(
-                        1L, "봇", "https://cdn/body.png", "https://cdn/icon.png", 7L, "룸", 3L, "DJ 챌린저")));
+                        864530440482800637L, "봇", "https://cdn/body.png", "https://cdn/icon.png", 7L, "룸", 3L, "DJ 챌린저")));
         mockMvc.perform(get("/api/v1/admin/virtual-crew/bots"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data[0].userId").value(1))
+                .andExpect(jsonPath("$.data[0].userId").value("864530440482800637"))
                 .andExpect(jsonPath("$.data[0].nickname").value("봇"))
                 .andExpect(jsonPath("$.data[0].avatarBodyUri").value("https://cdn/body.png"))
                 .andExpect(jsonPath("$.data[0].avatarIconUri").value("https://cdn/icon.png"))
@@ -631,9 +632,9 @@ class AdminVirtualCrewControllerTest {
                                 {"botIds":[1,2],"bodyUris":["https://cdn/a.png","https://cdn/b.png"]}
                                 """))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.assigned[0].userId").value(1))
+                .andExpect(jsonPath("$.data.assigned[0].userId").value("1"))
                 .andExpect(jsonPath("$.data.assigned[0].avatarBodyUri").value("https://cdn/a.png"))
-                .andExpect(jsonPath("$.data.assigned[1].userId").value(2));
+                .andExpect(jsonPath("$.data.assigned[1].userId").value("2"));
         verify(botAvatarAdminService).distribute(List.of(1L, 2L), List.of("https://cdn/a.png", "https://cdn/b.png"));
     }
 


### PR DESCRIPTION
develop → release(staging) 승격.

포함 변경: 봇 관리 어드민 응답의 TSID userId 문자열 직렬화 (#345, ADM-004 픽스).
- 로컬 풀스택 실측 왕복 검증 완료(실제 18자리 TSID 봇 닉네임 변경 204).
- develop CI green.

⚠️ 짝 프론트(pfplay-admin#36)는 Cloudflare native(GHA 없음) — stg 워커 `stg-pfplay-admin` 수동 배포 필요(사용자 게이트). 백엔드 단독 stg 반영으로도 기존 프론트는 문자열 userId를 그대로 왕복해 동작(JSON.parse가 문자열은 무손실).

🤖 Generated with [Claude Code](https://claude.com/claude-code)