### PR TITLE
ci: PR 커밋당 테스트 1회 실행 — 이중 트리거 제거 + concurrency (#364)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,10 +1,18 @@
 name: CI Test
 
 on:
+  # #364 PR 브랜치는 pull_request 1회만 — push '**' 와의 이중 실행(플레이크 노출 2배,
+  # 실측: PR#362 동일 커밋 쌍둥이 잡 중 1개만 실패)을 제거한다.
+  # push 는 장수 브랜치의 머지 후 통합 검증(각 PR CI 는 자기 브랜치 기준이므로 조합 안전망)만 담당.
   push:
-    branches: ['**']
+    branches: [main, develop, release]
   pull_request:
     branches: [main, develop, release]
+
+# 같은 ref 에 연속 push 시 낡은 런 자동 취소 — 장수 브랜치의 머지 후 검증은 취소하지 않는다.
+concurrency:
+  group: ci-test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## 요약 (#364 — 신뢰성 로드맵 Phase 1, 1순위)

`push: '**'` + `pull_request` 이중 트리거로 **PR 커밋마다 동일 스위트가 2회** 돌던 것을 1회로.

- 실측 근거: PR#362에서 동일 커밋 쌍둥이 잡 중 1개만 실패(RaceIT 플레이크) — 노출면 2배의 실증
- push는 장수 브랜치(main/develop/release) 한정 — **머지 후 조합 검증은 유지**(각 PR CI는 자기 브랜치 기준이므로 이 안전망은 필요)
- concurrency: 연속 push 시 낡은 PR 런 자동 취소(장수 브랜치 런은 미취소)

## 검증
CI 설정 전용(코드 무변경) — 본 PR의 CI 실행 자체가 검증: **pull_request 트리거 1런만 생성되는지** 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)