### PR TITLE
feat(party): 내 활성 파티룸 스냅샷 조회 API (#477)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/PartyroomQueryController.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/PartyroomQueryController.java
@@ -4,6 +4,7 @@ import com.pfplaybackend.api.common.ApiCommonResponse;
 import com.pfplaybackend.api.common.config.swagger.ApiErrorCodes;
 import com.pfplaybackend.api.common.domain.value.UserId;
 import com.pfplaybackend.api.party.adapter.in.web.payload.response.info.QueryDjQueueResponse;
+import com.pfplaybackend.api.party.adapter.in.web.payload.response.info.QueryMyActivePartyroomResponse;
 import com.pfplaybackend.api.party.adapter.in.web.payload.response.info.QueryPartyroomListResponse;
 import com.pfplaybackend.api.party.adapter.in.web.payload.response.info.QueryPartyroomListResponse.PartyroomElement;
 import com.pfplaybackend.api.party.application.dto.partyroom.PartyroomWithCrewDto;
@@ -59,6 +60,21 @@ public class PartyroomQueryController {
     public ResponseEntity<ApiCommonResponse<PartyroomSummaryResult>> getPartyroomSummaryInfo(
             @Parameter(description = "파티룸 ID") @PathVariable Long partyroomId) {
         return ResponseEntity.ok().body(ApiCommonResponse.success(partyroomQueryService.getSummaryInfo(new PartyroomId(partyroomId))));
+    }
+
+    /**
+     * 현재 로그인 사용자가 활성 crew로 속한 파티룸을 조회한다 (스냅샷).
+     * → 재연결 resync가 기억하던 방을 되훔침(재입장)하는 대신, 서버 권위 스냅샷으로 분기하기 위한 API.
+     *   멀티 디바이스 승계(new-session-wins)에서 밀려난 브라우저의 세션 되훔침(핑퐁)을 차단한다. (#477)
+     */
+    @Operation(summary = "내 활성 파티룸 스냅샷 조회", description = "현재 로그인 사용자가 활성 crew로 속한 파티룸을 조회합니다. 재연결 시 클라이언트는 기억하던 방을 재주장하는 대신 이 스냅샷으로 분기합니다. 활성 방이 있으면 200 + 스냅샷, 없으면 204 No Content.")
+    @SecurityRequirement(name = "cookieAuth")
+    @GetMapping("/me/active")
+    public ResponseEntity<ApiCommonResponse<QueryMyActivePartyroomResponse>> getMyActivePartyroom() {
+        // 활성 방 없음을 200 + {data:null} 로 주면 web 인터셉터가 래퍼를 벗기지 못해 오역된다 → 204 로 표현.
+        return partyroomQueryService.getMyActivePartyroom()
+                .map(dto -> ResponseEntity.ok(ApiCommonResponse.success(QueryMyActivePartyroomResponse.from(dto))))
+                .orElseGet(() -> ResponseEntity.noContent().build());
     }
 
     @Operation(summary = "DJ 큐 조회", description = "특정 파티룸의 DJ 큐 정보를 조회합니다. 현재 재생 중인 DJ, 대기 중인 DJ 목록, 큐 상태 등을 포함합니다.")

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/payload/response/info/QueryMyActivePartyroomResponse.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/web/payload/response/info/QueryMyActivePartyroomResponse.java
@@ -1,0 +1,14 @@
+package com.pfplaybackend.api.party.adapter.in.web.payload.response.info;
+
+import com.pfplaybackend.api.party.application.dto.partyroom.ActivePartyroomDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "내 활성 파티룸 스냅샷 응답")
+public record QueryMyActivePartyroomResponse(
+        @Schema(description = "활성 파티룸 ID") Long partyroomId,
+        @Schema(description = "해당 파티룸에서의 내 crew ID") Long crewId) {
+
+    public static QueryMyActivePartyroomResponse from(ActivePartyroomDto dto) {
+        return new QueryMyActivePartyroomResponse(dto.id(), dto.crewId());
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/PartyroomQueryControllerTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/in/web/PartyroomQueryControllerTest.java
@@ -1,5 +1,6 @@
 package com.pfplaybackend.api.party.adapter.in.web;
 
+import com.pfplaybackend.api.party.application.dto.partyroom.ActivePartyroomDto;
 import com.pfplaybackend.api.party.application.dto.result.DjQueueInfoResult;
 import com.pfplaybackend.api.party.domain.enums.QueueStatus;
 import org.junit.jupiter.api.DisplayName;
@@ -7,11 +8,13 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class PartyroomQueryControllerTest extends AbstractPartyQueryWebMvcTest {
@@ -52,5 +55,33 @@ class PartyroomQueryControllerTest extends AbstractPartyQueryWebMvcTest {
         mockMvc.perform(get("/api/v1/partyrooms/1/dj-queue")
                         .with(jwt().authorities(() -> "ROLE_MEMBER")))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("getMyActivePartyroom — 활성 방 있음: 200 + 스냅샷(partyroomId, crewId) 반환")
+    void getMyActivePartyroomReturnsSnapshot() throws Exception {
+        // given — 재연결 resync가 되훔침(tryEnter) 대신 조회할 '내 활성 방' 스냅샷
+        when(partyroomQueryService.getMyActivePartyroom()).thenReturn(
+                Optional.of(new ActivePartyroomDto(42L, false, 7L, false, null, null)));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/partyrooms/me/active")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.partyroomId").value(42))
+                .andExpect(jsonPath("$.data.crewId").value(7));
+    }
+
+    @Test
+    @DisplayName("getMyActivePartyroom — 활성 방 없음: 204 No Content (로비로 분기)")
+    void getMyActivePartyroomReturnsNoContentWhenNoActiveRoom() throws Exception {
+        // given
+        when(partyroomQueryService.getMyActivePartyroom()).thenReturn(Optional.empty());
+
+        // when & then — 200 + {data:null} 은 web 인터셉터(response.data?.data ?? response.data)에서
+        // 래퍼 객체로 오역되므로, "활성 방 없음" 은 본문 없는 204 로 명확히 표현한다.
+        mockMvc.perform(get("/api/v1/partyrooms/me/active")
+                        .with(jwt().authorities(() -> "ROLE_MEMBER")))
+                .andExpect(status().isNoContent());
     }
 }


### PR DESCRIPTION
## 개요
멀티 디바이스 세션 승계(new-session-wins) 3종 세트 중 **정합성 핵심(web#477)** 의 서버 노출분.

재연결 resync가 기억하던 방을 `tryEnter`로 재주장하는 대신 서버 권위 스냅샷으로 분기할 수 있도록 `GET /api/v1/partyrooms/me/active`를 노출한다. 밀려난 브라우저가 재연결 순간 새 기기의 방을 역으로 밀어내는 세션 되훔침(핑퐁)을 차단한다.

## 변경
- `GET /api/v1/partyrooms/me/active`
  - 활성 방 있으면 **200 + 스냅샷** `{ partyroomId, crewId }`
  - 활성 방 없으면 **204 No Content**
  - 조회 로직은 기존 `PartyroomQueryService.getMyActivePartyroom()` 재사용 (신규 쿼리 0)
- WebMvc 테스트로 200/204 계약 커버

## 설계 노트
- 활성 방 없음을 `200 + {data:null}`로 주면 web 응답 인터셉터 `response.data?.data ?? response.data`가 래퍼를 벗기지 못해 오역된다 → **204**로 표현.

## 검증
- 전체 `:app:test` GREEN (235 클래스, ArchUnit 포함)

## ⚠️ 머지 보류
- web#477(재연결 resync 스냅샷 분기)과 세트. 라이브 멀티 디바이스 e2e 실행 후 머지 예정.

관련: #477