### PR TITLE
fix(admin): 파티룸 크루 수 라이브 COUNT 전환 — crew_count 드리프트 불일치 제거 (#358)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/administration/adapter/out/persistence/impl/AdminPartyroomQueryRepositoryImpl.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/adapter/out/persistence/impl/AdminPartyroomQueryRepositoryImpl.java
@@ -93,6 +93,17 @@ public class AdminPartyroomQueryRepositoryImpl implements AdminPartyroomQueryRep
                 .from(dj)
                 .where(dj.partyroomId.id.eq(p.id));
 
+        // #358 크루 수 = 라이브 진실(crew.is_active=1) 상관 서브쿼리. partyroom.crew_count
+        // 컬럼은 ENTER/EXIT 이벤트 구동 카운터라 이벤트 없는 상태 변경(V38 collapse, 운영 수동
+        // SQL 등)에서 드리프트해 상세의 라이브 크루 목록과 불일치했다(목록 3 ↔ 상세 크루 없음).
+        // 고객 로비 목록(PartyroomRepositoryImpl.getCrewDataByPartyroomId)과 동일한 방식.
+        QCrewData liveCrew = new QCrewData("liveCrew");
+        JPQLQuery<Long> activeCrewCountSubquery = JPAExpressions
+                .select(liveCrew.count())
+                .from(liveCrew)
+                .where(liveCrew.partyroomId.id.eq(p.id)
+                        .and(liveCrew.isActive.isTrue()));
+
         // 봇 DJ 카운트: DJ → CrewData(is_active=true 단언, stale DJ 방어) → user_account(is_dummy=true).
         // DjData 에는 userId 가 없어 crew 를 경유한다.
         // 조인키 + is_active 단언은 ActiveDjSnapshotQueryRepositoryImpl 의 canonical 패턴을 그대로 미러링한다.
@@ -115,7 +126,7 @@ public class AdminPartyroomQueryRepositoryImpl implements AdminPartyroomQueryRep
                         p.stageType,
                         ua.userId.uid,
                         profile.bio.nickname,
-                        p.activeCrewCount,
+                        activeCrewCountSubquery,
                         djCountSubquery,
                         pb.isActivated,
                         p.status,
@@ -134,7 +145,7 @@ public class AdminPartyroomQueryRepositoryImpl implements AdminPartyroomQueryRep
                 .leftJoin(cfg).on(cfg.partyroomId.eq(p.id))
                 .where(where);
 
-        applySort(query, pageable.getSort(), p, nicknameLikeExpr);
+        applySort(query, pageable.getSort(), p, nicknameLikeExpr, activeCrewCountSubquery);
 
         Long total = queryFactory
                 .select(p.count())
@@ -151,7 +162,7 @@ public class AdminPartyroomQueryRepositoryImpl implements AdminPartyroomQueryRep
                 .fetch();
 
         List<AdminPartyroomListRow> content = tuples.stream()
-                .map(t -> mapRow(t, p, ua, profile, pb, djCountSubquery, cfg, botDjCountSubquery))
+                .map(t -> mapRow(t, p, ua, profile, pb, activeCrewCountSubquery, djCountSubquery, cfg, botDjCountSubquery))
                 .toList();
 
         return new PageImpl<>(content, pageable, total == null ? 0L : total);
@@ -162,12 +173,13 @@ public class AdminPartyroomQueryRepositoryImpl implements AdminPartyroomQueryRep
                                          QUserAccountData ua,
                                          QProfileData profile,
                                          QPartyroomPlaybackData pb,
+                                         JPQLQuery<Long> activeCrewCountSubquery,
                                          JPQLQuery<Long> djCountSubquery,
                                          QPartyroomVirtualCrewConfigData cfg,
                                          JPQLQuery<Long> botDjCountSubquery) {
         Nickname nickname = t.get(profile.bio.nickname);
         Long djCount = t.get(djCountSubquery);
-        Integer crewCount = t.get(p.activeCrewCount);
+        Long liveCrewCount = t.get(activeCrewCountSubquery); // #358 라이브 COUNT (컬럼 드리프트 면역)
         // 가상 DJ 요약: config row 가 없으면 left join 으로 cfg.status 가 null → virtualCrew=null.
         VirtualCrewStatus vcrewStatus = t.get(cfg.status);
         VirtualCrewSummary virtualCrew = null;
@@ -185,7 +197,7 @@ public class AdminPartyroomQueryRepositoryImpl implements AdminPartyroomQueryRep
                 t.get(p.stageType),
                 t.get(ua.userId.uid),
                 nickname == null ? null : nickname.value(),
-                crewCount == null ? 0 : crewCount,
+                liveCrewCount == null ? 0 : liveCrewCount.intValue(),
                 djCount == null ? 0L : djCount,
                 t.get(pb.isActivated),
                 t.get(p.status),
@@ -233,16 +245,24 @@ public class AdminPartyroomQueryRepositoryImpl implements AdminPartyroomQueryRep
      * caller (rather than silently ignore the requested order).
      */
     private void applySort(JPAQuery<?> query, Sort sort,
-                           QPartyroomData p, StringExpression nicknameExpr) {
+                           QPartyroomData p, StringExpression nicknameExpr,
+                           JPQLQuery<Long> activeCrewCountSubquery) {
         if (sort.isUnsorted()) {
             query.orderBy(p.createdAt.desc());
             return;
         }
         for (Sort.Order order : sort) {
+            // #358 crewCount 정렬도 표시값과 동일한 라이브 서브쿼리 기준 (컬럼 드리프트 면역)
+            if ("crewCount".equals(order.getProperty())) {
+                query.orderBy(new com.querydsl.core.types.OrderSpecifier<>(
+                        order.isAscending() ? com.querydsl.core.types.Order.ASC
+                                            : com.querydsl.core.types.Order.DESC,
+                        activeCrewCountSubquery));
+                continue;
+            }
             ComparableExpressionBase<?> path = switch (order.getProperty()) {
                 case "createdAt"      -> p.createdAt;
                 case "lastActivityAt" -> p.lastActivityAt;
-                case "crewCount"      -> p.activeCrewCount;
                 case "title"          -> p.title;
                 case "hostNickname"   -> nicknameExpr;
                 default -> throw new IllegalArgumentException(

--- a/app/src/main/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomQueryService.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomQueryService.java
@@ -166,7 +166,8 @@ public class AdminPartyroomQueryService {
                 hostUserId == null ? null : hostUserId.getUid(),
                 extractNickname(hostMember),
                 hostAccount == null ? null : hostAccount.getEmail(),
-                partyroom.getActiveCrewCount(),
+                // #358 크루 수 = 라이브 목록과 동일 소스(activeCrews) — crew_count 컬럼 드리프트 면역
+                activeCrews.size(),
                 partyroom.getLastActivityAt(),
                 partyroom.getStageType(),
                 playbackLimitMinutes,

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/persistence/impl/AdminPartyroomQueryRepositoryImplIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/persistence/impl/AdminPartyroomQueryRepositoryImplIT.java
@@ -316,6 +316,32 @@ class AdminPartyroomQueryRepositoryImplIT extends AbstractIntegrationTest {
     }
 
     @Test
+    @DisplayName("#358 크루 수 = 라이브 COUNT — 드리프트된 crew_count 컬럼(3)이 아니라 실제 활성 crew(1)")
+    void crewCount_reads_live_count_not_drifted_column() {
+        PartyroomData room = seedRoom(aliceUid, "drift-room", PartyroomStatus.ACTIVE);
+        // 컬럼 드리프트 재현: 이벤트 없는 상태 변경(V38 collapse·운영 수동 SQL)이 남기는 상태.
+        org.springframework.test.util.ReflectionTestUtils.setField(room, "activeCrewCount", 3);
+        partyroomRepository.saveAndFlush(room);
+        // 실제 활성 crew 1 + 비활성 1
+        CrewData active = crewRepository.saveAndFlush(CrewData.create(
+                new PartyroomId(room.getId()), new UserId(bobUid), GradeType.LISTENER, null));
+        CrewData exited = crewRepository.saveAndFlush(CrewData.create(
+                new PartyroomId(room.getId()), new UserId(aliceUid), GradeType.LISTENER, null));
+        exited.deactivatePresence();
+        crewRepository.saveAndFlush(exited);
+
+        Page<AdminPartyroomListRow> result = queryRepository.findAdminList(
+                new AdminPartyroomListFilter(null, null, null, null, null),
+                PageRequest.of(0, 10)
+        );
+
+        AdminPartyroomListRow row = result.getContent().stream()
+                .filter(r -> r.partyroomId().equals(room.getId()))
+                .findFirst().orElseThrow();
+        assertThat(row.crewCount()).isEqualTo(1); // 컬럼(3) 무시, 라이브 활성 crew 만
+    }
+
+    @Test
     @DisplayName("페이징 — page 0 size 1 → 컨텐츠 1개, totalElements=2")
     void paging() {
         seedRoom(aliceUid, "room-1", PartyroomStatus.ACTIVE);

--- a/app/src/test/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomQueryServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/application/service/AdminPartyroomQueryServiceTest.java
@@ -194,7 +194,9 @@ class AdminPartyroomQueryServiceTest {
         assertThat(detail.hostUserAccountId()).isEqualTo(7L);
         assertThat(detail.hostEmail()).isEqualTo("host@example.com");
         assertThat(detail.hostNickname()).isEqualTo("hostNick");
-        assertThat(detail.crewCount()).isEqualTo(4);
+        // #358 상세 크루 수 = 라이브 목록(findActiveCrews)과 동일 소스 — 드리프트 가능한
+        // crew_count 컬럼(reflection 으로 4 세팅됨)이 아니라 activeCrews.size()=1 이어야 한다.
+        assertThat(detail.crewCount()).isEqualTo(1);
         // PR 14g §5: root-level introduction + playbackTimeLimit (minutes) 노출
         assertThat(detail.introduction()).isEqualTo("intro");
         assertThat(detail.playbackTimeLimit()).isEqualTo(5);


### PR DESCRIPTION
## 요약 (#358)

어드민 파티룸 목록의 크루 숫자와 상세의 크루 목록이 불일치(예: 목록 3 ↔ 상세 "크루 없음")하던 버그 수정 — 크루 수를 **라이브 진실**로 통일.

## 근본원인

크루 "숫자"(목록·상세 모두)가 `partyroom.crew_count` 컬럼을 읽음. 이 컬럼은 ENTER/EXIT **이벤트 구동 카운터**라 이벤트 없는 상태 변경(#349 V38 collapse, 운영 수동 SQL, 과거 버스트 중복 ENTER)에서 드리프트한다. 반면 상세의 크루 "목록"은 라이브 `is_active=1` 조회 → 숫자·목록 불일치. (고객 로비는 이미 라이브 서브쿼리라 무영향)

## 변경

- **목록**: `p.activeCrewCount` → 라이브 `COUNT(crew WHERE is_active=1)` 상관 서브쿼리(기존 djCountSubquery 스타일 미러). `crewCount` **정렬도 동일 서브쿼리** 기준 — 표시값과 정렬 기준 일치.
- **상세**: `partyroom.getActiveCrewCount()` → `activeCrews.size()` — 이미 조회한 라이브 목록 재사용(추가 쿼리 0).
- **회귀**: IT — 드리프트 컬럼(3) vs 라이브(활성1+비활성1) → **1** 반환 잠금. 단위 테스트 detail 단언을 라이브 기준으로 갱신.

`crew_count` 컬럼은 이로써 표시 경로 완전 비의존(레거시화). 잔존 드리프트 보정은 운영 SQL(C 항목) 별도.

## 검증

- 타깃: AdminPartyroomQueryServiceTest·AdminPartyroomQueryRepositoryImplIT GREEN
- **전체 `:app:test`(ArchUnit 포함) + 전체 `:app:integrationTest` GREEN**(종료코드 실측). 최초 combined 런의 1회 실패는 자정 시간대 기지 플레이크 정합(Carry saga 운영시간) — 단독 재실행 안정 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
