### PR TITLE
chore(release): dev→stg 승격 — crew 다중활성 wedge 서버 강제(V38)+CRW-005 (#349·#351)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/impl/PartyroomRepositoryImpl.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/persistence/impl/PartyroomRepositoryImpl.java
@@ -38,7 +38,6 @@ public class PartyroomRepositoryImpl implements PartyroomRepositoryCustom {
 
     @Override
     public Optional<ActivePartyroomDto> getActivePartyroomByUserId(UserId userId) {
-        QPartyroomData qPartyroomData = QPartyroomData.partyroomData;
         QCrewData qCrewData = QCrewData.crewData;
         QPartyroomPlaybackData qPlayback = QPartyroomPlaybackData.partyroomPlaybackData;
         QDjQueueData qDjQueue = QDjQueueData.djQueueData;
@@ -46,20 +45,34 @@ public class PartyroomRepositoryImpl implements PartyroomRepositoryCustom {
         ActivePartyroomDto activePartyroomDto = queryFactory
                 .select(Projections.constructor(
                         ActivePartyroomDto.class,
-                        qPartyroomData.id,
-                        qDjQueue.isClosed,
+                        // #349 id 는 CREW 의 partyroom_id 에서 직접 취득 — PARTYROOM 조인 불필요.
+                        // "내 활성 방"의 단일 진실원천은 CREW 이므로, 조인 대상 부재로 crew 가 조회에서
+                        // 통째로 탈락(masking)하는 경로를 원천 차단한다.
+                        qCrewData.partyroomId.id,
+                        // #349 LEFT JOIN 방어: DJ_QUEUE / PARTYROOM_PLAYBACK 행이 없으면(레거시·부분손상)
+                        // NULL 이 primitive boolean 으로 언박싱되며 투영 시점에 NPE. coalesce(false) 로
+                        // 결정적 기본값 부여 — queueClosed 는 소비처 없음, playbackActivated=false 는
+                        // "활성 재생 없음"이라는 sane default (무행 방은 재생 비활성으로 표시).
+                        qDjQueue.isClosed.coalesce(false),
                         qCrewData.id.as("crewId"),
-                        qPlayback.isActivated,
+                        qPlayback.isActivated.coalesce(false),
                         qPlayback.currentPlaybackId,
                         qPlayback.currentDjCrewId
                 ))
                 .from(qCrewData)
-                .join(qPartyroomData).on(qPartyroomData.id.eq(qCrewData.partyroomId.id))
-                .join(qPlayback).on(qPlayback.partyroomId.id.eq(qPartyroomData.id))
-                .join(qDjQueue).on(qDjQueue.partyroomId.id.eq(qPartyroomData.id))
+                // #349 INNER→LEFT: 하위행(playback/djqueue) 부재로 활성 crew 가 masking 되면 auto-exit·
+                // presence 가 그 crew 를 못 봐 고아를 못 치우고(누적), 새 uk_crew_active_user 유니크와
+                // 결합 시 "고아가 있으면 어느 방도 못 들어가는" 하드 wedge 로 승격된다. LEFT 로 제거.
+                .leftJoin(qPlayback).on(qPlayback.partyroomId.id.eq(qCrewData.partyroomId.id))
+                .leftJoin(qDjQueue).on(qDjQueue.partyroomId.id.eq(qCrewData.partyroomId.id))
                 .where(qCrewData.userId.eq(userId)
                         .and(qCrewData.isActive.eq(true)))
-                .fetchOne();
+                // #349: "유저당 활성 방 1개"는 uk_crew_active_user 유니크로 DB가 보장하므로 정상 상태에선
+                // 최대 1행이다. fetchOne 은 (혹시라도 다중 활성이 남은 비정상 상태에서) 정합성 강제/조회
+                // 경로 자체를 NonUniqueResultException 으로 자멸시켰다(입장 전면 wedge). 결정적 최신 1행을
+                // 고르도록 orderBy + fetchFirst 로 전환 — 어떤 데이터 상태에서도 던지지 않는다.
+                .orderBy(qCrewData.enteredAt.desc(), qCrewData.id.desc())
+                .fetchFirst();
 
         return Optional.ofNullable(activePartyroomDto);
     }

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
@@ -273,7 +273,15 @@ public class PartyroomAccessCommandService {
         // enterByHost를 거치지 않고 tryEnter가 처리하므로 이중 exit 없음.
         autoExitPriorActiveRoomIfDifferent(hostId, partyroom.getPartyroomId());
         CrewData crew = CrewData.create(partyroom.getPartyroomId(), hostId, GradeType.HOST, null, LocalDateTime.now(clock));
-        aggregatePort.saveCrew(crew);
+        try {
+            aggregatePort.saveCrew(crew);
+        } catch (DataIntegrityViolationException e) {
+            // #351 auto-exit statement 와 본 INSERT 사이의 밀리초 창에 같은 유저의 타 기기
+            // tryEnter 가 active_user_id 슬롯을 선점하면 uk_crew_active_user 위반. 정합성은
+            // 무해(방 생성 포함 outer tx 전체 롤백)하므로 미처리 500 대신 ensureCrewActive 와
+            // 동일하게 CRW-005 CONFLICT 로 매핑해 재시도를 유도한다. 그 외 위반은 원예외 유지.
+            throw asConcurrentEntryOrRethrow(e);
+        }
     }
 
     /**

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
@@ -149,7 +149,16 @@ public class PartyroomAccessCommandService {
         PartyroomId pid = partyroom.getPartyroomId();
         LocalDateTime now = LocalDateTime.now(clock);
 
-        int activated = aggregatePort.activateCrew(pid, userId, now);
+        int activated;
+        try {
+            activated = aggregatePort.activateCrew(pid, userId, now);
+        } catch (DataIntegrityViolationException e) {
+            // #349 activateCrew UPDATE(is_active false→true)가 위반할 수 있는 유일한 유니크는
+            // uk_crew_active_user 다 = 동시에 다른 방 입장이 이 유저를 먼저 active 로 선점(버스트 패자).
+            // 조용한 다중 활성 대신 CONFLICT 로 실패 → outer tx 롤백 → 활성 방은 정확히 1개 유지.
+            // (PR2 의 유저 단위 락이 들어오면 애초에 이 경쟁 자체가 사라져 이 경로는 사문화된다.)
+            throw asConcurrentEntryOrRethrow(e);
+        }
         if (activated == 1) {
             CrewData crew = aggregatePort.findCrew(pid, userId).orElseThrow();
             crew.updateCountryCode(countryCode);
@@ -162,7 +171,12 @@ public class PartyroomAccessCommandService {
                 CrewData newCrew = CrewData.create(pid, userId, GradeType.LISTENER, countryCode, now);
                 return new CrewActivationResult(aggregatePort.saveCrew(newCrew), true, false);
             } catch (DataIntegrityViolationException e) {
-                // INSERT race 패배 — outer tx가 rollback-only 상태. winner row 조회는 별 트랜잭션에서.
+                // #349 INSERT 가 uk_crew_active_user 위반이면 다른 방 동시 입장 패자 → CONFLICT.
+                if (isActiveUserConstraint(e)) {
+                    throw ExceptionCreator.create(CrewException.CONCURRENT_ACTIVE_ROOM);
+                }
+                // uk_crew_partyroom_user 위반 = 같은 방 동시 INSERT 패배 — outer tx가 rollback-only 상태.
+                // winner row 조회는 별 트랜잭션에서.
                 log.info("[ensureCrewActive] CONCURRENT_INSERT_LOSER - userId={}, partyroomId={}",
                         userId, pid.getId());
                 CrewData winner = findCrewInNewTransaction(pid, userId);
@@ -174,6 +188,29 @@ public class PartyroomAccessCommandService {
         CrewData crew = existing.get();
         crew.updateCountryCode(countryCode);
         return new CrewActivationResult(aggregatePort.saveCrew(crew), false, false);
+    }
+
+    /**
+     * #349 "유저당 활성 방 1개" DB 불변식(uk_crew_active_user)을 강제하는 UNIQUE 이름.
+     * MySQL 무결성 위반 메시지("Duplicate entry '...' for key 'CREW.uk_crew_active_user'")로 식별한다.
+     */
+    private static final String ACTIVE_USER_UNIQUE_CONSTRAINT = "uk_crew_active_user";
+
+    /**
+     * activateCrew UPDATE 가 던진 무결성 위반이 uk_crew_active_user 면 동시 입장 경쟁 패자로 간주해
+     * CONFLICT 도메인 예외로 매핑, 아니면(예상 밖 무결성 위반) 원 예외를 그대로 surface 한다.
+     */
+    private RuntimeException asConcurrentEntryOrRethrow(DataIntegrityViolationException e) {
+        if (isActiveUserConstraint(e)) {
+            return ExceptionCreator.create(CrewException.CONCURRENT_ACTIVE_ROOM);
+        }
+        return e;
+    }
+
+    private boolean isActiveUserConstraint(DataIntegrityViolationException e) {
+        Throwable root = e.getMostSpecificCause();
+        String msg = (root == null) ? null : root.getMessage();
+        return msg != null && msg.contains(ACTIVE_USER_UNIQUE_CONSTRAINT);
     }
 
     /**

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/exception/CrewException.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/exception/CrewException.java
@@ -9,7 +9,10 @@ public enum CrewException implements DomainException {
     NOT_FOUND_ACTIVE_ROOM("CRW-001", "참여 중인 파티룸을 찾을 수 없습니다", ErrorType.NOT_FOUND),
     INVALID_ACTIVE_ROOM("CRW-002", "유효하지 않은 파티룸 참여 상태입니다", ErrorType.CONFLICT),
     NOT_FOUND_ROOM("CRW-003", "파티룸의 크루가 아닙니다", ErrorType.NOT_FOUND),
-    PROFILE_REQUIRED("CRW-004", "프로필 등록이 완료되어야 파티룸에 참여할 수 있습니다", ErrorType.FORBIDDEN);
+    PROFILE_REQUIRED("CRW-004", "프로필 등록이 완료되어야 파티룸에 참여할 수 있습니다", ErrorType.FORBIDDEN),
+    // #349 동시 입장 경쟁 패자: 다른 방 입장이 이 유저를 먼저 active 로 만들어(uk_crew_active_user)
+    // 본 입장이 거부됨. "유저당 활성 방 1개" DB 불변식이 다중 활성을 조용히 허용하던 자리를 대체한다.
+    CONCURRENT_ACTIVE_ROOM("CRW-005", "다른 파티룸 입장이 처리 중입니다. 잠시 후 다시 시도해 주세요", ErrorType.CONFLICT);
 
     private final String errorCode;
     private final String message;

--- a/app/src/main/resources/db/migration/V38__enforce_single_active_crew_per_user.sql
+++ b/app/src/main/resources/db/migration/V38__enforce_single_active_crew_per_user.sql
@@ -1,0 +1,36 @@
+-- Issue #349: "유저당 활성 파티룸 1개" 불변식을 DB 차원에서 강제한다.
+--
+-- 배경: 그동안 이 불변식은 앱 코드(PartyroomAccessCommandService.autoExitPriorActiveRoomIfDifferent)의
+-- best-effort 정리로만 유지되었고, DB 제약은 (partyroom_id, user_id) 유니크뿐이라 한 유저가 여러 방에서
+-- is_active=1 을 갖는 것을 막지 못했다. 클라이언트의 재연결 핸들러 누수로 다수의 tryEnter 가 동시 발사되면
+-- (스냅샷 격리로 서로의 미커밋 활성 crew 를 못 봐) auto-exit 이 모두 실패 → 유저당 활성 crew 다중 생성 →
+-- getActivePartyroomByUserId 의 fetchOne 이 NonUniqueResultException 을 던져 입장 전면 불가(wedge).
+--
+-- 조치:
+--   1) 기존 중복 활성 crew 를 유저별 1개(entered_at 최신, tie 시 crew_id 최대)만 남기고 collapse.
+--   2) is_active 일 때만 user_id, 아니면 NULL 인 STORED 생성컬럼 + 유니크 → 두 번째 활성화를 DB 가 물리 거부.
+--      (유니크 인덱스에서 NULL 은 서로 중복 허용되므로 비활성 crew 행은 유저당 무제한 유지 가능)
+
+-- ── 1. 기존 중복 활성 collapse (유니크 추가 전 선행 필수) ─────────────────────────────
+-- ROW_NUMBER 로 유저별 최신 활성 1개(rn=1)만 남기고 나머지(rn>1) 를 비활성화.
+-- 정렬: entered_at DESC, crew_id DESC → 마이크로초 동률에도 정확히 1개만 keeper 로 결정(불변식 위반 없음).
+UPDATE crew c
+JOIN (
+    SELECT crew_id,
+           ROW_NUMBER() OVER (
+               PARTITION BY user_id
+               ORDER BY entered_at DESC, crew_id DESC
+           ) AS rn
+    FROM crew
+    WHERE is_active = 1
+) ranked ON ranked.crew_id = c.crew_id
+SET c.is_active      = 0,
+    c.exited_at      = NOW(6),
+    c.pending_exit_at = NULL
+WHERE ranked.rn > 1;
+
+-- ── 2. 생성컬럼 + 유저당 활성 유니크 (단일 ALTER = 테이블 리빌드 1회) ──────────────────
+ALTER TABLE crew
+    ADD COLUMN active_user_id BIGINT
+        GENERATED ALWAYS AS (IF(is_active, user_id, NULL)) STORED,
+    ADD CONSTRAINT uk_crew_active_user UNIQUE (active_user_id);

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/CrewRepositoryAtomicToggleIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/CrewRepositoryAtomicToggleIT.java
@@ -2,6 +2,8 @@ package com.pfplaybackend.api.party.adapter.out.persistence;
 
 import com.pfplaybackend.api.common.AbstractIntegrationTest;
 import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.application.dto.partyroom.ActivePartyroomDto;
+import com.pfplaybackend.api.party.application.port.out.PartyroomQueryPort;
 import com.pfplaybackend.api.party.domain.entity.data.CrewData;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
 import com.pfplaybackend.api.party.domain.value.CountryCode;
@@ -9,17 +11,20 @@ import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Transactional
 class CrewRepositoryAtomicToggleIT extends AbstractIntegrationTest {
 
     @Autowired private CrewRepository crewRepository;
+    @Autowired private PartyroomQueryPort partyroomQueryPort;
 
     private CrewData seedActiveCrew(long roomId, long uid) {
         CrewData crew = CrewData.create(new PartyroomId(roomId), new UserId(uid),
@@ -143,5 +148,64 @@ class CrewRepositoryAtomicToggleIT extends AbstractIntegrationTest {
         int affected = crewRepository.bulkDeactivateByPartyroomId(
                 new PartyroomId(99_999L), LocalDateTime.now());
         assertThat(affected).isZero();
+    }
+
+    // ── #349 uk_crew_active_user: "유저당 활성 방 1개" DB 불변식 ────────────
+
+    @Test
+    @DisplayName("#349 같은 유저를 두 방에 동시 active → uk_crew_active_user 위반")
+    void active_user_unique_rejects_second_active_room() {
+        long uid = 6001L;
+        seedActiveCrew(6001L, uid);   // 방 A 활성
+
+        // 다른 방 B 에 같은 유저를 또 active INSERT → 생성컬럼 active_user_id 충돌
+        CrewData second = CrewData.create(new PartyroomId(6002L), new UserId(uid),
+                GradeType.LISTENER, CountryCode.of("KR"), LocalDateTime.now());
+        assertThatThrownBy(() -> crewRepository.saveAndFlush(second))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("#349 유저의 비활성 crew 는 여러 방에 공존 가능 (active_user_id NULL 중복 허용)")
+    void inactive_crews_coexist_across_rooms() {
+        long uid = 6010L;
+        seedInactiveCrew(6011L, uid);
+        seedInactiveCrew(6012L, uid);   // 위반 없이 둘 다 저장돼야 함
+
+        assertThat(crewRepository.findByPartyroomIdAndUserId(new PartyroomId(6011L), new UserId(uid))).isPresent();
+        assertThat(crewRepository.findByPartyroomIdAndUserId(new PartyroomId(6012L), new UserId(uid))).isPresent();
+    }
+
+    @Test
+    @DisplayName("#349 기존 방 비활성화 후 다른 방 활성화는 성공 (collapse 후 재입장 경로)")
+    void reactivate_in_other_room_after_deactivate_succeeds() {
+        long uid = 6020L;
+        CrewData a = seedActiveCrew(6021L, uid);   // 방 A 활성
+        crewRepository.deactivateCrew(a.getPartyroomId(), a.getUserId(), LocalDateTime.now()); // A 비활성 → active_user_id=NULL
+
+        CrewData b = CrewData.create(new PartyroomId(6022L), new UserId(uid),
+                GradeType.LISTENER, CountryCode.of("KR"), LocalDateTime.now());
+        CrewData savedB = crewRepository.saveAndFlush(b);
+
+        assertThat(savedB.isActive()).isTrue();
+    }
+
+    // ── #349 getActivePartyroomByUserId de-masking (LEFT JOIN + coalesce) ──────
+
+    @Test
+    @DisplayName("#349 하위행(playback/djqueue) 없이도 활성 crew 는 조회됨 (masking 제거) + boolean coalesce")
+    void active_room_resolved_even_without_playback_or_djqueue_rows() {
+        long roomId = 6030L;
+        long uid = 6030L;
+        seedActiveCrew(roomId, uid);   // CREW 만 존재 — PARTYROOM_PLAYBACK / DJ_QUEUE 행 없음
+
+        Optional<ActivePartyroomDto> result = partyroomQueryPort.getActivePartyroomByUserId(new UserId(uid));
+
+        // INNER JOIN 시절이면 하위행 부재로 빈 Optional(masking) → 이제는 crew 기준으로 해석돼 present.
+        assertThat(result).isPresent();
+        assertThat(result.get().id()).isEqualTo(roomId);
+        // coalesce(false) 방어 — NULL 언박싱 NPE 없이 결정적 기본값.
+        assertThat(result.get().playbackActivated()).isFalse();
+        assertThat(result.get().queueClosed()).isFalse();
     }
 }

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceEnterByHostConflictTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceEnterByHostConflictTest.java
@@ -1,0 +1,95 @@
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.exception.http.ConflictException;
+import com.pfplaybackend.api.party.application.port.out.PlaybackControlPort;
+import com.pfplaybackend.api.party.application.port.out.UserProfileQueryPort;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
+import com.pfplaybackend.api.party.domain.service.PartyroomAggregateService;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * #351 enterByHost 의 uk_crew_active_user 위반 매핑 회귀 잠금.
+ *
+ * <p>auto-exit statement 와 HOST crew INSERT 사이의 밀리초 창에 같은 유저의 타 기기 tryEnter 가
+ * active_user_id 슬롯을 선점하면 INSERT 가 유니크 위반을 맞는다. 이때 미처리 500 대신
+ * CRW-005 CONFLICT 로 매핑되어야 하고(재시도 유도), 그 외 무결성 위반은 원예외를 유지해야 한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class PartyroomAccessCommandServiceEnterByHostConflictTest {
+
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private PartyroomAggregatePort aggregatePort;
+    @Mock private PartyroomAggregateService partyroomAggregateService;
+    @Mock private PartyroomQueryService partyroomQueryService;
+    @Mock private PlaybackControlPort playbackControlPort;
+    @Mock private UserProfileQueryPort userProfileQueryPort;
+    @Mock private Clock clock;
+    @Mock private PlatformTransactionManager transactionManager;
+
+    @InjectMocks
+    private PartyroomAccessCommandService service;
+
+    private final UserId hostId = new UserId(1001L);
+    private PartyroomData partyroom;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(clock.instant()).thenReturn(Instant.parse("2025-01-01T00:00:00Z"));
+        lenient().when(clock.getZone()).thenReturn(ZoneId.of("Asia/Seoul"));
+        // 프로필 존재(assertHasProfile 통과) + 기존 활성 방 없음(auto-exit 미발동)
+        lenient().when(userProfileQueryPort.getUsersProfileSetting(List.of(hostId)))
+                .thenReturn(Map.of(hostId, mock(ProfileSettingDto.class)));
+        lenient().when(partyroomQueryService.getMyActivePartyroom(hostId)).thenReturn(Optional.empty());
+
+        partyroom = mock(PartyroomData.class);
+        lenient().when(partyroom.getPartyroomId()).thenReturn(new PartyroomId(77L));
+    }
+
+    @Test
+    @DisplayName("HOST crew INSERT 가 uk_crew_active_user 위반 → CRW-005 CONFLICT 매핑")
+    void active_user_constraint_maps_to_conflict() {
+        when(aggregatePort.saveCrew(any())).thenThrow(new DataIntegrityViolationException(
+                "could not execute statement; Duplicate entry '1001' for key 'crew.uk_crew_active_user'"));
+
+        assertThatThrownBy(() -> service.enterByHost(hostId, partyroom))
+                .isInstanceOf(ConflictException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "CRW-005");
+    }
+
+    @Test
+    @DisplayName("그 외 무결성 위반(uk_crew_partyroom_user 등) → 원예외 그대로 전파")
+    void other_constraint_rethrows_original() {
+        DataIntegrityViolationException original = new DataIntegrityViolationException(
+                "could not execute statement; Duplicate entry '77-1001' for key 'crew.uk_crew_partyroom_user'");
+        when(aggregatePort.saveCrew(any())).thenThrow(original);
+
+        assertThatThrownBy(() -> service.enterByHost(hostId, partyroom))
+                .isSameAs(original);
+    }
+}


### PR DESCRIPTION
## dev→stg 승격 (2건)

- **#350 (#349)**: crew 다중 활성방 wedge 근본 수정 — **V38 마이그레이션**(기존 중복 활성 collapse + `active_user_id` STORED 생성컬럼 + `uk_crew_active_user` 유니크), `getActivePartyroomByUserId` fetchFirst+LEFT JOIN de-masking, 동시 입장 패자 CRW-005(409) 매핑.
- **#353 (#351)**: `enterByHost` 유니크 위반도 CRW-005 매핑(미처리 500 제거).

## 전제/호환

- **web lockstep 충족**: stg web은 development 기반이라 재연결 핸들러 누수 수정(#470)·CRW-005 알럿(#474)이 이미 반영됨 → "구web+신백엔드 로비 바운스" 조합 없음.
- V38 collapse가 stg 잔존 중복 활성을 배포 시점에 정리. collapse가 남길 수 있는 DJ 고아는 기배포 reconcile cron(#308)이 자동 치유.
- dev 검증: `[deploy:dev] OK` ×2, web 사후 E2E success. 로컬 풀게이트(전체 IT·실데이터 V38·풀 e2e 21/21) 완료.

## 배포 후 확인 (stg DB)

```sql
select user_id, count(*) from crew where is_active=1 group by user_id having count(*)>1; -- 0행
select index_name from information_schema.statistics where table_schema=database() and table_name='crew' and index_name='uk_crew_active_user' limit 1; -- 존재
```
+ crew_count 보정 SQL(운영 수동, #351 검토 C항목) 실행 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
