### PR TITLE
ci: 문서만 변경된 머지가 배포를 유발하지 않도록 paths-ignore 도입 (#374)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [closed]
     branches: [develop]
+    # 문서만 바뀐 머지는 배포하지 않는다 (#374).
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 env:
   IMAGE: ghcr.io/pfplay/pfplay-api

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -4,6 +4,11 @@ name: Deploy to prod (GCP VM via IAP)
 on:
   push:
     branches: [main]
+    # 문서만 바뀐 push 는 배포하지 않는다 (#374).
+    # 코드가 섞인 릴리스 머지는 그대로 배포된다.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 env:
   PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [closed]
     branches: [release]
+    # 문서만 바뀐 머지는 배포하지 않는다 (#374).
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 env:
   IMAGE: ghcr.io/pfplay/pfplay-api


### PR DESCRIPTION
closes #374

## 문제

배포 워크플로 3종에 `paths`/`paths-ignore` 필터가 **전혀 없었다.** 브랜치 이벤트만 보고 무조건 배포가 돈다 — 마크다운 한 줄만 고쳐도 `bootJar` → GHCR push → **app 컨테이너 재기동**. prod 에서는 수 초~수십 초 중단 + 접속 중인 전원 WS 끊김(presence grace·reconcile 경로 실제 발동)을 의미한다.

## 변경

| 파일 | 트리거 | 추가 |
|---|---|---|
| `deploy-dev.yml` | `pull_request: closed → develop` | `paths-ignore: ['**.md', 'docs/**']` |
| `deploy-stg.yml` | `pull_request: closed → release` | 동일 |
| `deploy-prod.yml` | `push → main` | 동일 |

`docs/**` 가 `docs/asyncapi/asyncapi.yml` 도 덮는다(문서용 스펙이며 빌드·런타임 참조 0건).

## 의도적으로 하지 않은 것

- **`ci-test.yml` 에는 걸지 않았다.** 검증 워크플로는 싸고 스킵해서 얻는 게 없다. 더 중요한 이유: 현재 브랜치 보호가 없지만(확인함) 나중에 required status check 로 등록되면 **`paths` 로 스킵된 체크가 "대기 중"으로 남아 PR 이 영구 머지 불가**가 되는 알려진 함정이 있다. 배포 워크플로는 PR 체크가 아니므로 이 위험이 없다.
- `registry-cleanup.yml` — `workflow_dispatch` 라 무관.

## 한계 (기대치 조정)

`main` 으로 가는 머지는 대개 코드가 섞인 릴리스라 **prod 에서는 대부분 걸리지 않는다.** 실질 이득은 dev 단계이고, prod 는 "문서만을 위한 승격을 하지 않는다"는 운영 규칙이 함께 있어야 한다.

## 검증

- 세 워크플로 YAML 파싱 확인 — 트리거 구조가 의도대로 (`pull_request.paths-ignore`, `push.paths-ignore`), `ci-test.yml` 은 무변경
- 실제 동작 확인은 머지 후: 이 PR 자체는 워크플로 변경이라 **정상적으로 dev 배포가 돈다**. 이어서 머지할 문서 PR #373 이 **skipped** 로 표시되면 의도대로 동작하는 것