### PR TITLE
feat(presence): liveness 스윕 — 신호 유실 고아 활성 crew(유령) 자가 치유 (#356)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/LivenessSweepQueryAdapter.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/out/external/LivenessSweepQueryAdapter.java
@@ -1,0 +1,41 @@
+package com.pfplaybackend.api.party.adapter.out.external;
+
+import com.pfplaybackend.api.party.application.port.out.LivenessSweepQueryPort;
+import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.entity.data.QCrewData;
+import com.pfplaybackend.api.user.domain.entity.data.QUserAccountData;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * #356 liveness 스윕 후보 조회 — crew × user_account(is_dummy) cross-BC read-only 조인.
+ *
+ * <p>{@code adapter.out.external} 은 party 모듈의 합법적 cross-BC 통합 경계
+ * (CrossContextDependencyTest 예외 패키지). 조인 선례: virtualcrew
+ * {@code ActiveDjSnapshotQueryRepositoryImpl} 의 crew × user_account.
+ */
+@Component
+@RequiredArgsConstructor
+public class LivenessSweepQueryAdapter implements LivenessSweepQueryPort {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CrewData> findLivenessSweepCandidates(LocalDateTime enteredBefore) {
+        QCrewData qCrewData = QCrewData.crewData;
+        QUserAccountData qUserAccount = QUserAccountData.userAccountData;
+
+        return queryFactory
+                .selectFrom(qCrewData)
+                .join(qUserAccount).on(qUserAccount.userId.uid.eq(qCrewData.userId.uid))
+                .where(qCrewData.isActive.isTrue()
+                        .and(qCrewData.pendingExitAt.isNull())
+                        .and(qUserAccount.isDummy.isFalse())
+                        .and(qCrewData.enteredAt.lt(enteredBefore)))
+                .fetch();
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/application/port/out/LivenessSweepQueryPort.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/port/out/LivenessSweepQueryPort.java
@@ -1,0 +1,24 @@
+package com.pfplaybackend.api.party.application.port.out;
+
+import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * #356 presence liveness 스윕 후보 조회 포트.
+ *
+ * <p>봇 판별(user_account.is_dummy)이 필요해 cross-BC 조인을 수반하므로, party 모듈의
+ * 합법적 통합 경계인 {@code adapter.out.external} 어댑터로 분리한다
+ * (CrossContextDependencyTest — party 는 user.domain 직접 참조 금지).
+ */
+public interface LivenessSweepQueryPort {
+
+    /**
+     * 후보: {@code is_active=1 AND pending_exit_at IS NULL} 인 crew 중
+     * <b>봇 제외</b>(is_dummy=false — 봇은 WS 세션이 없어 미제외 시 전 봇이 스윕 대상)
+     * + <b>최근 입장 유예</b>({@code entered_at < enteredBefore} — WS 연결 수립 전 오탐 방지).
+     * 세션 존재 여부(liveness) 판정은 호출자 몫.
+     */
+    List<CrewData> findLivenessSweepCandidates(LocalDateTime enteredBefore);
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomPresenceService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomPresenceService.java
@@ -2,6 +2,7 @@ package com.pfplaybackend.api.party.application.service;
 
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.operations.application.service.SystemConfigCache;
+import com.pfplaybackend.api.party.application.port.out.LivenessSweepQueryPort;
 import com.pfplaybackend.api.party.application.service.lock.DistributedLockExecutor;
 import com.pfplaybackend.api.party.domain.entity.data.CrewData;
 import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
@@ -11,6 +12,7 @@ import com.pfplaybackend.api.party.domain.value.PartyroomId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.user.SimpUserRegistry;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,6 +57,12 @@ public class PartyroomPresenceService {
     private final RedisTemplate<String, Object> redisTemplate;
     private final DistributedLockExecutor distributedLockExecutor;
     private final Clock clock;
+    // #356 in-process 실연결 진실원천(STOMP Principal name = uid 문자열). Redis 기반
+    // UserSessionRegistry 는 disconnect 이벤트 유실 시 스테일 세션이 남아 "살아있음"으로
+    // 거짓말할 수 있으므로 liveness 판정에는 쓰지 않는다.
+    private final SimpUserRegistry simpUserRegistry;
+    // #356 후보 조회는 봇 판별(user_account.is_dummy) cross-BC 조인이 필요해 external 어댑터 포트로 분리.
+    private final LivenessSweepQueryPort livenessSweepQueryPort;
 
     /**
      * ONLINE → PENDING_EXIT. Idempotent: re-firing while already pending is a no-op
@@ -178,6 +186,58 @@ public class PartyroomPresenceService {
      * which re-checks DB and returns early if the row no longer qualifies. The
      * per-crew distributed lock prevents simultaneous publish of the EXIT event.
      */
+    /**
+     * #356 presence liveness 스윕 — "떠남 신호가 유실된" 고아 활성 crew(유령) 자가 치유.
+     *
+     * <p>{@code is_active=1 AND pending_exit_at IS NULL} 인 crew 는 disconnect 이벤트가 유실되면
+     * (WS silent death, markPending 중 Redis 실패 롤백, 배포/크래시 시점 유실 등) grace/Redis/
+     * reconcile 어디에도 잡히지 않아 본인이 재입장할 때까지 불멸이다 — #241 이 prod 에서 실증됨
+     * (실유저 2명이 수일간 유령 잔존). 이 크론이 그 사각을 메운다.
+     *
+     * <p>판정·조치 설계:
+     * <ul>
+     *   <li><b>판정 = {@link SimpUserRegistry}</b>(in-process 실연결). 단일 인스턴스 전제 —
+     *       스케일아웃 시 각 인스턴스가 자기 세션만 아는 문제가 생기므로 그때는 인스턴스별
+     *       스윕 or Redis 세션 union 으로 승격 필요(#356 참조).</li>
+     *   <li><b>조치 = {@link #markPending}(즉시 exit 아님)</b> — 기존 상태머신 재사용. 만에 하나
+     *       오탐이어도 grace 안 reconnect 의 clearPending 이 취소하고, 진짜 유령이면 grace 만료로
+     *       정상 exit(DJ큐 정리 + EXIT 이벤트) 된다.</li>
+     *   <li><b>오탐 가드</b>: 후보 쿼리가 봇(is_dummy)과 최근 입장(연결 수립 전) 을 제외하고,
+     *       {@code initialDelay} 가 부팅 직후 재연결 창(레지스트리 재수화)을 건너뛴다.</li>
+     * </ul>
+     *
+     * <p>{@code @Transactional}: markPending 은 self-invocation 이라 프록시를 타지 않으므로
+     * 스윕 자체를 트랜잭션 경계로 삼아 내부 @Modifying UPDATE 가 tx 안에서 실행되게 한다.
+     */
+    @Scheduled(fixedDelay = LIVENESS_SWEEP_INTERVAL_MS, initialDelay = LIVENESS_SWEEP_BOOT_DELAY_MS)
+    @Transactional
+    public void sweepOrphanActiveCrews() {
+        LocalDateTime enteredBefore = LocalDateTime.now(clock).minusSeconds(LIVENESS_RECENT_ENTER_GRACE_SECONDS);
+        List<CrewData> candidates = livenessSweepQueryPort.findLivenessSweepCandidates(enteredBefore);
+        if (candidates.isEmpty()) return;
+
+        int swept = 0;
+        for (CrewData crew : candidates) {
+            // STOMP Principal name = String.valueOf(uid) — ConnectionEventListener 의 register 와 동일 표현.
+            if (simpUserRegistry.getUser(crew.getUserId().toString()) != null) {
+                continue; // 살아있는 세션 존재 — 정상 접속자
+            }
+            markPending(crew.getPartyroomId(), crew.getUserId());
+            swept++;
+        }
+        if (swept > 0) {
+            log.info("[presence] liveness sweep - {} orphan-active crew(s) → PENDING_EXIT (candidates={})",
+                    swept, candidates.size());
+        }
+    }
+
+    /** 스윕 주기. 유령은 수일 단위로 잔존하던 클래스라 저빈도(5분)로 충분 — DB 부하 최소화. */
+    private static final long LIVENESS_SWEEP_INTERVAL_MS = 300_000;
+    /** 부팅 직후 재연결 창 유예 — in-process 레지스트리가 비어 전원 유령으로 보이는 오탐 방지. */
+    private static final long LIVENESS_SWEEP_BOOT_DELAY_MS = 300_000;
+    /** 입장 직후 WS 연결 수립 전 오탐 방지용 최근-입장 제외 창. */
+    private static final long LIVENESS_RECENT_ENTER_GRACE_SECONDS = 600;
+
     @Scheduled(fixedDelay = 60_000)
     public void reconcileStalePending() {
         long maxGrace = Math.max(systemConfigCache.getDjGraceSeconds(),

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/LivenessSweepCandidatesIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/out/persistence/LivenessSweepCandidatesIT.java
@@ -1,0 +1,91 @@
+package com.pfplaybackend.api.party.adapter.out.persistence;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.domain.entity.data.CrewData;
+import com.pfplaybackend.api.party.domain.enums.GradeType;
+import com.pfplaybackend.api.party.application.port.out.LivenessSweepQueryPort;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #356 liveness 스윕 후보 쿼리 회귀 잠금 — 필터 4종(활성·미pending·봇제외·최근입장 유예)을
+ * 실제 MySQL(crew × user_account 조인)로 검증한다. 세션 판정(SimpUserRegistry)은 서비스
+ * 단위테스트가 커버.
+ */
+@Transactional
+class LivenessSweepCandidatesIT extends AbstractIntegrationTest {
+
+    @Autowired private CrewRepository crewRepository;
+    @Autowired private UserAccountRepository userAccountRepository;
+    @Autowired private LivenessSweepQueryPort livenessSweepQueryPort;
+
+    private static final LocalDateTime OLD = LocalDateTime.of(2026, 7, 1, 12, 0);
+
+    private UserId seedHuman(long uid) {
+        userAccountRepository.save(UserAccountData.createForLocalWithMandatoryChange(
+                new UserId(uid), "sweep-" + uid + "@it.local", "h"));
+        return new UserId(uid);
+    }
+
+    private UserId seedBot(long uid) {
+        UserAccountData bot = UserAccountData.createForLocalWithMandatoryChange(
+                new UserId(uid), "sweep-bot-" + uid + "@it.local", "h");
+        bot.markAsDummy();
+        userAccountRepository.save(bot);
+        return new UserId(uid);
+    }
+
+    private CrewData seedCrew(long roomId, UserId userId, LocalDateTime enteredAt) {
+        return crewRepository.saveAndFlush(
+                CrewData.create(new PartyroomId(roomId), userId, GradeType.LISTENER, null, enteredAt));
+    }
+
+    @Test
+    @DisplayName("#356 활성+미pending+비봇+오래된 입장만 후보 — 봇/pending/비활성/최근입장 제외")
+    void candidates_filtered_by_liveness_preconditions() {
+        LocalDateTime threshold = LocalDateTime.of(2026, 7, 21, 12, 0);
+
+        // A: 후보 — 사람, 활성, pending 없음, 오래된 입장
+        UserId ghost = seedHuman(9101L);
+        CrewData ghostCrew = seedCrew(9101L, ghost, OLD);
+
+        // B: 봇 — 제외 (봇은 WS 세션이 없어 미제외 시 전 봇이 스윕 대상)
+        UserId bot = seedBot(9102L);
+        seedCrew(9102L, bot, OLD);
+
+        // C: pending 진행 중 — 제외 (기존 grace/reconcile 관할)
+        UserId pendingUser = seedHuman(9103L);
+        CrewData pendingCrew = seedCrew(9103L, pendingUser, OLD);
+        pendingCrew.markPending(OLD.plusDays(1));
+        crewRepository.saveAndFlush(pendingCrew);
+
+        // D: 최근 입장 — 제외 (WS 연결 수립 전 오탐 방지)
+        UserId recent = seedHuman(9104L);
+        seedCrew(9104L, recent, threshold.plusMinutes(1));
+
+        // E: 비활성 — 제외
+        UserId exited = seedHuman(9105L);
+        CrewData exitedCrew = seedCrew(9105L, exited, OLD);
+        exitedCrew.deactivatePresence(OLD.plusHours(1));
+        crewRepository.saveAndFlush(exitedCrew);
+
+        List<CrewData> candidates = livenessSweepQueryPort.findLivenessSweepCandidates(threshold);
+
+        assertThat(candidates)
+                .extracting(c -> c.getUserId().getUid())
+                .contains(ghost.getUid())
+                .doesNotContain(bot.getUid(), pendingUser.getUid(), recent.getUid(), exited.getUid());
+        assertThat(candidates).extracting(CrewData::getId).contains(ghostCrew.getId());
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomPresenceServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomPresenceServiceTest.java
@@ -49,6 +49,8 @@ class PartyroomPresenceServiceTest {
     @Mock RedisTemplate<String, Object> redisTemplate;
     @Mock ValueOperations<String, Object> valueOps;
     @Mock DistributedLockExecutor distributedLockExecutor;
+    @Mock org.springframework.messaging.simp.user.SimpUserRegistry simpUserRegistry;
+    @Mock com.pfplaybackend.api.party.application.port.out.LivenessSweepQueryPort livenessSweepQueryPort;
 
     PartyroomPresenceService service;
     Clock clock;
@@ -57,7 +59,8 @@ class PartyroomPresenceServiceTest {
     void setUp() {
         clock = Clock.fixed(Instant.parse("2026-05-09T12:00:00Z"), ZoneId.of("UTC"));
         service = new PartyroomPresenceService(aggregatePort, partyroomAccessCommandService,
-                systemConfigCache, redisTemplate, distributedLockExecutor, clock);
+                systemConfigCache, redisTemplate, distributedLockExecutor, clock, simpUserRegistry,
+                livenessSweepQueryPort);
         lenient().when(redisTemplate.opsForValue()).thenReturn(valueOps);
     }
 
@@ -296,5 +299,64 @@ class PartyroomPresenceServiceTest {
         lenient().when(playback.isActivated()).thenReturn(currentDj);
         lenient().when(playback.isCurrentDj(any(CrewId.class))).thenReturn(currentDj);
         return playback;
+    }
+
+    // ── #356 liveness 스윕: 신호 유실 고아 활성 crew(유령) → markPending ──────────
+
+    @Test
+    @DisplayName("#356 세션 없는 고아 활성 crew → markPending (grace 시작)")
+    void sweep_marks_orphan_active_crew_pending() {
+        CrewData ghost = activeCrew(false);
+        when(livenessSweepQueryPort.findLivenessSweepCandidates(any(LocalDateTime.class)))
+                .thenReturn(java.util.List.of(ghost));
+        when(simpUserRegistry.getUser(userId().toString())).thenReturn(null); // 살아있는 세션 없음
+        when(aggregatePort.findCrew(roomId(), userId())).thenReturn(Optional.of(ghost));
+        when(aggregatePort.markCrewPending(eq(roomId()), eq(userId()), any(LocalDateTime.class)))
+                .thenReturn(1);
+        when(systemConfigCache.getListenerGraceSeconds()).thenReturn(10);
+
+        service.sweepOrphanActiveCrews();
+
+        verify(aggregatePort).markCrewPending(eq(roomId()), eq(userId()), any(LocalDateTime.class));
+        verify(valueOps).set(anyString(), any(), eq(10L), eq(TimeUnit.SECONDS));
+    }
+
+    @Test
+    @DisplayName("#356 살아있는 세션이 있는 crew 는 스윕 대상 아님")
+    void sweep_skips_crew_with_live_session() {
+        CrewData live = activeCrew(false);
+        when(livenessSweepQueryPort.findLivenessSweepCandidates(any(LocalDateTime.class)))
+                .thenReturn(java.util.List.of(live));
+        when(simpUserRegistry.getUser(userId().toString()))
+                .thenReturn(org.mockito.Mockito.mock(org.springframework.messaging.simp.user.SimpUser.class));
+
+        service.sweepOrphanActiveCrews();
+
+        verify(aggregatePort, never()).markCrewPending(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("#356 후보 없음 → no-op")
+    void sweep_noop_when_no_candidates() {
+        when(livenessSweepQueryPort.findLivenessSweepCandidates(any(LocalDateTime.class)))
+                .thenReturn(java.util.List.of());
+
+        service.sweepOrphanActiveCrews();
+
+        verify(aggregatePort, never()).markCrewPending(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("#356 최근 입장 유예: enteredBefore = now - 600s 로 후보를 조회한다")
+    void sweep_queries_with_recent_enter_grace_threshold() {
+        org.mockito.ArgumentCaptor<LocalDateTime> captor =
+                org.mockito.ArgumentCaptor.forClass(LocalDateTime.class);
+        when(livenessSweepQueryPort.findLivenessSweepCandidates(any(LocalDateTime.class)))
+                .thenReturn(java.util.List.of());
+
+        service.sweepOrphanActiveCrews();
+
+        verify(livenessSweepQueryPort).findLivenessSweepCandidates(captor.capture());
+        assertThat(captor.getValue()).isEqualTo(LocalDateTime.now(clock).minusSeconds(600));
     }
 }


### PR DESCRIPTION
## 배경 (#356 — #241 prod 실증)

떠남 신호(disconnect→markPending)가 유실된 crew(`is_active=1, pending_exit_at IS NULL`)는 grace/Redis/reconcile 어느 치유망에도 잡히지 않아 본인이 재입장할 때까지 **불멸 유령**이 된다. 2026-07-21 prod에서 실유저 2명이 이 상태로 수일간 잔존(크루 목록 유령 노출·crew_count 오염) — 상세 증거사슬은 #356.

## 변경

**5분 주기 presence liveness 스윕** (`PartyroomPresenceService.sweepOrphanActiveCrews`):
- 후보: `is_active=1 AND pending IS NULL` + **봇 제외**(`user_account.is_dummy` 조인 — 봇은 WS 세션이 없어 미제외 시 전 봇 대량퇴장 사고) + **최근입장 10분 유예**(연결 수립 전 오탐 방지)
- 판정: **`SimpUserRegistry`**(in-process 실연결, STOMP Principal=uid). Redis 세션 레지스트리는 이벤트 유실 시 스테일 엔트리로 "살아있음" 오판 가능해 배제. 단일 인스턴스 전제 — 스케일아웃 시 승격 경로는 코드 주석·#356에 기록
- 조치: **`markPending`(즉시 exit 아님)** — 오탐이어도 reconnect의 `clearPending`이 취소, 진짜 유령이면 grace 만료로 정상 exit(DJ큐 정리+EXIT 이벤트). 기존 상태머신 재사용으로 부작용 면적 최소
- 부팅 5분 `initialDelay`(재연결 창 유예) + `@Transactional`(markPending self-invocation의 `@Modifying` tx 요구 대응)

## 검증

- 단위 4케이스(유령→pending / 세션有 스킵 / 후보없음 / threshold) + 기존 presence 테스트 GREEN
- 후보쿼리 필터 IT(봇·pending·비활성·최근입장 제외, 실 MySQL crew×user_account) GREEN
- **전체 :app:integrationTest BUILD SUCCESSFUL(8m15s)**
- 로컬 풀부팅 + **풀 web E2E**: 스윕이 잔존 유령 1건만 정확히 정리하고 접속 중 유저 전원 스킵(candidates=1 로그 실증). e2e 실패는 전량 pytube 간헐/미기동(운영 실수)으로 판정 — 실패 3종 warm 재실행 10/10 green
- ⚠️ 첫 e2e run의 8건 실패는 스택 재기동 시 pytube 컨테이너 누락(op error)이 원인 — 스윕 무관

## 운영 노트

- 배포되면 **prod 잔존 유령 2건(crew 587·579)도 첫 틱(부팅+5분)에 자가 치유**됨 — 수동 SQL은 선택사항이 됨(단 EXIT 이벤트 발행되는 스윕 치유가 counter 정합에도 더 깔끔).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
