### PR TITLE
feat(admin): 전역 일별 입퇴장 분석 API — 대시보드 v1 백엔드 (#361)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/AdminAnalyticsController.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/AdminAnalyticsController.java
@@ -1,0 +1,35 @@
+package com.pfplaybackend.api.administration.adapter.in.web;
+
+import com.pfplaybackend.api.administration.adapter.in.web.payload.response.AdminAttendanceAnalyticsResponse;
+import com.pfplaybackend.api.administration.application.service.AdminGlobalAnalyticsQueryService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * #361 어드민 전역 분석 API — 대시보드 v1.
+ *
+ * <p>경로를 {@code /admin/partyrooms/**} 와 분리한 별도 리소스({@code /admin/analytics})로 둔다 —
+ * {@code /admin/partyrooms/{id}/...} 의 경로 변수와 충돌하지 않고, 향후 히트맵/Top룸 등
+ * 전역 분석 엔드포인트의 자연스러운 뿌리가 된다. 인증/인가는 어드민 SecurityFilterChain
+ * ({@code /api/v1/admin/**})이 담당 — sibling 컨트롤러들과 동일.
+ */
+@Tag(name = "Admin Global Analytics API", description = "대시보드 v1 — 전역 일별 입퇴장")
+@RestController
+@RequestMapping("/api/v1/admin/analytics")
+@RequiredArgsConstructor
+public class AdminAnalyticsController {
+
+    private final AdminGlobalAnalyticsQueryService service;
+
+    @GetMapping("/attendance")
+    public ResponseEntity<AdminAttendanceAnalyticsResponse> attendance(
+            @RequestParam(defaultValue = "7") int days,
+            @RequestParam(defaultValue = "true") boolean excludeBots) {
+        return ResponseEntity.ok(service.getAttendance(days, excludeBots));
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/payload/response/AdminAttendanceAnalyticsResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/adapter/in/web/payload/response/AdminAttendanceAnalyticsResponse.java
@@ -1,0 +1,33 @@
+package com.pfplaybackend.api.administration.adapter.in.web.payload.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * #361 어드민 대시보드 v1 — 전역 일별 입퇴장 분석 응답.
+ *
+ * <p>{@code exitRecordRate} = totalExited/totalEntered. 퇴장 이벤트는 유실될 수 있으므로
+ * (신호 유실 유령 — #356 계보) 1.0 미만이 정상이며, 급락은 이탈 품질/데이터 품질 신호다.
+ * 입장 0건이면 null.
+ */
+public record AdminAttendanceAnalyticsResponse(
+        int days,
+        boolean excludeBots,
+        Summary summary,
+        List<Daily> daily
+) {
+    public record Summary(
+            long totalEntered,
+            long totalExited,
+            long uniqueVisitors,
+            long activeRoomCount,
+            Double exitRecordRate
+    ) {}
+
+    public record Daily(
+            LocalDate date,
+            long entered,
+            long exited,
+            long uniqueVisitors
+    ) {}
+}

--- a/app/src/main/java/com/pfplaybackend/api/administration/adapter/out/persistence/AdminGlobalAnalyticsRepository.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/adapter/out/persistence/AdminGlobalAnalyticsRepository.java
@@ -1,0 +1,131 @@
+package com.pfplaybackend.api.administration.adapter.out.persistence;
+
+import com.pfplaybackend.api.administration.application.dto.DailyAttendanceBucket;
+import com.pfplaybackend.api.administration.application.dto.DailyUniqueVisitorsBucket;
+import com.pfplaybackend.api.administration.domain.entity.QUserActivityLogData;
+import com.pfplaybackend.api.administration.domain.enums.UserActivityEventType;
+import com.pfplaybackend.api.party.domain.entity.data.QPartyroomData;
+import com.pfplaybackend.api.party.domain.enums.PartyroomStatus;
+import com.pfplaybackend.api.user.domain.entity.data.QUserAccountData;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.DateTemplate;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * #361 전역(서비스 전체) 입퇴장 집계 리포지토리 — 어드민 대시보드 v1.
+ *
+ * <p>방 단위 {@link UserActivityLogAnalyticsRepository} 의 전역 변형: partyroom_id 키잉을 제거하고
+ * <b>봇 제외</b>(user_activity_log × user_account, {@code is_dummy=false}) 조인을 추가한다.
+ * 봇도 실유저와 동일한 tryEnter 경로로 activity 이벤트를 남기므로, 봇 배치/재배치가 전역
+ * 수치를 왜곡한다 — 분석 기본값은 제외(excludeBots=true), 토글로 포함 가능.
+ *
+ * <p>시각 기준은 방 단위 분석과 동일: occurred_at 은 KST 로컬시각, DATE() 벽시계 달력일 버킷.
+ * cross-BC 참조(party/user 엔티티)는 administration 리포지토리 계층의 기존 관례
+ * ({@code AdminPartyroomQueryRepositoryImpl})를 따른다.
+ */
+@Repository
+@RequiredArgsConstructor
+public class AdminGlobalAnalyticsRepository {
+
+    private static final String ENTERED = UserActivityEventType.PARTYROOM_ENTERED.name();
+    private static final String EXITED  = UserActivityEventType.PARTYROOM_EXITED.name();
+
+    private final JPAQueryFactory queryFactory;
+
+    /** 일자별 entered/exited (전역). 발생한 날만, asc. */
+    public List<DailyAttendanceBucket> findDailyAttendance(LocalDateTime from, LocalDateTime now, boolean excludeBots) {
+        QUserActivityLogData q = QUserActivityLogData.userActivityLogData;
+        DateTemplate<java.sql.Date> day = Expressions.dateTemplate(java.sql.Date.class, "DATE({0})", q.occurredAt);
+        NumberExpression<Integer> enteredCase = new CaseBuilder().when(q.eventType.eq(ENTERED)).then(1).otherwise(0).sum();
+        NumberExpression<Integer> exitedCase  = new CaseBuilder().when(q.eventType.eq(EXITED)).then(1).otherwise(0).sum();
+
+        JPAQuery<?> query = queryFactory
+                .select(day, enteredCase, exitedCase)
+                .from(q)
+                .where(baseWindow(q, from, now));
+        applyBotExclusion(query, q, excludeBots);
+
+        return query
+                .groupBy(day)
+                .orderBy(day.asc())
+                .fetch()
+                .stream()
+                .map(t -> {
+                    com.querydsl.core.Tuple tuple = (com.querydsl.core.Tuple) t;
+                    return new DailyAttendanceBucket(
+                            tuple.get(day).toLocalDate(), nz(tuple.get(enteredCase)), nz(tuple.get(exitedCase)));
+                })
+                .toList();
+    }
+
+    /** 일자별 순 방문자(ENTERED distinct user, 전역). 발생한 날만, asc. */
+    public List<DailyUniqueVisitorsBucket> findDailyUniqueVisitors(LocalDateTime from, LocalDateTime now, boolean excludeBots) {
+        QUserActivityLogData q = QUserActivityLogData.userActivityLogData;
+        DateTemplate<java.sql.Date> day = Expressions.dateTemplate(java.sql.Date.class, "DATE({0})", q.occurredAt);
+
+        JPAQuery<?> query = queryFactory
+                .select(day, q.userAccountId.countDistinct())
+                .from(q)
+                .where(baseWindow(q, from, now).and(q.eventType.eq(ENTERED)));
+        applyBotExclusion(query, q, excludeBots);
+
+        return query
+                .groupBy(day)
+                .orderBy(day.asc())
+                .fetch()
+                .stream()
+                .map(t -> {
+                    com.querydsl.core.Tuple tuple = (com.querydsl.core.Tuple) t;
+                    Long c = tuple.get(q.userAccountId.countDistinct());
+                    return new DailyUniqueVisitorsBucket(tuple.get(day).toLocalDate(), c == null ? 0L : c);
+                })
+                .toList();
+    }
+
+    /** 윈도우 전체 순 방문자(ENTERED distinct user, 전역). */
+    public long countUniqueVisitors(LocalDateTime from, LocalDateTime now, boolean excludeBots) {
+        QUserActivityLogData q = QUserActivityLogData.userActivityLogData;
+        JPAQuery<Long> query = queryFactory
+                .select(q.userAccountId.countDistinct())
+                .from(q)
+                .where(baseWindow(q, from, now).and(q.eventType.eq(ENTERED)));
+        applyBotExclusion(query, q, excludeBots);
+        Long c = query.fetchOne();
+        return c == null ? 0L : c;
+    }
+
+    /** 현재 ACTIVE 파티룸 수 (시계열 아님 — KPI 스냅샷). */
+    public long countActiveRooms() {
+        QPartyroomData p = QPartyroomData.partyroomData;
+        Long c = queryFactory.select(p.count()).from(p)
+                .where(p.status.eq(PartyroomStatus.ACTIVE))
+                .fetchOne();
+        return c == null ? 0L : c;
+    }
+
+    private BooleanBuilder baseWindow(QUserActivityLogData q, LocalDateTime from, LocalDateTime now) {
+        return new BooleanBuilder()
+                .and(q.eventType.in(ENTERED, EXITED))
+                .and(q.occurredAt.goe(from))
+                .and(q.occurredAt.lt(now));
+    }
+
+    /** excludeBots=true 면 user_account 조인으로 봇(is_dummy) 이벤트를 제외한다. */
+    private void applyBotExclusion(JPAQuery<?> query, QUserActivityLogData q, boolean excludeBots) {
+        if (!excludeBots) return;
+        QUserAccountData ua = QUserAccountData.userAccountData;
+        query.join(ua).on(ua.userId.uid.eq(q.userAccountId))
+             .where(ua.isDummy.isFalse());
+    }
+
+    private static int nz(Integer v) { return v == null ? 0 : v; }
+}

--- a/app/src/main/java/com/pfplaybackend/api/administration/application/dto/DailyUniqueVisitorsBucket.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/application/dto/DailyUniqueVisitorsBucket.java
@@ -1,0 +1,6 @@
+package com.pfplaybackend.api.administration.application.dto;
+
+import java.time.LocalDate;
+
+/** #361 전역 일별 순 방문자(ENTERED distinct user) 버킷. */
+public record DailyUniqueVisitorsBucket(LocalDate date, long uniqueVisitors) {}

--- a/app/src/main/java/com/pfplaybackend/api/administration/application/service/AdminGlobalAnalyticsQueryService.java
+++ b/app/src/main/java/com/pfplaybackend/api/administration/application/service/AdminGlobalAnalyticsQueryService.java
@@ -1,0 +1,75 @@
+package com.pfplaybackend.api.administration.application.service;
+
+import com.pfplaybackend.api.administration.adapter.in.web.payload.response.AdminAttendanceAnalyticsResponse;
+import com.pfplaybackend.api.administration.adapter.in.web.payload.response.AdminAttendanceAnalyticsResponse.Daily;
+import com.pfplaybackend.api.administration.adapter.in.web.payload.response.AdminAttendanceAnalyticsResponse.Summary;
+import com.pfplaybackend.api.administration.adapter.out.persistence.AdminGlobalAnalyticsRepository;
+import com.pfplaybackend.api.administration.application.dto.DailyAttendanceBucket;
+import com.pfplaybackend.api.administration.application.dto.DailyUniqueVisitorsBucket;
+import com.pfplaybackend.api.common.exception.http.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * #361 어드민 대시보드 v1 — 전역 입퇴장 분석 조합 서비스.
+ *
+ * <p>방 단위 {@link AdminPartyroomAnalyticsQueryService} 와 동일한 시각 규약(Asia/Seoul 벽시계,
+ * days 1..90)을 따른다. 일별 attendance 와 일별 unique 는 별도 그룹 쿼리로 얻어 날짜 기준으로
+ * 병합한다(둘 중 한쪽에만 존재하는 날짜도 노출 — 값 0 채움).
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminGlobalAnalyticsQueryService {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+    private static final int MIN_DAYS = 1;
+    private static final int MAX_DAYS = 90;
+
+    private final AdminGlobalAnalyticsRepository repository;
+
+    public AdminAttendanceAnalyticsResponse getAttendance(int days, boolean excludeBots) {
+        if (days < MIN_DAYS || days > MAX_DAYS) {
+            throw new BadRequestException("ADM-GA-001", "days out of range (1..90): " + days);
+        }
+        LocalDateTime now = LocalDateTime.now(SEOUL);
+        LocalDateTime from = now.minusDays(days);
+
+        List<DailyAttendanceBucket> attendance = repository.findDailyAttendance(from, now, excludeBots);
+        Map<LocalDate, DailyUniqueVisitorsBucket> uniqueByDate =
+                repository.findDailyUniqueVisitors(from, now, excludeBots).stream()
+                        .collect(Collectors.toMap(DailyUniqueVisitorsBucket::date, Function.identity()));
+
+        // 날짜 병합 (asc 정렬 보장) — attendance 없는 날짜에 unique 만 있는 경우도 보존
+        Map<LocalDate, Daily> merged = new TreeMap<>();
+        for (DailyAttendanceBucket b : attendance) {
+            DailyUniqueVisitorsBucket u = uniqueByDate.get(b.date());
+            merged.put(b.date(), new Daily(b.date(), b.entered(), b.exited(), u == null ? 0L : u.uniqueVisitors()));
+        }
+        for (DailyUniqueVisitorsBucket u : uniqueByDate.values()) {
+            merged.putIfAbsent(u.date(), new Daily(u.date(), 0L, 0L, u.uniqueVisitors()));
+        }
+
+        long totalEntered = attendance.stream().mapToLong(DailyAttendanceBucket::entered).sum();
+        long totalExited = attendance.stream().mapToLong(DailyAttendanceBucket::exited).sum();
+        long uniqueVisitors = repository.countUniqueVisitors(from, now, excludeBots);
+        long activeRoomCount = repository.countActiveRooms();
+        Double exitRecordRate = totalEntered == 0 ? null : (double) totalExited / totalEntered;
+
+        return new AdminAttendanceAnalyticsResponse(
+                days, excludeBots,
+                new Summary(totalEntered, totalExited, uniqueVisitors, activeRoomCount, exitRecordRate),
+                List.copyOf(merged.values())
+        );
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/persistence/AdminGlobalAnalyticsRepositoryIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/adapter/out/persistence/AdminGlobalAnalyticsRepositoryIT.java
@@ -1,0 +1,132 @@
+package com.pfplaybackend.api.administration.adapter.out.persistence;
+
+import com.pfplaybackend.api.administration.application.dto.DailyAttendanceBucket;
+import com.pfplaybackend.api.administration.application.dto.DailyUniqueVisitorsBucket;
+import com.pfplaybackend.api.administration.domain.entity.UserActivityLogData;
+import com.pfplaybackend.api.administration.domain.enums.UserActivityEventType;
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.user.adapter.out.persistence.UserAccountRepository;
+import com.pfplaybackend.api.user.domain.entity.data.UserAccountData;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #361 전역 입퇴장 집계 IT — 일자 버킷 · 봇 제외(is_dummy 조인) · distinct 순방문자를
+ * 실 MySQL 로 잠근다. (활성 방 수 스냅샷은 party 시드가 무거워 서비스/기존 IT 관할)
+ */
+class AdminGlobalAnalyticsRepositoryIT extends AbstractIntegrationTest {
+
+    private static final long ROOM = 991001L;
+    private static final long HUMAN_A = 991101L;
+    private static final long HUMAN_B = 991102L;
+    private static final long BOT     = 991103L;
+
+    private static final LocalDate DAY1 = LocalDate.of(2026, 7, 1);
+    private static final LocalDate DAY2 = LocalDate.of(2026, 7, 2);
+    private static final LocalDateTime FROM = DAY1.atStartOfDay();
+    private static final LocalDateTime NOW = LocalDate.of(2026, 7, 3).atStartOfDay();
+
+    @Autowired AdminGlobalAnalyticsRepository repository;
+    @Autowired UserActivityLogRepository userActivityLogRepository;
+    @Autowired UserAccountRepository userAccountRepository;
+    @Autowired TransactionTemplate transactionTemplate;
+    @Autowired EntityManager entityManager;
+
+    @BeforeEach
+    void seedAll() {
+        userAccountRepository.save(UserAccountData.createForLocalWithMandatoryChange(
+                new UserId(HUMAN_A), "ga-human-a@it.local", "h"));
+        userAccountRepository.save(UserAccountData.createForLocalWithMandatoryChange(
+                new UserId(HUMAN_B), "ga-human-b@it.local", "h"));
+        UserAccountData bot = UserAccountData.createForLocalWithMandatoryChange(
+                new UserId(BOT), "ga-bot@it.local", "h");
+        bot.markAsDummy();
+        userAccountRepository.save(bot);
+
+        // DAY1: humanA 입장×2(같은 유저 재입장)·퇴장×1, humanB 입장×1, bot 입장×1
+        seed(HUMAN_A, UserActivityEventType.PARTYROOM_ENTERED, DAY1.atTime(10, 0));
+        seed(HUMAN_A, UserActivityEventType.PARTYROOM_ENTERED, DAY1.atTime(12, 0));
+        seed(HUMAN_A, UserActivityEventType.PARTYROOM_EXITED, DAY1.atTime(13, 0));
+        seed(HUMAN_B, UserActivityEventType.PARTYROOM_ENTERED, DAY1.atTime(14, 0));
+        seed(BOT, UserActivityEventType.PARTYROOM_ENTERED, DAY1.atTime(15, 0));
+        // DAY2: bot 만 활동 (봇 제외 시 이 날짜 버킷 자체가 없어야 함)
+        seed(BOT, UserActivityEventType.PARTYROOM_ENTERED, DAY2.atTime(10, 0));
+        seed(BOT, UserActivityEventType.PARTYROOM_EXITED, DAY2.atTime(11, 0));
+    }
+
+    private void seed(long uid, UserActivityEventType type, LocalDateTime at) {
+        userActivityLogRepository.saveAndFlush(UserActivityLogData.of(uid, type, ROOM, null, at));
+    }
+
+    @AfterEach
+    void cleanup() {
+        transactionTemplate.executeWithoutResult(status -> {
+            entityManager.createNativeQuery("DELETE FROM user_activity_log WHERE partyroom_id = :r")
+                    .setParameter("r", ROOM).executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM user_account WHERE user_id IN (:ids)")
+                    .setParameter("ids", List.of(HUMAN_A, HUMAN_B, BOT)).executeUpdate();
+        });
+    }
+
+    @Test
+    @DisplayName("excludeBots=true — 봇 이벤트 제외: DAY1 entered=3/exited=1, DAY2 버킷 없음")
+    void daily_attendance_excludes_bots() {
+        List<DailyAttendanceBucket> daily = repository.findDailyAttendance(FROM, NOW, true);
+
+        assertThat(daily).hasSize(1);
+        assertThat(daily.get(0).date()).isEqualTo(DAY1);
+        assertThat(daily.get(0).entered()).isEqualTo(3); // humanA×2 + humanB×1
+        assertThat(daily.get(0).exited()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("excludeBots=false — 봇 포함: DAY1 entered=4, DAY2 entered=1/exited=1")
+    void daily_attendance_includes_bots() {
+        List<DailyAttendanceBucket> daily = repository.findDailyAttendance(FROM, NOW, false);
+
+        assertThat(daily).hasSize(2);
+        assertThat(daily.get(0).date()).isEqualTo(DAY1);
+        assertThat(daily.get(0).entered()).isEqualTo(4);
+        assertThat(daily.get(1).date()).isEqualTo(DAY2);
+        assertThat(daily.get(1).entered()).isEqualTo(1);
+        assertThat(daily.get(1).exited()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("일별 순 방문자 — 재입장 dedup: DAY1 unique=2(humanA,humanB), 봇 제외")
+    void daily_unique_visitors_dedups_and_excludes_bots() {
+        List<DailyUniqueVisitorsBucket> daily = repository.findDailyUniqueVisitors(FROM, NOW, true);
+
+        assertThat(daily).hasSize(1);
+        assertThat(daily.get(0).date()).isEqualTo(DAY1);
+        assertThat(daily.get(0).uniqueVisitors()).isEqualTo(2); // humanA(재입장 1로 dedup) + humanB
+    }
+
+    @Test
+    @DisplayName("윈도우 전체 순 방문자 — excludeBots=true → 2, false → 3")
+    void total_unique_visitors() {
+        assertThat(repository.countUniqueVisitors(FROM, NOW, true)).isEqualTo(2L);
+        assertThat(repository.countUniqueVisitors(FROM, NOW, false)).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("윈도우 밖 이벤트는 미집계")
+    void window_bounds_respected() {
+        seed(HUMAN_A, UserActivityEventType.PARTYROOM_ENTERED, NOW.plusHours(1)); // 윈도우 밖
+
+        List<DailyAttendanceBucket> daily = repository.findDailyAttendance(FROM, NOW, true);
+        assertThat(daily).hasSize(1); // DAY1 만 — NOW 이후는 미포함
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/administration/application/service/AdminGlobalAnalyticsQueryServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/administration/application/service/AdminGlobalAnalyticsQueryServiceTest.java
@@ -1,0 +1,85 @@
+package com.pfplaybackend.api.administration.application.service;
+
+import com.pfplaybackend.api.administration.adapter.in.web.payload.response.AdminAttendanceAnalyticsResponse;
+import com.pfplaybackend.api.administration.adapter.out.persistence.AdminGlobalAnalyticsRepository;
+import com.pfplaybackend.api.administration.application.dto.DailyAttendanceBucket;
+import com.pfplaybackend.api.administration.application.dto.DailyUniqueVisitorsBucket;
+import com.pfplaybackend.api.common.exception.http.BadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.offset;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.when;
+
+/** #361 전역 분석 서비스 단위 — days 검증·일자 병합·exitRecordRate. */
+@ExtendWith(MockitoExtension.class)
+class AdminGlobalAnalyticsQueryServiceTest {
+
+    @Mock private AdminGlobalAnalyticsRepository repository;
+    @InjectMocks private AdminGlobalAnalyticsQueryService service;
+
+    private static final LocalDate D1 = LocalDate.of(2026, 7, 1);
+    private static final LocalDate D2 = LocalDate.of(2026, 7, 2);
+
+    @Test
+    @DisplayName("days 범위 밖(0, 91) → ADM-GA-001 BadRequest")
+    void days_out_of_range_rejected() {
+        assertThatThrownBy(() -> service.getAttendance(0, true))
+                .isInstanceOf(BadRequestException.class);
+        assertThatThrownBy(() -> service.getAttendance(91, true))
+                .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    @DisplayName("일자 병합 — attendance·unique 를 날짜로 병합, 한쪽에만 있는 날짜는 0 채움")
+    void merges_daily_rows_by_date() {
+        when(repository.findDailyAttendance(any(), any(), anyBoolean()))
+                .thenReturn(List.of(new DailyAttendanceBucket(D1, 5, 4)));
+        when(repository.findDailyUniqueVisitors(any(), any(), anyBoolean()))
+                .thenReturn(List.of(
+                        new DailyUniqueVisitorsBucket(D1, 3),
+                        new DailyUniqueVisitorsBucket(D2, 1))); // attendance 없는 날짜
+        when(repository.countUniqueVisitors(any(), any(), anyBoolean())).thenReturn(4L);
+        when(repository.countActiveRooms()).thenReturn(2L);
+
+        AdminAttendanceAnalyticsResponse res = service.getAttendance(7, true);
+
+        assertThat(res.daily()).hasSize(2);
+        assertThat(res.daily().get(0).date()).isEqualTo(D1);
+        assertThat(res.daily().get(0).entered()).isEqualTo(5);
+        assertThat(res.daily().get(0).uniqueVisitors()).isEqualTo(3);
+        assertThat(res.daily().get(1).date()).isEqualTo(D2);
+        assertThat(res.daily().get(1).entered()).isZero();
+        assertThat(res.daily().get(1).uniqueVisitors()).isEqualTo(1);
+        assertThat(res.summary().totalEntered()).isEqualTo(5);
+        assertThat(res.summary().totalExited()).isEqualTo(4);
+        assertThat(res.summary().uniqueVisitors()).isEqualTo(4);
+        assertThat(res.summary().activeRoomCount()).isEqualTo(2);
+        assertThat(res.summary().exitRecordRate()).isCloseTo(0.8, offset(1e-9));
+    }
+
+    @Test
+    @DisplayName("입장 0건 → exitRecordRate=null (0 나누기 방지)")
+    void exit_record_rate_null_when_no_enters() {
+        when(repository.findDailyAttendance(any(), any(), anyBoolean())).thenReturn(List.of());
+        when(repository.findDailyUniqueVisitors(any(), any(), anyBoolean())).thenReturn(List.of());
+        when(repository.countUniqueVisitors(any(), any(), anyBoolean())).thenReturn(0L);
+        when(repository.countActiveRooms()).thenReturn(0L);
+
+        AdminAttendanceAnalyticsResponse res = service.getAttendance(7, true);
+
+        assertThat(res.summary().exitRecordRate()).isNull();
+        assertThat(res.daily()).isEmpty();
+    }
+}


### PR DESCRIPTION
## 요약 (#361 — 대시보드 v1 백엔드)

일별 입퇴장을 방 단위가 아니라 **서비스 전역**으로 집계하는 분석가용 API. UI 는 pfplay-admin#39.

`GET /api/v1/admin/analytics/attendance?days={1..90}&excludeBots={기본 true}` → summary(총입장·총퇴장·순방문자·활성방·퇴장기록률) + daily[](date, entered, exited, uniqueVisitors)

## 설계 포인트

- **봇 제외 기본 ON**: 봇도 실유저와 동일한 tryEnter 로 activity 이벤트를 남겨 배치/재배치가 전역 수치를 왜곡 — `user_account.is_dummy` 조인으로 제외, 토글로 포함 가능.
- **exitRecordRate** = exited/entered — 퇴장 이벤트는 유실될 수 있음이 실증(#356 유령 계보)되어, 이탈+데이터 품질 신호로 노출(입장 0이면 null). 전역 무음이탈은 방 단위 SilenceExitCalculator 와 의미가 달라 v1.5.
- 방 단위 분석(#33)과 동일 시각 규약(Asia/Seoul 벽시계 DATE() 버킷, days 1..90). 컨트롤러는 `/admin/partyrooms/**` 경로변수 충돌을 피해 `/admin/analytics` 뿌리 신설.

## 검증 (3종 게이트)

- 단위: 서비스 3종(days 검증·일자 병합·rate null) — exit=0
- IT: 리포지토리 5종(봇 제외/포함 버킷·distinct dedup·전체 unique·윈도우 경계) — exit=0
- **전체 :app:test + :app:integrationTest exit=0** · 로컬 풀부팅+엔드포인트 스모크(401=배선·보안) · **풀 web E2E 18+1(기지 display-board 플레이크→warm 6/6)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
