### PR TITLE
fix(party): enterByHost 유니크 위반 CRW-005 매핑 — 미처리 500 제거 (#351)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
@@ -273,7 +273,15 @@ public class PartyroomAccessCommandService {
         // enterByHost를 거치지 않고 tryEnter가 처리하므로 이중 exit 없음.
         autoExitPriorActiveRoomIfDifferent(hostId, partyroom.getPartyroomId());
         CrewData crew = CrewData.create(partyroom.getPartyroomId(), hostId, GradeType.HOST, null, LocalDateTime.now(clock));
-        aggregatePort.saveCrew(crew);
+        try {
+            aggregatePort.saveCrew(crew);
+        } catch (DataIntegrityViolationException e) {
+            // #351 auto-exit statement 와 본 INSERT 사이의 밀리초 창에 같은 유저의 타 기기
+            // tryEnter 가 active_user_id 슬롯을 선점하면 uk_crew_active_user 위반. 정합성은
+            // 무해(방 생성 포함 outer tx 전체 롤백)하므로 미처리 500 대신 ensureCrewActive 와
+            // 동일하게 CRW-005 CONFLICT 로 매핑해 재시도를 유도한다. 그 외 위반은 원예외 유지.
+            throw asConcurrentEntryOrRethrow(e);
+        }
     }
 
     /**

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceEnterByHostConflictTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceEnterByHostConflictTest.java
@@ -1,0 +1,95 @@
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.exception.http.ConflictException;
+import com.pfplaybackend.api.party.application.port.out.PlaybackControlPort;
+import com.pfplaybackend.api.party.application.port.out.UserProfileQueryPort;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
+import com.pfplaybackend.api.party.domain.service.PartyroomAggregateService;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * #351 enterByHost 의 uk_crew_active_user 위반 매핑 회귀 잠금.
+ *
+ * <p>auto-exit statement 와 HOST crew INSERT 사이의 밀리초 창에 같은 유저의 타 기기 tryEnter 가
+ * active_user_id 슬롯을 선점하면 INSERT 가 유니크 위반을 맞는다. 이때 미처리 500 대신
+ * CRW-005 CONFLICT 로 매핑되어야 하고(재시도 유도), 그 외 무결성 위반은 원예외를 유지해야 한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class PartyroomAccessCommandServiceEnterByHostConflictTest {
+
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private PartyroomAggregatePort aggregatePort;
+    @Mock private PartyroomAggregateService partyroomAggregateService;
+    @Mock private PartyroomQueryService partyroomQueryService;
+    @Mock private PlaybackControlPort playbackControlPort;
+    @Mock private UserProfileQueryPort userProfileQueryPort;
+    @Mock private Clock clock;
+    @Mock private PlatformTransactionManager transactionManager;
+
+    @InjectMocks
+    private PartyroomAccessCommandService service;
+
+    private final UserId hostId = new UserId(1001L);
+    private PartyroomData partyroom;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(clock.instant()).thenReturn(Instant.parse("2025-01-01T00:00:00Z"));
+        lenient().when(clock.getZone()).thenReturn(ZoneId.of("Asia/Seoul"));
+        // 프로필 존재(assertHasProfile 통과) + 기존 활성 방 없음(auto-exit 미발동)
+        lenient().when(userProfileQueryPort.getUsersProfileSetting(List.of(hostId)))
+                .thenReturn(Map.of(hostId, mock(ProfileSettingDto.class)));
+        lenient().when(partyroomQueryService.getMyActivePartyroom(hostId)).thenReturn(Optional.empty());
+
+        partyroom = mock(PartyroomData.class);
+        lenient().when(partyroom.getPartyroomId()).thenReturn(new PartyroomId(77L));
+    }
+
+    @Test
+    @DisplayName("HOST crew INSERT 가 uk_crew_active_user 위반 → CRW-005 CONFLICT 매핑")
+    void active_user_constraint_maps_to_conflict() {
+        when(aggregatePort.saveCrew(any())).thenThrow(new DataIntegrityViolationException(
+                "could not execute statement; Duplicate entry '1001' for key 'crew.uk_crew_active_user'"));
+
+        assertThatThrownBy(() -> service.enterByHost(hostId, partyroom))
+                .isInstanceOf(ConflictException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "CRW-005");
+    }
+
+    @Test
+    @DisplayName("그 외 무결성 위반(uk_crew_partyroom_user 등) → 원예외 그대로 전파")
+    void other_constraint_rethrows_original() {
+        DataIntegrityViolationException original = new DataIntegrityViolationException(
+                "could not execute statement; Duplicate entry '77-1001' for key 'crew.uk_crew_partyroom_user'");
+        when(aggregatePort.saveCrew(any())).thenThrow(original);
+
+        assertThatThrownBy(() -> service.enterByHost(hostId, partyroom))
+                .isSameAs(original);
+    }
+}


### PR DESCRIPTION
## 요약 (#351)

`enterByHost`(방 생성)의 HOST crew INSERT 가 `uk_crew_active_user` 위반 시 미처리 500 이 나던 것을 `CRW-005 CONCURRENT_ACTIVE_ROOM`(409)로 매핑. PR #350 사이드이펙트 검토의 B 항목.

## 시나리오

auto-exit statement 와 HOST crew INSERT 사이의 밀리초 창에, 같은 유저의 타 기기 `tryEnter` 가 `active_user_id` 슬롯을 선점하는 극단 레이스. 정합성은 원래 무해(방 생성 포함 outer tx 전체 롤백) — 에러 계약만 정정한다(재시도 유도 409).

## 변경

- `enterByHost` 의 `saveCrew` 를 `ensureCrewActive` 와 동일 패턴으로 감쌈 — 기존 `asConcurrentEntryOrRethrow` 헬퍼 재사용. `uk_crew_active_user` → CRW-005, 그 외 무결성 위반은 원예외 유지.
- 회귀 단위테스트 2건(매핑 / 원예외 전파).

## ⚠️ 머지 순서

**PR #350 에 스택**(base = `feat/enforce-single-active-crew-349`) — 유니크·CRW-005·헬퍼가 #350 산출물. #350 머지 후 base 가 develop 로 자동 retarget 되면 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
