### PR TITLE
feat(party): 멀티 디바이스 승계 SESSION_SUPERSEDED 개인 큐 알림 (#369)

### DIFF
--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/SessionSupersedeNotifier.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/SessionSupersedeNotifier.java
@@ -1,0 +1,42 @@
+package com.pfplaybackend.api.party.adapter.in.listener;
+
+import com.pfplaybackend.api.party.adapter.in.listener.message.SessionSupersededMessage;
+import com.pfplaybackend.api.party.domain.event.SessionSupersededEvent;
+import com.pfplaybackend.realtime.sender.SimpMessageSender;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 멀티 디바이스 세션 승계(#369) — 밀려난 유저에게 SESSION_SUPERSEDED 개인 큐 알림을 발송한다.
+ *
+ * <p>{@code AFTER_COMMIT} 에서만 발송한다 — 밀어냄(crew EXIT)이 커밋되어 서버 상태가 확정된 뒤에만
+ * 알리기 위함이다. WS 발송뿐(DB 쓰기 없음)이라 새 트랜잭션(REQUIRES_NEW)은 불필요하다.
+ * 알림 미도달은 정합성에 무해하다 — 밀려남은 서버가 이미 완결했고, 재연결 스냅샷 resync(web#477)가
+ * 정합성 백스톱이다.
+ *
+ * <p>단일 인스턴스 전제(SimpUserRegistry in-process). 다중 인스턴스로 확장 시 밀려난 세션이 다른
+ * 인스턴스에 있으면 이 direct send 는 도달하지 못하므로 그룹 브로드캐스트처럼 Redis 릴레이가 필요하다
+ * — 그때도 정합성 백스톱(resync)은 유지된다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SessionSupersedeNotifier {
+
+    private final SimpMessageSender simpMessageSender;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void on(SessionSupersededEvent event) {
+        log.info("[session] SESSION_SUPERSEDED notify - userId={}, supersededRoomId={}, newRoomId={}",
+                event.getUserId(), event.getSupersededPartyroomId().getId(), event.getNewPartyroomId().getId());
+        simpMessageSender.sendToOneSession(
+                event.getUserId().toString(),
+                SessionSupersededMessage.of(
+                        event.getNewPartyroomId().getId(),
+                        event.getSupersededPartyroomId().getId(),
+                        event.getOccurredAtEpochMilli()));
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/message/SessionSupersededMessage.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/adapter/in/listener/message/SessionSupersededMessage.java
@@ -1,0 +1,22 @@
+package com.pfplaybackend.api.party.adapter.in.listener.message;
+
+import java.io.Serializable;
+
+/**
+ * 멀티 디바이스 세션 승계 알림 페이로드 (#369). 밀려난 유저의 개인 큐(/user/sub/session)로 발송된다.
+ *
+ * <p>같은 유저의 여러 세션(밀려난 옛 기기 A + 새 기기 B)이 동일 principal 을 공유하므로 이 알림은
+ * 양쪽 모두에 도달한다. 수신 클라이언트는 {@code supersededPartyroomId}(밀려난 방)와
+ * {@code newPartyroomId}(새 방)로 자신이 밀려난 쪽인지 판별한다 — 옛 방에 있던 세션만 밀려남 처리한다.
+ */
+public record SessionSupersededMessage(
+        String type,
+        long newPartyroomId,
+        long supersededPartyroomId,
+        long occurredAt
+) implements Serializable {
+
+    public static SessionSupersededMessage of(long newPartyroomId, long supersededPartyroomId, long occurredAt) {
+        return new SessionSupersededMessage("SESSION_SUPERSEDED", newPartyroomId, supersededPartyroomId, occurredAt);
+    }
+}

--- a/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandService.java
@@ -15,6 +15,7 @@ import com.pfplaybackend.api.party.domain.enums.DjChangeType;
 import com.pfplaybackend.api.party.domain.enums.GradeType;
 import com.pfplaybackend.api.party.domain.event.CrewAccessedEvent;
 import com.pfplaybackend.api.party.domain.event.DjQueueChangedEvent;
+import com.pfplaybackend.api.party.domain.event.SessionSupersededEvent;
 import com.pfplaybackend.api.party.domain.exception.CrewException;
 import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
 import com.pfplaybackend.api.party.domain.service.PartyroomAggregateService;
@@ -320,6 +321,12 @@ public class PartyroomAccessCommandService {
                 log.info("[autoExitPriorActiveRoom] Auto-exit from another room - userId={}, exitingRoomId={}, enteringRoomId={}",
                         userId, activeRoomInfo.id(), target.getId());
                 exitInternal(new PartyroomId(activeRoomInfo.id()), userId);
+                // #369 멀티 디바이스 승계 — 밀려난 유저에게 SESSION_SUPERSEDED 알림을 보내기 위한 이벤트.
+                // exit 는 위에서 서버가 이미 완결했고, 이 이벤트/알림은 순수 UX 신호다. AFTER_COMMIT 리스너가
+                // 소비하므로 exit 이 커밋된 뒤에만 발송된다(서버 권위). tryEnter/enterByHost 공용 helper 라
+                // 양 진입 경로의 밀어냄을 모두 커버한다.
+                eventPublisher.publishEvent(new SessionSupersededEvent(
+                        userId, new PartyroomId(activeRoomInfo.id()), target, clock.millis()));
             }
         }
         return optActiveRoomInfo;

--- a/app/src/main/java/com/pfplaybackend/api/party/domain/event/SessionSupersededEvent.java
+++ b/app/src/main/java/com/pfplaybackend/api/party/domain/event/SessionSupersededEvent.java
@@ -1,0 +1,35 @@
+package com.pfplaybackend.api.party.domain.event;
+
+import com.pfplaybackend.api.common.domain.event.DomainEvent;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import lombok.Getter;
+
+/**
+ * 멀티 디바이스 세션 승계(new-session-wins) 발생 이벤트 (#369).
+ *
+ * <p>같은 유저가 다른 방으로 입장해 기존 활성 crew 가 auto-exit 된 순간 발행된다.
+ * 밀려난 유저의 개인 큐로 SESSION_SUPERSEDED 알림을 보내는 AFTER_COMMIT 리스너가 소비한다.
+ * 밀려남 자체(crew EXIT)는 서버가 이미 완결했으며 이 이벤트/알림은 순수 UX 신호다
+ * (정합성은 서버 권위 + 재연결 스냅샷 resync 가 보장).
+ */
+@Getter
+public class SessionSupersededEvent extends DomainEvent {
+    private final UserId userId;
+    private final PartyroomId supersededPartyroomId;
+    private final PartyroomId newPartyroomId;
+    private final long occurredAtEpochMilli;
+
+    public SessionSupersededEvent(UserId userId, PartyroomId supersededPartyroomId,
+                                  PartyroomId newPartyroomId, long occurredAtEpochMilli) {
+        this.userId = userId;
+        this.supersededPartyroomId = supersededPartyroomId;
+        this.newPartyroomId = newPartyroomId;
+        this.occurredAtEpochMilli = occurredAtEpochMilli;
+    }
+
+    @Override
+    public String getAggregateId() {
+        return userId.toString();
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/adapter/in/listener/SessionSupersedeNotifierTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/adapter/in/listener/SessionSupersedeNotifierTest.java
@@ -1,0 +1,44 @@
+package com.pfplaybackend.api.party.adapter.in.listener;
+
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.party.adapter.in.listener.message.SessionSupersededMessage;
+import com.pfplaybackend.api.party.domain.event.SessionSupersededEvent;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.realtime.sender.SimpMessageSender;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * #369 밀려난 유저에게 SESSION_SUPERSEDED user-queue 알림을 발송하는 AFTER_COMMIT 리스너 단위 테스트.
+ */
+class SessionSupersedeNotifierTest {
+
+    @Test
+    @DisplayName("SessionSupersededEvent 수신 → 밀려난 유저(uid principal)의 개인 큐로 SESSION_SUPERSEDED 발송")
+    void on_sends_session_superseded_to_pushed_out_user() {
+        SimpMessageSender sender = mock(SimpMessageSender.class);
+        SessionSupersedeNotifier notifier = new SessionSupersedeNotifier(sender);
+
+        UserId user = new UserId(555L);
+        SessionSupersededEvent event =
+                new SessionSupersededEvent(user, new PartyroomId(10L), new PartyroomId(20L), 1234L);
+
+        notifier.on(event);
+
+        // 개인 큐 대상 = uid principal 문자열 (WS handshake uid 와 매칭)
+        ArgumentCaptor<Object> payload = ArgumentCaptor.forClass(Object.class);
+        verify(sender).sendToOneSession(eq("555"), payload.capture());
+
+        SessionSupersededMessage msg = (SessionSupersededMessage) payload.getValue();
+        assertThat(msg.type()).isEqualTo("SESSION_SUPERSEDED");
+        assertThat(msg.newPartyroomId()).isEqualTo(20L);
+        assertThat(msg.supersededPartyroomId()).isEqualTo(10L);
+        assertThat(msg.occurredAt()).isEqualTo(1234L);
+    }
+}

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceTest.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/PartyroomAccessCommandServiceTest.java
@@ -15,6 +15,7 @@ import com.pfplaybackend.api.party.domain.enums.GradeType;
 import com.pfplaybackend.api.party.domain.enums.PartyroomStatus;
 import com.pfplaybackend.api.party.domain.event.CrewAccessedEvent;
 import com.pfplaybackend.api.party.domain.event.CrewGradeChangedEvent;
+import com.pfplaybackend.api.party.domain.event.SessionSupersededEvent;
 import com.pfplaybackend.api.party.domain.port.PartyroomAggregatePort;
 import com.pfplaybackend.api.party.domain.service.PartyroomAggregateService;
 import com.pfplaybackend.api.party.domain.value.CountryCode;
@@ -194,8 +195,10 @@ class PartyroomAccessCommandServiceTest {
         // when — 예외 없이 정상 실행되어야 함
         var result = partyroomAccessCommandService.tryEnter(newRoomId, null);
 
-        // then — EXIT event (from old room exit) + ENTER event (new room) = exactly 2 publish calls
-        verify(eventPublisher, times(2)).publishEvent(any(Object.class));
+        // then — EXIT(기존 룸 exit) + SESSION_SUPERSEDED(#369 밀어냄 알림) + ENTER(새 룸) = 3 publish
+        verify(eventPublisher, times(3)).publishEvent(any(Object.class));
+        // #369 밀려난 유저 알림 이벤트가 발행되어야 한다 (다른 룸으로의 전환)
+        verify(eventPublisher).publishEvent(any(SessionSupersededEvent.class));
         // inactive→active 재활성(transitioned) → reactivated=true (#402)
         assertThat(result.reactivated()).isTrue();
     }

--- a/app/src/test/java/com/pfplaybackend/api/party/application/service/SessionSupersededEventIT.java
+++ b/app/src/test/java/com/pfplaybackend/api/party/application/service/SessionSupersededEventIT.java
@@ -1,0 +1,171 @@
+package com.pfplaybackend.api.party.application.service;
+
+import com.pfplaybackend.api.common.AbstractIntegrationTest;
+import com.pfplaybackend.api.common.ThreadLocalContext;
+import com.pfplaybackend.api.common.aspect.context.AuthContext;
+import com.pfplaybackend.api.common.domain.value.UserId;
+import com.pfplaybackend.api.common.enums.AuthorityTier;
+import com.pfplaybackend.api.party.adapter.out.persistence.DjQueueRepository;
+import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomPlaybackRepository;
+import com.pfplaybackend.api.party.adapter.out.persistence.PartyroomRepository;
+import com.pfplaybackend.api.party.application.port.out.PlaylistCommandPort;
+import com.pfplaybackend.api.party.application.port.out.PlaylistQueryPort;
+import com.pfplaybackend.api.party.application.port.out.UserProfileQueryPort;
+import com.pfplaybackend.api.party.domain.entity.data.DjQueueData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomData;
+import com.pfplaybackend.api.party.domain.entity.data.PartyroomPlaybackData;
+import com.pfplaybackend.api.party.domain.enums.StageType;
+import com.pfplaybackend.api.party.domain.event.SessionSupersededEvent;
+import com.pfplaybackend.api.party.domain.value.CountryCode;
+import com.pfplaybackend.api.party.domain.value.LinkDomain;
+import com.pfplaybackend.api.party.domain.value.PartyroomId;
+import com.pfplaybackend.api.party.domain.value.PlaybackTimeLimit;
+import com.pfplaybackend.api.user.application.dto.shared.ProfileSettingDto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+/**
+ * #369 멀티 디바이스 세션 승계 — 밀어냄 발생 시 SessionSupersededEvent 발행 검증.
+ *
+ * <p>같은 유저가 다른 방으로 입장해 기존 활성 crew 가 auto-exit 될 때만 이벤트가 발행되어야 하며,
+ * 최초 입장·같은 방 재입장(멀티탭) 등 밀어냄이 없는 경로에서는 발행되지 않아야 한다. 이벤트는
+ * 밀려난 유저의 개인 큐 알림(SESSION_SUPERSEDED)을 트리거하는 신호다.
+ */
+@RecordApplicationEvents
+class SessionSupersededEventIT extends AbstractIntegrationTest {
+
+    @Autowired private PartyroomAccessCommandService accessCommandService;
+    @Autowired private PartyroomRepository partyroomRepository;
+    @Autowired private PartyroomPlaybackRepository partyroomPlaybackRepository;
+    @Autowired private DjQueueRepository djQueueRepository;
+    @Autowired private PlatformTransactionManager transactionManager;
+    @Autowired private ApplicationEvents applicationEvents;
+
+    private final List<Long> createdRoomIds = new ArrayList<>();
+
+    @MockBean private UserProfileQueryPort userProfileQueryPort;
+    @MockBean private PlaylistQueryPort playlistQueryPort;
+    @MockBean private PlaylistCommandPort playlistCommandPort;
+
+    @BeforeEach
+    void stubBoundaryPorts() {
+        lenient().when(userProfileQueryPort.getUsersProfileSetting(any()))
+                .thenAnswer(inv -> {
+                    List<UserId> ids = inv.getArgument(0);
+                    Map<UserId, ProfileSettingDto> result = new java.util.HashMap<>();
+                    for (UserId id : ids) {
+                        result.put(id, mock(ProfileSettingDto.class));
+                    }
+                    return result;
+                });
+        lenient().when(playlistQueryPort.isOwnedBy(anyLong(), anyLong())).thenReturn(true);
+        lenient().when(playlistQueryPort.isEmptyPlaylist(anyLong())).thenReturn(false);
+    }
+
+    private long createActiveRoom(long hostUid, String linkSuffix) {
+        PartyroomData p = PartyroomData.create(
+                "supersede-it", "intro", LinkDomain.of("link-supersede-" + linkSuffix),
+                PlaybackTimeLimit.ofMinutes(5), StageType.GENERAL,
+                new UserId(hostUid));
+        long id = partyroomRepository.saveAndFlush(p).getId();
+        partyroomPlaybackRepository.save(PartyroomPlaybackData.createFor(new PartyroomId(id)));
+        djQueueRepository.save(DjQueueData.createFor(new PartyroomId(id)));
+        createdRoomIds.add(id);
+        return id;
+    }
+
+    private void enterAs(UserId user, long roomId) {
+        ThreadLocalContext.setContext(new AuthContext(user, AuthorityTier.GT));
+        accessCommandService.tryEnter(new PartyroomId(roomId), CountryCode.of("KR"));
+    }
+
+    @AfterEach
+    void cleanup() {
+        ThreadLocalContext.clearContext();
+        if (createdRoomIds.isEmpty()) return;
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            entityManager.createNativeQuery("DELETE FROM crew WHERE partyroom_id IN (:ids)")
+                    .setParameter("ids", createdRoomIds).executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM dj WHERE partyroom_id IN (:ids)")
+                    .setParameter("ids", createdRoomIds).executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM dj_queue WHERE partyroom_id IN (:ids)")
+                    .setParameter("ids", createdRoomIds).executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM partyroom_playback WHERE partyroom_id IN (:ids)")
+                    .setParameter("ids", createdRoomIds).executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM partyroom WHERE partyroom_id IN (:ids)")
+                    .setParameter("ids", createdRoomIds).executeUpdate();
+        });
+        createdRoomIds.clear();
+    }
+
+    @Test
+    @DisplayName("다른 방으로 밀어냄 → SessionSupersededEvent 발행 + 밀려난 crew is_active=0/exited_at (★#369)")
+    void supersede_publishes_event_and_deactivates_prior_crew() {
+        long roomX = createActiveRoom(9001L, "x");
+        long roomY = createActiveRoom(9002L, "y");
+        UserId user = new UserId(8801L);
+
+        enterAs(user, roomX);
+        enterAs(user, roomY); // 밀어냄: X 에서 auto-exit → Y 활성
+
+        List<SessionSupersededEvent> events =
+                applicationEvents.stream(SessionSupersededEvent.class).toList();
+        assertThat(events).hasSize(1);
+        SessionSupersededEvent event = events.get(0);
+        assertThat(event.getUserId()).isEqualTo(user);
+        assertThat(event.getSupersededPartyroomId()).isEqualTo(new PartyroomId(roomX));
+        assertThat(event.getNewPartyroomId()).isEqualTo(new PartyroomId(roomY));
+        assertThat(event.getOccurredAtEpochMilli()).isPositive();
+
+        // 회귀: 밀려난 crew 는 is_active=0 + exited_at 기록 (기존 동작 보존)
+        Number activeInX = (Number) entityManager.createNativeQuery(
+                        "SELECT COUNT(*) FROM crew WHERE partyroom_id = :id AND user_id = :uid AND is_active = 1")
+                .setParameter("id", roomX).setParameter("uid", 8801L).getSingleResult();
+        Number exitedRecorded = (Number) entityManager.createNativeQuery(
+                        "SELECT COUNT(*) FROM crew WHERE partyroom_id = :id AND user_id = :uid AND exited_at IS NOT NULL")
+                .setParameter("id", roomX).setParameter("uid", 8801L).getSingleResult();
+        assertThat(activeInX.longValue()).as("밀려난 crew 는 비활성화").isZero();
+        assertThat(exitedRecorded.longValue()).as("밀려난 crew 는 exited_at 기록").isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("최초 입장(밀어냄 없음) → SessionSupersededEvent 미발행 (#369)")
+    void first_entry_does_not_publish_event() {
+        long roomX = createActiveRoom(9003L, "first");
+        UserId user = new UserId(8802L);
+
+        enterAs(user, roomX);
+
+        assertThat(applicationEvents.stream(SessionSupersededEvent.class)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("같은 방 재입장(멀티탭/재연결) → SessionSupersededEvent 미발행 (#369)")
+    void same_room_re_entry_does_not_publish_event() {
+        long roomX = createActiveRoom(9004L, "same");
+        UserId user = new UserId(8803L);
+
+        enterAs(user, roomX);
+        enterAs(user, roomX); // 같은 방 재입장 — 밀어냄 아님
+
+        assertThat(applicationEvents.stream(SessionSupersededEvent.class)).isEmpty();
+    }
+}

--- a/realtime/src/main/java/com/pfplaybackend/realtime/sender/SimpMessageSender.java
+++ b/realtime/src/main/java/com/pfplaybackend/realtime/sender/SimpMessageSender.java
@@ -17,4 +17,13 @@ public class SimpMessageSender {
     public void sendToOne(String user, String message) {
         simpMessagingTemplate.convertAndSendToUser(user, "/sub/heartbeat", message);
     }
+
+    /**
+     * 특정 유저의 개인 세션 큐로 발송한다 (uid principal → /user/sub/session). #369 세션 승계 알림용.
+     * 브로커가 {@code /sub} prefix 만 relay 하므로 user destination 도 {@code /sub/*} 를 사용한다
+     * (heartbeat 와 동일 관례).
+     */
+    public void sendToOneSession(String user, Object object) {
+        simpMessagingTemplate.convertAndSendToUser(user, "/sub/session", object);
+    }
 }


### PR DESCRIPTION
## 개요
멀티 디바이스 세션 승계(new-session-wins) 3종 세트 중 **알림 채널**. 같은 유저가 다른 방으로 입장해 기존 활성 crew 가 auto-exit 될 때, 밀려난 옛 브라우저에 그 사실을 알리는 서버 신호를 추가한다.

## 변경
- `autoExitPriorActiveRoomIfDifferent` 밀어냄 분기(tryEnter/enterByHost 공용)에서 **`SessionSupersededEvent` 발행** — 밀어냄 없는 경로(최초 입장/같은 방 재입장)에선 미발행
- **AFTER_COMMIT 리스너**(`SessionSupersedeNotifier`)가 밀려난 유저의 개인 큐로 `convertAndSendToUser(uid, "/sub/session", SESSION_SUPERSEDED{ newPartyroomId, supersededPartyroomId, occurredAt })` 발송. WS 발송뿐이라 REQUIRES_NEW 불필요
- 밀려남(crew EXIT)은 서버가 이미 완결 — 알림은 **순수 UX 신호**, 정합성 백스톱은 재연결 스냅샷 resync(#477)

## 설계 노트
- user destination 을 **`/sub/session`** 으로 씀 — 브로커가 `/sub` prefix 만 relay 하고 heartbeat 도 `/user/sub/heartbeat` 관례라, 이슈 원문의 `/queue/session` 은 브로커 미등록으로 미전달됨.
- 같은 유저의 두 세션(밀려난 A + 새 B)이 동일 principal 을 공유해 알림이 양쪽에 도달 → 수신 클라이언트가 `supersededPartyroomId`/`newPartyroomId` 로 자신이 밀려난 쪽인지 판별(web#476 담당).
- 단일 인스턴스 전제(SimpUserRegistry in-process). 다중 인스턴스 확장 시 Redis 릴레이 필요 — 그때도 정합성 백스톱(resync)은 유지.

## 검증
- IT: 밀어냄 → `SessionSupersededEvent` 1건 + 밀려난 crew is_active=0/exited_at, 최초 입장·같은 방 재입장 → 미발행
- 단위: 리스너가 uid principal 로 SESSION_SUPERSEDED 발송
- **전체 `:app:test`(ArchUnit) + `:app:integrationTest` GREEN**

## ⚠️ 머지 보류
- 수신측 web#476(밀려남 모달)과 세트. 세트 전체 검토 후 머지 결정.

관련: #369, #477